### PR TITLE
深度アウトラインエフェクトの追加と改善

### DIFF
--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
@@ -39,7 +39,6 @@ void GamePlayScene::Initialize()
 	// terrainの生成と初期化
 	objectTerrain_ = std::make_unique<Object3D>();
 	objectTerrain_->Initialize("terrain.obj");
-	objectTerrain_->SetTranslate({ 0.0f, -1.0f, 0.0f });
 	objectTerrain_->SetReflectivity(0.0f);
 
 	objectBall_ = std::make_unique<Object3D>();

--- a/Project/EngineLayer/Managers/PostEffectManager/PostEffectManager.h
+++ b/Project/EngineLayer/Managers/PostEffectManager/PostEffectManager.h
@@ -35,6 +35,17 @@ private: /// ---------- 構造体 ---------- ///
 		std::string category; // 任意（例："Visual", "Debug", "Color"など）
 	};
 
+public:
+
+	struct RenderTarget
+	{
+		ComPtr<ID3D12Resource> resource; // レンダーテクスチャリソース
+		D3D12_CPU_DESCRIPTOR_HANDLE rtvHandle; // RTVハンドル
+		D3D12_RESOURCE_STATES state = D3D12_RESOURCE_STATE_COMMON; // リソース状態
+		uint32_t srvIndex = 0; // SRVインデックス
+		Vector4 clearColor = { 0.08f, 0.08f, 0.18f, 1.0f }; // クリアカラー
+	};
+
 public: /// ---------- メンバ関数 ---------- ///
 
 	// シングルトンインスタンス
@@ -57,6 +68,9 @@ public: /// ---------- メンバ関数 ---------- ///
 
 	// ImGuiの描画
 	void ImGuiRender();
+
+	void EnableEffect(const std::string& effectName) { effectEnableFlags_[effectName] = true; } // エフェクトを有効化
+	void DisableEffect(const std::string& effectName) { effectEnableFlags_[effectName] = false; }  // エフェクトを無効化
 
 private: /// ---------- メンバ関数 ---------- ///
 
@@ -85,6 +99,7 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	// エフェクトを有効にするかどうかのフラグ
 	std::unordered_map<std::string, bool> effectEnabled_;
+	std::unordered_map<std::string, bool> effectEnableFlags_; // エフェクトのON/OFFフラグ
 
 	// ポストエフェクトの適用順（名前と順序番号）
 	std::vector<std::pair<std::string, int>> effectOrder_;
@@ -93,7 +108,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	std::unordered_map<std::string, std::string> effectCategory_;
 
 	// レンダーテクスチャのクリアカラー
-	const Vector4 kRenderTextureClearColor_ = { 0.08f, 0.08f, 0.16f, 1.0f }; // 分かりやすいように一旦赤色にする
+	const Vector4 kRenderTextureClearColor_ = { 0.08f, 0.08f, 0.18f, 1.0f }; // 分かりやすいように一旦赤色にする
 
 	ComPtr <ID3DBlob> signatureBlob_;
 	ComPtr <ID3DBlob> errorBlob_;
@@ -107,16 +122,8 @@ private: /// ---------- メンバ変数 ---------- ///
 	D3D12_RESOURCE_STATES depthState_ = D3D12_RESOURCE_STATE_DEPTH_WRITE;
 	uint32_t dsvSrvIndex_ = 0;
 
-	// 複数のポストエフェクトを適用するためのリソース
-	ComPtr<ID3D12Resource> renderResourceA_;
-	ComPtr<ID3D12Resource> renderResourceB_;
-	uint32_t srvIndexA_;
-	uint32_t srvIndexB_;
-	D3D12_CPU_DESCRIPTOR_HANDLE rtvHandleA_;
-	D3D12_CPU_DESCRIPTOR_HANDLE rtvHandleB_;
-
-	D3D12_RESOURCE_STATES renderStateA_ = D3D12_RESOURCE_STATE_COMMON;
-	D3D12_RESOURCE_STATES renderStateB_ = D3D12_RESOURCE_STATE_COMMON;
+	static constexpr int kPostRTCount = 1; // ポストエフェクト用のレンダーテクスチャ数
+	std::vector<RenderTarget> renderTargets_; // レンダーテクスチャのリスト
 
 private: /// ---------- コピー禁止 ---------- ///
 

