### PR TITLE
FPSカメラと射撃機能の改善とリコイル処理の追加

### DIFF
--- a/Project/ApplicationLayer/Player/Player.cpp
+++ b/Project/ApplicationLayer/Player/Player.cpp
@@ -49,6 +49,8 @@ void Player::Update()
 
 	if (isDead_) return; // 死亡後は行動不可
 
+	weapons_[currentWeaponIndex_]->SetFpsCamera(fpsCamera_);
+
 	// プレイヤーの移動処理
 	Move();
 
@@ -70,9 +72,6 @@ void Player::Update()
 		weapon->Update();
 	}
 
-	// 発射入力
-	bool isFireTriggered = input_->TriggerMouse(0) || input_->TriggerButton(XButtons.R_Trigger) || input_->TriggerKey(DIK_F);
-
 	// 照準モードかどうかを確認
 	if (!weapons_[currentWeaponIndex_]->IsReloading()) // リロード中は発射不可
 	{
@@ -88,14 +87,14 @@ void Player::Update()
 	// 武器に応じて発射（Rifleなら押しっぱなし、Shotgunなら単発）
 	if (GetCurrentWeapon()->GetWeaponType() == WeaponType::Rifle)
 	{
-		if (input_->PushMouse(0))
+		if (controller_->IsPushShooting())
 		{
 			FireWeapon();
 		}
 	}
 	else if (GetCurrentWeapon()->GetWeaponType() == WeaponType::Shotgun)
 	{
-		if (isFireTriggered)
+		if (controller_->IsTriggerShooting())
 		{
 			FireWeapon();
 		}
@@ -333,7 +332,7 @@ void Player::FireWeapon()
 	else
 	{
 		// 通常時は右手（モデル上の銃口）から発射
-		Vector3 localMuzzleOffset = { 5.0f, 20.0f, 5.0f };
+		Vector3 localMuzzleOffset = { 2.0f, 1.65f, 5.0f };
 		Vector3 scale = { 1.0f, 1.0f, 1.0f };
 		Vector3 rotation = { 0.0f,animationModel_->GetRotate().y, 0.0f };
 		Vector3 translation = animationModel_->GetTranslate();

--- a/Project/ApplicationLayer/Player/Player.h
+++ b/Project/ApplicationLayer/Player/Player.h
@@ -93,10 +93,19 @@ public: /// ---------- ゲッタ ---------- ///
 	// しゃがみを取得
 	bool IsCrouching() const { return isCrouching_; }
 
+	// コントローラーを取得
+	PlayerController* GetController() const { return controller_.get(); }
+
+	// FPSカメラを取得
+	FpsCamera* GetFpsCamera() const { return fpsCamera_; }
+
 public: /// ---------- セッタ ---------- ///
 
 	// 追従カメラを設定
 	void SetCamera(Camera* camera) { camera_ = camera; }
+
+	// FPSカメラをセット
+	void SetFpsCamera(FpsCamera* fpsCamera) { fpsCamera_ = fpsCamera; }
 
 	// HPを追加
 	void AddHP(int amount);
@@ -120,6 +129,7 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	Input* input_ = nullptr; // 入力クラス
 	Camera* camera_ = nullptr; // カメラクラス
+	FpsCamera* fpsCamera_ = nullptr;
 
 	std::vector<std::unique_ptr<Weapon>> weapons_; // 武器クラス
 	int currentWeaponIndex_ = 0; // 現在の武器インデックス

--- a/Project/ApplicationLayer/Player/PlayerController.cpp
+++ b/Project/ApplicationLayer/Player/PlayerController.cpp
@@ -35,6 +35,10 @@ void PlayerController::Update()
 	// ゲームパッドのBボタンでしゃがみ
 	if (input_->PushButton(XButtons.B)) crouch_ = true;
 
+	// 左クリック or RT（ゲームパッド）で射撃
+	isTriggerShooting_ = input_->TriggerMouse(0);// || input_->PushButton(XButtons.RT);
+	isPushShooting_ = input_->PushMouse(0);
+
 	// --- ゲームパッド入力（左スティック） ---
 	if (!input_->LStickInDeadZone())
 	{

--- a/Project/ApplicationLayer/Player/PlayerController.h
+++ b/Project/ApplicationLayer/Player/PlayerController.h
@@ -31,6 +31,10 @@ public: /// ---------- メンバ関数 ---------- ///
 	// デバッグカメラフラグを取得
 	bool IsDebugCamera() const { return isDebugCamera_; }
 
+	void SetShooting(bool shooting) { isTriggerShooting_ = shooting; }
+	bool IsTriggerShooting() const { return isTriggerShooting_; }
+	bool IsPushShooting() const { return isPushShooting_; }
+
 	// デバッグカメラフラグを設定
 	void SetDebugCamera(bool isDebugCamera) { isDebugCamera_ = isDebugCamera; }
 
@@ -41,5 +45,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	bool jump_ = false; // ジャンプ入力フラグ
 	bool crouch_ = false; // しゃがみ入力フラグ
 	bool isDebugCamera_ = false; // デバッグカメラフラグ
+	bool isTriggerShooting_ = false; // ← 射撃中フラグ
+	bool isPushShooting_ = false; // ← 射撃中フラグ
 };
 

--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
@@ -53,6 +53,7 @@ void GamePlayScene::Initialize()
 
 	// プレイヤーにカメラを設定
 	player_->SetCamera(fpsCamera_->GetCamera());
+	player_->SetFpsCamera(fpsCamera_.get());
 
 	// クロスヘアの生成と初期化
 	crosshair_ = std::make_unique<Crosshair>();

--- a/Project/ApplicationLayer/Weapon/Weapon.cpp
+++ b/Project/ApplicationLayer/Weapon/Weapon.cpp
@@ -2,6 +2,8 @@
 #include "Weapon.h"
 #include <Bullet.h>
 #include <AudioManager.h>
+#include <Player.h>
+#include <FpsCamera.h>
 
 #include <imgui.h>
 
@@ -20,14 +22,14 @@ void Weapon::Initialize()
 	switch (type_)
 	{
 	case WeaponType::Rifle:
-		ammoInfo_ = { 30, 90, 30, 90, 1, 25.0f, 1000.0f }; // 30回撃てて、1回で1発出す
+		ammoInfo_ = { 3000000, 90, 30, 90, 1, 25.0f, 1000.0f }; // 30回撃てて、1回で1発出す
 		reloadTime_ = 1.5f; // ライフルはリロード時間が短い
 		bulletSpeed_ = 40.0f; // ライフルの弾速はショットガンより速い
 		fireSEPath_ = "gun.mp3";
 		break;
 
 	case WeaponType::Shotgun:
-		ammoInfo_ = { 6, 30, 6, 30, 8, 10.0f, 100.0f }; // 6回撃てて、1回で8粒出す
+		ammoInfo_ = { 600000, 30, 6, 30, 8, 10.0f, 100.0f }; // 6回撃てて、1回で8粒出す
 		reloadTime_ = 2.5f; // ショットガンはリロード時間が長い
 		bulletSpeed_ = 24.0f; // ショットガンの弾速はライフルより遅い
 		fireSEPath_ = "shotgunFire.mp3";
@@ -107,6 +109,8 @@ void Weapon::TryFire(const Vector3& position, const Vector3& direction)
 	case WeaponType::Rifle: // ライフルの場合は単発弾を発射
 		FireSingleBullet(position, direction);
 
+		if (fpsCamera_) fpsCamera_->AddRecoil(0.004, 0.0045);
+
 		// サウンド再生
 		AudioManager::GetInstance()->PlaySE(fireSEPath_, 0.5f, 2.0f);
 
@@ -114,6 +118,8 @@ void Weapon::TryFire(const Vector3& position, const Vector3& direction)
 
 	case WeaponType::Shotgun: // ショットガンの場合は散弾を発射
 		FireShotgunSpread(position, direction);
+
+		if (fpsCamera_) fpsCamera_->AddRecoil(0.008, 0.007);
 
 		// サウンド再生
 		AudioManager::GetInstance()->PlaySE(fireSEPath_);

--- a/Project/ApplicationLayer/Weapon/Weapon.h
+++ b/Project/ApplicationLayer/Weapon/Weapon.h
@@ -23,6 +23,10 @@ struct AmmoInfo
 	float range = 100;		// 弾丸の射程（メートル単位）
 };
 
+/// ---------- 前方宣言 ---------- ///
+class Player;
+class FpsCamera;
+
 
 /// -------------------------------------------------------------
 ///				　		武器クラス
@@ -74,10 +78,17 @@ public: /// ---------- ゲッタ ---------- ///
 
 	int GetAmmoReserve() const { return ammoInfo_.reserveAmmo; }
 
+	Player* GetPlayer() const { return player_; }
+	FpsCamera* GetFpsCamera() const { return fpsCamera_; }
+
 public: /// ---------- セッター ---------- ///
 
 	// 武器の種類を設定
 	void SetWeaponType(WeaponType type) { type_ = type; }
+
+	void SetPlayer(Player* player) { player_ = player; }
+
+	void SetFpsCamera(FpsCamera* fpsCamera) { fpsCamera_ = fpsCamera; }
 
 private: /// ---------- メンバ変数 ---------- ///
 
@@ -104,6 +115,9 @@ private: /// ---------- メンバ変数 ---------- ///
 	WeaponType type_ = WeaponType::Rifle; // 武器の種類
 
 	AmmoInfo ammoInfo_; // 弾薬情報
+
+	Player* player_ = nullptr;
+	FpsCamera* fpsCamera_ = nullptr;
 
 	// 弾丸のプレハブ
 	std::vector<std::unique_ptr<Bullet>> bullets_;

--- a/Project/EngineLayer/CameraManagement/FPSCamera/FpsCamera.h
+++ b/Project/EngineLayer/CameraManagement/FPSCamera/FpsCamera.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <Quaternion.h>
+#include <random>
 
 /// ---------- 前方宣言 ---------- ///
 class Player;
@@ -21,6 +22,8 @@ public: // ---------- 関数 ---------- //
 
 	// デバッグ用カメラの位置をワイヤーフレームで描画
 	void DrawDebugCamera();
+
+	void AddRecoil(float verticalAmount = 0.0f, float horizontalAmount = 0.0f);
 
 public: // ---------- ゲッタ ---------- //
 
@@ -88,4 +91,8 @@ private: // ---------- メンバ ---------- //
 	float landingBounceTimer_ = 0.0f;
 	const float landingBounceDuration_ = 0.25f; // バウンドの持続時間
 	const float landingBounceAmplitude_ = 0.25f; // バウンドの深さ
+
+	float recoilOffsetPitch_ = 0.0f;
+	float recoilOffsetYaw_ = 0.0f;
+	std::default_random_engine randomEngine_;
 };


### PR DESCRIPTION
PlayerクラスにFPSカメラを設定する機能を追加。
発射入力処理をコントローラーに基づくものに変更。
発射位置のオフセットを調整し、リアルな発射位置に。
PlayerControllerに射撃トリガー処理を追加。
Weaponクラスの弾薬情報を増加し、反動処理を追加。
FpsCameraに反動を加えるメソッドとオフセットを追加。