### PR TITLE
角度補間の関数変更と武器初期化の改善

### DIFF
--- a/Project/ApplicationLayer/Enemy/Grunt/EnemyAttackState.cpp
+++ b/Project/ApplicationLayer/Enemy/Grunt/EnemyAttackState.cpp
@@ -3,6 +3,7 @@
 #include "Player.h"
 #include "EnemyIdleState.h"
 #include <EnemyChaseState.h>
+#include "LinearInterpolation.h"
 
 
 /// -------------------------------------------------------------
@@ -37,7 +38,7 @@ void EnemyAttackState::Update(Enemy* enemy)
 	// プレイヤーの方向へ回転だけ追従する
 	float targetYaw = std::atan2(-toPlayer.x, toPlayer.z);
 	float currentYaw = enemy->GetRotate().y;
-	float newYaw = Vector3::LerpAngle(currentYaw, targetYaw, 0.2f); // ← 追従の滑らかさ
+	float newYaw = LerpAngle(currentYaw, targetYaw, 0.2f); // ← 追従の滑らかさ
 
 	enemy->SetRotate({ 0.0f, newYaw, 0.0f });
 

--- a/Project/ApplicationLayer/Enemy/Grunt/EnemyChaseState.cpp
+++ b/Project/ApplicationLayer/Enemy/Grunt/EnemyChaseState.cpp
@@ -3,6 +3,7 @@
 #include "Player.h"
 #include "EnemyAttackState.h"
 #include <EnemyIdleState.h>
+#include "LinearInterpolation.h"
 
 
 /// -------------------------------------------------------------
@@ -39,7 +40,7 @@ void EnemyChaseState::Update(Enemy* enemy)
 	enemy->SetTranslate(enemy->GetWorldPosition() + direction * 0.25f);
 
 	float yaw = std::atan2(-direction.x, direction.z);
-	enemy->SetRotate({ 0.0f, Vector3::LerpAngle(enemy->GetRotate().y, yaw, 0.1f), 0.0f });
+	enemy->SetRotate({ 0.0f, LerpAngle(enemy->GetRotate().y, yaw, 0.1f), 0.0f });
 }
 
 

--- a/Project/ApplicationLayer/Player/Player.h
+++ b/Project/ApplicationLayer/Player/Player.h
@@ -32,13 +32,10 @@ public: /// ---------- メンバ関数 ---------- ///
 	// ダメージを受ける
 	void TakeDamage(float damage);
 
-	// 死亡フラグを取得
-	bool IsDead() const { return isDead_; }
-
 private: /// ---------- メンバ関数 ---------- ///
 
-	// プレイヤー専用パーツの初期化
-	void InitializeParts();
+	// 武器の初期化処理
+	void InitializeWeapons();
 
 	// 移動処理
 	void Move();
@@ -46,7 +43,19 @@ private: /// ---------- メンバ関数 ---------- ///
 	// 衝突判定と応答
 	void OnCollision(Collider* other) override;
 
+	// 弾丸発射処理位置
+	void FireWeapon();
+
 public: /// ---------- ゲッタ ---------- ///
+
+	// 死亡フラグを取得
+	bool IsDead() const { return isDead_; }
+
+	// 時間を取得
+	float GetDeltaTime() const { return deltaTime; }
+
+	// ダッシュ状態を取得
+	bool IsDashing() const { return isDashing_; }
 
 	// 全ての弾丸を取得
 	std::vector<const Bullet*> GetAllBullets() const;
@@ -72,6 +81,15 @@ public: /// ---------- ゲッタ ---------- ///
 	// 最大HPの取得
 	float GetMaxHP() const { return maxHP_; }
 
+	// 地面にいるかどうかを取得
+	bool IsGrounded() const { return isGrounded_; }
+
+	// 移動ベクトル取得
+	Vector3 GetMoveInput() const { return controller_->GetMoveInput(); }
+
+	// デバッグ用のフラグを取得
+	bool IsDebugCamera() const { return controller_->IsDebugCamera(); }
+
 public: /// ---------- セッタ ---------- ///
 
 	// 追従カメラを設定
