### PR TITLE
.gitignore に compile_commands.json を追加

### DIFF
--- a/Project/.gitignore
+++ b/Project/.gitignore
@@ -410,3 +410,7 @@ compile_commands.json
 .vscode/
 build/
 out/
+
+# Assimp の lib ファイルだけは Git に含める
+!External/Assimp/lib/
+!External/Assimp/lib/*.lib


### PR DESCRIPTION
ビルド関連ファイルを Git から除外するために `compile_commands.json` を `.gitignore` に追加しました。また、`External/Assimp/lib` ディレクトリ内のライブラリファイルは Git に含めるための例外を設定しました。