### PR TITLE
描画方法の改善と新機能の追加

### DIFF
--- a/Project/ApplicationLayer/ResultManager/ResultManager.cpp
+++ b/Project/ApplicationLayer/ResultManager/ResultManager.cpp
@@ -69,11 +69,11 @@ void ResultManager::Draw()
 	titleText_->Draw();
 
 	scoreDrawer_->Reset();
-	scoreDrawer_->DrawNumber(finalScore_, { 600.0f, 200.0f });
+	scoreDrawer_->DrawNumberCentered(finalScore_, { 628.0f, 200.0f }, 24.0f);
 
 	killDrawer_->Reset();
-	killDrawer_->DrawNumber(killCount_, { 600.0f, 300.0f });
+	killDrawer_->DrawNumberCentered(killCount_, { 628.0f, 280.0f }, 24.0f);
 
 	waveDrawer_->Reset();
-	waveDrawer_->DrawNumber(waveCount_, { 600.0f, 400.0f });
+	waveDrawer_->DrawNumberCentered(waveCount_, { 628.0f, 360.0f }, 24.0f);
 }

--- a/Project/ApplicationLayer/Scene/GamePlayScene/HUDManager/HUDManager.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/HUDManager/HUDManager.cpp
@@ -76,20 +76,20 @@ void HUDManager::Draw()
 	scoreDrawer_->Reset();
 
 	// スコアの描画
-	scoreDrawer_->DrawNumber(score_, { 600.0f, 20.0f });
+	scoreDrawer_->DrawNumberCentered(score_, { 628.0f, 20.0f }, 24.0f);
 
 	// リセット
 	killDrawer_->Reset();
 
 	// キル数の描画
-	killDrawer_->DrawNumber(kills_, { 600.0f, 80.0f });
+	killDrawer_->DrawNumberCentered(kills_, { 628.0f, 80.0f });
 
 	// リセット
 	ammoDrawer_->Reset();
 
 	// 弾薬数の描画
-	ammoDrawer_->DrawNumber(ammoInClip_, { 1000.0f, 620.0f });
-	ammoDrawer_->DrawNumber(ammoReserve_, { 1120.0f, 620.0f });
+	ammoDrawer_->DrawNumberRightAligned(ammoInClip_, { 1060.0f, 620.0f });
+	ammoDrawer_->DrawNumberRightAligned(ammoReserve_, { 1140.0f, 620.0f });
 
 
 	// グレー背景の描画
@@ -117,7 +117,7 @@ void HUDManager::DrawDebugHUD()
 
 	// HPの描画
 	int percent = static_cast<int>((static_cast<float>(hp_) / maxHP_) * 100.0f);
-	hpDrawer_->DrawNumber(percent, { 85.0f, 620.0f });
+	hpDrawer_->DrawNumberLeftAligned(percent, { 85.0f, 620.0f });
 #endif // _DEBUG
 }
 

--- a/Project/ApplicationLayer/Scene/GamePlayScene/HUDManager/HUDManager.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/HUDManager/HUDManager.h
@@ -75,6 +75,6 @@ private: /// ---------- メンバ変数 ---------- ///
 	int ammoInClip_ = 0;  // 現在の弾薬数
 	int ammoReserve_ = 0; // 予備の弾薬数
 
-	const std::string texturePath_ = "Resources/number.png"; // 数字のテクスチャパス
+	const std::string texturePath_ = "Resources/Number.png"; // 数字のテクスチャパス
 };
 

--- a/Project/EngineLayer/2D/Sprite/NumberSpriteDrawer.cpp
+++ b/Project/EngineLayer/2D/Sprite/NumberSpriteDrawer.cpp
@@ -24,9 +24,9 @@ void NumberSpriteDrawer::Initialize(const std::string& texturePath, float digitW
 
 
 /// -------------------------------------------------------------
-///				　			数字の描画
+///				　	 左詰めで数字を描画
 /// -------------------------------------------------------------
-void NumberSpriteDrawer::DrawNumber(int value, const Vector2& position)
+void NumberSpriteDrawer::DrawNumberLeftAligned(int value, const Vector2& position, float spacing)
 {
 	// 桁数の制限
 	std::string numberStr = std::to_string(value);
@@ -44,7 +44,7 @@ void NumberSpriteDrawer::DrawNumber(int value, const Vector2& position)
 			// スプライトの再利用が必要な場合、新しいスプライトを作成
 			auto sprite = std::make_unique<Sprite>();
 			sprite->Initialize(texturePath_);
-			sprite->SetSize({ 48.0f, 48.0f });
+			sprite->SetSize({ digitWidth_, digitHeight_ });
 			reusableSprites_.push_back(std::move(sprite));
 		}
 
@@ -76,6 +76,32 @@ void NumberSpriteDrawer::DrawNumber(int value, const Vector2& position)
 		sprite->Draw();
 
 		// 次の桁の位置を計算
-		x += sprite->GetSize().x;
+		x += spacing;
 	}