--- a/Project/EngineLayer/PostEffectManagement/DepthOutlineEffect.cpp
+++ b/Project/EngineLayer/PostEffectManagement/DepthOutlineEffect.cpp
@@ -1,0 +1,68 @@
+#include "DepthOutlineEffect.h"
+#include <DirectXCommon.h>
+#include <LogString.h>
+#include <PostEffectPipelineBuilder.h>
+#include <ResourceManager.h>
+#include <SRVManager.h>
+#include <ShaderManager.h>
+#include <WinApp.h>
+#include "Camera.h"
+
+#include <cassert>
+#include <imgui.h>
+
+DepthOutlineEffect::DepthOutlineEffect(Camera* camera) : camera_(camera)
+{
+}
+
+void DepthOutlineEffect::Initialize(DirectXCommon* dxCommon, PostEffectPipelineBuilder* builder)
+{
+	dxCommon_ = dxCommon;
+
+	// ルートシグネチャの生成
+	rootSignature_ = builder->CreateRootSignature();
+
+	// パイプラインの生成
+	graphicsPipelineState_ = builder->CreateGraphicsPipeline(
+		ShaderManager::GetShaderPath(L"DepthOutlineEffect", L".PS.hlsl"),
+		rootSignature_.Get(),
+		false);
+
+	// リソースの生成
+	constantBuffer_ = ResourceManager::CreateBufferResource(dxCommon_->GetDevice(), sizeof(DepthOutlineSetting));
+
+	// データの設定
+	constantBuffer_->Map(0, nullptr, reinterpret_cast<void**>(&depthOutlineSetting_));
+
+	// アウトラインの設定
+	depthOutlineSetting_->texelSize = Vector2(1.0f / static_cast<float>(WinApp::kClientWidth), 1.0f / static_cast<float>(WinApp::kClientHeight));
+	depthOutlineSetting_->depthScale = 1.0f; // 輪郭の閾値
+	depthOutlineSetting_->edgeThickness = 2.0f; // ピクセル単位の太さ
+	depthOutlineSetting_->edgeColor = { 0.0f,0.0f,0.0f,1.0f }; // 黒色
+
+	// 毎フレーム（カメラ更新後に）
+	Matrix4x4 proj = camera_->GetProjectionMatrix();
+	depthOutlineSetting_->projectionInverse = Matrix4x4::Inverse(proj);
+}
+
+void DepthOutlineEffect::Apply(ID3D12GraphicsCommandList* commandList, uint32_t rtvSrvIndex, uint32_t dsvSrvIndex)
+{
+	depthOutlineSetting_->projectionInverse = Matrix4x4::Inverse(camera_->GetProjectionMatrix());
+
+	commandList->SetGraphicsRootSignature(rootSignature_.Get());
+	commandList->SetPipelineState(graphicsPipelineState_.Get());
+
+	// SRVヒープの設定はPostEffectManager側で済ませておく前提
+	commandList->SetGraphicsRootDescriptorTable(0, SRVManager::GetInstance()->GetGPUDescriptorHandle(rtvSrvIndex));
+	commandList->SetGraphicsRootConstantBufferView(1, constantBuffer_->GetGPUVirtualAddress());
+	commandList->SetGraphicsRootDescriptorTable(3, SRVManager::GetInstance()->GetGPUDescriptorHandle(dsvSrvIndex));
+	commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	commandList->DrawInstanced(3, 1, 0, 0);
+}
+
+void DepthOutlineEffect::DrawImGui()
+{
+	ImGui::SliderFloat("Depth Scale", &depthOutlineSetting_->depthScale, 0.0f, 100.0f);
+	ImGui::SliderFloat("Thickness", &depthOutlineSetting_->edgeThickness, 1.0f, 10.0f);
+	ImGui::ColorEdit4("Edge Color", &depthOutlineSetting_->edgeColor.x);
+}

--- a/Project/EngineLayer/PostEffectManagement/DepthOutlineEffect.h
+++ b/Project/EngineLayer/PostEffectManagement/DepthOutlineEffect.h
@@ -1,0 +1,67 @@
+#pragma once
+#include <IPostEffect.h>
+#include "Vector2.h"
+#include "Vector4.h"
+#include "Matrix4x4.h"
+
+/// ---------- 前方宣言 ---------- ///
+class Camera;
+
+
+class DepthOutlineEffect : public IPostEffect
+{
+private:
+
+	struct DepthOutlineSetting
+	{
+		Vector2 texelSize; // 1 / 解像度
+		float depthScale; // 深度差
+		float edgeThickness; // ピクセル単位の太さ
+		Vector4 edgeColor; // アウトラインの色
+		Matrix4x4 projectionInverse; // +64 = 96
+	};
+
+public: /// ---------- メンバ関数 ---------- ///
+
+	// コンストラクタ
+	DepthOutlineEffect(Camera* camera);
+
+	// 初期化処理
+	void Initialize(DirectXCommon* dxCommon, PostEffectPipelineBuilder* builder) override;
+
+	// 適用処理
+	void Apply(ID3D12GraphicsCommandList* commandList, uint32_t rtvSrvIndex, uint32_t dsvSrvIndex) override;
+
+	// ImGui描画処理
+	void DrawImGui() override;
+
+	// 名前の取得
+	const std::string& GetName() const override { return name_; }
+
+private: /// ---------- 構造体 ---------- ///
+
+	Camera* camera_ = nullptr; // カメラへのポインタ
+
+	// 名前
+	const std::string name_ = "DepthOutlineEffect";
+
+	// シェーダーコードのパス
+	std::string shaderPath_ = "Resources/Shaders/PostEffect/DepthOutlineEffect.PS.hlsl";
+
+	// DirectX共通クラス
+	DirectXCommon* dxCommon_ = nullptr;
+
+	// パイプラインビルダー
+	PostEffectPipelineBuilder* pipelineBuilder_;
+
+	// グラフィックスパイプラインステートオブジェクト
+	Microsoft::WRL::ComPtr<ID3D12PipelineState> graphicsPipelineState_;
+
+	// ルートシグネチャ
+	Microsoft::WRL::ComPtr<ID3D12RootSignature> rootSignature_;
+
+	// ガウシアンフィルタの設定
+	Microsoft::WRL::ComPtr<ID3D12Resource> constantBuffer_;
+	DepthOutlineSetting* depthOutlineSetting_ = nullptr;
+};
+

--- a/Project/EngineLayer/PostEffectManagement/PostEffectPipelineBuilder.cpp
+++ b/Project/EngineLayer/PostEffectManagement/PostEffectPipelineBuilder.cpp
@@ -159,3 +159,14 @@ ComPtr<ID3D12PipelineState> PostEffectPipelineBuilder::CreateGraphicsPipeline(co
 	assert(SUCCEEDED(hr));
 	return pso;
 }
