### PR TITLE
衝突判定システムの改善と新機能の追加

### DIFF
--- a/Project/ApplicationLayer/Colliders/Collider.h
+++ b/Project/ApplicationLayer/Colliders/Collider.h
@@ -1,11 +1,14 @@
 #pragma once
 #include <cstdint>
 #include "Vector3.h"
+#include "Vector4.h"
 #include "Matrix4x4.h"
-#include "Wireframe.h"
+
+#include "OBB.h"
+
 
 /// -------------------------------------------------------------
-///                         当たり判定クラス（OBB対応）
+///                     当たり判定クラス
 /// -------------------------------------------------------------
 class Collider
 {

--- a/Project/ApplicationLayer/Colliders/CollisionManager.h
+++ b/Project/ApplicationLayer/Colliders/CollisionManager.h
@@ -5,6 +5,9 @@
 #include "Vector3.h"
 #include "OBB.h"
 
+#include <functional>
+#include <map>
+
 
 /// ---------- 前方宣言 ---------- ///
 class Collider;
@@ -37,16 +40,22 @@ public: /// ---------- メンバ関数 ---------- ///
 
 	// コライダーを削除
 	void RemoveCollider(Collider* other);
-	
+
+	// 衝突判定
+	using CollisionFunc = std::function<bool(Collider*, Collider*)>;
+
 private: /// ---------- メンバ関数 ---------- ///
 
 	// コライダー2つの衝突判定と応答処理
 	void CheckCollisionPair(Collider* colliderA, Collider* colliderB);
 
-	// OBBの分離軸テスト
-	bool IsSeparatingAxis(const Vector3& axis, const OBB& obbA, const OBB& obbB);
+	// 初期化関数
+	void RegisterCollisionFuncsions();
 
 private: /// ---------- メンバ変数 ---------- ///
+
+	// 衝突判定関数の登録
+	std::map<std::pair<uint32_t, uint32_t>, CollisionFunc> collisionTable_;
 
 	// コライダーリスト
 	std::list<Collider*> colliders_;

--- a/Project/ApplicationLayer/Colliders/CollisionUtility.cpp
+++ b/Project/ApplicationLayer/Colliders/CollisionUtility.cpp
@@ -1,0 +1,261 @@
+#include "CollisionUtility.h"
+
+#include <algorithm>
+
+bool CollisionUtility::IsCollision(const Sphere& s1, const Sphere& s2)
+{
+	//2つの球の中心点間の距離を求める
+	float distance = Vector3::Length(Vector3::Subtract(s2.center, s1.center));
+	// 半径の合計よりも短ければ衝突
+	return distance <= (s1.radius + s2.radius);
+}
+
+bool CollisionUtility::IsCollision(const Sphere& sphere, const Plane& plane)
+{
+	// 平面の法線ベクトルと球の中心点との距離
+	float distance = Vector3::Dot(plane.normal, sphere.center) - plane.distance;
+	// その距離が球の半径以下なら衝突している
+	return fabs(distance) <= sphere.radius;
+}
+
+bool CollisionUtility::IsCollision(const Segment& segment, const Plane& plane)
+{
+	//まず垂直判定を行うために、法線と線の内積を求める
+	float dot = Vector3::Dot(plane.normal, segment.diff);
+
+	//垂直 = 平行であるので、衝突しているはずがない
+	// 浮動小数点数の比較は通常、直接の等号判定は避ける
+	const float epsilon = 1e-6f;
+	if (fabs(dot) < epsilon)
+	{
+		return false;
+	}
+
+	//tを求める
+	float t = (plane.distance - Vector3::Dot(segment.origin, plane.normal)) / dot;
+
+	//tの値と線の種類によって衝突しているかを判断する
+	return t >= 0.0f && t <= 1.0f;
+}
+
+bool CollisionUtility::IsCollision(const Triangle& triangle, const Segment& segment)
+{
+	// 三角形の辺
+	Vector3 edge1 = Vector3::Subtract(triangle.vertices[1], triangle.vertices[0]);
+	Vector3 edge2 = Vector3::Subtract(triangle.vertices[2], triangle.vertices[0]);
+
+	// 平面の法線ベクトルを計算
+	Vector3 normal = Vector3::Cross(edge1, edge2);
+	normal = Vector3::Normalize(normal);
+
+	// 線分の方向ベクトル
+	Vector3 dir = segment.diff;
+	dir = Vector3::Normalize(dir);
+
+	// 平面と線分の始点のベクトル
+	Vector3 diff = Vector3::Subtract(triangle.vertices[0], segment.origin);
+
+	// 線分が平面と平行かどうかをチェック
+	float dotND = Vector3::Dot(normal, dir);
+	if (fabs(dotND) < 1e-6f)
+	{
+		return false; // 線分が平面と平行
+	}
+
+	// 線分の始点と平面の交点を計算
+	float t = Vector3::Dot(normal, diff) / dotND;
+
+	if (t < 0.0f || t > Vector3::Length(segment.diff))
+	{
+		return false; // 線分上に交点がない
+	}
+
+	Vector3 intersection = Vector3::Add(segment.origin, Vector3::Multiply(t, dir));
+
+	// バリツチェックで三角形の内部に交点があるかを確認
+	Vector3 c0 = Vector3::Cross(Vector3::Subtract(triangle.vertices[1], triangle.vertices[0]), Vector3::Subtract(intersection, triangle.vertices[0]));
+	Vector3 c1 = Vector3::Cross(Vector3::Subtract(triangle.vertices[2], triangle.vertices[1]), Vector3::Subtract(intersection, triangle.vertices[1]));
+	Vector3 c2 = Vector3::Cross(Vector3::Subtract(triangle.vertices[0], triangle.vertices[2]), Vector3::Subtract(intersection, triangle.vertices[2]));
+
+	if (Vector3::Dot(c0, normal) >= 0.0f && Vector3::Dot(c1, normal) >= 0.0f && Vector3::Dot(c2, normal) >= 0.0f)
+	{
+		return true; // 衝突
+	}
+
+	return false; // 衝突なし
+}
+
+bool CollisionUtility::IsCollision(const AABB& aabb1, const AABB& aabb2)
+{
+	return
+		(aabb1.min.x <= aabb2.max.x && aabb1.max.x >= aabb2.min.x) && //x軸
+		(aabb1.min.y <= aabb2.max.y && aabb1.max.y >= aabb2.min.y) &&
+		(aabb1.min.z <= aabb2.max.z && aabb1.max.z >= aabb2.min.z);
+}
+
+bool CollisionUtility::IsCollision(const AABB& aabb, const Sphere& sphere)
+{
+	//最近接点を求める
+	Vector3 clossestPoint
+	{
+		std::clamp(sphere.center.x,aabb.min.x,aabb.max.x),
+		std::clamp(sphere.center.y,aabb.min.y,aabb.max.y),
+		std::clamp(sphere.center.z,aabb.min.z,aabb.max.z)
+	};
+	//最近接点と球の中途の距離を求める
+	float distance = Vector3::Length(Vector3::Subtract(clossestPoint, sphere.center));
+	//距離が半径よりも小さければ衝突
+	return distance <= sphere.radius;
+}
+
+bool CollisionUtility::IsCollision(const AABB& aabb, const Segment& segment)
+{
+	float tNearX = (aabb.min.x - segment.origin.x) / segment.diff.x;
+	float tFarX = (aabb.max.x - segment.origin.x) / segment.diff.x;
+	if (tNearX > tFarX) std::swap(tNearX, tFarX);
+
+	float tNearY = (aabb.min.y - segment.origin.y) / segment.diff.y;
+	float tFarY = (aabb.max.y - segment.origin.y) / segment.diff.y;
+	if (tNearY > tFarY) std::swap(tNearY, tFarY);
+
+	float tNearZ = (aabb.min.z - segment.origin.z) / segment.diff.z;
+	float tFarZ = (aabb.max.z - segment.origin.z) / segment.diff.z;
+	if (tNearZ > tFarZ) std::swap(tNearZ, tFarZ);
+
+	// 線分がAABBを貫通しているかどうかを判定
+	float tmin = std::max(std::max(tNearX, tNearY), tNearZ);
+	float tmax = std::min(std::min(tFarX, tFarY), tFarZ);
+
+	// 衝突しているかどうかの判定
+	if (tmin <= tmax && tmax >= 0.0f && tmin <= 1.0f) {
+		return true;
+	}
+	return false;
+}
+
+bool CollisionUtility::IsCollision(const OBB& obb, const Sphere& sphere)
+{
+	// Step 1: Transform the sphere's center into the OBB's local space
+	Matrix4x4 obbWorldMatrix = Matrix4x4::MakeAffineMatrix({ 1.0f, 1.0f, 1.0f }, { 0.0f, 0.0f, 0.0f }, obb.center);
+	Matrix4x4 obbRotationMatrix = Matrix4x4::MakeAffineMatrix({ 1.0f, 1.0f, 1.0f }, {}, Vector3());
+	obbRotationMatrix.m[0][0] = obb.orientations[0].x;
+	obbRotationMatrix.m[0][1] = obb.orientations[0].y;
+	obbRotationMatrix.m[0][2] = obb.orientations[0].z;
+
+	obbRotationMatrix.m[1][0] = obb.orientations[1].x;
+	obbRotationMatrix.m[1][1] = obb.orientations[1].y;
+	obbRotationMatrix.m[1][2] = obb.orientations[1].z;
+
+	obbRotationMatrix.m[2][0] = obb.orientations[2].x;
+	obbRotationMatrix.m[2][1] = obb.orientations[2].y;
+	obbRotationMatrix.m[2][2] = obb.orientations[2].z;
+
+	obbWorldMatrix = Matrix4x4::Multiply(obbWorldMatrix, obbRotationMatrix);
+	Matrix4x4 obbWorldMatrixInverse = Matrix4x4::Inverse(obbWorldMatrix);
+	Vector3 centerInOBBLocalSpace = Vector3::Transform(sphere.center, obbWorldMatrixInverse);
+
+	// Step 2: Find the closest point on the OBB to the sphere center in local space
+	Vector3 closestPoint = centerInOBBLocalSpace;
+	closestPoint.x = std::max(-obb.size.x * 0.5f, std::min(closestPoint.x, obb.size.x * 0.5f));
+	closestPoint.y = std::max(-obb.size.y * 0.5f, std::min(closestPoint.y, obb.size.y * 0.5f));
+	closestPoint.z = std::max(-obb.size.z * 0.5f, std::min(closestPoint.z, obb.size.z * 0.5f));
+
+	// Step 3: Calculate the distance between the sphere center and this closest point
+	Vector3 difference = centerInOBBLocalSpace - closestPoint;
+	float distanceSquared = Vector3::Dot(difference, difference);
+
+	// Step 4: Check if the distance is less than or equal to the sphere's radius squared
+	return distanceSquared <= sphere.radius * sphere.radius;
+}
+
+bool CollisionUtility::IsCollision(const OBB& obb, const Segment& segment)
+{
+	// OBBの回転行列を作成
+	Matrix4x4 rotationMatrix = {
+		obb.orientations[0].x, obb.orientations[0].y, obb.orientations[0].z, 0.0f,
+		obb.orientations[1].x, obb.orientations[1].y, obb.orientations[1].z, 0.0f,
+		obb.orientations[2].x, obb.orientations[2].y, obb.orientations[2].z, 0.0f,
+		0.0f, 0.0f, 0.0f, 1.0f
+	};
+
+	// OBBの逆変換行列（回転の転置行列と平行移動の逆変換）を作成
+	Matrix4x4 obbWorldMatrixInverse = Matrix4x4::Inverse(rotationMatrix);
+	obbWorldMatrixInverse.m[3][0] = -(obb.center.x * obbWorldMatrixInverse.m[0][0] + obb.center.y * obbWorldMatrixInverse.m[1][0] + obb.center.z * obbWorldMatrixInverse.m[2][0]);
+	obbWorldMatrixInverse.m[3][1] = -(obb.center.x * obbWorldMatrixInverse.m[0][1] + obb.center.y * obbWorldMatrixInverse.m[1][1] + obb.center.z * obbWorldMatrixInverse.m[2][1]);
+	obbWorldMatrixInverse.m[3][2] = -(obb.center.x * obbWorldMatrixInverse.m[0][2] + obb.center.y * obbWorldMatrixInverse.m[1][2] + obb.center.z * obbWorldMatrixInverse.m[2][2]);
+
+	// セグメントの始点と終点をOBBのローカル空間に変換
+	Vector3 localOrigin = Vector3::Transform(segment.origin, obbWorldMatrixInverse);
+	Vector3 localEnd = Vector3::Transform(segment.origin + segment.diff, obbWorldMatrixInverse);
+
+	// 変換後のセグメント
+	Segment localSegment;
+	localSegment.origin = localOrigin;
+	localSegment.diff = localEnd - localOrigin;
+
+	// OBBのローカル空間でAABBとの衝突判定を行う
+	AABB aabbOBBLocal{ -obb.size, obb.size };
+	return IsCollision(aabbOBBLocal, localSegment);
+}
+
+bool CollisionUtility::IsCollision(const OBB& obb1, const OBB& obb2)
+{
+	const float epsilon = 1e-5f;
+
+	// OBBの軸
+	Vector3 axes[15] = {
+		obb1.orientations[0],
+		obb1.orientations[1],
+		obb1.orientations[2],
+		obb2.orientations[0],
+		obb2.orientations[1],
+		obb2.orientations[2],
+		Vector3::Cross(obb1.orientations[0], obb2.orientations[0]),
+		Vector3::Cross(obb1.orientations[0], obb2.orientations[1]),
+		Vector3::Cross(obb1.orientations[0], obb2.orientations[2]),
+		Vector3::Cross(obb1.orientations[1], obb2.orientations[0]),
+		Vector3::Cross(obb1.orientations[1], obb2.orientations[1]),
+		Vector3::Cross(obb1.orientations[1], obb2.orientations[2]),
+		Vector3::Cross(obb1.orientations[2], obb2.orientations[0]),
+		Vector3::Cross(obb1.orientations[2], obb2.orientations[1]),
+		Vector3::Cross(obb1.orientations[2], obb2.orientations[2]),
+	};
+
+	// 各軸に対して分離が存在するかをチェック
+	for (int i = 0; i < 15; ++i) {
+		if (Vector3::Length(axes[i]) < epsilon) {
+			continue; // 無視できる軸
+		}
+
+		// 軸を正規化
+		Vector3 axis = Vector3::Normalize(axes[i]);
+
+		// OBB1の投影範囲
+		float center1 = Vector3::Dot(obb1.center, axis);
+		float extent1 =
+			std::abs(Vector3::Dot(obb1.orientations[0] * obb1.size.x, axis)) +
+			std::abs(Vector3::Dot(obb1.orientations[1] * obb1.size.y, axis)) +
+			std::abs(Vector3::Dot(obb1.orientations[2] * obb1.size.z, axis));
+
+		float min1 = center1 - extent1;
+		float max1 = center1 + extent1;
+
+		// OBB2の投影範囲
+		float center2 = Vector3::Dot(obb2.center, axis);
+		float extent2 =
+			std::abs(Vector3::Dot(obb2.orientations[0] * obb2.size.x, axis)) +
+			std::abs(Vector3::Dot(obb2.orientations[1] * obb2.size.y, axis)) +
+			std::abs(Vector3::Dot(obb2.orientations[2] * obb2.size.z, axis));
+
+		float min2 = center2 - extent2;
+		float max2 = center2 + extent2;
+
+		// 投影範囲が重ならなければ分離している
+		if (max1 < min2 || max2 < min1) {
+			return false; // 分離軸が存在する
+		}
+	}
+
+	// すべての軸で分離がなければ衝突している
+	return true;
+}

--- a/Project/ApplicationLayer/Colliders/CollisionUtility.h
+++ b/Project/ApplicationLayer/Colliders/CollisionUtility.h
@@ -1,0 +1,56 @@
+#pragma once
+#include "Sphere.h"
+#include "Plane.h"
+#include "Segment.h"
+#include "Triangle.h"
+#include "AABB.h"
+#include "OBB.h"
+#include "Matrix4x4.h"
+
+
+//// -------------------------------------------------------------
+///						衝突判定ユーティリティ
+/// -------------------------------------------------------------
+class CollisionUtility
+{
+public: /// ---------- メンバ関数 ---------- ///
+
+	// 球と球の衝突判定
+	static bool IsCollision(const Sphere& s1, const Sphere& s2);
+
+	// 球と平面の衝突判定
+	static bool IsCollision(const Sphere& sphere, const Plane& plane);
+
+	// 線分と平面の衝突判定
+	static bool IsCollision(const Segment& segment, const Plane& plane);
+
+	// 線分と三角形の衝突判定
+	static bool IsCollision(const Triangle& triangle, const Segment& segment);
+
+	// 球と三角形の衝突判定
+	static bool IsCollision(const AABB& aabb1, const AABB& aabb2);
+
+	// AABBと球の衝突判定
+	static bool IsCollision(const AABB& aabb, const Sphere& sphere);
+
+	// AABBと線分の衝突判定
+	static bool IsCollision(const AABB& aabb, const Segment& segment);
+
+	// AABBとOBBの衝突判定
+	static bool IsCollision(const OBB& obb, const Sphere& sphere);
+
+	// OBBと線分の衝突判定
+	static bool IsCollision(const OBB& obb, const Segment& segment);
+
+	// OBBとOBBの衝突判定
+	static bool IsCollision(const OBB& obb1, const OBB& obb2);
+
+	//// OBBとAABBの衝突判定
+	//static bool IsCollision(const OBB& obb, const AABB& aabb);
+
+	//// OBBと三角形の衝突判定
+	//static bool IsCollision(const OBB& obb, const Triangle& triangle);
+
+	//// OBBと球の衝突判定
+	//static bool IsCollision(const OBB& obb, const Sphere& sphere);
+};

--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
@@ -84,6 +84,11 @@ void GamePlayScene::Initialize()
 	ParticleManager::GetInstance()->CreateParticleGroup("TestParticle2", "gradationLine.png", ParticleEffectType::Cylinder);
 	particleEmitter2_ = std::make_unique<ParticleEmitter>(ParticleManager::GetInstance(), "TestParticle2");
 	particleEmitter2_->SetPosition({ -5.0f, 18.0f, 20.0f });
+
+	ParticleManager::GetInstance()->CreateParticleGroup("TestParticle3", "gradationLine.png", ParticleEffectType::Slash);
+	particleEmitter3_ = std::make_unique<ParticleEmitter>(ParticleManager::GetInstance(), "TestParticle3");
+	particleEmitter3_->SetPosition({ 5.0f, 18.0f, 20.0f });
+	particleEmitter3_->SetEmissionRate(3.0f);
 }
 
 
