### PR TITLE
プレイヤーと敵の位置取得方法を改善

### DIFF
--- a/Project/ApplicationLayer/Enemy/Enemy.cpp
+++ b/Project/ApplicationLayer/Enemy/Enemy.cpp
@@ -150,7 +150,7 @@ void Enemy::RequestShoot()
 	auto bullet = std::make_unique<EnemyBullet>();
 	bullet->Initialize();
 	Vector3 muzzlePos = body_.worldTransform_.translate_ + Vector3(0.0f, 13.0f, 0.0f);
-	Vector3 direction = Vector3::Normalize(player_->GetWorldPosition() - body_.worldTransform_.translate_);
+	Vector3 direction = Vector3::Normalize(player_->GetWorldTransform()->translate_ - body_.worldTransform_.translate_);
 	bullet->SetPosition(muzzlePos);
 	bullet->SetVelocity(direction * 0.5f);
 

--- a/Project/ApplicationLayer/Enemy/Grunt/EnemyAttackState.cpp
+++ b/Project/ApplicationLayer/Enemy/Grunt/EnemyAttackState.cpp
@@ -19,7 +19,7 @@ void EnemyAttackState::Enter(Enemy* enemy)
 /// -------------------------------------------------------------
 void EnemyAttackState::Update(Enemy* enemy)
 {
-	Vector3 toPlayer = enemy->GetTargetPlayer()->GetWorldPosition() - enemy->GetWorldPosition();
+	Vector3 toPlayer = enemy->GetTargetPlayer()->GetWorldTransform()->translate_ - enemy->GetWorldPosition();
 	float distance = Vector3::Length(toPlayer);
 
 	// 攻撃距離外に出たらIdleに戻る

--- a/Project/ApplicationLayer/Enemy/Grunt/EnemyChaseState.cpp
+++ b/Project/ApplicationLayer/Enemy/Grunt/EnemyChaseState.cpp
@@ -19,7 +19,7 @@ void EnemyChaseState::Enter(Enemy* enemy)
 /// -------------------------------------------------------------
 void EnemyChaseState::Update(Enemy* enemy)
 {
-	Vector3 toPlayer = enemy->GetTargetPlayer()->GetWorldPosition() - enemy->GetWorldPosition();
+	Vector3 toPlayer = enemy->GetTargetPlayer()->GetWorldTransform()->translate_ - enemy->GetWorldPosition();
 	float distance = Vector3::Length(toPlayer);
 
 	if (distance < 100.0f)

--- a/Project/ApplicationLayer/Enemy/Grunt/EnemyIdleState.cpp
+++ b/Project/ApplicationLayer/Enemy/Grunt/EnemyIdleState.cpp
@@ -31,7 +31,7 @@ void EnemyIdleState::Update(Enemy* enemy)
 
 	// 最低1秒間は移動のみ行う（攻撃遷移を抑制）
 	if (idleTimer_ >= 1.0f) {
-		Vector3 toPlayer = enemy->GetTargetPlayer()->GetWorldPosition() - enemy->GetWorldPosition();
+		Vector3 toPlayer = enemy->GetTargetPlayer()->GetWorldTransform()->translate_ - enemy->GetWorldPosition();
 		float distanceToPlayer = Vector3::Length(toPlayer);
 
 		if (distanceToPlayer < 100.0f) {

--- a/Project/ApplicationLayer/Enemy/Tank/TankIdleState.cpp
+++ b/Project/ApplicationLayer/Enemy/Tank/TankIdleState.cpp
@@ -17,7 +17,7 @@ void TankIdleState::Update(Enemy* enemy)
 
 	// 最低1秒間は移動のみ行う（攻撃遷移を抑制）
 	if (idleTimer_ >= 1.0f) {
-		Vector3 toPlayer = enemy->GetTargetPlayer()->GetWorldPosition() - enemy->GetWorldPosition();
+		Vector3 toPlayer = enemy->GetTargetPlayer()->GetWorldTransform()->translate_ - enemy->GetWorldPosition();
 		float distanceToPlayer = Vector3::Length(toPlayer);
 	}
 

--- a/Project/ApplicationLayer/Player/Player.h
+++ b/Project/ApplicationLayer/Player/Player.h
@@ -1,9 +1,10 @@
 #pragma once
-#include <BaseCharacter.h>
 #include <PlayerController.h>
 #include <Bullet.h>
 #include "Weapon.h" // 追加
 #include <NumberSpriteDrawer.h>
+#include <Collider.h>
+#include <AnimationModel.h>
 
 /// ---------- 前方宣言 ---------- ///
 class FpsCamera;
@@ -12,7 +13,7 @@ class FpsCamera;
 //// -------------------------------------------------------------
 ///					　プレイヤークラス
 /// -------------------------------------------------------------
-class Player : public BaseCharacter
+class Player : public Collider
 {
 public: /// ---------- メンバ関数 ---------- ///
 
@@ -37,7 +38,7 @@ public: /// ---------- メンバ関数 ---------- ///
 private: /// ---------- メンバ関数 ---------- ///
 
 	// プレイヤー専用パーツの初期化
-	void InitializeParts() override;
+	void InitializeParts();
 
 	// 移動処理
 	void Move();
@@ -51,13 +52,13 @@ public: /// ---------- ゲッタ ---------- ///
 	std::vector<const Bullet*> GetAllBullets() const;
 
 	// プレイヤーの向きを取得
-	float GetYaw() const { return body_.worldTransform_.rotate_.y; }
+	float GetYaw() const { return animationModel_->GetRotate().y; }
 
 	// 弾丸を取得
 	const std::vector<std::unique_ptr<Bullet>>& GetBullets() const { return weapons_[currentWeaponIndex_]->GetBullets(); }
 
 	// ワールド変換の取得
-	const WorldTransform* GetWorldTransform() { return &body_.worldTransform_; }
+	const WorldTransform* GetWorldTransform() { return &animationModel_->GetWorldTransform(); }
 
 	// 弾薬の取得
 	int GetAmmoInClip() const { return weapons_[currentWeaponIndex_]->GetAmmoInClip(); }
@@ -93,8 +94,6 @@ private: /// ---------- メンバ関数 ---------- ///
 	// 弾丸発射処理位置
 	void FireWeapon();
 
-	void PlaySE(const std::string& filePath, float volume, float pitch, bool loop);
-
 private: /// ---------- メンバ変数 ---------- ///
 
 	Input* input_ = nullptr; // 入力クラス
@@ -107,6 +106,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	std::vector<std::unique_ptr<Bullet>> bullets_; // 弾丸クラス
 
 	std::unique_ptr<NumberSpriteDrawer> numberSpriteDrawer_; // 数字スプライト描画クラス
+	std::unique_ptr<AnimationModel> animationModel_;
 
 private: /// ---------- ジャンプ機能 ---------- ///
 

--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
@@ -94,10 +94,6 @@ void GamePlayScene::Initialize()
 	particleEmitter3_ = std::make_unique<ParticleEmitter>(ParticleManager::GetInstance(), "TestParticle3");
 	particleEmitter3_->SetPosition({ 5.0f, 18.0f, 20.0f });
 	particleEmitter3_->SetEmissionRate(3.0f);
-
-	animationModel_ = std::make_unique<AnimationModel>();
-	animationModel_->Initialize("human.gltf");
-	animationModel_->SetSkinningEnabled(true);
 }
 
 
@@ -220,9 +216,6 @@ void GamePlayScene::Update()
 
 		break;
 	}
-
-	animationModel_->Update();
-
 	defaultEmitter_->Update();
 	particleEmitter_->Update();
 	particleEmitter2_->Update();
@@ -248,14 +241,14 @@ void GamePlayScene::Draw3DObjects()
 	// オブジェクト3D共通描画設定
 	Object3DCommon::GetInstance()->SetRenderSetting();
 
-	// プレイヤーの描画
-	player_->Draw();
-
 	// エネミースポナーの描画
 	enemyManager_->Draw();
 
 	// アイテムの描画
 	itemManager_->Draw();
+
+	// プレイヤーの描画
+	player_->Draw();
 
 #pragma endregion
 
@@ -264,8 +257,6 @@ void GamePlayScene::Draw3DObjects()
 
 	// アニメーションモデルの共通描画設定
 	AnimationPipelineBuilder::GetInstance()->SetRenderSetting();
-
-	animationModel_->Draw();
 
 #pragma endregion
 

--- a/Project/EngineLayer/CameraManagement/FPSCamera/FpsCamera.cpp
+++ b/Project/EngineLayer/CameraManagement/FPSCamera/FpsCamera.cpp
@@ -42,7 +42,7 @@ void FpsCamera::Update(bool ignoreInput)
 	}
 
 	// --- カメラ位置設定（プレイヤーの頭位置） ---
-	Vector3 playerPos = player_->GetWorldPosition();
+	Vector3 playerPos = player_->GetWorldTransform()->translate_;
 	Vector3 camPos = playerPos + Vector3{ 0, eyeHeight_, 0 };
 
 	// --- オイラー角ベースのビュー行列作成 ---

--- a/Project/EngineLayer/Managers/AnimationManager/AnimationModel.h
+++ b/Project/EngineLayer/Managers/AnimationManager/AnimationModel.h
@@ -60,6 +60,8 @@ public: /// ---------- メンバ関数 ---------- ///
 
 public: /// ---------- ゲッタ ---------- ///
 
+	const WorldTransform& GetWorldTransform() const { return worldTransform; }
+
 	// 座標を取得
 	const Vector3& GetTranslate() const { return worldTransform.translate_; }
 


### PR DESCRIPTION
・Enemyクラスの弾丸発射方向をプレイヤーのワールド変換から取得するように変更し、敵の距離計算も同様に修正しました。 ・Playerクラスではアニメーションモデルの初期化と更新を追加し、弾丸の発射位置をアニメーションモデルに基づいて計算するようにしました。 
・Playerクラスの継承関係を見直し、GamePlaySceneでのアニメーションモデルの描画を整理しました。 
・FpsCameraでのカメラ位置取得方法も改善し、AnimationModelにワールド変換を取得するゲッターメソッドを追加しました。 ・プレイヤーキャラにスキニングアニメーションモデルを適用
・FPSカメラの追従と回転処理を統合
・ジャンプ・移動処理をanimationModelに統一
・描画／操作基盤を刷新、次のコアシステム実装に備える