### PR TITLE
ボスの死亡演出とディゾルブ処理の追加

### DIFF
--- a/Project/ApplicationLayer/Colliders/Collider.h
+++ b/Project/ApplicationLayer/Colliders/Collider.h
@@ -87,10 +87,15 @@ public: /// ---------- 設定 ---------- ///
 	// シリアルナンバーを取得
 	uint32_t GetUniqueID() const { return serialNumber_; }
 
+	template<class T> void SetOwner(T* ptr) { owner_ = ptr; }
+	template<class T> T* GetOwner() const { return static_cast<T*>(owner_); }
+
 private: /// ---------- メンバ変数 ---------- ///
 
 	// 識別ID
 	uint32_t typeID_ = 0u;
+
+	void* owner_ = nullptr;
 
 private: /// ---------- OBBのメンバ変数 ---------- ///
 

--- a/Project/ApplicationLayer/Enemy/Boss.h
+++ b/Project/ApplicationLayer/Enemy/Boss.h
@@ -97,5 +97,13 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	float meleeDuration_ = 0.0f;
 	const float meleeMaxDuration_ = 1.0f;
+
+	bool isDying_ = false;   // 死亡演出中フラグ
+	float deathTime_ = 0.0f;   // 経過時間
+	const float kDeathDuration_ = 4.0f;   // 演出時間（秒）
+
+	bool isDissolving_ = false;
+	float dissolveTime_ = 0.0f;
+	float dissolveDuration_ = 2.0f; // ディゾルブ完了までの時間
 };
 

--- a/Project/ApplicationLayer/Player/Bullet.cpp
+++ b/Project/ApplicationLayer/Player/Bullet.cpp
@@ -6,6 +6,7 @@
 #include <Crosshair.h>
 #include <ParticleManager.h>
 #include <Enemy.h>
+#include <Boss.h>
 
 
 /// -------------------------------------------------------------
@@ -83,7 +84,10 @@ void Bullet::Draw()
 /// -------------------------------------------------------------
 void Bullet::OnCollision(Collider* other)
 {
-	// 衝突相手がエネミーかどうかを確認
+	// 衝突相手が nullptrの場合は処理をスキップ
+	if (other == nullptr) return;
+
+	// 衝突相手が「敵系」以外なら無視 
 	if (other->GetTypeID() != static_cast<uint32_t>(CollisionTypeIdDef::kEnemy)) return;
 
 	// 衝突相手のユニークIDを取得
@@ -109,6 +113,19 @@ void Bullet::OnCollision(Collider* other)
 			// スコアを加算
 			ScoreManager::GetInstance()->AddScore(50);
 		}
+	}
+	else if (auto boss = other->GetOwner<Boss>())        // ★ 追加
+	{
+		boss->TakeDamage(GetDamage());
+
+		// スコアやヒットマーカーなど Enemy と同じ扱いで OK
+		ScoreManager::GetInstance()->AddScore(100);
+		if (player_)
+			if (auto ch = player_->GetCrosshair()) ch->ShowHitMarker();
+
+		// ボスが死んだらキル加算
+		if (boss->IsDead())
+			ScoreManager::GetInstance()->AddKill();
 	}
 
 	// 🔽 ヒットマーカー通知

--- a/Project/ApplicationLayer/Player/Bullet.h
+++ b/Project/ApplicationLayer/Player/Bullet.h
@@ -54,17 +54,6 @@ public: /// ---------- メンバ関数 ---------- ///
 
 private: /// ---------- メンバ変数 ---------- ///
 
-	void PrewarmBulletAssets()
-	{
-		if (!Bullet::sModel_) {
-			Bullet::sModel_ = std::make_shared<Object3D>();
-			Bullet::sModel_->Initialize("cube.gltf");
-			Bullet::sModel_->SetScale({ 0.001f,0.001f,0.001f });
-		}
-	}
-
-private: /// ---------- メンバ変数 ---------- ///
-
 	Player* player_ = nullptr; // プレイヤーへの参照（必要なら）
 
 	static std::shared_ptr<Object3D> sModel_; // 静的モデル（全弾で共有）
@@ -74,7 +63,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	Vector3 velocity_ = {};               // 速度ベクトル
 	Vector3 previousPosition_ = {};       // 1フレーム前の位置
 	Segment segment_;                     // 線分（セグメント）