+
+// PostEffectPipelineBuilder.cpp
+void PostEffectPipelineBuilder::BuildCopyPipeline()
+{
+	// ① RootSig を生成（深度不要）
+	copyRootSignature_ = CreateRootSignature();
+
+	// ② FSQ 用ピクセルシェーダ（色をそのまま出力）
+	const std::wstring kCopyPS = L"Resources/Shaders/PostEffect/NormalEffect.PS.hlsl";
+	copyPipelineState_ = CreateGraphicsPipeline(kCopyPS, copyRootSignature_.Get(), false);
+}

--- a/Project/EngineLayer/PostEffectManagement/PostEffectPipelineBuilder.h
+++ b/Project/EngineLayer/PostEffectManagement/PostEffectPipelineBuilder.h
@@ -31,9 +31,20 @@ public: /// ---------- メンバ関数 ---------- ///
 	/// <returns></returns>
 	ComPtr<ID3D12PipelineState> CreateGraphicsPipeline(const std::wstring& pixelShaderPath, ID3D12RootSignature* rootSignature, bool enableDepth = false);
 
+	void BuildCopyPipeline();
+
+	// ルートシグネチャの取得
+	ComPtr<ID3D12RootSignature> GetCopyRootSignature() const { return copyRootSignature_; }
+
+	// パイプラインステートの取得
+	ComPtr<ID3D12PipelineState> GetCopyPipelineState() const { return copyPipelineState_; }
+
 private: /// ---------- メンバ変数 ---------- ///
 
 	// DirectX共通クラス
 	DirectXCommon* dxCommon_ = nullptr;
-};
 
+	// ★ 追加: 保管先
+	ComPtr<ID3D12RootSignature> copyRootSignature_;
+	ComPtr<ID3D12PipelineState> copyPipelineState_;
+};

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -126,6 +126,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="EngineLayer\Managers\DXCCompilerManager\DXCCompilerManager.cpp" />
     <ClCompile Include="EngineLayer\ParticleManagement\ParticleFactory.cpp" />
     <ClCompile Include="EngineLayer\PostEffectManagement\AbsorbEffect.cpp" />
+    <ClCompile Include="EngineLayer\PostEffectManagement\DepthOutlineEffect.cpp" />
     <ClCompile Include="EngineLayer\PostEffectManagement\DissolveEffect.cpp" />
     <ClCompile Include="EngineLayer\Managers\ModelManager\AssimpLoader.cpp" />
     <ClCompile Include="EngineLayer\Material\Material.cpp" />
@@ -367,6 +368,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="EngineLayer\ParticleManagement\ParticleEffectType.h" />
     <ClInclude Include="EngineLayer\ParticleManagement\ParticleFactory.h" />
     <ClInclude Include="EngineLayer\PostEffectManagement\AbsorbEffect.h" />
+    <ClInclude Include="EngineLayer\PostEffectManagement\DepthOutlineEffect.h" />
     <ClInclude Include="EngineLayer\PostEffectManagement\DissolveEffect.h" />
     <ClInclude Include="EngineLayer\Managers\ModelManager\AssimpLoader.h" />
     <ClInclude Include="EngineLayer\Managers\DSVManager\DSVManager.h" />

--- a/Project/Ken4lowEngine.vcxproj.filters
+++ b/Project/Ken4lowEngine.vcxproj.filters
@@ -79,21 +79,6 @@
   </ItemGroup>
   <ItemGroup>
     <ClCompile Include="WinMain.cpp" />
-    <ClCompile Include="EngineLayer\PostEffectManagement\AbsorbEffect.cpp">
-      <Filter>EngineLayer</Filter>
-    </ClCompile>
-    <ClCompile Include="ApplicationLayer\SceneManagement\AbstractSceneFactory\AbstractSceneFactory.cpp">
-      <Filter>EngineLayer</Filter>
-    </ClCompile>
-    <ClCompile Include="EngineLayer\Mesh\AnimationMesh.cpp">
-      <Filter>EngineLayer</Filter>
-    </ClCompile>
-    <ClCompile Include="EngineLayer\3D\AnimationManagement\AnimationModel.cpp">
-      <Filter>EngineLayer</Filter>
-    </ClCompile>
-    <ClCompile Include="EngineLayer\3D\AnimationManagement\AnimationPipelineBuilder.cpp">
-      <Filter>EngineLayer</Filter>
-    </ClCompile>
     <ClCompile Include="EngineLayer\Managers\ModelManager\AssimpLoader.cpp">
       <Filter>EngineLayer</Filter>
     </ClCompile>
@@ -101,9 +86,6 @@
       <Filter>EngineLayer</Filter>
     </ClCompile>
     <ClCompile Include="ApplicationLayer\SceneManagement\BaseScene\BaseScene.cpp">
-      <Filter>EngineLayer</Filter>
-    </ClCompile>
-    <ClCompile Include="EngineLayer\CameraManagement\Camera\Camera.cpp">
       <Filter>EngineLayer</Filter>
     </ClCompile>
     <ClCompile Include="ApplicationLayer\Colliders\Collider.cpp">
@@ -118,13 +100,7 @@
     <ClCompile Include="EngineLayer\ResourceChecker\LeakCheck\D3DResourceLeakChecker.cpp">
       <Filter>EngineLayer</Filter>
     </ClCompile>
