### PR TITLE
アウトラインの描画バグ有

### DIFF
--- a/Project/ApplicationLayer/Scene/GameClearScene/GameClearScene.cpp
+++ b/Project/ApplicationLayer/Scene/GameClearScene/GameClearScene.cpp
@@ -24,11 +24,11 @@ void GameClearScene::Update()
 {
 }
 
+void GameClearScene::Draw3DObjects()
+{
+}
 
-/// -------------------------------------------------------------
-///				　			描画処理
-/// -------------------------------------------------------------
-void GameClearScene::Draw()
+void GameClearScene::Draw2DSprites()
 {
 }
 

--- a/Project/ApplicationLayer/Scene/GameClearScene/GameClearScene.h
+++ b/Project/ApplicationLayer/Scene/GameClearScene/GameClearScene.h
@@ -23,8 +23,11 @@ public: /// ---------- メンバ関数 ---------- ///
 	// 更新処理
 	void Update() override;
 
-	// 描画処理
-	void Draw() override;
+	// 3Dオブジェクトの描画
+	void Draw3DObjects() override;
+
+	// 2Dオブジェクトの描画
+	void Draw2DSprites() override;
 
 	// 終了処理
 	void Finalize() override;

--- a/Project/ApplicationLayer/Scene/GameOverScene/GameOverScene.cpp
+++ b/Project/ApplicationLayer/Scene/GameOverScene/GameOverScene.cpp
@@ -24,11 +24,11 @@ void GameOverScene::Update()
 {
 }
 
+void GameOverScene::Draw3DObjects()
+{
+}
 
-/// -------------------------------------------------------------
-///				　			描画処理
-/// -------------------------------------------------------------
-void GameOverScene::Draw()
+void GameOverScene::Draw2DSprites()
 {
 }
 

--- a/Project/ApplicationLayer/Scene/GameOverScene/GameOverScene.h
+++ b/Project/ApplicationLayer/Scene/GameOverScene/GameOverScene.h
@@ -24,8 +24,11 @@ public: /// ---------- メンバ関数 ---------- ///
 	// 更新処理
 	void Update() override;
 
-	// 描画処理
-	void Draw() override;
+	// 3Dオブジェクトの描画
+	void Draw3DObjects() override;
+
+	// 2Dオブジェクトの描画
+	void Draw2DSprites() override;
 
 	// 終了処理
 	void Finalize() override;

--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
@@ -98,25 +98,16 @@ void GamePlayScene::Update()
 	CheckAllCollisions();
 }
 
-
 /// -------------------------------------------------------------
 ///				　			　 描画処理
 /// -------------------------------------------------------------
-void GamePlayScene::Draw()
+void GamePlayScene::Draw3DObjects()
 {
 #pragma region スカイボックスの描画
 
 	// スカイボックスの共通描画設定
 	SkyBoxManager::GetInstance()->SetRenderSetting();
-	skyBox_->Draw();
-
-#pragma endregion
-
-
-#pragma region スプライトの描画                    
-
-	// 背景用の共通描画設定（後面）
-	SpriteManager::GetInstance()->SetRenderSetting_Background();
+	//skyBox_->Draw();
 
 #pragma endregion
 
@@ -130,11 +121,22 @@ void GamePlayScene::Draw()
 	objectTerrain_->Draw();
 
 	// 球体の描画
-	objectBall_->Draw();
+	//objectBall_->Draw();
 
 	animationModelNoskeleton_->Draw();
 
 	animationModelSkeleton_->Draw();
+
+#pragma endregion
+}
+
+
+void GamePlayScene::Draw2DSprites()
+{
+#pragma region スプライトの描画                    
+
+	// 背景用の共通描画設定（後面）
+	SpriteManager::GetInstance()->SetRenderSetting_Background();
 
 #pragma endregion
 
@@ -147,7 +149,7 @@ void GamePlayScene::Draw()
 #pragma endregion
 
 	// ワイヤーフレームの描画
-	Wireframe::GetInstance()->DrawGrid(100.0f, 20.0f, { 0.25f, 0.25f, 0.25f,1.0f });
+	//Wireframe::GetInstance()->DrawGrid(100.0f, 20.0f, { 0.25f, 0.25f, 0.25f,1.0f });
 }
 
 

--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.h
@@ -32,8 +32,11 @@ public: /// ---------- メンバ関数 ---------- ///
 	// 更新処理
 	void Update() override;
 
-	// 描画処理
-	void Draw() override;
+	// 3Dオブジェクトの描画
+	void Draw3DObjects() override;
+
+	// 2Dオブジェクトの描画
+	void Draw2DSprites() override;
 
 	// 終了処理
 	void Finalize() override;

--- a/Project/ApplicationLayer/Scene/TitleScene/TitleScene.cpp
+++ b/Project/ApplicationLayer/Scene/TitleScene/TitleScene.cpp
@@ -74,11 +74,18 @@ void TitleScene::Update()
 	}
 }
 