-	float damage_ = 10.0f;                // 与ダメージ
+	float damage_ = 100.0f;                // 与ダメージ
 	float maxDistance_ = 1000.0f;         // 最大飛距離
 	float distanceTraveled_ = 0.0f;       // 現在の飛距離
 	bool isDead_ = false;                 // 死亡フラグ

--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
@@ -42,9 +42,6 @@ void GamePlayScene::Initialize()
 	player_ = std::make_unique<Player>();
 	player_->Initialize();
 
-	dummyModel_ = std::make_unique<DummyModel>();
-	dummyModel_->Initialize();
-
 	boss_ = std::make_unique<Boss>();
 	boss_->Initialize();
 	boss_->SetPlayer(player_.get());
@@ -88,6 +85,7 @@ void GamePlayScene::Initialize()
 	terrein_ = std::make_unique<Object3D>();
 	// 地形オブジェクトの初期化
 	terrein_->Initialize("Terrain.gltf");
+	terrein_->SetScale({ 100.0f, 100.0f, 100.0f });
 }
 
 
@@ -104,7 +102,7 @@ void GamePlayScene::Update()
 		Object3DCommon::GetInstance()->SetDebugCamera(!Object3DCommon::GetInstance()->GetDebugCamera());
 		Wireframe::GetInstance()->SetDebugCamera(!Wireframe::GetInstance()->GetDebugCamera());
 		ParticleManager::GetInstance()->SetDebugCamera(!ParticleManager::GetInstance()->GetDebugCamera());
-		//skyBox_->SetDebugCamera(!skyBox_->GetDebugCamera());
+		skyBox_->SetDebugCamera(!skyBox_->GetDebugCamera());
 		player_->SetDebugCamera(!player_->IsDebugCamera());
 		isDebugCamera_ = !isDebugCamera_;
 		Input::GetInstance()->SetLockCursor(isDebugCamera_);
@@ -188,8 +186,6 @@ void GamePlayScene::Update()
 
 		player_->Update();
 		boss_->Update();
-
-		dummyModel_->Update();
 
 		fpsCamera_->Update();
 
@@ -278,8 +274,6 @@ void GamePlayScene::Draw3DObjects()
 
 	boss_->Draw();
 
-	dummyModel_->Draw();
-
 #pragma endregion
 
 
@@ -291,7 +285,7 @@ void GamePlayScene::Draw3DObjects()
 	fpsCamera_->DrawDebugCamera();
 
 	// ワイヤーフレームの描画
-	Wireframe::GetInstance()->DrawGrid(100.0f, 100.0f, { 0.25f, 0.25f, 0.25f,1.0f });
+	//Wireframe::GetInstance()->DrawGrid(100.0f, 100.0f, { 0.25f, 0.25f, 0.25f,1.0f });
 
 #endif // _DEBUG
 }
@@ -349,8 +343,6 @@ void GamePlayScene::DrawImGui()
 
 	boss_->DrawImGui();
 
-	dummyModel_->DrawImGui();
-
 	terrein_->DrawImGui();
 
 	// エネミースポナー
@@ -369,7 +361,6 @@ void GamePlayScene::CheckAllCollisions()
 	// コライダーをリストに登録
 	//enemyManager_->RegisterColliders(collisionManager_.get());
 	player_->RegisterColliders(collisionManager_.get()); // プレイヤーのコライダーを登録
-	dummyModel_->RegisterColliders(collisionManager_.get());
 	boss_->RegisterColliders(collisionManager_.get());
 
 	// プレイヤーの弾の登録
@@ -377,7 +368,6 @@ void GamePlayScene::CheckAllCollisions()
 	{
 		if (!bullet->IsDead()) collisionManager_->AddCollider(bullet.get());
 	}
-
 
 	// プレイヤーが死亡している場合、コライダーを削除
 	if (player_->IsDead()) collisionManager_->RemoveCollider(player_.get());

--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.h
@@ -6,6 +6,7 @@
 #include "ParticleManager.h"
 #include "ParticleEmitter.h"
 #include <BaseScene.h>
+#include <SkyBox.h>
 
 #include "CollisionManager.h"
 
