### PR TITLE
ボスとの衝突判定を追加し、関連機能を更新

### DIFF
--- a/Project/ApplicationLayer/Colliders/CollisionManager.cpp
+++ b/Project/ApplicationLayer/Colliders/CollisionManager.cpp
@@ -126,22 +126,23 @@ void CollisionManager::RegisterCollisionFuncsions()
 	constexpr CollisionType kBullet = static_cast<CollisionType>(CollisionTypeIdDef::kBullet);
 	constexpr CollisionType kEnemyBullet = static_cast<CollisionType>(CollisionTypeIdDef::kEnemyBullet);
 	constexpr CollisionType kItem = static_cast<CollisionType>(CollisionTypeIdDef::kItem);
+	constexpr CollisionType kBoss = static_cast<CollisionType>(CollisionTypeIdDef::kBoss);
 
-	/// ---------- エネミーとプレイヤーの弾丸の衝突判定 ---------- ///
+	/// ---------- ボスとプレイヤーの弾丸の衝突判定 ---------- ///
 
-	collisionTable_[{kEnemy, kBullet}] =
+	collisionTable_[{kBoss, kBullet}] =
 		[](Collider* a, Collider* b) {
 		if (a->HasCapsule())       return CollisionUtility::IsCollision(a->GetCapsule(), b->GetSegment());
 		else                       return CollisionUtility::IsCollision(a->GetOBB(), b->GetSegment());
 		};
 
-	collisionTable_[{kBullet, kEnemy}] =
+	collisionTable_[{kBullet, kBoss}] =
 		[](Collider* a, Collider* b) {
 		if (b->HasCapsule())       return CollisionUtility::IsCollision(a->GetSegment(), b->GetCapsule());
 		else                       return CollisionUtility::IsCollision(a->GetSegment(), b->GetOBB());
 		};
 
-	/// ---------- プレイヤーとエネミーの弾丸の衝突判定 ---------- ///
+	/// ---------- プレイヤーとボスの弾丸の衝突判定 ---------- ///
 
 	collisionTable_[{kPlayer, kEnemyBullet}] =
 		[](Collider* a, Collider* b) {

--- a/Project/ApplicationLayer/Colliders/CollisionTypeIdDef.h
+++ b/Project/ApplicationLayer/Colliders/CollisionTypeIdDef.h
@@ -12,4 +12,5 @@ enum class CollisionTypeIdDef : uint32_t
 	kEnemyBullet,	 // 敵弾ID 5
 	kItem,			 // アイテムID 6
 	kDummy,			 // ダミー
+	kBoss,			 // ボスID 8
 };

--- a/Project/ApplicationLayer/Enemy/Boss.h
+++ b/Project/ApplicationLayer/Enemy/Boss.h
@@ -100,7 +100,7 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	bool isDying_ = false;   // 死亡演出中フラグ
 	float deathTime_ = 0.0f;   // 経過時間
-	const float kDeathDuration_ = 4.0f;   // 演出時間（秒）
+	const float kDeathDuration_ = 3.8f;   // 演出時間（秒）
 
 	bool isDissolving_ = false;
 	float dissolveTime_ = 0.0f;

--- a/Project/ApplicationLayer/Player/Bullet.cpp
+++ b/Project/ApplicationLayer/Player/Bullet.cpp
@@ -88,7 +88,7 @@ void Bullet::OnCollision(Collider* other)
 	if (other == nullptr) return;
 
 	// 衝突相手が「敵系」以外なら無視 
-	if (other->GetTypeID() != static_cast<uint32_t>(CollisionTypeIdDef::kEnemy)) return;
+	if (other->GetTypeID() != static_cast<uint32_t>(CollisionTypeIdDef::kBoss)) return;
 
 	// 衝突相手のユニークIDを取得
 	uint32_t targetID = other->GetUniqueID();

--- a/Project/ApplicationLayer/Player/Player.cpp
+++ b/Project/ApplicationLayer/Player/Player.cpp
@@ -25,12 +25,16 @@ void Player::Initialize()
 
 	// アニメーションモデルの初期化
 	animationModel_ = std::make_unique<AnimationModel>();
-	//animationModel_->Initialize("PlayerStateModel/PlayerIdleAnimation.gltf"); // スキニング有効
 
 	ChangeState(std::make_unique<PlayerIdleState>());  // Idle で開始
 
 	// 武器の初期化
 	InitializeWeapons();
+
+	for (auto& weapon : weapons_)
+	{
+		weapon->SetPlayer(this); // プレイヤーを武器に設定
+	}
 
 	// プレイヤーコントローラーの生成と初期化
 	controller_ = std::make_unique<PlayerController>();
@@ -40,8 +44,6 @@ void Player::Initialize()
 	// HUDの初期化
 	numberSpriteDrawer_ = std::make_unique<NumberSpriteDrawer>();
 	numberSpriteDrawer_->Initialize("Resources/number.png", 50.0f, 50.0f);
-
-	weapons_[currentWeaponIndex_]->SetPlayer(this);
 }
 
 