@@ -89,10 +107,8 @@ public: /// ---------- セッタ ---------- ///
 	// Aimng状態を取得
 	bool IsAiming() const { return isAiming_; }
 
-private: /// ---------- メンバ関数 ---------- ///
-
-	// 弾丸発射処理位置
-	void FireWeapon();
+	// デバッグカメラフラグを設定
+	void SetDebugCamera(bool isDebugCamera) { controller_->SetDebugCamera(isDebugCamera); }
 
 private: /// ---------- メンバ変数 ---------- ///
 
@@ -130,5 +146,7 @@ private: /// ---------- プレイヤーの状態 ---------- ///
 
 	bool isAiming_ = false; // エイミング状態
 	float adsSpeedFactor_ = 0.5f;  // ADS時の移動速度倍率（例：50%）
+
+	bool isDebugCamera_ = false; // デバッグカメラフラグ
 };
 

--- a/Project/ApplicationLayer/Player/PlayerController.cpp
+++ b/Project/ApplicationLayer/Player/PlayerController.cpp
@@ -16,6 +16,8 @@ void PlayerController::Initialize()
 /// -------------------------------------------------------------
 void PlayerController::Update()
 {
+	if (isDebugCamera_) return; // デバッグカメラ中は入力を無視
+
 	move_ = { 0.0f, 0.0f, 0.0f };
 	jump_ = false;
 

--- a/Project/ApplicationLayer/Player/PlayerController.h
+++ b/Project/ApplicationLayer/Player/PlayerController.h
@@ -25,10 +25,17 @@ public: /// ---------- メンバ関数 ---------- ///
 	// ジャンプ入力を取得
 	bool IsJumpTriggered() const { return jump_; }
 
+	// デバッグカメラフラグを取得
+	bool IsDebugCamera() const { return isDebugCamera_; }
+
+	// デバッグカメラフラグを設定
+	void SetDebugCamera(bool isDebugCamera) { isDebugCamera_ = isDebugCamera; }
+
 private: /// ---------- メンバ変数 ---------- ///
 
 	Input* input_ = nullptr;
 	Vector3 move_{};
 	bool jump_ = false;
+	bool isDebugCamera_ = false; // デバッグカメラフラグ
 };
 

--- a/Project/EngineLayer/CameraManagement/FPSCamera/FpsCamera.cpp
+++ b/Project/EngineLayer/CameraManagement/FPSCamera/FpsCamera.cpp
@@ -4,7 +4,8 @@
 #include "Player.h"
 #include <Camera.h>
 #include <Input.h>