@@ -148,6 +153,7 @@ void GamePlayScene::Update()
 	defaultEmitter_->Update();
 	particleEmitter_->Update();
 	particleEmitter2_->Update();
+	particleEmitter3_->Update();
 }
 
 

--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.h
@@ -78,6 +78,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	std::unique_ptr< ParticleEmitter> defaultEmitter_ = nullptr;
 	std::unique_ptr< ParticleEmitter> particleEmitter_ = nullptr;
 	std::unique_ptr< ParticleEmitter> particleEmitter2_ = nullptr;
+	std::unique_ptr< ParticleEmitter> particleEmitter3_ = nullptr;
 
 
 	// デバッグカメラのON/OFF用

--- a/Project/EngineLayer/Managers/ParticleManager/ParticleManager.cpp
+++ b/Project/EngineLayer/Managers/ParticleManager/ParticleManager.cpp
@@ -50,6 +50,7 @@ void ParticleManager::Initialize(DirectXCommon* dxCommon, Camera* camera)
 
 	// メッシュデータの初期化
 	meshMap_[ParticleEffectType::Default].Initialize();
+	meshMap_[ParticleEffectType::Slash].InitializeRing();
 	meshMap_[ParticleEffectType::Ring].InitializeRing();
 	meshMap_[ParticleEffectType::Cylinder].InitializeCylinder();
 }
