### PR TITLE
コンピュートシェーダー関連の機能を追加

### DIFF
--- a/Project/EngineLayer/Managers/AnimationManager/AnimationPipelineBuilder.cpp
+++ b/Project/EngineLayer/Managers/AnimationManager/AnimationPipelineBuilder.cpp
@@ -29,6 +29,12 @@ void AnimationPipelineBuilder::Initialize(DirectXCommon* dxCommon)
 	// パイプラインを生成
 	CreatePSO();
 
+	// ルートシグネチャの生成（コンピュート用）
+	CreateComputeRootSignature();
+
+	// パイプラインの生成（コンピュート用）
+	CreateComputePSO();
+
 	LightManager::GetInstance()->Initialize(dxCommon_); // ライトマネージャの初期化
 }
 
@@ -227,4 +233,120 @@ void AnimationPipelineBuilder::CreatePSO()
 	// パイプラインステートオブジェクトの生成
 	hr = dxCommon_->GetDevice()->CreateGraphicsPipelineState(&graphicsPipelineStateDesc, IID_PPV_ARGS(&graphicsPipelineState));
 	assert(SUCCEEDED(hr));
+}
+
+void AnimationPipelineBuilder::CreateComputeRootSignature()
+{
+	// デスクリプタレンジ設定
+	// t0
+	D3D12_DESCRIPTOR_RANGE srvRange0{};
+	srvRange0.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
+	srvRange0.NumDescriptors = 1; // 1つのSRV
+	srvRange0.BaseShaderRegister = 0; // t0
+	srvRange0.RegisterSpace = 0; // スペース0
+	srvRange0.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
+
+	// t1
+	D3D12_DESCRIPTOR_RANGE srvRange1{};
+	srvRange1.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
+	srvRange1.NumDescriptors = 1; // 1つのSRV
+	srvRange1.BaseShaderRegister = 1; // t1
+	srvRange1.RegisterSpace = 0; // スペース0
+	srvRange1.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
+
+	// t2
+	D3D12_DESCRIPTOR_RANGE srvRange2{};
+	srvRange2.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
+	srvRange2.NumDescriptors = 1; // 1つのSRV
+	srvRange2.BaseShaderRegister = 2; // t2
+	srvRange2.RegisterSpace = 0; // スペース0
+	srvRange2.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
+
+	// u0
+	D3D12_DESCRIPTOR_RANGE uavRange{};
+	uavRange.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_UAV;
+	uavRange.NumDescriptors = 1; // 1つのUAV
+	uavRange.BaseShaderRegister = 0; // u0
+	uavRange.RegisterSpace = 0; // スペース0
+	uavRange.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
+
+	// ルートパラメータ設定
+	std::vector<D3D12_ROOT_PARAMETER> rootParams(6);
+
+	// SRV (t0) マトリックスパレット
+	rootParams[0].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+	rootParams[0].DescriptorTable.NumDescriptorRanges = 1; // t0
+	rootParams[0].DescriptorTable.pDescriptorRanges = &srvRange0;
+	rootParams[0].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
+
+	// SRV （t1）頂点入力
+	rootParams[1].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+	rootParams[1].DescriptorTable.NumDescriptorRanges = 1; // t1
+	rootParams[1].DescriptorTable.pDescriptorRanges = &srvRange1;
+	rootParams[1].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
+
+	// SRV（t2）インフルエンス
+	rootParams[2].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+	rootParams[2].DescriptorTable.NumDescriptorRanges = 1; // t2
+	rootParams[2].DescriptorTable.pDescriptorRanges = &srvRange2;
+	rootParams[2].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
+
+	// UAV (u0) 頂点出力
+	rootParams[3].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+	rootParams[3].DescriptorTable.NumDescriptorRanges = 1; // u0
+	rootParams[3].DescriptorTable.pDescriptorRanges = &uavRange;
+	rootParams[3].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
+
+	// 定数バッファ (b0)
+	rootParams[4].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
+	rootParams[4].Descriptor.ShaderRegister = 0; // b0
+	rootParams[4].Descriptor.RegisterSpace = 0; // スペース0
+	rootParams[4].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
+
+	// 定数バッファ（b1）
+	rootParams[5].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
+	rootParams[5].Descriptor.ShaderRegister = 1; // b1
+	rootParams[5].Descriptor.RegisterSpace = 0; // スペース0
+	rootParams[5].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
+
+	// サンプラー（s0）
+	D3D12_STATIC_SAMPLER_DESC samplerDesc[1]{};
+	samplerDesc[0].Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+	samplerDesc[0].AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+	samplerDesc[0].AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+	samplerDesc[0].AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+	samplerDesc[0].ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
+	samplerDesc[0].MaxLOD = D3D12_FLOAT32_MAX;
+	samplerDesc[0].ShaderRegister = 0; // s0
+	samplerDesc[0].RegisterSpace = 0;
+	samplerDesc[0].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
+
+	// ルートシグネチャの設定
+	D3D12_ROOT_SIGNATURE_DESC rootSigDesc{};
+	rootSigDesc.NumParameters = static_cast<UINT>(rootParams.size());
+	rootSigDesc.pParameters = rootParams.data();
+	rootSigDesc.NumStaticSamplers = 1; // サンプラーは1つ
+	rootSigDesc.pStaticSamplers = samplerDesc;
+	rootSigDesc.Flags = D3D12_ROOT_SIGNATURE_FLAG_NONE; // コンピュートシェーダーでは特にフラグは不要
+
+	ComPtr<ID3DBlob> sigBlob, errorBlog;
+	HRESULT hr = D3D12SerializeRootSignature(&rootSigDesc, D3D_ROOT_SIGNATURE_VERSION_1, &sigBlob, &errorBlog);
+	assert(SUCCEEDED(hr) && "RootSignature Serialize Failed");
+
+	// ルートシグネチャの生成
+	hr = dxCommon_->GetDevice()->CreateRootSignature(0, sigBlob->GetBufferPointer(), sigBlob->GetBufferSize(), IID_PPV_ARGS(&computeRootSignature_));
+	assert(SUCCEEDED(hr) && "CreateRootSignature Failed");
+}
+
+void AnimationPipelineBuilder::CreateComputePSO()
+{
+	ComPtr<IDxcBlob> computeShader = ShaderCompiler::CompileShader(L"Resources/Shaders/Skinning/SkinningObject3d.CS.hlsl", L"cs_6_0", dxCommon_->GetDXCCompilerManager());
+	assert(computeShader != nullptr);
+
+	D3D12_COMPUTE_PIPELINE_STATE_DESC desc{};
+	desc.pRootSignature = computeRootSignature_.Get();
+	desc.CS = { computeShader->GetBufferPointer(), computeShader->GetBufferSize() };
+
+	HRESULT hr = dxCommon_->GetDevice()->CreateComputePipelineState(&desc, IID_PPV_ARGS(&computePipelineState_));
+	assert(SUCCEEDED(hr) && "CreateComputePipelineState Failed");
 }