+void TitleScene::Draw3DObjects()
+{
+#pragma region オブジェクト3Dの描画
 
-/// -------------------------------------------------------------
-///				　			　 描画処理
-/// -------------------------------------------------------------
-void TitleScene::Draw()
+	// オブジェクト3D共通描画設定
+	Object3DCommon::GetInstance()->SetRenderSetting();
+
+#pragma endregion
+
+}
+
+void TitleScene::Draw2DSprites()
 {
 #pragma region 背景の描画（後面）
 
@@ -94,19 +101,12 @@ void TitleScene::Draw()
 #pragma endregion
 
 
-#pragma region オブジェクト3Dの描画
-
-	// オブジェクト3D共通描画設定
-	Object3DCommon::GetInstance()->SetRenderSetting();
-
-#pragma endregion
-
-
 #pragma region UIの描画（前面）
 	// UI用の共通描画設定
 	SpriteManager::GetInstance()->SetRenderSetting_UI();
 
 #pragma endregion
+
 }
 
 

--- a/Project/ApplicationLayer/Scene/TitleScene/TitleScene.h
+++ b/Project/ApplicationLayer/Scene/TitleScene/TitleScene.h
@@ -25,8 +25,11 @@ public: /// ---------- メンバ関数 ---------- ///
 	// 更新処理
 	void Update() override;
 
-	// 描画処理
-	void Draw() override;
+	// 3Dオブジェクトの描画
+	void Draw3DObjects() override;
+
+	// 2Dオブジェクトの描画
+	void Draw2DSprites() override;
 
 	// 終了処理
 	void Finalize() override;

--- a/Project/ApplicationLayer/SceneManagement/BaseScene/BaseScene.h
+++ b/Project/ApplicationLayer/SceneManagement/BaseScene/BaseScene.h
@@ -21,7 +21,13 @@ public: /// ---------- 純粋仮想関数 ---------- ///
 	virtual void Update() = 0;
 
 	// 仮想描画処理
-	virtual void Draw() = 0;
+	//virtual void Draw() = 0;
+
+	// 仮想3D描画処理
+	virtual void Draw3DObjects() = 0;
+
+	// 仮想2D描画処理
+	virtual void Draw2DSprites() = 0;
 
 	// 仮想終了処理
 	virtual void Finalize() = 0;

--- a/Project/ApplicationLayer/SceneManagement/SceneManager/SceneManager.cpp
+++ b/Project/ApplicationLayer/SceneManagement/SceneManager/SceneManager.cpp
@@ -42,17 +42,17 @@ void SceneManager::Update()
 	}
 }
 