@@ -215,9 +216,6 @@ void ParticleManager::Draw()
 
 	//プリミティブトポロジを設定
 	commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-
-	// VBVを設定
-	commandList->IASetVertexBuffers(0, 1, &mesh_.GetVertexBufferView());
 
 	// すべてのパーティクルグループについて処理する
 	for (auto& group : particleGroups)

--- a/Project/EngineLayer/Managers/ParticleManager/ParticleManager.h
+++ b/Project/EngineLayer/Managers/ParticleManager/ParticleManager.h
@@ -143,10 +143,6 @@ private: /// ---------- メンバ変数 ---------- ///
 	ParticleTransform transform;
 	ParticleMaterial material_;
 
-	ParticleMesh mesh_;
-	ParticleMesh ringMesh_;
-	ParticleMesh cylinderMesh_;
-
 	std::unordered_map<ParticleEffectType, ParticleMesh> meshMap_;
 
 	BlendMode cuurenttype = BlendMode::kBlendModeAdd;
@@ -161,14 +157,9 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	ComPtr <ID3D12RootSignature> rootSignature = nullptr;
 	ComPtr <ID3D12PipelineState> graphicsPipelineState = nullptr;
-	ComPtr <ID3D12Resource> materialResource;
-	ComPtr <ID3D12Resource> vertexResource;
 
 	// モデルの読み込み
 	ModelData modelData;