-    <ClCompile Include="EngineLayer\CameraManagement\DebugCamera\DebugCamera.cpp">
-      <Filter>EngineLayer</Filter>
-    </ClCompile>
     <ClCompile Include="EngineLayer\Base\DirectXCommon\DirectXCommon.cpp">
-      <Filter>EngineLayer</Filter>
-    </ClCompile>
-    <ClCompile Include="EngineLayer\PostEffectManagement\DissolveEffect.cpp">
       <Filter>EngineLayer</Filter>
     </ClCompile>
     <ClCompile Include="EngineLayer\Managers\DSVManager\DSVManager.cpp">
@@ -163,16 +139,7 @@
     <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\GamePlayScene.cpp">
       <Filter>ApplicationLayer</Filter>
     </ClCompile>
-    <ClCompile Include="EngineLayer\PostEffectManagement\GaussianFilterEffect.cpp">
-      <Filter>EngineLayer</Filter>
-    </ClCompile>
-    <ClCompile Include="EngineLayer\PostEffectManagement\GrayScaleEffect.cpp">
-      <Filter>EngineLayer</Filter>
-    </ClCompile>
     <ClCompile Include="EngineLayer\Input\Input.cpp">
-      <Filter>EngineLayer</Filter>
-    </ClCompile>
-    <ClCompile Include="EngineLayer\PostEffectManagement\IPostEffect.cpp">
       <Filter>EngineLayer</Filter>
     </ClCompile>
     <ClCompile Include="EngineLayer\3D\LevelData\LevelLoader.cpp">
@@ -187,13 +154,7 @@
     <ClCompile Include="EngineLayer\FrameworkLayer\Log\LogString.cpp">
       <Filter>EngineLayer</Filter>
     </ClCompile>
-    <ClCompile Include="EngineLayer\PostEffectManagement\LuminanceOutlineEffect.cpp">
-      <Filter>EngineLayer</Filter>
-    </ClCompile>
     <ClCompile Include="EngineLayer\Material\Material.cpp">
-      <Filter>EngineLayer</Filter>
-    </ClCompile>
-    <ClCompile Include="EngineLayer\Math\Matrix\Matrix4x4.cpp">
       <Filter>EngineLayer</Filter>
     </ClCompile>
     <ClCompile Include="EngineLayer\Mesh\Mesh.cpp">
@@ -209,9 +170,6 @@
       <Filter>EngineLayer</Filter>
     </ClCompile>
     <ClCompile Include="EngineLayer\Audio\MP3Loader.cpp">
-      <Filter>EngineLayer</Filter>
-    </ClCompile>
-    <ClCompile Include="EngineLayer\PostEffectManagement\NormalEffect.cpp">
       <Filter>EngineLayer</Filter>
     </ClCompile>
     <ClCompile Include="EngineLayer\3D\Object3D\Object3D.cpp">
@@ -238,21 +196,6 @@
     <ClCompile Include="EngineLayer\WorldTransform\ParticleTransform.cpp">
       <Filter>EngineLayer</Filter>
     </ClCompile>
-    <ClCompile Include="EngineLayer\Managers\PostEffectManager\PostEffectManager.cpp">
-      <Filter>EngineLayer</Filter>
-    </ClCompile>
-    <ClCompile Include="EngineLayer\PostEffectManagement\PostEffectPipelineBuilder.cpp">
-      <Filter>EngineLayer</Filter>
-    </ClCompile>
-    <ClCompile Include="EngineLayer\Math\Quaternion\Quaternion.cpp">
-      <Filter>EngineLayer</Filter>
-    </ClCompile>
-    <ClCompile Include="EngineLayer\PostEffectManagement\RadialBlurEffect.cpp">
-      <Filter>EngineLayer</Filter>
-    </ClCompile>
-    <ClCompile Include="EngineLayer\PostEffectManagement\RandomEffect.cpp">
-      <Filter>EngineLayer</Filter>
-    </ClCompile>
     <ClCompile Include="EngineLayer\Managers\ResourceManager\ResourceManager.cpp">
       <Filter>EngineLayer</Filter>
     </ClCompile>
@@ -265,19 +208,10 @@
     <ClCompile Include="EngineLayer\Managers\ShaderManager\ShaderManager.cpp">
       <Filter>EngineLayer</Filter>
     </ClCompile>
-    <ClCompile Include="EngineLayer\3D\AnimationManagement\Skeleton.cpp">
-      <Filter>EngineLayer</Filter>
-    </ClCompile>
-    <ClCompile Include="EngineLayer\3D\AnimationManagement\SkinCluster.cpp">
-      <Filter>EngineLayer</Filter>
-    </ClCompile>
     <ClCompile Include="EngineLayer\3D\SkyBox\SkyBox.cpp">
       <Filter>EngineLayer</Filter>
     </ClCompile>
     <ClCompile Include="EngineLayer\Managers\SkyBoxManager\SkyBoxManager.cpp">
-      <Filter>EngineLayer</Filter>
-    </ClCompile>
-    <ClCompile Include="EngineLayer\PostEffectManagement\SmoothingEffect.cpp">
       <Filter>EngineLayer</Filter>
     </ClCompile>
     <ClCompile Include="EngineLayer\2D\Sprite\Sprite.cpp">
@@ -325,16 +259,7 @@
     <ClCompile Include="Externals\imgui\imgui_widgets.cpp">
       <Filter>Externals\imgui</Filter>
     </ClCompile>
