### PR TITLE
レーザービーム演出の追加と関連ファイルの修正

### DIFF
--- a/Project/ApplicationLayer/Enemy/Boss/BossWeapon.cpp
+++ b/Project/ApplicationLayer/Enemy/Boss/BossWeapon.cpp
@@ -1,4 +1,5 @@
 #include "BossWeapon.h"
+#include <ParticleManager.h>
 
 void BossWeapon::Initialize()
 {
@@ -41,6 +42,21 @@ void BossWeapon::TryFire(const Vector3& pos, const Vector3& dir)
 	bullet->SetBoss(boss_);
 
 	bullets_.push_back(std::move(bullet));
+
+	// ✅ レーザービーム演出
+	float beamLength = 60.0f;
+	int segmentCount = 30;
+	Vector4 beamColor = { 0.0f, 1.0f, 1.0f, 0.8f };
+
+	ParticleManager::GetInstance()->EmitLaserBeamFakeStretch(
+		"Laser",
+		pos + dir, // 銃口から少し前に
+		dir,
+		Vector3::Normalize(dir) * bulletSpeed_,
+		beamLength,
+		segmentCount,
+		beamColor
+	);
 }
 
 void BossWeapon::Draw()

--- a/Project/ApplicationLayer/Player/Player.cpp
+++ b/Project/ApplicationLayer/Player/Player.cpp
@@ -279,7 +279,7 @@ void Player::FireWeapon()
 	else
 	{
 		// 通常時は右手（モデル上の銃口）から発射
-		Vector3 localMuzzleOffset = { 2.0f, 1.65f, 5.0f };
+		Vector3 localMuzzleOffset = { 0.0f, 1.65f, 0.0f };
 		Vector3 scale = { 1.0f, 1.0f, 1.0f };
 		Vector3 rotation = { 0.0f,animationModel_->GetRotate().y, 0.0f };
 		Vector3 translation = animationModel_->GetTranslate();

--- a/Project/ApplicationLayer/Weapon/Weapon.h
+++ b/Project/ApplicationLayer/Weapon/Weapon.h
@@ -58,6 +58,8 @@ public: /// ---------- メンバ関数 ---------- ///
 
 	void UpdateBulletsOnly();
 
+	void CreateBullet(const Vector3& position, const Vector3& direction);
+
 public: /// ---------- ゲッタ ---------- ///
 
 	// 弾丸の取得

--- a/Project/EngineLayer/Managers/ParticleManager/ParticleManager.cpp
+++ b/Project/EngineLayer/Managers/ParticleManager/ParticleManager.cpp
@@ -67,6 +67,8 @@ void ParticleManager::Initialize(DirectXCommon* dxCommon, Camera* camera)
 	meshMap_[ParticleEffectType::Explosion].Initialize(); // 同上
 
 	meshMap_[ParticleEffectType::Blood].Initialize();     // 血飛沫用のメッシュ
+
+	meshMap_[ParticleEffectType::LaserBeam].Initialize(); // レーザービーム用のメッシュ
 }
 
 
@@ -261,6 +263,13 @@ void ParticleManager::Update()
 
 	// マテリアル更新
 	material_.Update();
+
+	// --- emitQueue の実行 ---
+	for (const auto& emitFunc : emitQueue)
+	{
+		emitFunc();
+	}
+	emitQueue.clear();
 }
 
 
@@ -346,6 +355,45 @@ void ParticleManager::Emit(const std::string name, const Vector3 position, uint3
 		// パーティクルの生成と追加
 		particleGroup.particles.push_back(ParticleFactory::Create(randomEngin, position, type));
 	}