-
-	VertexData* vertexData = nullptr;
-	D3D12_VERTEX_BUFFER_VIEW vertexBufferView{};
 
 	// パーティクルグループコンテナ
 	std::unordered_map<std::string, ParticleGroup> particleGroups;
@@ -185,16 +176,6 @@ private: /// ---------- メンバ変数 ---------- ///
 	bool isWind = false;
 
 	bool isDebugCamera_ = false;
-
-	// 分割数
-	uint32_t kSubdivision = 32;
-
-	// 緯度・経度の分割数に応じた角度の計算
-	float kLatEvery = std::numbers::pi_v<float> / float(kSubdivision);
-	float kLonEvery = 2.0f * std::numbers::pi_v<float> / float(kSubdivision);
-
-	// 球体の頂点数の計算
-	uint32_t TotalVertexCount = kSubdivision * kSubdivision * 6;
 
 	// Fieldを作る
 	AccelerationField accelerationField;

--- a/Project/EngineLayer/Math/Line.h
+++ b/Project/EngineLayer/Math/Line.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "Vector3.h"
+
+//直線
+struct Line final
+{
+	Vector3 origin;		//始点
+	Vector3 diff;		//終点からの差分
+};

--- a/Project/EngineLayer/Math/Plane.h
+++ b/Project/EngineLayer/Math/Plane.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "Vector3.h"
+
+//平面
+struct Plane final
+{
+	Vector3 normal;		//!< 法線
+	float distance;		//!< 距離
+};