--- a/Project/EngineLayer/Managers/AnimationManager/AnimationPipelineBuilder.h
+++ b/Project/EngineLayer/Managers/AnimationManager/AnimationPipelineBuilder.h
@@ -48,13 +48,24 @@ private: /// ---------- メンバ関数 ---------- ///
 	// パイプラインの生成
 	void CreatePSO();
 
+	// ルートシグネチャの生成（コンピュート用）
+	void CreateComputeRootSignature();
+
+	// パイプラインの生成（コンピュート用）
+	void CreateComputePSO();
+
 private: /// ---------- メンバ変数 ---------- ///
 
 	DirectXCommon* dxCommon_ = nullptr;
 
 	// ルートシグネチャとパイプラインステート
-	ComPtr <ID3D12RootSignature> rootSignature;
-	ComPtr <ID3D12PipelineState> graphicsPipelineState;
+	ComPtr<ID3D12RootSignature> rootSignature;
+	ComPtr<ID3D12PipelineState> graphicsPipelineState;
+
+	// コンピュート用ルートシグネチャとパイプライン
+	ComPtr <ID3D12RootSignature> computeRootSignature_;
+	ComPtr<ID3D12PipelineState> computePipelineState_;
+
 	D3D12_INPUT_LAYOUT_DESC inputLayoutDesc{};
 
 	// ブレンドモード

--- a/Project/EngineLayer/Managers/AnimationManager/SkinCluster.cpp
+++ b/Project/EngineLayer/Managers/AnimationManager/SkinCluster.cpp
@@ -25,6 +25,7 @@ void SkinCluster::Initialize(const ModelData& modelData, Skeleton& skeleton)
 	paletteResource_->Map(0, nullptr, reinterpret_cast<void**>(&mappedPalette));
 	mappedPalette_ = { mappedPalette, joints.size() }; // spanを使ってアクセスするようにする
 
+	// SRVのインデックスを確保
 	paletteSrvIndex_ = SRVManager::GetInstance()->Allocate();
 	paletteSrvHandle_.first = SRVManager::GetInstance()->GetCPUDescriptorHandle(paletteSrvIndex_);
 	paletteSrvHandle_.second = SRVManager::GetInstance()->GetGPUDescriptorHandle(paletteSrvIndex_);