+}
+
+void ParticleManager::EmitLaser(const std::string& name, const Vector3& position, float length, const Vector3& color)
+{
+	assert(particleGroups.find(name) != particleGroups.end());
+
+	ParticleGroup& group = particleGroups[name];
+	if (group.particles.size() >= kNumMaxInstance) return;
+
+	group.particles.push_back(ParticleFactory::CreateLaserBeam(position, length, color));
+}
+
+void ParticleManager::EmitLaserBeamFakeStretch(const std::string& name, const Vector3& startPos, const Vector3& direction, const Vector3& velocity, float totalLength, int count, const Vector4& color)
+{
+	Vector3 dirNorm = direction;
+	Vector3::Normalize(dirNorm);
+	float step = totalLength / (count * 2.0f); // 実質2倍に密集
+
+	emitQueue.push_back([=, this]() {
+		auto& group = GetGroup(name);
+
+		for (int i = 0; i < count; ++i)
+		{
+			Vector3 pos = startPos + dirNorm * (i * step);
+
+			Particle p;
+			p.transform.translate_ = pos;
+			p.transform.scale_ = { 0.1f, 0.1f, 0.1f };
+			p.startScale = p.transform.scale_;
+			p.endScale = { 0.0f, 0.0f, 0.0f };
+			p.transform.rotate_ = { 0.0f, 0.0f, 0.0f };
+			p.color = color;
+			p.lifeTime = 0.2f;
+			p.velocity = velocity; // 弾と同じ方向に一定速度で移動させる（数値は速度）
+			p.currentTime = 0.0f;
+
+			group.particles.push_back(p);
+		}
+		});
 }
 
 

--- a/Project/EngineLayer/Managers/ParticleManager/ParticleManager.h
+++ b/Project/EngineLayer/Managers/ParticleManager/ParticleManager.h
@@ -5,12 +5,14 @@
 #include <ParticleMaterial.h>
 #include <Particle.h>
 #include <ParticleMesh.h>
-#include "ParticleFactory.h" // 追加
+#include "ParticleFactory.h"
 
 #include <unordered_map>
 #include <list>
 #include <random>
 #include <numbers>
+#include <functional>
+
 #include <AABB.h>
 
 /// ---------- 前方宣言 ----------///
@@ -97,6 +99,10 @@ public: /// ---------- メンバ関数 ---------- ///
 	// パーティクルの発生
 	void Emit(const std::string name, const Vector3 position, uint32_t count, ParticleEffectType type);
 
+	void EmitLaser(const std::string& name, const Vector3& position, float length, const Vector3& color);
+
+	void EmitLaserBeamFakeStretch(const std::string& name, const Vector3& startPos, const Vector3& direction, const Vector3& velocity, float totalLength, int count, const Vector4& color);
+
 	std::unordered_map<std::string, ParticleManager::ParticleGroup> GetParticleGroups() { return particleGroups; }
 
 	// ImGuiの描画
@@ -176,6 +182,8 @@ private: /// ---------- メンバ変数 ---------- ///
 	// ランダムエンジン
 	std::random_device seedGeneral;
 	std::mt19937 randomEngin;
+
+	std::vector<std::function<void()>> emitQueue;
 
 	// 描画数
 	const uint32_t kNumMaxInstance = 1024;

--- a/Project/EngineLayer/ParticleManagement/ParticleEffectType.h
+++ b/Project/EngineLayer/ParticleManagement/ParticleEffectType.h
@@ -16,4 +16,5 @@ enum class ParticleEffectType
 	Charge,       // 新しく追加：収束中にぐるぐる回る
 	Explosion,    // 爆発用
 	Blood,		  // 血飛沫
+	LaserBeam,	  // レーザービーム
 };