-    <ClCompile Include="EngineLayer\PostEffectManagement\VignetteEffect.cpp">
-      <Filter>EngineLayer</Filter>
-    </ClCompile>
     <ClCompile Include="EngineLayer\Audio\WavLoader.cpp">
-      <Filter>EngineLayer</Filter>
-    </ClCompile>
-    <ClCompile Include="EngineLayer\Math\Vectors\Vector2.cpp">
-      <Filter>EngineLayer</Filter>
-    </ClCompile>
-    <ClCompile Include="EngineLayer\Math\Vectors\Vector3.cpp">
       <Filter>EngineLayer</Filter>
     </ClCompile>
     <ClCompile Include="EngineLayer\FrameworkLayer\WindowsAPI\WinApp.cpp">
@@ -346,26 +271,86 @@
     <ClCompile Include="EngineLayer\WorldTransform\WorldTransform.cpp">
       <Filter>EngineLayer</Filter>
     </ClCompile>
+    <ClCompile Include="EngineLayer\Math\Matrix\Matrix4x4.cpp">
+      <Filter>EngineLayer\Math</Filter>
+    </ClCompile>
+    <ClCompile Include="EngineLayer\Math\Vectors\Vector2.cpp">
+      <Filter>EngineLayer\Math</Filter>
+    </ClCompile>
+    <ClCompile Include="EngineLayer\Math\Vectors\Vector3.cpp">
+      <Filter>EngineLayer\Math</Filter>
+    </ClCompile>
+    <ClCompile Include="EngineLayer\CameraManagement\Camera\Camera.cpp">
+      <Filter>EngineLayer\Camera</Filter>
+    </ClCompile>
+    <ClCompile Include="EngineLayer\CameraManagement\DebugCamera\DebugCamera.cpp">
+      <Filter>EngineLayer\Camera</Filter>
+    </ClCompile>
+    <ClCompile Include="EngineLayer\Math\Quaternion\Quaternion.cpp">
+      <Filter>EngineLayer\Math</Filter>
+    </ClCompile>
+    <ClCompile Include="EngineLayer\PostEffectManagement\AbsorbEffect.cpp">
+      <Filter>EngineLayer\PostEffect</Filter>
+    </ClCompile>
+    <ClCompile Include="ApplicationLayer\SceneManagement\AbstractSceneFactory\AbstractSceneFactory.cpp">
+      <Filter>EngineLayer\PostEffect</Filter>
+    </ClCompile>
+    <ClCompile Include="EngineLayer\PostEffectManagement\DissolveEffect.cpp">
+      <Filter>EngineLayer\PostEffect</Filter>
+    </ClCompile>
+    <ClCompile Include="EngineLayer\PostEffectManagement\GaussianFilterEffect.cpp">
+      <Filter>EngineLayer\PostEffect</Filter>
+    </ClCompile>
+    <ClCompile Include="EngineLayer\PostEffectManagement\GrayScaleEffect.cpp">
+      <Filter>EngineLayer\PostEffect</Filter>
+    </ClCompile>
+    <ClCompile Include="EngineLayer\PostEffectManagement\IPostEffect.cpp">
+      <Filter>EngineLayer\PostEffect</Filter>
+    </ClCompile>
+    <ClCompile Include="EngineLayer\PostEffectManagement\LuminanceOutlineEffect.cpp">
+      <Filter>EngineLayer\PostEffect</Filter>
+    </ClCompile>
+    <ClCompile Include="EngineLayer\PostEffectManagement\NormalEffect.cpp">
+      <Filter>EngineLayer\PostEffect</Filter>
+    </ClCompile>
+    <ClCompile Include="EngineLayer\Managers\PostEffectManager\PostEffectManager.cpp">
+      <Filter>EngineLayer\PostEffect</Filter>
+    </ClCompile>
+    <ClCompile Include="EngineLayer\PostEffectManagement\PostEffectPipelineBuilder.cpp">
+      <Filter>EngineLayer\PostEffect</Filter>
+    </ClCompile>
+    <ClCompile Include="EngineLayer\PostEffectManagement\RadialBlurEffect.cpp">
+      <Filter>EngineLayer\PostEffect</Filter>
+    </ClCompile>
+    <ClCompile Include="EngineLayer\PostEffectManagement\RandomEffect.cpp">
+      <Filter>EngineLayer\PostEffect</Filter>
+    </ClCompile>
+    <ClCompile Include="EngineLayer\PostEffectManagement\SmoothingEffect.cpp">
+      <Filter>EngineLayer\PostEffect</Filter>
+    </ClCompile>
+    <ClCompile Include="EngineLayer\PostEffectManagement\VignetteEffect.cpp">
+      <Filter>EngineLayer\PostEffect</Filter>
+    </ClCompile>
+    <ClCompile Include="EngineLayer\Mesh\AnimationMesh.cpp">
+      <Filter>EngineLayer\Animation</Filter>
+    </ClCompile>
+    <ClCompile Include="EngineLayer\3D\AnimationManagement\AnimationModel.cpp">
+      <Filter>EngineLayer\Animation</Filter>
+    </ClCompile>
+    <ClCompile Include="EngineLayer\3D\AnimationManagement\AnimationPipelineBuilder.cpp">
+      <Filter>EngineLayer\Animation</Filter>
+    </ClCompile>
+    <ClCompile Include="EngineLayer\3D\AnimationManagement\Skeleton.cpp">
+      <Filter>EngineLayer\Animation</Filter>
+    </ClCompile>
+    <ClCompile Include="EngineLayer\3D\AnimationManagement\SkinCluster.cpp">
+      <Filter>EngineLayer\Animation</Filter>
+    </ClCompile>
+    <ClCompile Include="EngineLayer\PostEffectManagement\DepthOutlineEffect.cpp">
+      <Filter>EngineLayer\PostEffect</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
-    <ClInclude Include="EngineLayer\Math\AABB.h">
-      <Filter>EngineLayer</Filter>
-    </ClInclude>
-    <ClInclude Include="EngineLayer\PostEffectManagement\AbsorbEffect.h">
-      <Filter>EngineLayer</Filter>
-    </ClInclude>
-    <ClInclude Include="ApplicationLayer\SceneManagement\AbstractSceneFactory\AbstractSceneFactory.h">
-      <Filter>EngineLayer</Filter>
-    </ClInclude>
-    <ClInclude Include="EngineLayer\Mesh\AnimationMesh.h">
-      <Filter>EngineLayer</Filter>
-    </ClInclude>
-    <ClInclude Include="EngineLayer\3D\AnimationManagement\AnimationModel.h">
-      <Filter>EngineLayer</Filter>
-    </ClInclude>
-    <ClInclude Include="EngineLayer\3D\AnimationManagement\AnimationPipelineBuilder.h">
-      <Filter>EngineLayer</Filter>
-    </ClInclude>
     <ClInclude Include="EngineLayer\Managers\ModelManager\AssimpLoader.h">
       <Filter>EngineLayer</Filter>
     </ClInclude>