@@ -92,7 +93,7 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	std::unique_ptr<EnemyManager> enemyManager_ = nullptr;
 
-	std::unique_ptr<DummyModel> dummyModel_ = nullptr;
+	//std::unique_ptr<DummyModel> dummyModel_ = nullptr;
 
 	std::unique_ptr<AnimationModel> dModel_;
 
@@ -109,6 +110,8 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	// アニメーションモデル
 	std::unique_ptr<AnimationModel> animationModel_ = nullptr;
+
+	std::unique_ptr<SkyBox> skyBox_ = nullptr; // スカイボックス
 
 	// デバッグカメラのON/OFF用
 	bool isDebugCamera_ = false;

--- a/Project/ApplicationLayer/Weapon/Weapon.cpp
+++ b/Project/ApplicationLayer/Weapon/Weapon.cpp
@@ -49,7 +49,7 @@ void Weapon::Update()
 	// リロード中の処理
 	if (isReloading_)
 	{
-		reloadTimer_ += 1.0f / 60.0f;
+		reloadTimer_ += player_->GetAnimationModel()->GetDeltaTime();
 
 		// リロード完了チェック
 		if (reloadTimer_ >= reloadTime_)
@@ -62,7 +62,7 @@ void Weapon::Update()
 		}
 	}
 
-	fireTimer_ += 1.0f / 60.0f;  // 60FPS前提。可変FPSなら deltaTime を使う
+	fireTimer_ += player_->GetAnimationModel()->GetDeltaTime();  // 60FPS前提。可変FPSなら deltaTime を使う
 
 	// 弾の更新
 	for (auto& bullet : bullets_) bullet->Update();
@@ -191,7 +191,7 @@ void Weapon::FireSingleBullet(const Vector3& pos, const Vector3& dir)
 	bullet->SetVelocity(dir * bulletSpeed_);
 	bullet->SetDamage(ammoInfo_.bulletDamage);  // ← 新しく追加
 
-	// 🔽 命中通知用に Player を渡す
+	// 命中通知用に Player を渡す
 	bullet->SetPlayer(player_);
 
 	bullets_.push_back(std::move(bullet));

--- a/Project/EngineLayer/Managers/AnimationManager/AnimationModel.h
+++ b/Project/EngineLayer/Managers/AnimationManager/AnimationModel.h
@@ -42,6 +42,14 @@ private: /// ---------- 構造体 ---------- ///
 		Vector3 padding; // 16バイトアライメントを保つためのパディング
 	};
 
+	struct DissolveSetting
+	{
+		float threshold; // 閾値
+		float edgeThickness; // エッジの範囲（0.05など）
+		float padding[2];
+		Vector4 edgeColor; // エッジ部分の色
+	};
+
 	struct BodyPartCollider
 	{
 		std::string name;         // 名前（"LeftArm", "RightLeg", ...）
@@ -77,6 +85,10 @@ public: /// ---------- メンバ関数 ---------- ///
 	void DrawSkeletonWireframe();
 
 	void DrawBodyPartColliders();
+
+	// AnimationModel.h に追加
+	void SetDissolveThreshold(float threshold) { dissolveSetting_->threshold = threshold; }
+	float GetDissolveThreshold() const { return dissolveSetting_->threshold; }
 
 public: /// ---------- ゲッタ ---------- ///
 
@@ -121,6 +133,8 @@ public: /// ---------- セッタ ---------- ///
 
 	void SetScaleFactor(float factor) { scaleFactor = factor; }
 
+	void SetIsPlaying(bool isPlaying) { isAnimationPlaying_ = isPlaying; }
+
 private: /// ---------- メンバ関数 ---------- ///
 
 	// アニメーションを更新
@@ -131,6 +145,9 @@ private: /// ---------- メンバ関数 ---------- ///
 
 	// スキニングリソースの作成
 	void CreateSkinningSettingResource();
+
+	// Dissolve設定リソースの作成
+	void CreateDissolveSettingResource();
 
 	// ボーン情報の初期化
 	void InitializeBones();
@@ -203,6 +220,9 @@ private: /// ---------- メンバ変数 ---------- ///
 	ComPtr<ID3D12Resource> skinningSettingResource_; // スキニング設定用のリソース
 	SkinningSetting* skinningSetting_; // スキニング設定
 
+	ComPtr<ID3D12Resource> dissolveSettingResource_; // Dissolve設定用のリソース
+	DissolveSetting* dissolveSetting_ = nullptr; // Dissolve設定
+	uint32_t dissolveMaskSrvIndex_ = 0; // SRV index for mask
 
 	ComPtr <ID3D12Resource> wvpResource;
 	ComPtr <ID3D12Resource> cameraResource;
@@ -214,5 +234,7 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	bool hideHead_ = false; // デフォルトは表示
 	float scaleFactor = 1.0f;
+
+	bool isAnimationPlaying_ = true; // アニメーションが再生中かどうか
 };
 