--- a/Project/EngineLayer/ParticleManagement/ParticleFactory.cpp
+++ b/Project/EngineLayer/ParticleManagement/ParticleFactory.cpp
@@ -6,7 +6,8 @@ Particle ParticleFactory::Create(std::mt19937& randomEngine, const Vector3& posi
 
 	switch (effectType)
 	{
-	case ParticleEffectType::Default: {
+	case ParticleEffectType::Default:
+	{
 		std::uniform_real_distribution<float> distribution(-1.0f, 1.0f);
 		std::uniform_real_distribution<float> distColor(0.0f, 1.0f);
 		std::uniform_real_distribution<float> distTime(1.0f, 3.0f);
@@ -21,7 +22,8 @@ Particle ParticleFactory::Create(std::mt19937& randomEngine, const Vector3& posi
 		break;
 	}
 
-	case ParticleEffectType::Slash: {
+	case ParticleEffectType::Slash:
+	{
 		std::uniform_real_distribution<float> distScale(0.8f, 3.0f);
 		std::uniform_real_distribution<float> distRotate(-std::numbers::pi_v<float>, std::numbers::pi_v<float>);
 
@@ -35,7 +37,8 @@ Particle ParticleFactory::Create(std::mt19937& randomEngine, const Vector3& posi
 		particle.velocity = { 0.0f, 0.0f, 0.0f };
 		break;
 	}
-	case ParticleEffectType::Ring: {
+	case ParticleEffectType::Ring:
+	{
 		std::uniform_real_distribution<float> distScale(0.5f, 1.0f);
 		std::uniform_real_distribution<float> distTime(0.3f, 0.5f);
 
@@ -53,7 +56,8 @@ Particle ParticleFactory::Create(std::mt19937& randomEngine, const Vector3& posi
 		particle.velocity = { 0.0f, 0.0f, 0.0f }; // 拡大で動きを表現する
 		break;
 	}
-	case ParticleEffectType::Blast: {
+	case ParticleEffectType::Blast:
+	{
 		std::uniform_real_distribution<float> distAngle(-std::numbers::pi_v<float>, std::numbers::pi_v<float>);
 		std::uniform_real_distribution<float> distScale(10.0f, 24.0f);
 		std::uniform_real_distribution<float> distLifetime(0.5f, 1.0f);
@@ -77,7 +81,8 @@ Particle ParticleFactory::Create(std::mt19937& randomEngine, const Vector3& posi
 
 		break;
 	}
-	case ParticleEffectType::Cylinder: {
+	case ParticleEffectType::Cylinder:
+	{
 		std::uniform_real_distribution<float> distColor(0.0f, 1.0f);
 
 		particle.transform.translate_ = position;
@@ -91,7 +96,8 @@ Particle ParticleFactory::Create(std::mt19937& randomEngine, const Vector3& posi
 		particle.endScale = particle.transform.scale_;
 		break;
 	}
-	case ParticleEffectType::Star: {
+	case ParticleEffectType::Star:
+	{
 		std::uniform_real_distribution<float> distColor(0.8f, 1.0f);
 		particle.transform.translate_ = position;
 		particle.transform.scale_ = { 0.5f, 0.5f, 0.5f };
@@ -103,7 +109,8 @@ Particle ParticleFactory::Create(std::mt19937& randomEngine, const Vector3& posi
 		particle.endScale = { 0.0f, 0.0f, 0.0f };
 		break;
 	}
-	case ParticleEffectType::Smoke: {
+	case ParticleEffectType::Smoke:
+	{
 		std::uniform_real_distribution<float> distOffset(-0.3f, 0.3f);
 		std::uniform_real_distribution<float> distScale(3.0f, 6.0f);
 		std::uniform_real_distribution<float> distTime(0.6f, 1.2f);
@@ -131,7 +138,8 @@ Particle ParticleFactory::Create(std::mt19937& randomEngine, const Vector3& posi
 		break;
 	}
 
-	case ParticleEffectType::Flash: {
+	case ParticleEffectType::Flash:
+	{
 		std::uniform_real_distribution<float> distColor(0.6f, 1.0f);
 		// 一瞬だけ光るフラッシュ
 		particle.transform.translate_ = position;
@@ -150,7 +158,8 @@ Particle ParticleFactory::Create(std::mt19937& randomEngine, const Vector3& posi
 		break;
 	}
 
-	case ParticleEffectType::Spark: {
+	case ParticleEffectType::Spark:
+	{
 		std::uniform_real_distribution<float> distDir(-1.0f, 1.0f);
 		std::uniform_real_distribution<float> distSpeed(3.0f, 5.0f);
 
@@ -172,7 +181,8 @@ Particle ParticleFactory::Create(std::mt19937& randomEngine, const Vector3& posi
 		break;
 	}
 
-	case ParticleEffectType::EnergyGather: {
+	case ParticleEffectType::EnergyGather:
+	{
 		std::uniform_real_distribution<float> distPos(-3.0f, 3.0f);
 		std::uniform_real_distribution<float> distTime(0.4f, 0.8f);
 		std::uniform_real_distribution<float> distAlpha(0.5f, 1.0f);
@@ -251,7 +261,8 @@ Particle ParticleFactory::Create(std::mt19937& randomEngine, const Vector3& posi
 	}
 	break;
 
-	case ParticleEffectType::Explosion: {
+	case ParticleEffectType::Explosion:
+	{
 		std::uniform_real_distribution<float> distDir(-1.0f, 1.0f);
 		std::uniform_real_distribution<float> distSpeed(5.0f, 12.0f);
 		std::uniform_real_distribution<float> distScale(1.2f, 2.4f);
@@ -282,7 +293,8 @@ Particle ParticleFactory::Create(std::mt19937& randomEngine, const Vector3& posi
 
 		break;
 	}
-	case ParticleEffectType::Blood: {
+	case ParticleEffectType::Blood:
+	{
 		std::uniform_real_distribution<float> distDir(-1.0f, 1.0f);
 		std::uniform_real_distribution<float> distSpeed(3.0f, 7.0f);
 		std::uniform_real_distribution<float> distLife(0.5f, 1.5f);
@@ -316,8 +328,36 @@ Particle ParticleFactory::Create(std::mt19937& randomEngine, const Vector3& posi
 		};
 		break;
 	}
+	case ParticleEffectType::LaserBeam:
+	{
+		particle.transform.translate_ = position;
+		particle.transform.scale_ = { 0.1f, 0.1f, 10.0f }; // Z方向に長い
+		particle.startScale = particle.transform.scale_;
+		particle.endScale = { 0.0f, 0.0f, 0.0f }; // 徐々に消える
+		particle.transform.rotate_ = { 0.0f, 0.0f, 0.0f }; // 向きは外から設定するならあとで
+		particle.color = { 1.0f, 0.0f, 0.0f, 1.0f }; // 赤いレーザー風
+		particle.lifeTime = 0.1f; // 一瞬だけ表示
+		particle.velocity = { 0.0f, 0.0f, 0.0f };
+		break;
+	}
 	}
 
+	particle.currentTime = 0.0f;
+	return particle;
+}
+
+
+Particle ParticleFactory::CreateLaserBeam(const Vector3& position, float length, const Vector3& color)
+{
+	Particle particle;
+	particle.transform.translate_ = position;
+	particle.transform.scale_ = { 0.1f, 0.1f, length }; // 長さZだけ動的に指定
+	particle.startScale = particle.transform.scale_;
+	particle.endScale = { 0.0f, 0.0f, 0.0f }; // 消える
+	particle.transform.rotate_ = { 0.0f, 0.0f, 0.0f }; // 任意で向きも指定可能
+	particle.color = { color.x, color.y, color.z, 1.0f };
+	particle.lifeTime = 0.1f;
+	particle.velocity = { 0.0f, 0.0f, 0.0f };
 	particle.currentTime = 0.0f;
 	return particle;
 }

--- a/Project/EngineLayer/ParticleManagement/ParticleFactory.h
+++ b/Project/EngineLayer/ParticleManagement/ParticleFactory.h
@@ -13,5 +13,7 @@ public: /// ---------- メンバ関数 ---------- ///
 
 	// パーティクルを生成する関数
 	static Particle Create(std::mt19937& randomEngine, const Vector3& position, ParticleEffectType effectType);
+	
+	static Particle CreateLaserBeam(const Vector3& position, float length, const Vector3& color);
 };
 


### PR DESCRIPTION
BossWeapon.cppでレーザービームの発射処理を追加し、Player.cppで発射位置を調整しました。 Weapon.cppでは弾薬情報の変更とCreateBulletメソッドを新設し、ParticleManagerにレーザービーム用のパーティクル生成メソッドを追加しました。ParticleEffectType.hにレーザービームのエフェクトタイプを追加し、ParticleFactoryにも関連メソッドを実装しました。