@@ -384,9 +369,6 @@
     <ClInclude Include="EngineLayer\Base\MultipleStructs\BlendModeType.h">
       <Filter>EngineLayer</Filter>
     </ClInclude>
-    <ClInclude Include="EngineLayer\CameraManagement\Camera\Camera.h">
-      <Filter>EngineLayer</Filter>
-    </ClInclude>
     <ClInclude Include="ApplicationLayer\Colliders\Collider.h">
       <Filter>EngineLayer</Filter>
     </ClInclude>
@@ -402,13 +384,7 @@
     <ClInclude Include="EngineLayer\ResourceChecker\LeakCheck\D3DResourceLeakChecker.h">
       <Filter>EngineLayer</Filter>
     </ClInclude>
-    <ClInclude Include="EngineLayer\CameraManagement\DebugCamera\DebugCamera.h">
-      <Filter>EngineLayer</Filter>
-    </ClInclude>
     <ClInclude Include="EngineLayer\Base\DirectXCommon\DirectXCommon.h">
-      <Filter>EngineLayer</Filter>
-    </ClInclude>
-    <ClInclude Include="EngineLayer\PostEffectManagement\DissolveEffect.h">
       <Filter>EngineLayer</Filter>
     </ClInclude>
     <ClInclude Include="EngineLayer\Managers\DSVManager\DSVManager.h">
@@ -453,16 +429,7 @@
     <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\GamePlayScene.h">
       <Filter>ApplicationLayer</Filter>
     </ClInclude>
-    <ClInclude Include="EngineLayer\PostEffectManagement\GrayScaleEffect.h">
-      <Filter>EngineLayer</Filter>
-    </ClInclude>
-    <ClInclude Include="EngineLayer\PostEffectManagement\GaussianFilterEffect.h">
-      <Filter>EngineLayer</Filter>
-    </ClInclude>
     <ClInclude Include="EngineLayer\Input\Input.h">
-      <Filter>EngineLayer</Filter>
-    </ClInclude>
-    <ClInclude Include="EngineLayer\PostEffectManagement\IPostEffect.h">
       <Filter>EngineLayer</Filter>
     </ClInclude>
     <ClInclude Include="EngineLayer\3D\LevelData\LevelData.h">
@@ -480,13 +447,7 @@
     <ClInclude Include="EngineLayer\FrameworkLayer\Log\LogString.h">
       <Filter>EngineLayer</Filter>
     </ClInclude>
-    <ClInclude Include="EngineLayer\PostEffectManagement\LuminanceOutlineEffect.h">
-      <Filter>EngineLayer</Filter>
-    </ClInclude>
     <ClInclude Include="EngineLayer\Material\Material.h">
-      <Filter>EngineLayer</Filter>
-    </ClInclude>
-    <ClInclude Include="EngineLayer\Math\Matrix\Matrix4x4.h">
       <Filter>EngineLayer</Filter>
     </ClInclude>
     <ClInclude Include="EngineLayer\Mesh\Mesh.h">
@@ -505,12 +466,6 @@
       <Filter>EngineLayer</Filter>
     </ClInclude>
     <ClInclude Include="EngineLayer\Audio\MP3Loader.h">
-      <Filter>EngineLayer</Filter>
-    </ClInclude>
-    <ClInclude Include="EngineLayer\PostEffectManagement\NormalEffect.h">
-      <Filter>EngineLayer</Filter>
-    </ClInclude>
-    <ClInclude Include="EngineLayer\Math\OBB.h">
       <Filter>EngineLayer</Filter>
     </ClInclude>
     <ClInclude Include="EngineLayer\3D\Object3D\Object3D.h">
@@ -540,21 +495,6 @@
     <ClInclude Include="EngineLayer\WorldTransform\ParticleTransform.h">
       <Filter>EngineLayer</Filter>
     </ClInclude>