-
+#include "LinearInterpolation.h"
+#include <Wireframe.h>
 
 void FpsCamera::Initialize(Player* player)
 {
@@ -16,20 +17,22 @@ void FpsCamera::Initialize(Player* player)
 void FpsCamera::Update(bool ignoreInput)
 {
 	if (!player_ || !camera_) return;
+	if (player_->IsDebugCamera()) return; // デバッグカメラ中は更新しない
 
 	if (!ignoreInput)
 	{
-		int mouseDX = input_->GetMouseMoveX();
-		int mouseDY = input_->GetMouseMoveY();
+		int mouseDX = input_->GetMouseMoveX(); // マウスのX軸移動量
+		int mouseDY = input_->GetMouseMoveY(); // マウスのY軸移動量
 
 		// --- ADS状態によって感度を変更 ---
 		float effectiveMouseSensitivity = isAiming_ ? mouseSensitivity_ * 0.5f : mouseSensitivity_;
 		float effectiveControllerSensitivity = isAiming_ ? controllerSensitivity_ * 0.5f : controllerSensitivity_;
 
+		// --- マウスとコントローラーの入力を組み合わせて視点を更新 ---
 		float sensitivityModifier = player_->IsAiming() ? adsSensitivityFactor_ : 1.0f;
 
-		float deltaYaw = -mouseDX * mouseSensitivity_ * sensitivityModifier;
-		float deltaPitch = mouseDY * mouseSensitivity_ * sensitivityModifier;
+		float deltaYaw = -mouseDX * mouseSensitivity_ * sensitivityModifier; // マウスのX軸移動量に基づくヨー角の変化
+		float deltaPitch = mouseDY * mouseSensitivity_ * sensitivityModifier; // マウスのY軸移動量に基づくピッチ角の変化
 
 		Vector2 rStick = input_->GetRightStick();
 		if (!input_->RStickInDeadZone()) {
@@ -45,6 +48,35 @@ void FpsCamera::Update(bool ignoreInput)
 	Vector3 playerPos = player_->GetWorldTransform()->translate_;
 	Vector3 camPos = playerPos + Vector3{ 0, eyeHeight_, 0 };
 
+	// --- ボビング処理 ---
+	Vector3 moveInput = player_->GetMoveInput(); // Player経由で移動ベクトル取得
+	bool isMoving = Vector3::Length(moveInput) > 0.01f;
+	bool isGrounded = player_->IsGrounded(); // Playerに関数があれば（無ければpublic bool参照）
+	bool isDashing = player_->IsDashing(); // ダッシュ状態を取得
+
+	float bobbingOffsetY = 0.0f; // ボビングのYオフセット
+
+	// 状態に応じて揺れを変更
+	float speed = isDashing ? 14.0f : 10.0f;        // 揺れる速さ
+	float amplitude = isDashing ? 0.14f : 0.1f;    // 揺れの高さ
+
+	// 徐々に追従（Lerp）
+	currentBobbingSpeed_ = Lerp(currentBobbingSpeed_, speed, 0.1f);
+	currentBobbingAmplitude_ = Lerp(currentBobbingAmplitude_, amplitude, 0.1f);
+
+	// ボビング時間加算
+	if (isMoving && isGrounded && !isAiming_)
+	{
+		bobbingTimer_ += speed * deltaTime_;
+		bobbingOffsetY = std::sinf(bobbingTimer_) * currentBobbingAmplitude_;
+	}
+	else
+	{
+		bobbingTimer_ = 0.0f;
+	}
+
+	camPos.y += bobbingOffsetY;
+
 	// --- オイラー角ベースのビュー行列作成 ---
 	Vector3 camEuler = { pitch_, yaw_, 0.0f }; // X, Y 回転
 	Matrix4x4 rotMat = Matrix4x4::MakeRotateMatrix(camEuler);
@@ -54,4 +86,13 @@ void FpsCamera::Update(bool ignoreInput)
 	camera_->SetViewMatrix(viewMat);
 	camera_->SetTranslate(camPos);
 	camera_->SetRotate(camEuler);
+}
+
+void FpsCamera::DrawDebugCamera()
+{
+	AABB aabb;
+	aabb.min = { -0.125f, eyeHeight_, -0.125f };
+	aabb.max = { 0.125f, eyeHeight_,  0.125f };
+
+	Wireframe::GetInstance()->DrawAABB(aabb, { 0.0f, 0.0f, 1.0f, 1.0f });
 }

--- a/Project/EngineLayer/CameraManagement/FPSCamera/FpsCamera.h
+++ b/Project/EngineLayer/CameraManagement/FPSCamera/FpsCamera.h
@@ -16,6 +16,9 @@ public: // ---------- 関数 ---------- //
 	void Initialize(Player* player);
 	void Update(bool ignoreInput = false);
 
+	// デバッグ用カメラの位置をワイヤーフレームで描画
+	void DrawDebugCamera();
+
 public: // ---------- ゲッタ ---------- //
 
 	// カメラ取得
@@ -30,8 +33,11 @@ public: // ---------- セッタ ---------- //
 	// Aiming状態を設定
 	void SetAiming(bool isAiming) { isAiming_ = isAiming; }
 
-
+	// ADS状態の感度補正係数を設定
 	void SetAdsSensitivityFactor(float factor) { adsSensitivityFactor_ = factor; }
+
+	// 外部から時間を貰う
+	void SetDeltaTime(float deltaTime) { deltaTime_ = deltaTime; }
 
 private: // ---------- メンバ ---------- //
 
@@ -52,10 +58,19 @@ private: // ---------- メンバ ---------- //
 	const float maxPitch_ = +1.5f; // 上限
 
 	// カメラ高さオフセット（頭位置）
-	const float eyeHeight_ = 20.0f;
+	const float eyeHeight_ = 1.74f;
 
 	// Aiming状態フラグ
 	bool isAiming_ = false;
 	// ADS状態の感度補正係数（例: 0.5で半分の感度）
 	float adsSensitivityFactor_ = 0.5f;
+
+	// ボビング処理用
+	float currentBobbingSpeed_;
+	float currentBobbingAmplitude_;
+	float bobbingTimer_ = 0.0f;
+	float bobbingAmplitude_ = 0.25f;   // 振れ幅
+	float bobbingSpeed_ = 10.0f;       // サイクル速度
+	float deltaTime_ = 1.0f / 60.0f;    // 仮：外部から渡すべき
+
 };

--- a/Project/EngineLayer/Managers/AnimationManager/AnimationModel.cpp
+++ b/Project/EngineLayer/Managers/AnimationManager/AnimationModel.cpp
@@ -75,7 +75,7 @@ void AnimationModel::Initialize(const std::string& fileName)
 void AnimationModel::Update()
 {
 	// FPSの取得 deltaTimeの計算
-	float deltaTime = 1.0f / dxCommon_->GetFPSCounter().GetFPS();
+	deltaTime = 1.0f / dxCommon_->GetFPSCounter().GetFPS();
 	animationTime_ += deltaTime;
 	animationTime_ = std::fmod(animationTime_, animation.duration);
 

--- a/Project/EngineLayer/Managers/AnimationManager/AnimationModel.h
+++ b/Project/EngineLayer/Managers/AnimationManager/AnimationModel.h
@@ -74,6 +74,8 @@ public: /// ---------- ゲッタ ---------- ///
 	// メッシュを取得
 	AnimationMesh* GetAnimationMesh() { return animationMesh_.get(); }
 
+	float GetDeltaTime() const { return deltaTime; }
+
 public: /// ---------- セッタ ---------- ///
 
 	// 座標を設定
@@ -173,5 +175,7 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	// アニメーションタイム
 	float animationTime_ = 0.0f;
+
+	float deltaTime = 0.0f;
 };
 

--- a/Project/EngineLayer/Math/LinearInterpolation.h
+++ b/Project/EngineLayer/Math/LinearInterpolation.h
@@ -1,0 +1,187 @@
+#pragma once
+#include <cmath>
+#include <numbers>
+
+/// -------------------------------------------------------------
+///						線形補間を行う関数
+/// -------------------------------------------------------------
+
+/// ---------- 線形補間を行う関数 ---------- ///
+inline float Lerp(float a, float b, float t) { return a + (b - a) * t; }
+
+/// ---------- 角度を正規化する関数 ---------- ///
+inline float NormalizeAngle(float angle)
+{
+	// -π 〜 +π に収める
+	angle = std::fmod(angle + std::numbers::pi_v<float>, 2.0f * std::numbers::pi_v<float>);
+	if (angle < 0) angle += 2.0f * std::numbers::pi_v<float>;
+	return angle - std::numbers::pi_v<float>;
+}
+
+/// ---------- 角度の線形補間を行う関数 ---------- ///
+inline float LerpAngle(float a, float b, float t)
+{
+	a = NormalizeAngle(a);
+	b = NormalizeAngle(b);
+
+	float diff = b - a;
+
+	// 最短方向へ補間（例: -179° → +179°）
+	if (diff > std::numbers::pi_v<float>)
+		diff -= 2.0f * std::numbers::pi_v<float>;
+	else if (diff < -std::numbers::pi_v<float>)
+		diff += 2.0f * std::numbers::pi_v<float>;
+
+	return a + diff * t;
+}
+
+/// ---------- イージング関数 ---------- ///
+inline float EaseInSine(float t) { return 1.0f - cosf(t * (std::numbers::pi_v<float> / 2.0f)); }
+
+/// ---------- イーズアウト関数 ---------- ///
+inline float EaseOutSine(float t) { return sinf(t * (std::numbers::pi_v<float> / 2.0f)); }
+
+/// ---------- イーズインアウト関数 ---------- ///
+inline float EaseInOutSine(float t) { return (cosf(std::numbers::pi_v<float> *t) - 1.0f) / 2.0f; }
+
+/// ---------- イーズクアッド関数 ---------- ///
+inline float EaseInQuad(float t) { return t * t; }
+
+/// ---------- イーズアウトクアッド関数 ---------- ///
+inline float EaseOutQuad(float t) { return 1.0f - pow(1.0f - t, 2.0f); }
+
+/// ---------- イーズインアウトクアッド関数 ---------- ///
+inline float EaseInOutQuad(float t) { return (t < 0.5f) ? 2.0f * t * t : pow(-2.0f * t + 2.0f, 2.0f) / 2.0f; }
+
+/// ---------- イーズインキュービック関数 ---------- ///
+inline float EaseInCubic(float t) { return t * t * t; }
+
+/// ---------- イーズアウトキュービック関数 ---------- ///
+inline float EaseOutCubic(float t) { return 1.0f - pow(1.0f - t, 3.0f); }
+
+/// ---------- イーズインアウトキュービック関数 ---------- ///
+inline float EaseInOutCubic(float t) { return (t < 0.5f) ? 4.0f * t * t * t : 1.0f - pow(-2.0f * t + 2.0f, 3.0f) / 2.0f; }
+
+/// ---------- イーズインクォート関数 ---------- ///
+inline float EaseInQuart(float t) { return t * t * t * t; }
+
+/// ---------- イーズアウトクォート関数 ---------- ///
+inline float EaseOutQuart(float t) { return 1.0f - pow(1.0f - t, 4.0f); }
+
+/// ---------- イーズインアウトクォート関数 ---------- ///
+inline float EaseInOutQuart(float t) { return (t < 0.5f) ? 8.0f * t * t * t * t : 1.0f - pow(-2.0f * t + 2.0f, 4.0f) / 2.0f; }
+
+/// ---------- イーズインクインテック関数 ---------- ///
+inline float EaseInQuint(float t) { return t * t * t * t * t; }
+
+/// ---------- イーズアウトクインテック関数 ---------- ///
+inline float EaseOutQuint(float t) { return 1.0f - pow(1.0f - t, 5.0f); }
+
+/// ---------- イーズインアウトクインテック関数 ---------- ///
+inline float EaseInOutQuint(float t) { return (t < 0.5f) ? 16.0f * t * t * t * t * t : 1.0f - pow(-2.0f * t + 2.0f, 5.0f) / 2.0f; }
+
+/// ---------- イーズインエクスポネンシャル関数 ---------- ///
+inline float EaseInExpo(float t) { return (t == 0.0f) ? 0.0f : pow(2.0f, 10.0f * t - 10.0f); }
+
+/// ---------- イーズアウトエクスポネンシャル関数 ---------- ///
+inline float EaseOutExpo(float t) { return (t == 1.0f) ? 1.0f : 1.0f - pow(2.0f, -10.0f * t); }
+
+/// ---------- イーズインアウトエクスポネンシャル関数 ---------- ///
+inline float EaseInOutExpo(float t)
+{
+	if (t == 0.0f) return 0.0f;
+	if (t == 1.0f) return 1.0f;
+	return (t < 0.5f) ? pow(2.0f, 20.0f * t - 10.0f) / 2.0f : (2.0f - pow(2.0f, -20.0f * t + 10.0f)) / 2.0f;
+}
+
+/// ---------- イーズインカーシアン関数 ---------- ///
+inline float EaseInCirc(float t) { return 1.0f - sqrt(1.0f - pow(t, 2.0f)); }
+
+/// ---------- イーズアウトカーシアン関数 ---------- ///
+inline float EaseOutCirc(float t) { return sqrt(1.0f - pow(t - 1.0f, 2.0f)); }
+
+/// ---------- イーズインアウトカーシアン関数 ---------- ///
+inline float EaseInOutCirc(float t) { return (t < 0.5f) ? (1.0f - sqrt(1.0f - pow(2.0f * t, 2.0f))) / 2.0f : (sqrt(1.0f - pow(-2.0f * t + 2.0f, 2.0f)) + 1.0f) / 2.0f; }
+
+/// ---------- イーズインバック関数 ---------- ///
+inline float EaseInBack(float t, float s = 1.70158f) { return t * t * ((s + 1.0f) * t - s); }
+
+/// ---------- イーズアウトバック関数 ---------- ///
+inline float EaseOutBack(float t, float s = 1.70158f) { return 1.0f + t * t * ((s + 1.0f) * t + s); }
+
+/// ---------- イーズインアウトバック関数 ---------- ///
+inline float EaseInOutBack(float t, float s = 1.70158f) { return (t < 0.5f) ? (2.0f * t * t * ((s + 1.0f) * 2.0f * t - s)) / 2.0f : (1.0f + 2.0f * t * t * ((s + 1.0f) * 2.0f * t + s)) / 2.0f; }
+
+/// ---------- イーズインエラスティック関数 ---------- ///
+inline float EaseInElastic(float t, float a = 1.0f, float p = 0.3f)
+{
+	if (t == 0.0f) return 0.0f;
+	if (t == 1.0f) return 1.0f;
+	float s = p / (2.0f * std::numbers::pi_v<float>) * asin(1.0f / a);
+	return -(a * pow(2.0f, 10.0f * t - 10.0f) * sin((t * 10.0f - s) * (2.0f * std::numbers::pi_v<float>) / p));
+}
+
+/// ---------- イーズアウトエラスティック関数 ---------- ///
+inline float EaseOutElastic(float t, float a = 1.0f, float p = 0.3f)
+{
+	if (t == 0.0f) return 0.0f;
+	if (t == 1.0f) return 1.0f;
+	float s = p / (2.0f * std::numbers::pi_v<float>) * asin(1.0f / a);
+	return a * pow(2.0f, -10.0f * t) * sin((t * 10.0f - s) * (2.0f * std::numbers::pi_v<float>) / p) + 1.0f;
+}
+
+/// ---------- イーズインアウトエラスティック関数 ---------- ///
+inline float EaseInOutElastic(float t, float a = 1.0f, float p = 0.3f)
+{
+	if (t == 0.0f) return 0.0f;
+	if (t == 1.0f) return 1.0f;
+	float s = p / (2.0f * std::numbers::pi_v<float>) * asin(1.0f / a);
+	if (t < 0.5f)
+	{
+		return -(a * pow(2.0f, 20.0f * t - 10.0f) * sin((20.0f * t - s) * (2.0f * std::numbers::pi_v<float>) / p)) / 2.0f;
+	}
+	else
+	{
+		return a * pow(2.0f, -20.0f * t + 10.0f) * sin((20.0f * t - s) * (2.0f * std::numbers::pi_v<float>) / p) / 2.0f + 1.0f;
+	}
+}
+
+/// ---------- イーズアウトボウンス関数 ---------- ///
+inline float EaseOutBounce(float t)
+{
+	if (t < (1.0f / 2.75f))
+	{
+		return 7.5625f * t * t;
+	}
+	else if (t < (2.0f / 2.75f))
+	{
+		t -= (1.5f / 2.75f);
+		return 7.5625f * t * t + 0.75f;
+	}
+	else if (t < (2.5f / 2.75f))
+	{
+		t -= (2.25f / 2.75f);
+		return 7.5625f * t * t + 0.9375f;
+	}
+	else
+	{
+		t -= (2.625f / 2.75f);
+		return 7.5625f * t * t + 0.984375f;
+	}
+}
+
+/// ---------- イーズインボウンス関数 ---------- ///
+inline float EaseInBounce(float t) { return 1.0f - EaseOutBounce(1.0f - t); }
+
+/// ---------- イーズインアウトボウンス関数 ---------- ///
+inline float EaseInOutBounce(float t)
+{
+	if (t < 0.5f)
+	{
+		return EaseInBounce(t * 2.0f) / 2.0f;
+	}
+	else
+	{
+		return EaseOutBounce(t * 2.0f - 1.0f) / 2.0f + 0.5f;
+	}
+}

--- a/Project/EngineLayer/Math/Vectors/Vector3.h
+++ b/Project/EngineLayer/Math/Vectors/Vector3.h
@@ -14,34 +14,6 @@ class Vector3
 public:
 	float x, y, z;
 
-	// 任意の共通ヘッダ（例：MathUtil.h）に置くと便利
-	static inline float Lerp(float a, float b, float t) { return a + (b - a) * t; }
-
-	static inline float LerpAngle(float a, float b, float t)
-	{
-		a = NormalizeAngle(a);
-		b = NormalizeAngle(b);
-
-		float diff = b - a;
-
-		// 最短方向へ補間（例: -179° → +179°）
-		if (diff > std::numbers::pi_v<float>)
-			diff -= 2.0f * std::numbers::pi_v<float>;
-		else if (diff < -std::numbers::pi_v<float>)
-			diff += 2.0f * std::numbers::pi_v<float>;
-
-		return a + diff * t;
-	}
-
-	static inline float NormalizeAngle(float angle)
-	{
-		// -π 〜 +π に収める
-		angle = std::fmod(angle + std::numbers::pi_v<float>, 2.0f * std::numbers::pi_v<float>);
-		if (angle < 0) angle += 2.0f * std::numbers::pi_v<float>;
-		return angle - std::numbers::pi_v<float>;
-	}
-
-
 	Vector3() : x(0), y(0), z(0) {};
 	Vector3(float x, float y, float z) : x(x), y(y), z(z) {};
 

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -516,6 +516,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="ApplicationLayer\Item\ItemType.h" />
     <ClInclude Include="ApplicationLayer\Enemy\Sniper\SniperIdleState.h" />
     <ClInclude Include="ApplicationLayer\Enemy\Tank\TankIdleState.h" />
+    <ClInclude Include="EngineLayer\Math\LinearInterpolation.h" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="externals\DirectXTex\DirectXTex_Desktop_2022_Win10.vcxproj">


### PR DESCRIPTION
EnemyAttackState.cppとEnemyChaseState.cppで、角度の補間に関する関数をVector3::LerpAngleからLerpAngleに変更し、LinearInterpolation.hを使用するようにしました。 
Player.cppでは、武器の初期化を行うInitializeWeapons関数を追加し、従来の `InitializeParts` 関数を削除しました。 
Updateメソッドに死亡状態のチェックを追加し、FireWeaponメソッドでリロード中の発射不可ロジックを追加しました。 PlayerController.cpp では、デバッグカメラ中に入力を無視する処理を追加しました。 
FpsCamera.cppでは、デバッグカメラの描画処理とボビング効果を追加しました。
LinearInterpolation.h に線形補間や角度の正規化、イージング関数を追加し、
Player.h と FpsCamera.h にデバッグカメラの状態を取得・設定する関数を追加しました。 
GamePlayScene.cpp では、カメラの初期化時にデルタタイムを設定する処理を追加し、プロジェクトファイルに `LinearInterpolation.h` のインクルードを追加しました。