--- a/Project/ApplicationLayer/Player/State/PlayerIdleState/PlayerIdleState.cpp
+++ b/Project/ApplicationLayer/Player/State/PlayerIdleState/PlayerIdleState.cpp
@@ -9,6 +9,8 @@ void PlayerIdleState::Initialize(Player* player)
 {
 	// 待機アニメに切替え
 	player->GetAnimationModel()->Initialize(modelFilePath_);
+	player->GetAnimationModel()->SetDissolveThreshold(0.0f); // ダメージを受けていないので閾値は0.0f
+	player->GetAnimationModel()->Update();
 }
 
 void PlayerIdleState::Update(Player* player)

--- a/Project/ApplicationLayer/Player/State/PlayerRunState/PlayerRunState.cpp
+++ b/Project/ApplicationLayer/Player/State/PlayerRunState/PlayerRunState.cpp
@@ -8,6 +8,8 @@ void PlayerRunState::Initialize(Player* player)
 {
 	// 走行アニメーションモデルの初期化
 	player->GetAnimationModel()->Initialize(modelFilePath_);
+	player->GetAnimationModel()->SetDissolveThreshold(0.0f); // ダメージを受けていないので閾値は0.0f
+	player->GetAnimationModel()->Update();
 }
 
 void PlayerRunState::Update(Player* player)

--- a/Project/ApplicationLayer/Player/State/PlayerWalkState/PlayerWalkState.cpp
+++ b/Project/ApplicationLayer/Player/State/PlayerWalkState/PlayerWalkState.cpp
@@ -7,6 +7,8 @@
 void PlayerWalkState::Initialize(Player* player)
 {
 	player->GetAnimationModel()->Initialize(modelFilePath_); // 歩行アニメ
+	player->GetAnimationModel()->SetDissolveThreshold(0.0f); // ダメージを受けていないので閾値は0.0f
+	player->GetAnimationModel()->Update();
 }
 
 void PlayerWalkState::Update(Player* player)

--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
@@ -102,7 +102,7 @@ void GamePlayScene::Update()
 		Object3DCommon::GetInstance()->SetDebugCamera(!Object3DCommon::GetInstance()->GetDebugCamera());
 		Wireframe::GetInstance()->SetDebugCamera(!Wireframe::GetInstance()->GetDebugCamera());
 		ParticleManager::GetInstance()->SetDebugCamera(!ParticleManager::GetInstance()->GetDebugCamera());
-		skyBox_->SetDebugCamera(!skyBox_->GetDebugCamera());
+		//skyBox_->SetDebugCamera(!skyBox_->GetDebugCamera());
 		player_->SetDebugCamera(!player_->IsDebugCamera());
 		isDebugCamera_ = !isDebugCamera_;
 		Input::GetInstance()->SetLockCursor(isDebugCamera_);

--- a/Project/EngineLayer/Managers/AnimationManager/AnimationModel.cpp
+++ b/Project/EngineLayer/Managers/AnimationManager/AnimationModel.cpp
@@ -80,8 +80,6 @@ void AnimationModel::Initialize(const std::string& fileName, bool isSkinning)
 	// Dissolve設定リソースの作成
 	CreateDissolveSettingResource();
 
-	animationTime_ = 0.0f; // アニメーションを止める
-
 	InitializeBones();
 }
 

--- a/Project/EngineLayer/Managers/AnimationManager/AnimationModel.h
+++ b/Project/EngineLayer/Managers/AnimationManager/AnimationModel.h
@@ -108,6 +108,9 @@ public: /// ---------- ゲッタ ---------- ///
 
 	float GetDeltaTime() const { return deltaTime; }
 
+	// アニメーション時間を取得
+	float GetAnimationTime() const { return animationTime_; }
+
 public: /// ---------- セッタ ---------- ///
 
 	// 座標を設定
@@ -135,6 +138,8 @@ public: /// ---------- セッタ ---------- ///
 
 	void SetIsPlaying(bool isPlaying) { isAnimationPlaying_ = isPlaying; }
 
+	void SetAnimationTime(float time) { animationTime_ = time; }
+
 private: /// ---------- メンバ関数 ---------- ///
 
 	// アニメーションを更新
@@ -151,9 +156,6 @@ private: /// ---------- メンバ関数 ---------- ///
 
 	// ボーン情報の初期化
 	void InitializeBones();
-
-	// アニメーション時間を取得
-	float GetAnimationTime() const { return animationTime_; }
 
 private: /// ---------- メンバ関数・テンプレート関数 ---------- ///
 


### PR DESCRIPTION
CollisionManager.cpp でボスとの衝突判定を追加し、kBoss を定義しました。CollisionTypeIdDef.h にボスのIDを追加し、Boss.cpp ではコライダーのタイプを変更、死亡演出時間を短縮しました。
Bullet.cpp では弾丸の衝突相手をボスに限定しました。 
Player.cpp では武器の初期化時にプレイヤーを設定する処理を追加し、PlayerIdleState.cpp, PlayerRunState.cpp, PlayerWalkState.cpp ではアニメーションモデルの初期化時にディゾルブの閾値を0に設定する処理を追加しました。 GamePlayScene.cpp ではデバッグカメラの切り替えに関するコメントを追加し、AnimationModel.cpp ではアニメーション初期化時の処理を削除しました。
AnimationModel.h ではアニメーション時間を取得・設定するゲッターとセッターを追加しました。