-    <ClInclude Include="EngineLayer\Managers\PostEffectManager\PostEffectManager.h">
-      <Filter>EngineLayer</Filter>
-    </ClInclude>
-    <ClInclude Include="EngineLayer\PostEffectManagement\PostEffectPipelineBuilder.h">
-      <Filter>EngineLayer</Filter>
-    </ClInclude>
-    <ClInclude Include="EngineLayer\Math\Quaternion\Quaternion.h">
-      <Filter>EngineLayer</Filter>
-    </ClInclude>
-    <ClInclude Include="EngineLayer\PostEffectManagement\RadialBlurEffect.h">
-      <Filter>EngineLayer</Filter>
-    </ClInclude>
-    <ClInclude Include="EngineLayer\PostEffectManagement\RandomEffect.h">
-      <Filter>EngineLayer</Filter>
-    </ClInclude>
     <ClInclude Include="EngineLayer\Managers\ResourceManager\ResourceManager.h">
       <Filter>EngineLayer</Filter>
     </ClInclude>
@@ -567,19 +507,10 @@
     <ClInclude Include="EngineLayer\Managers\ShaderManager\ShaderManager.h">
       <Filter>EngineLayer</Filter>
     </ClInclude>
-    <ClInclude Include="EngineLayer\3D\AnimationManagement\Skeleton.h">
-      <Filter>EngineLayer</Filter>
-    </ClInclude>
-    <ClInclude Include="EngineLayer\3D\AnimationManagement\SkinCluster.h">
-      <Filter>EngineLayer</Filter>
-    </ClInclude>
     <ClInclude Include="EngineLayer\3D\SkyBox\SkyBox.h">
       <Filter>EngineLayer</Filter>
     </ClInclude>
     <ClInclude Include="EngineLayer\Managers\SkyBoxManager\SkyBoxManager.h">
-      <Filter>EngineLayer</Filter>
-    </ClInclude>
-    <ClInclude Include="EngineLayer\PostEffectManagement\SmoothingEffect.h">
       <Filter>EngineLayer</Filter>
     </ClInclude>
     <ClInclude Include="EngineLayer\2D\Sprite\Sprite.h">
@@ -639,22 +570,10 @@
     <ClInclude Include="Externals\Audio\minimp3\minimp3_ex.h">
       <Filter>Externals\mipmp3</Filter>
     </ClInclude>
-    <ClInclude Include="EngineLayer\PostEffectManagement\VignetteEffect.h">
-      <Filter>EngineLayer</Filter>
-    </ClInclude>
     <ClInclude Include="EngineLayer\Audio\WavLoader.h">
       <Filter>EngineLayer</Filter>
     </ClInclude>
     <ClInclude Include="EngineLayer\Audio\WavLoaderException.h">
-      <Filter>EngineLayer</Filter>
-    </ClInclude>
-    <ClInclude Include="EngineLayer\Math\Vectors\Vector2.h">
-      <Filter>EngineLayer</Filter>
-    </ClInclude>
-    <ClInclude Include="EngineLayer\Math\Vectors\Vector3.h">
-      <Filter>EngineLayer</Filter>
-    </ClInclude>
-    <ClInclude Include="EngineLayer\Math\Vectors\Vector4.h">
       <Filter>EngineLayer</Filter>
     </ClInclude>
     <ClInclude Include="EngineLayer\Base\MultipleStructs\VertexData.h">
@@ -671,6 +590,93 @@
     </ClInclude>
     <ClInclude Include="EngineLayer\Base\MultipleStructs\TransformationMatrix.h">
       <Filter>EngineLayer</Filter>