--- a/Project/EngineLayer/Managers/AnimationManager/SkinCluster.h
+++ b/Project/EngineLayer/Managers/AnimationManager/SkinCluster.h
@@ -36,9 +36,9 @@ private: /// ---------- メンバ変数 ---------- ///
 	std::span<VertexInfluence> mappedInfluenceData_; // マッピングしたデータ
 
 	// palette（ジョイント行列の配列）
-	ComPtr<ID3D12Resource> paletteResource_;
-	std::span<WellForGPU> mappedPalette_;
-	uint32_t paletteSrvIndex_ = UINT32_MAX;
-	std::pair<D3D12_CPU_DESCRIPTOR_HANDLE, D3D12_GPU_DESCRIPTOR_HANDLE> paletteSrvHandle_;
+	ComPtr<ID3D12Resource> paletteResource_; // パレットリソース
+	std::span<WellForGPU> mappedPalette_; // マッピングしたデータ
+	uint32_t paletteSrvIndex_ = UINT32_MAX; // SRVのインデックス
+	std::pair<D3D12_CPU_DESCRIPTOR_HANDLE, D3D12_GPU_DESCRIPTOR_HANDLE> paletteSrvHandle_; // SRVのハンドル
 };
 

--- a/Project/EngineLayer/PostEffectManagement/PostEffectPipelineBuilder.cpp
+++ b/Project/EngineLayer/PostEffectManagement/PostEffectPipelineBuilder.cpp
@@ -177,7 +177,7 @@ ComPtr<ID3D12RootSignature> PostEffectPipelineBuilder::CreateComputeRootSignatur
 	D3D12_DESCRIPTOR_RANGE srvRange1{};
 	srvRange1.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
 	srvRange1.NumDescriptors = 1; // 1つのSRV
-	srvRange1.BaseShaderRegister = 1; // t2
+	srvRange1.BaseShaderRegister = 1; // t1
 	srvRange1.RegisterSpace = 0; // スペース0
 	srvRange1.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
 

--- a/Project/Resources/Shaders/Skinning/SkinningObject3d.CS.hlsl
+++ b/Project/Resources/Shaders/Skinning/SkinningObject3d.CS.hlsl
@@ -1,3 +1,51 @@
+// スキニングのコンピュートシェーダ
+
+// 頂点情報
+struct Vertex
+{
+    float4 position; // 座標
+    float2 texcoord; // テクスチャ座標
+    float3 normal; // 法線
+};
+
+// インフルエンス
+struct VertexInfulence
+{
+    float4 weight; // ウェイト
+    int4 index; // インデックス
+};
+
+// MatrixPaletteを追加
+struct Well
+{
+    float4x4 skeletonSpaceMatrix;
+    float4x4 skeletonSpaceInverseTransposeMatrix;
+};
+
+// 変換行列
+struct TransformationAnimationMatrix
+{
+    float4x4 WVP; // ワールド・ビュー・プロジェクション行列
+    float4x4 World; // ワールド行列
+    float4x4 WorldInverseTranspose; // 法線変換用（法線行列）
+};
+
+// 設定
+struct SkinningSettings
+{
+    uint numVertices; // 頂点数
+    int isSkinning; // スキニングの有効するかどうか
+};
+
+RWStructuredBuffer<Vertex> gOutputVertices : register(u0); // 頂点出力
+
+StructuredBuffer<Well> gMatrixPalette : register(t0); // マトリックスパレット
+StructuredBuffer<Vertex> gInputVertices : register(t1); // 頂点入力
+StructuredBuffer<VertexInfulence> gInfulences : register(t2); // インフルエンス
+
+ConstantBuffer<TransformationAnimationMatrix> gTransformationAnimationMatrix : register(b0); // 変換行列
+ConstantBuffer<SkinningSettings> gSetting : register(b1); // スキニングの設定
+
 [numthreads(1024, 1, 1)]
 void main(uint3 DTid : SV_DispatchThreadID)
 {


### PR DESCRIPTION
`AnimationPipelineBuilder` にコンピュートシェーダー用のルートシグネチャとパイプラインステートオブジェクトを生成するメソッドを追加しました。これに伴い、ヘッダーファイルにも新しいメンバ関数と変数を追加しました。

`SkinCluster` では、SRVのインデックス確保とハンドル取得の処理を実装し、リソース管理を強化しました。また、SRV関連のメンバ変数の整理を行い、可読性を向上させました。

`PostEffectPipelineBuilder` では、SRVのベースシェーダーレジスタ設定を修正しました。

`SkinningObject3d.CS.hlsl` には、スキニングに関連する新しい構造体を追加し、コンピュートシェーダーでのスキニング処理を可能にしました。