--- a/Project/EngineLayer/Managers/AnimationManager/AnimationPipelineBuilder.cpp
+++ b/Project/EngineLayer/Managers/AnimationManager/AnimationPipelineBuilder.cpp
@@ -77,11 +77,16 @@ void AnimationPipelineBuilder::CreateRootSignature()
 	descriptionRootSignature.NumStaticSamplers = _countof(staticSamplers); // サンプラの数
 
 	// DescriptorRangeの設定
-	D3D12_DESCRIPTOR_RANGE descriptorRange[1] = {};
-	descriptorRange[0].BaseShaderRegister = 0;
+	D3D12_DESCRIPTOR_RANGE descriptorRange[2] = {};
+	descriptorRange[0].BaseShaderRegister = 0; // register(t0) に対応
 	descriptorRange[0].NumDescriptors = 1;
 	descriptorRange[0].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
 	descriptorRange[0].OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
+
+	descriptorRange[1].BaseShaderRegister = 1; // register(t1) に対応
+	descriptorRange[1].NumDescriptors = 1;
+	descriptorRange[1].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
+	descriptorRange[1].OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
 
 	// 追加する SRV の DescriptorRange 設定
 	D3D12_DESCRIPTOR_RANGE srvDescriptorRange{};
@@ -91,7 +96,7 @@ void AnimationPipelineBuilder::CreateRootSignature()
 	srvDescriptorRange.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
 
 	// ルートシグネチャの生成
-	D3D12_ROOT_PARAMETER rootParameters[9] = {};
+	D3D12_ROOT_PARAMETER rootParameters[10] = {};
 
 	// マテリアル用のルートシグパラメータの設定
 	rootParameters[0].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;    // 定数バッファビュー
@@ -103,7 +108,7 @@ void AnimationPipelineBuilder::CreateRootSignature()
 	rootParameters[1].ShaderVisibility = D3D12_SHADER_VISIBILITY_VERTEX; // バーテックスシェーダーで使用
 	rootParameters[1].Descriptor.ShaderRegister = 0;					 // レジスタ番号0
 
-	// テクスチャのディスクリプタテーブル
+	// ピクセルシェーダー用のテクスチャ2つ (t0, t1)
 	rootParameters[2].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;      // ディスクリプタテーブル
 	rootParameters[2].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL; 	           // ピクセルシェーダーで使用
 	rootParameters[2].DescriptorTable.pDescriptorRanges = descriptorRange;             // ディスクリプタテーブルの設定
@@ -139,6 +144,11 @@ void AnimationPipelineBuilder::CreateRootSignature()
 	rootParameters[8].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
 	rootParameters[8].ShaderVisibility = D3D12_SHADER_VISIBILITY_VERTEX;
 	rootParameters[8].Descriptor.ShaderRegister = 1; // b1 に対応
+
+	// Dissolve設定用の定数バッファ（ピクセルシェーダー用）
+	rootParameters[9].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
+	rootParameters[9].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+	rootParameters[9].Descriptor.ShaderRegister = 5; // register(b5)
 
 	// ルートシグネチャの設定
 	descriptionRootSignature.pParameters = rootParameters;


### PR DESCRIPTION
Collider.hにオーナー設定用の関数を追加し、Bossクラスに死亡演出の管理機能を実装しました。
 ボスのHP表示やコライダーの管理も強化され、Bulletクラスにボスへのダメージ処理を追加しました。
GamePlaySceneでのダミーモデルの処理を削除し、ボスの初期化と更新処理を強調しました。 
AnimationModelにディゾルブ設定用のリソースを追加しました。
ピクセルシェーダーにディゾルブ処理も追加しました。