+    </ClInclude>
+    <ClInclude Include="EngineLayer\Math\AABB.h">
+      <Filter>EngineLayer\Math</Filter>
+    </ClInclude>
+    <ClInclude Include="EngineLayer\Math\Matrix\Matrix4x4.h">
+      <Filter>EngineLayer\Math</Filter>
+    </ClInclude>
+    <ClInclude Include="EngineLayer\Math\Vectors\Vector2.h">
+      <Filter>EngineLayer\Math</Filter>
+    </ClInclude>
+    <ClInclude Include="EngineLayer\Math\Vectors\Vector3.h">
+      <Filter>EngineLayer\Math</Filter>
+    </ClInclude>
+    <ClInclude Include="EngineLayer\Math\Vectors\Vector4.h">
+      <Filter>EngineLayer\Math</Filter>
+    </ClInclude>
+    <ClInclude Include="EngineLayer\Math\OBB.h">
+      <Filter>EngineLayer\Math</Filter>
+    </ClInclude>
+    <ClInclude Include="EngineLayer\CameraManagement\Camera\Camera.h">
+      <Filter>EngineLayer\Camera</Filter>
+    </ClInclude>
+    <ClInclude Include="EngineLayer\CameraManagement\DebugCamera\DebugCamera.h">
+      <Filter>EngineLayer\Camera</Filter>
+    </ClInclude>
+    <ClInclude Include="EngineLayer\Math\Quaternion\Quaternion.h">
+      <Filter>EngineLayer\Math</Filter>
+    </ClInclude>
+    <ClInclude Include="EngineLayer\PostEffectManagement\AbsorbEffect.h">
+      <Filter>EngineLayer\PostEffect</Filter>
+    </ClInclude>
+    <ClInclude Include="ApplicationLayer\SceneManagement\AbstractSceneFactory\AbstractSceneFactory.h">
+      <Filter>EngineLayer\PostEffect</Filter>
+    </ClInclude>
+    <ClInclude Include="EngineLayer\PostEffectManagement\DissolveEffect.h">
+      <Filter>EngineLayer\PostEffect</Filter>
+    </ClInclude>
+    <ClInclude Include="EngineLayer\PostEffectManagement\GaussianFilterEffect.h">
+      <Filter>EngineLayer\PostEffect</Filter>
+    </ClInclude>
+    <ClInclude Include="EngineLayer\PostEffectManagement\GrayScaleEffect.h">
+      <Filter>EngineLayer\PostEffect</Filter>
+    </ClInclude>
+    <ClInclude Include="EngineLayer\PostEffectManagement\IPostEffect.h">
+      <Filter>EngineLayer\PostEffect</Filter>
+    </ClInclude>
+    <ClInclude Include="EngineLayer\PostEffectManagement\LuminanceOutlineEffect.h">
+      <Filter>EngineLayer\PostEffect</Filter>
+    </ClInclude>
+    <ClInclude Include="EngineLayer\PostEffectManagement\NormalEffect.h">
+      <Filter>EngineLayer\PostEffect</Filter>
+    </ClInclude>
+    <ClInclude Include="EngineLayer\Managers\PostEffectManager\PostEffectManager.h">
+      <Filter>EngineLayer\PostEffect</Filter>
+    </ClInclude>
+    <ClInclude Include="EngineLayer\PostEffectManagement\PostEffectPipelineBuilder.h">
+      <Filter>EngineLayer\PostEffect</Filter>
+    </ClInclude>
+    <ClInclude Include="EngineLayer\PostEffectManagement\RadialBlurEffect.h">
+      <Filter>EngineLayer\PostEffect</Filter>
+    </ClInclude>
+    <ClInclude Include="EngineLayer\PostEffectManagement\RandomEffect.h">
+      <Filter>EngineLayer\PostEffect</Filter>
+    </ClInclude>
+    <ClInclude Include="EngineLayer\PostEffectManagement\SmoothingEffect.h">
+      <Filter>EngineLayer\PostEffect</Filter>
+    </ClInclude>
+    <ClInclude Include="EngineLayer\PostEffectManagement\VignetteEffect.h">
+      <Filter>EngineLayer\PostEffect</Filter>
+    </ClInclude>
+    <ClInclude Include="EngineLayer\Mesh\AnimationMesh.h">
+      <Filter>EngineLayer\Animation</Filter>
+    </ClInclude>
+    <ClInclude Include="EngineLayer\3D\AnimationManagement\AnimationModel.h">
+      <Filter>EngineLayer\Animation</Filter>
+    </ClInclude>
+    <ClInclude Include="EngineLayer\3D\AnimationManagement\AnimationPipelineBuilder.h">
+      <Filter>EngineLayer\Animation</Filter>
+    </ClInclude>
+    <ClInclude Include="EngineLayer\3D\AnimationManagement\Skeleton.h">
+      <Filter>EngineLayer\Animation</Filter>
+    </ClInclude>
+    <ClInclude Include="EngineLayer\3D\AnimationManagement\SkinCluster.h">
+      <Filter>EngineLayer\Animation</Filter>
+    </ClInclude>
+    <ClInclude Include="EngineLayer\PostEffectManagement\DepthOutlineEffect.h">
+      <Filter>EngineLayer\PostEffect</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>
@@ -735,6 +741,18 @@
     </Filter>
     <Filter Include="Shader\Object3D">
       <UniqueIdentifier>{5ea0d569-7b0c-43a8-8a37-8e2ff42fa8d9}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="EngineLayer\Camera">
+      <UniqueIdentifier>{b2f356a2-8777-4d51-af02-198b083c1dc3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="EngineLayer\Math">
+      <UniqueIdentifier>{5d72c54e-91ef-4e38-a493-72d8d0df2bb3}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="EngineLayer\PostEffect">
+      <UniqueIdentifier>{84a93521-f509-4a9b-8944-1a3e39629d3a}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="EngineLayer\Animation">
+      <UniqueIdentifier>{5a52fd2a-29cc-40b1-b4a1-b99aa53abbc7}</UniqueIdentifier>
     </Filter>
   </ItemGroup>
   <ItemGroup>


### PR DESCRIPTION
GamePlayScene.cppのInitialize関数でterrainオブジェクトの位置設定を削除し、反射率の設定を追加しました。 PostEffectManager.cppにDepthOutlineEffectのインクルードを追加し、Transition関数を定義しました。 
Initialieze関数でコピー用パイプラインのビルドとレンダーターゲットの確保を追加し、ビューポートとシザー矩形の設定を削除しました。 
Update関数でレンダーターゲットの設定を変更し、クリアカラーの設定を更新しました。
BeginDrawおよびEndDraw関数で深度リソースの状態遷移を追加し、レンダーターゲットの設定を変更しました。 AllocateRTVAndSRV関数でレンダーテクスチャの生成方法を変更し、RenderTarget構造体を導入しました。 DepthOutlineEffect.cppと.hを新たに追加し、深度アウトラインエフェクトの初期化と適用処理を実装しました。 PostEffectPipelineBuilder.cppにコピー用パイプラインを構築する関数を追加しました。 プロジェクトファイルにDepthOutlineEffect関連のファイルを追加し、他のエフェクト関連のファイルを削除しました。 
DepthOutlineEffect.PS.hlslでエッジの色を設定する変数を追加し、ピクセルシェーダーの処理を変更しました。