--- a/Project/EngineLayer/Math/Ray.h
+++ b/Project/EngineLayer/Math/Ray.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "Vector3.h"
+
+//半直線
+struct Ray final
+{
+	Vector3 origin;		//始点
+	Vector3 diff;		//終点からの差分
+};

--- a/Project/EngineLayer/Math/Segment.h
+++ b/Project/EngineLayer/Math/Segment.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "Vector3.h"
+
+//線分
+struct Segment final
+{
+	Vector3 origin;      //始点
+	Vector3 diff;        //終点からの差分
+};

--- a/Project/EngineLayer/Math/Sphere.h
+++ b/Project/EngineLayer/Math/Sphere.h
@@ -1,0 +1,9 @@
+#pragma once
+#include "Vector3.h"
+
+//球
+struct Sphere final
+{
+	Vector3 center;	//!<中心点
+	float radius;	//!<半径
+};

--- a/Project/EngineLayer/Math/Triangle.h
+++ b/Project/EngineLayer/Math/Triangle.h
@@ -1,0 +1,8 @@
+#pragma once
+#include "Vector3.h"
+
+//三角形の頂点
+struct Triangle final
+{
+	Vector3 vertices[3];	//!< 頂点
+};

--- a/Project/Externals/DirectXTex/Bin/Desktop_2022_Win10/x64/Debug/DirectXTex_Desktop_2022_Win10.log
+++ b/Project/Externals/DirectXTex/Bin/Desktop_2022_Win10/x64/Debug/DirectXTex_Desktop_2022_Win10.log
@@ -1,6 +1,1 @@
-﻿  BC.cpp
-  BC4BC5.cpp
-  BC6HBC7.cpp
-  BCDirectCompute.cpp
-  コードを生成中...
-  DirectXTex_Desktop_2022_Win10.vcxproj -> C:\Users\k023g\Downloads\Gread2\GE3\CG2_DirectXGame-07_01\CG2_DirectXGame-07_01\Project\externals\DirectXTex\Bin\Desktop_2022_Win10\x64\Debug\DirectXTex.lib
+﻿  DirectXTex_Desktop_2022_Win10.vcxproj -> C:\Users\k023g\Downloads\Gread2\GE3\CG2_DirectXGame-07_01\CG2_DirectXGame-07_01\Project\externals\DirectXTex\Bin\Desktop_2022_Win10\x64\Debug\DirectXTex.lib

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -118,6 +118,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="ApplicationLayer\Player\Bullet.cpp" />
     <ClCompile Include="ApplicationLayer\Crosshair\Crosshair.cpp" />
     <ClCompile Include="ApplicationLayer\Enemy\Enemy.cpp" />