-
-
-/// -------------------------------------------------------------
-///					　		描画処理
-/// -------------------------------------------------------------
-void SceneManager::Draw()
+void SceneManager::Draw3DObjects()
 {
-	// 現在のシーンを描画
-	if (scene_)
-	{
-		scene_->Draw();
+	if (scene_) {
+		scene_->Draw3DObjects();
+	}
+}
+
+void SceneManager::Draw2DSprites()
+{
+	if (scene_) {
+		scene_->Draw2DSprites();
 	}
 }
 

--- a/Project/ApplicationLayer/SceneManagement/SceneManager/SceneManager.h
+++ b/Project/ApplicationLayer/SceneManagement/SceneManager/SceneManager.h
@@ -17,8 +17,11 @@ public: /// ---------- メンバ関数 ---------- ///
 	// 更新処理
 	void Update();
 
-	// 描画処理
-	void Draw();
+	// 3Dオブジェクトの描画
+	void Draw3DObjects();
+
+	// 2Dオブジェクトの描画
+	void Draw2DSprites();
 
 	// ImGui描画処理
 	void DrawImGui();

--- a/Project/EngineLayer/Base/DirectXCommon/DirectXCommon.cpp
+++ b/Project/EngineLayer/Base/DirectXCommon/DirectXCommon.cpp
@@ -102,9 +102,6 @@ void DirectXCommon::EndDraw()
 {
 	HRESULT hr{};
 
-	// ポストエフェクトを適用
-	PostEffectManager::GetInstance()->RenderPostEffect();
-
 	// **バックバッファの取得**
 	backBufferIndex = swapChain_->GetSwapChain()->GetCurrentBackBufferIndex();
 	ComPtr<ID3D12Resource> backBuffer = GetBackBuffer(backBufferIndex);

--- a/Project/EngineLayer/Managers/DSVManager/DSVManager.cpp
+++ b/Project/EngineLayer/Managers/DSVManager/DSVManager.cpp
@@ -91,9 +91,22 @@ void DSVManager::CreateDSVForDepthBuffer(uint32_t dsvIndex, ID3D12Resource* dept
 	D3D12_DEPTH_STENCIL_VIEW_DESC dsvDesc{};
 	dsvDesc.Format = DXGI_FORMAT_D24_UNORM_S8_UINT;
 	dsvDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
+	dsvDesc.Flags = D3D12_DSV_FLAG_NONE;
+	dsvDesc.Texture2D.MipSlice = 0;
 
 	// DSVを作成
 	dxCommon_->GetDevice()->CreateDepthStencilView(depthResource, &dsvDesc, GetCPUDescriptorHandle(dsvIndex));
+}
+
+void DSVManager::CreateDSVForTexture2D(uint32_t dsvIndex, ID3D12Resource* resource)
+{
+	D3D12_DEPTH_STENCIL_VIEW_DESC dsvDesc{};
+	dsvDesc.Format = DXGI_FORMAT_D24_UNORM_S8_UINT;
+	dsvDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
+	dsvDesc.Flags = D3D12_DSV_FLAG_NONE;
+	dsvDesc.Texture2D.MipSlice = 0;
+
+	dxCommon_->GetDevice()->CreateDepthStencilView(resource, &dsvDesc, GetCPUDescriptorHandle(dsvIndex));
 }
 
 

--- a/Project/EngineLayer/Managers/DSVManager/DSVManager.h
+++ b/Project/EngineLayer/Managers/DSVManager/DSVManager.h
@@ -32,6 +32,9 @@ public: /// ---------- メンバ関数 ---------- ///
 	// 指定された深度バッファリソースのDSVを作成する
 	void CreateDSVForDepthBuffer(uint32_t dsvIndex, ID3D12Resource* depthResource);
 
+	// 指定されたテクスチャリソースのDSVを作成する
+	void CreateDSVForTexture2D(uint32_t dsvIndex, ID3D12Resource* resource);
+
 public: /// ---------- ゲッター ---------- ///
 
 	// デスクリプタヒープを取得

--- a/Project/EngineLayer/Managers/ParticleManager/ParticleManager.cpp
+++ b/Project/EngineLayer/Managers/ParticleManager/ParticleManager.cpp
@@ -479,7 +479,7 @@ void ParticleManager::CreatePSO()
 
 	D3D12_DEPTH_STENCIL_DESC depthStencilDesc{};
 	//Depthの機能を有効化する
-	depthStencilDesc.DepthEnable = true;
+	depthStencilDesc.DepthEnable = false;
 	//書き込みします
 	depthStencilDesc.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL;
 	//比較関数はLessEqual。つまり、近ければ描画される

--- a/Project/EngineLayer/Managers/SpriteManager/SpriteManager.cpp
+++ b/Project/EngineLayer/Managers/SpriteManager/SpriteManager.cpp
@@ -168,7 +168,7 @@ void SpriteManager::CreatePSO()
 	// --- 背景用（Zバッファ書き込みあり） ---
 	{
 		D3D12_DEPTH_STENCIL_DESC depthStencilDesc{};
-		depthStencilDesc.DepthEnable = true;
+		depthStencilDesc.DepthEnable = false;
 		depthStencilDesc.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ALL;  // 書き込みあり
 		depthStencilDesc.DepthFunc = D3D12_COMPARISON_FUNC_LESS_EQUAL;
 
@@ -194,7 +194,7 @@ void SpriteManager::CreatePSO()
 	// --- UI用（Zバッファ書き込みなし） ---
 	{
 		D3D12_DEPTH_STENCIL_DESC depthStencilDesc{};
-		depthStencilDesc.DepthEnable = true;
+		depthStencilDesc.DepthEnable = false;
 		depthStencilDesc.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ZERO; // 書き込みなし
 		depthStencilDesc.DepthFunc = D3D12_COMPARISON_FUNC_LESS_EQUAL;
 

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -199,6 +199,12 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
     </FxCompile>
+    <FxCompile Include="Resources\Shaders\DepthOutline.PS.hlsl">
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Pixel</ShaderType>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Pixel</ShaderType>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </FxCompile>
     <FxCompile Include="Resources\Shaders\DissolveEffect.PS.hlsl">
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Pixel</ShaderType>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Pixel</ShaderType>

--- a/Project/imgui.ini
+++ b/Project/imgui.ini
@@ -8,22 +8,24 @@ Pos=5,11
 Size=187,39
 
 [Window][Camera]
-Pos=0,100
+Pos=193,13
 Size=244,84
 
 [Window][Test Window]
-Pos=881,30
+Pos=880,30
 Size=366,368
+Collapsed=1
 
 [Window][Particle Manager]
-Pos=-2,255
+Pos=438,13
 Size=136,77
+Collapsed=1
 
 [Window][Animation Debug]
 Pos=60,60
 Size=275,123
 
 [Window][Post Effect Settings]
-Pos=14,356
-Size=515,285
+Pos=6,64
+Size=274,369
 


### PR DESCRIPTION
・ゲームエンジンの描画の仕方を変更
・ポストエフェクトを3D描画中心に行うようにした
・2DSpriteなどのUIに無駄なく処理の削減を行った
・シーンマネージャーで3D描画用と2D描画用と分けた
・ほかのシーンにも適用