+}
+
+
+/// -------------------------------------------------------------
+///				　	 中央揃えで数字を描画
+/// -------------------------------------------------------------
+void NumberSpriteDrawer::DrawNumberCentered(int value, const Vector2& centerPosition, float spacing)
+{
+	std::string numberStr = std::to_string(value);
+	float totalWidth = static_cast<float>(numberStr.size()) * spacing;
+	float x = centerPosition.x - totalWidth / 2.0f;
+
+	DrawNumberLeftAligned(value, { x, centerPosition.y }, spacing);
+}
+
+
+/// -------------------------------------------------------------
+///				　	 右詰めで数字を描画
+/// -------------------------------------------------------------
+void NumberSpriteDrawer::DrawNumberRightAligned(int value, Vector2 rightPosition, float spacing)
+{
+	std::string numberStr = std::to_string(value);
+	float totalWidth = static_cast<float>(numberStr.size()) * spacing;
+	float x = rightPosition.x - totalWidth;
+
+	DrawNumberLeftAligned(value, { x, rightPosition.y }, spacing);
 }

--- a/Project/EngineLayer/2D/Sprite/NumberSpriteDrawer.h
+++ b/Project/EngineLayer/2D/Sprite/NumberSpriteDrawer.h
@@ -22,11 +22,28 @@ public: /// ---------- メンバ関数 ---------------- ///
 	void Initialize(const std::string& texturePath, float digitWidth = 50.0f, float digitHeight = 50.0f);
 
 	/// <summary>
-	/// 数字テクスチャの描画
+	/// 左詰めで数字を描画
 	/// </summary>
 	/// <param name="value">数字</param>
 	/// <param name="position">座標</param>
-	void DrawNumber(int value, const Vector2& position);
+	/// <param name="spacing">桁間のスペース</param>
+	void DrawNumberLeftAligned(int value, const Vector2& position, float spacing = 24.0f);
+
+	/// <summary>
+	/// 中央揃えで数字を描画
+	/// </summary>
+	/// <param name="value">数字</param>
+	/// <param name="centerPosition">座標</param>
+	/// <param name="spacing">桁間のスペース</param>
+	void DrawNumberCentered(int value, const Vector2& centerPosition, float spacing = 24.0f);
+
+	/// <summary>
+	/// 右詰めで数字を描画
+	/// </summary>
+	/// <param name="value">数字</param>
+	/// <param name="rightPosition">座標</param>
+	/// <param name="spacing">桁間のスペース</param>
+	void DrawNumberRightAligned(int value, Vector2 rightPosition, float spacing = 24.0f);
 
 	/// <summary>
 	/// インデックスをリセット
@@ -41,4 +58,6 @@ private: /// ---------- メンバ変数 ---------------- ///
 	size_t maxDigits_ = 4; // 最大桁数
 	std::vector<std::unique_ptr<Sprite>> reusableSprites_; // 桁数分のスプライト
 	size_t currentIndex_ = 0; // 再利用管理用
+
+	Vector2 textureSize_ = { 1.0f,1.0f }; // テクスチャのサイズ（1辺のピクセル数）
 };


### PR DESCRIPTION
ResultManager と HUDManager の描画メソッドを更新し、
スコア、キル数、ウェーブ数を中央揃えで表示するように変更しました。
 弾薬数は右詰めで描画されるようになりました。
また、HPの描画方法も改善されました。
NumberSpriteDrawer クラスに新しいメソッドを追加し、数字の描画方法を多様化しました。 
さらに、DrawNumber メソッドの引数を変更し、桁間のスペースを指定できるようにしました。
テクスチャパスの修正と新しいメンバ変数 textureSize_ の追加も行いました。