+    <ClCompile Include="ApplicationLayer\Colliders\CollisionUtility.cpp" />
     <ClCompile Include="EngineLayer\Mesh\AnimationMesh.cpp" />
     <ClCompile Include="EngineLayer\Audio\AudioManager.cpp" />
     <ClCompile Include="EngineLayer\Audio\MP3Loader.cpp" />
@@ -359,6 +360,12 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="ApplicationLayer\Player\Bullet.h" />
     <ClInclude Include="ApplicationLayer\Crosshair\Crosshair.h" />
     <ClInclude Include="ApplicationLayer\Enemy\Enemy.h" />
+    <ClInclude Include="ApplicationLayer\Colliders\CollisionUtility.h" />
+    <ClInclude Include="EngineLayer\Math\Line.h" />
+    <ClInclude Include="EngineLayer\Math\Plane.h" />
+    <ClInclude Include="EngineLayer\Math\Ray.h" />
+    <ClInclude Include="EngineLayer\Math\Segment.h" />
+    <ClInclude Include="EngineLayer\Math\Triangle.h" />
     <ClInclude Include="EngineLayer\Mesh\AnimationMesh.h" />
     <ClInclude Include="EngineLayer\Audio\AudioCategory.h" />
     <ClInclude Include="EngineLayer\Audio\AudioManager.h" />
@@ -478,6 +485,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="EngineLayer\ParticleManagement\ParticleFactory.h" />
     <ClInclude Include="ApplicationLayer\Weapon\Weapon.h" />
     <ClInclude Include="EngineLayer\2D\Sprite\NumberSpriteDrawer.h" />
+    <ClInclude Include="EngineLayer\Math\Sphere.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="externals\DirectXTex\DirectXTex_Desktop_2022_Win10.vcxproj">

--- a/Project/imgui.ini
+++ b/Project/imgui.ini
@@ -1,6 +1,6 @@
 [Window][Debug##Default]
 Pos=791,2
-Size=489,403
+Size=489,225
 
 [Window][Global Variables]
 Pos=2,3
@@ -9,7 +9,6 @@ Size=221,38
 [Window][Camera]
 Pos=448,0
 Size=244,84
-Collapsed=1
 
 [Window][Test Window]
 Pos=907,32


### PR DESCRIPTION
Collider.hにOBBとMatrix4x4のインクルードを追加し、Wireframe.hを削除。Colliderクラスに関するコメントを追加。 CollisionManager.cppでCollisionUtility.hをインクルードし、Initialize関数内でRegisterCollisionFuncsionsを呼び出すように変更。 CheckCollisionPair関数の衝突判定ロジックをcollisionTable_を使用する形に改良。 CollisionManager.hにstd::mapでcollisionTable_を追加し、RegisterCollisionFuncsions関数を宣言。 IsSeparatingAxis関数を削除。
CollisionUtility.cppにOBBと他の形状との衝突判定関数を追加。
CollisionUtility.hに衝突判定ユーティリティクラスを追加。
GamePlayScene.cppでparticleEmitter3_を追加し、InitializeおよびUpdate関数を更新。 ParticleManager.cppでSlashタイプのパーティクルエミッターの初期化を追加。
ParticleManager.hでParticleMeshのメンバ変数を削除し、meshMap_を使用するように変更。 新たにLine.h、Plane.h、Ray.h、Segment.h、Sphere.h、Triangle.hを追加。