### PR TITLE
コードの最適化と未使用警告の回避

### DIFF
--- a/Project/ApplicationLayer/Character/Player/Player.cpp
+++ b/Project/ApplicationLayer/Character/Player/Player.cpp
@@ -173,7 +173,7 @@ void Player::Update(float deltaTime)
 			float pitch = fpsCamera_->GetPitch();
 			Vector3 forward = {
 				-std::sinf(yaw) * std::cosf(pitch), // x
-				 std::sinf(pitch),                  // y
+				-std::sinf(pitch),                  // y
 				 std::cosf(yaw) * std::cosf(pitch)  // z
 			};
 
@@ -230,6 +230,30 @@ void Player::Draw()
 
 	// 弾道エフェクト描画
 	ballisticEffect_->Draw();
+}
+
+/// -------------------------------------------------------------
+///				　	衝突時に呼ばれる仮想関数
+/// -------------------------------------------------------------
+void Player::OnCollision(Collider* other)
+{
+	//// 他のコライダーのタイプIDを取得
+	//uint32_t otherTypeID = other->GetTypeID();
+	//// 地面との衝突判定（仮実装）
+	//if (otherTypeID == static_cast<uint32_t>(CollisionTypeIdDef::kGround))
+	//{
+	//	// 着地処理
+	//	if (!isGrounded_)
+	//	{
+	//		groundY_ = body_.transform.translate_.y; // 今の高さを床として扱う
+	//		vY_ = 0.0f;							     // 縦速度リセット
+	//		isGrounded_ = true;					     // 接地状態へ
+	//		// 着地音再生（仮実装）
+	//		AudioManager::GetInstance()->PlayWave("Assets/Audio/footstep.wav", 0.5f);
+	//	}
+	//}
+
+	(void)other; // 未使用警告回避
 }
 
 /// -------------------------------------------------------------

--- a/Project/ApplicationLayer/Character/Player/Player.h
+++ b/Project/ApplicationLayer/Character/Player/Player.h
@@ -43,7 +43,7 @@ public: /// ---------- メンバ関数 ---------- ///
 	WorldTransformEx* GetWorldTransform() { return &body_.transform; }
 
 	// 衝突時に呼ばれる仮想関数
-	void OnCollision(Collider* other) override {};
+	void OnCollision(Collider* other) override;
 
 	// 中心座標を取得する純粋仮想関数
 	Vector3 GetCenterPosition() const override;

--- a/Project/ApplicationLayer/Item/Item.cpp
+++ b/Project/ApplicationLayer/Item/Item.cpp
@@ -23,24 +23,31 @@ void Item::Initialize(ItemType type, const Vector3& pos)
 	switch (type_)
 	{
 	case ItemType::HealSmall:
-		modelPath = "cube.gltf"; break;
+		modelPath = "cube.gltf";
+		object3d_->Initialize(modelPath);
 		object3d_->SetColor({ 1.0f,0.0f,0.0f,1.0f }); // 赤色
+		break;
 
 	case ItemType::AmmoSmall:
-		modelPath = "cube.gltf"; break;
+		modelPath = "cube.gltf";
+		object3d_->Initialize(modelPath);
 		object3d_->SetColor({ 0.0f, 0.0f, 1.0f, 1.0f }); // 青色
+		break;
 
 	case ItemType::ScoreBonus:
-		modelPath = "cube.gltf"; break;
+		modelPath = "cube.gltf";
+		object3d_->Initialize(modelPath);
 		object3d_->SetColor({ 1.0f, 1.0f, 0.0f, 1.0f }); // 黄色
+		break;
 
 	case ItemType::PowerUp:
-		modelPath = "cube.gltf"; break;
+		modelPath = "cube.gltf";
+		object3d_->Initialize(modelPath);
 		object3d_->SetColor({ 1.0f, 0.5f, 0.0f, 1.0f }); // オレンジ色
+		break;
 
 	}
 
-	object3d_->Initialize(modelPath);
 	object3d_->SetTranslate(position_);
 	object3d_->SetScale(scale_); // サイズを設定
 
@@ -119,6 +126,8 @@ bool Item::CheckCollisionWithPlayer(const Vector3& playerPos)
 void Item::ApplyTo(Player* player)
 {
 	if (collected_) return;
+
+	(void)player;
 
 	//switch (type_)
 	//{

--- a/Project/ApplicationLayer/Item/Item.h
+++ b/Project/ApplicationLayer/Item/Item.h
@@ -53,7 +53,7 @@ public: /// ---------- オーバーライド ---------- ///
 private: /// ---------- メンバ変数 ---------- ///
 
 	// アイテムの種類
-	ItemType type_;
+	ItemType type_ = {};
 
 	// スプライト
 	std::unique_ptr<Object3D> object3d_;

--- a/Project/ApplicationLayer/Item/ItemManager.cpp
+++ b/Project/ApplicationLayer/Item/ItemManager.cpp
@@ -16,6 +16,8 @@ void ItemManager::Initialize()
 /// -------------------------------------------------------------
 void ItemManager::Update(Player* player)
 {
+	(void)player;
+
 	// アイテムの更新とプレイヤーとの衝突判定
 	for (auto& item : items_) item->Update();
 

--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
@@ -52,8 +52,8 @@ void GamePlayScene::Initialize()
 	DebugCamera::GetInstance()->Initialize();
 #endif // _DEBUG
 
-	StartIntroCutscene();
-	gameState_ = GameState::CutScene;   // 最初は必ずCutSceneへ
+	//StartIntroCutscene();
+	//gameState_ = GameState::CutScene;   // 最初は必ずCutSceneへ
 	Input::GetInstance()->SetLockCursor(true);
 	ShowCursor(false);
 
@@ -128,28 +128,28 @@ void GamePlayScene::Update()
 		}
 	}
 
-	// カットシーン中の処理
-	if (gameState_ == GameState::CutScene)
-	{
-		// カットシーン更新のみ
-		bool finished = UpdateIntroCutscene(dt);
+	//// カットシーン中の処理
+	//if (gameState_ == GameState::CutScene)
+	//{
+	//	// カットシーン更新のみ
+	//	bool finished = UpdateIntroCutscene(dt);
 
-		// 画的に必要な更新だけ許可
-		skyBox_->Update();
-		stage_->Update();
-		fadeController_->Update(dt);
-		scarecrow_->Update();
-		itemManager_->Update(player_.get());
+	//	// 画的に必要な更新だけ許可
+	//	skyBox_->Update();
+	//	stage_->Update();
+	//	fadeController_->Update(dt);
+	//	scarecrow_->Update();
+	//	itemManager_->Update(player_.get());
 
-		if (finished)
-		{
-			gameState_ = GameState::Playing;
-			introDone_ = true;
-			/*Input::GetInstance()->SetLockCursor(true);
-			ShowCursor(false);*/
-		}
-		return; // ここで早期リターン → 以降のプレイ処理を止める
-	}
+	//	if (finished)
+	//	{
+	//		gameState_ = GameState::Playing;
+	//		introDone_ = true;
+	//		/*Input::GetInstance()->SetLockCursor(true);
+	//		ShowCursor(false);*/
+	//	}
+	//	return; // ここで早期リターン → 以降のプレイ処理を止める
+	//}
 
 	switch (gameState_)
 	{

--- a/Project/ApplicationLayer/WeaponSystem/BaseWeapon/BaseWeapon.h
+++ b/Project/ApplicationLayer/WeaponSystem/BaseWeapon/BaseWeapon.h
@@ -24,16 +24,13 @@ public: /// ---------- メンバ関数 ---------- ///
 	// 描画処理
 	virtual void Draw() = 0;
 
-	// 単射
-	virtual void Fire(const Vector3& muzzlePosition, const Vector3& forward) = 0;
-
 	// リロード
 	virtual void Reload() = 0;
 
 public: /// ---------- 仮想関数 ---------- ///
 
 	// 衝突時に呼ばれる仮想関数
-	virtual void OnCollision(Collider* other) override {};
+	virtual void OnCollision(Collider* other) override;
 
 	// 中心座標を取得する純粋仮想関数
 	virtual Vector3 GetCenterPosition() const override = 0;

--- a/Project/ApplicationLayer/WeaponSystem/PistolWeapon/PistolWeapon.cpp
+++ b/Project/ApplicationLayer/WeaponSystem/PistolWeapon/PistolWeapon.cpp
@@ -71,31 +71,18 @@ void PistolWeapon::DrawImGui()
 }
 
 /// -------------------------------------------------------------
-///				　			　 単射
-/// -------------------------------------------------------------
-void PistolWeapon::Fire(const Vector3& muzzlePosition, const Vector3&)
-{
-	// 見た目補正(+90°)を発射ロジックからは引く
-	constexpr float kHalfPi = std::numbers::pi_v<float> *0.5f;
-	float yaw = transform_.rotate_.y;
-	float pitch = transform_.rotate_.x - kHalfPi;
-
-	Vector3 forward{
-		std::sin(yaw) * std::cos(pitch),
-		-std::sin(pitch),
-		std::cos(yaw) * std::cos(pitch)
-	};
-	forward = Vector3::Normalize(forward);
-
-	const Vector3 muzzlePos = transform_.translate_;              // 銃口の基準（必要なら微調整）
-	const Vector3 velocity = forward * weaponConfig_.muzzleSpeed; // 武器設定の初速
-}
-
-/// -------------------------------------------------------------
 ///				　			　 リロード
 /// -------------------------------------------------------------
 void PistolWeapon::Reload()
 {
+}
+
+/// -------------------------------------------------------------
+///				　			　 衝突時処理
+/// -------------------------------------------------------------
+void BaseWeapon::OnCollision(Collider* other)
+{
+	(void)other; // 他のオブジェクトと衝突したときの処理をここに実装
 }
 
 /// -------------------------------------------------------------

--- a/Project/ApplicationLayer/WeaponSystem/PistolWeapon/PistolWeapon.h
+++ b/Project/ApplicationLayer/WeaponSystem/PistolWeapon/PistolWeapon.h
@@ -25,9 +25,6 @@ public: /// ---------- メンバ関数 ---------- ///
 	// ImGui描画処理
 	void DrawImGui();
 
-	// 単射
-	void Fire(const Vector3& muzzlePosition, const Vector3& forward) override;
-
 	// リロード
 	void Reload() override;
 

--- a/Project/EngineLayer/3D/SkyBox/SkyBox.h
+++ b/Project/EngineLayer/3D/SkyBox/SkyBox.h
@@ -87,7 +87,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	WorldTransform worldTransform_;
 
 	// テクスチャ番号
-	D3D12_GPU_DESCRIPTOR_HANDLE gpuHandle_;
+	D3D12_GPU_DESCRIPTOR_HANDLE gpuHandle_ = {};
 
 	//スプライト用のマテリアルソースを作る
 	ComPtr <ID3D12Resource> materialResource;

--- a/Project/EngineLayer/Base/DirectXCommon/DirectXCommon.cpp
+++ b/Project/EngineLayer/Base/DirectXCommon/DirectXCommon.cpp
@@ -106,8 +106,6 @@ void DirectXCommon::BeginDraw()
 /// -------------------------------------------------------------
 void DirectXCommon::EndDraw()
 {
-	HRESULT hr{};
-
 	// **バックバッファの取得**
 	backBufferIndex = swapChain_->GetSwapChain()->GetCurrentBackBufferIndex();
 	ComPtr<ID3D12Resource> backBuffer = GetBackBuffer(backBufferIndex);

--- a/Project/EngineLayer/PostEffectManagement/AbsorbEffect/AbsorbEffect.cpp
+++ b/Project/EngineLayer/PostEffectManagement/AbsorbEffect/AbsorbEffect.cpp
@@ -58,6 +58,9 @@ void AbsorbEffect::Update()
 /// -------------------------------------------------------------
 void AbsorbEffect::Apply(ID3D12GraphicsCommandList* commandList, uint32_t srvIndex, uint32_t uavIndex, uint32_t dsvIndex)
 {
+	(void)uavIndex; // 未使用
+	(void)dsvIndex; // 未使用
+
 	commandList->SetGraphicsRootSignature(rootSignature_.Get());
 	commandList->SetPipelineState(graphicsPipelineState_.Get());
 

--- a/Project/EngineLayer/PostEffectManagement/AbsorbEffect/AbsorbEffect.h
+++ b/Project/EngineLayer/PostEffectManagement/AbsorbEffect/AbsorbEffect.h
@@ -37,7 +37,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	DirectXCommon* dxCommon_ = nullptr;
 
 	// パイプラインビルダー
-	PostEffectPipelineBuilder* pipelineBuilder_;
+	PostEffectPipelineBuilder* pipelineBuilder_ = nullptr;
 
 	// グラフィックスパイプラインステートオブジェクト
 	Microsoft::WRL::ComPtr<ID3D12PipelineState> graphicsPipelineState_;

--- a/Project/EngineLayer/PostEffectManagement/DepthOutlineEffect/DepthOutlineEffect.cpp
+++ b/Project/EngineLayer/PostEffectManagement/DepthOutlineEffect/DepthOutlineEffect.cpp
@@ -11,10 +11,16 @@
 #include <cassert>
 #include <imgui.h>
 
+/// -------------------------------------------------------------
+///				　		　コンストラクタ
+/// -------------------------------------------------------------
 DepthOutlineEffect::DepthOutlineEffect(Camera* camera) : camera_(camera)
 {
 }
 
+/// -------------------------------------------------------------
+///							初期化処理
+/// -------------------------------------------------------------
 void DepthOutlineEffect::Initialize(DirectXCommon* dxCommon, PostEffectPipelineBuilder* builder)
 {
 	dxCommon_ = dxCommon;
@@ -45,8 +51,13 @@ void DepthOutlineEffect::Initialize(DirectXCommon* dxCommon, PostEffectPipelineB
 	depthOutlineSetting_->projectionInverse = Matrix4x4::Inverse(proj);
 }
 
+/// -------------------------------------------------------------
+///							適用処理
+/// -------------------------------------------------------------
 void DepthOutlineEffect::Apply(ID3D12GraphicsCommandList* commandList, uint32_t srvIndex, uint32_t uavIndex, uint32_t dsvIndex)
 {
+	(void)uavIndex; // 未使用
+
 	depthOutlineSetting_->projectionInverse = Matrix4x4::Inverse(camera_->GetProjectionMatrix());
 
 	commandList->SetGraphicsRootSignature(rootSignature_.Get());
@@ -60,6 +71,9 @@ void DepthOutlineEffect::Apply(ID3D12GraphicsCommandList* commandList, uint32_t 
 	commandList->DrawInstanced(3, 1, 0, 0);
 }
 
+/// -------------------------------------------------------------
+///						ImGui描画処理
+/// -------------------------------------------------------------
 void DepthOutlineEffect::DrawImGui()
 {
 	ImGui::SliderFloat("Depth Scale", &depthOutlineSetting_->depthScale, 0.0f, 100.0f);

--- a/Project/EngineLayer/PostEffectManagement/DepthOutlineEffect/DepthOutlineEffect.h
+++ b/Project/EngineLayer/PostEffectManagement/DepthOutlineEffect/DepthOutlineEffect.h
@@ -7,18 +7,21 @@
 /// ---------- 前方宣言 ---------- ///
 class Camera;
 
-
+/// -------------------------------------------------------------
+///				　  DepthOutlineEffectクラス
+/// -------------------------------------------------------------
 class DepthOutlineEffect : public IPostEffect
 {
-private:
+private: /// ---------- 構造体 ---------- ///
 
+	// 深度アウトライン設定構造体
 	struct DepthOutlineSetting
 	{
-		Vector2 texelSize; // 1 / 解像度
-		float depthScale; // 深度差
-		float edgeThickness; // ピクセル単位の太さ
-		Vector4 edgeColor; // アウトラインの色
-		Matrix4x4 projectionInverse; // +64 = 96
+		Vector2 texelSize;			 // 1 / 解像度
+		float depthScale;			 // 深度差
+		float edgeThickness;		 // ピクセル単位の太さ
+		Vector4 edgeColor;			 // アウトラインの色
+		Matrix4x4 projectionInverse; // 逆射影行列
 	};
 
 public: /// ---------- メンバ関数 ---------- ///
@@ -43,7 +46,7 @@ private: /// ---------- 構造体 ---------- ///
 	DirectXCommon* dxCommon_ = nullptr;
 
 	// パイプラインビルダー
-	PostEffectPipelineBuilder* pipelineBuilder_;
+	PostEffectPipelineBuilder* pipelineBuilder_ = nullptr;
 
 	// グラフィックスパイプラインステートオブジェクト
 	Microsoft::WRL::ComPtr<ID3D12PipelineState> graphicsPipelineState_;

--- a/Project/EngineLayer/PostEffectManagement/GaussianFilterEffect/GaussianFilterEffect.cpp
+++ b/Project/EngineLayer/PostEffectManagement/GaussianFilterEffect/GaussianFilterEffect.cpp
@@ -45,6 +45,8 @@ void GaussianFilterEffect::Initialize(DirectXCommon* dxCommon, PostEffectPipelin
 /// -------------------------------------------------------------
 void GaussianFilterEffect::Apply(ID3D12GraphicsCommandList* commandList, uint32_t srvIndex, uint32_t uavIndex, uint32_t dsvIndex)
 {
+	(void)dsvIndex; // 未使用
+
 	// ① コンピュート用のルートシグネチャとPSOを設定
 	commandList->SetComputeRootSignature(computeRootSignature_.Get());
 	commandList->SetPipelineState(computePipelineState_.Get());

--- a/Project/EngineLayer/PostEffectManagement/GaussianFilterEffect/GaussianFilterEffect.h
+++ b/Project/EngineLayer/PostEffectManagement/GaussianFilterEffect/GaussianFilterEffect.h
@@ -12,12 +12,12 @@ private: /// ---------- 構造体 ---------- ///
 	// ガウシアンフィルタの設定
 	struct GaussianFilterSetting
 	{
-		int kernelType; // カーネルサイズ
-		float intensity; // 強度
-		float threshold; // 閾値
-		float sigma; // ガウス関数の標準偏差
+		int kernelType;    // カーネルサイズ
+		float intensity;   // 強度
+		float threshold;   // 閾値
+		float sigma;	   // ガウス関数の標準偏差
 		bool isHorizontal; // 水平方向か垂直方向か
-		float padding[3]; // アライメント調整
+		float padding[3];  // アライメント調整
 	};
 
 public: /// ---------- メンバ関数 ---------- ///
@@ -37,7 +37,7 @@ private: /// ---------- 構造体 ---------- ///
 	DirectXCommon* dxCommon_ = nullptr;
 
 	// パイプラインビルダー
-	PostEffectPipelineBuilder* pipelineBuilder_;
+	PostEffectPipelineBuilder* pipelineBuilder_ = nullptr;
 
 	// コンピュートパイプラインステートオブジェクト
 	Microsoft::WRL::ComPtr<ID3D12PipelineState> computePipelineState_;

--- a/Project/EngineLayer/PostEffectManagement/GrayScaleEffect/GrayScaleEffect.cpp
+++ b/Project/EngineLayer/PostEffectManagement/GrayScaleEffect/GrayScaleEffect.cpp
@@ -41,6 +41,8 @@ void GrayScaleEffect::Initialize(DirectXCommon* dxCommon, PostEffectPipelineBuil
 /// -------------------------------------------------------------
 void GrayScaleEffect::Apply(ID3D12GraphicsCommandList* commandList, uint32_t srvIndex, uint32_t uavIndex, uint32_t dsvIndex)
 {
+	(void)dsvIndex; // 未使用
+
 	// ① コンピュート用のルートシグネチャとPSOを設定
 	commandList->SetComputeRootSignature(computeRootSignature_.Get());
 	commandList->SetPipelineState(computePipelineState_.Get());

--- a/Project/EngineLayer/PostEffectManagement/GrayScaleEffect/GrayScaleEffect.h
+++ b/Project/EngineLayer/PostEffectManagement/GrayScaleEffect/GrayScaleEffect.h
@@ -43,7 +43,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	DirectXCommon* dxCommon_ = nullptr;
 
 	// パイプラインビルダー
-	PostEffectPipelineBuilder* pipelineBuilder_;
+	PostEffectPipelineBuilder* pipelineBuilder_ = nullptr;
 
 	// コンピュートパイプラインステートオブジェクト
 	Microsoft::WRL::ComPtr<ID3D12PipelineState> computePipelineState_;

--- a/Project/EngineLayer/PostEffectManagement/LuminanceOutlineEffect/LuminanceOutlineEffect.cpp
+++ b/Project/EngineLayer/PostEffectManagement/LuminanceOutlineEffect/LuminanceOutlineEffect.cpp
@@ -44,6 +44,8 @@ void LuminanceOutlineEffect::Initialize(DirectXCommon* dxCommon, PostEffectPipel
 /// -------------------------------------------------------------
 void LuminanceOutlineEffect::Apply(ID3D12GraphicsCommandList* commandList, uint32_t srvIndex, uint32_t uavIndex, uint32_t dsvIndex)
 {
+	(void)dsvIndex; // 未使用
+
 	// ① コンピュート用のルートシグネチャとPSOを設定
 	commandList->SetComputeRootSignature(computeRootSignature_.Get());
 	commandList->SetPipelineState(computePipelineState_.Get());

--- a/Project/EngineLayer/PostEffectManagement/LuminanceOutlineEffect/LuminanceOutlineEffect.h
+++ b/Project/EngineLayer/PostEffectManagement/LuminanceOutlineEffect/LuminanceOutlineEffect.h
@@ -37,7 +37,7 @@ private: /// ---------- 構造体 ---------- ///
 	DirectXCommon* dxCommon_ = nullptr;
 
 	// パイプラインビルダー
-	PostEffectPipelineBuilder* pipelineBuilder_;
+	PostEffectPipelineBuilder* pipelineBuilder_ = nullptr;
 
 	// コンピュートパイプラインステートオブジェクト
 	Microsoft::WRL::ComPtr<ID3D12PipelineState> computePipelineState_;

--- a/Project/EngineLayer/PostEffectManagement/NormalEffect/NormalEffect.cpp
+++ b/Project/EngineLayer/PostEffectManagement/NormalEffect/NormalEffect.cpp
@@ -31,6 +31,9 @@ void NormalEffect::Initialize(DirectXCommon* dxCommon, PostEffectPipelineBuilder
 /// -------------------------------------------------------------
 void NormalEffect::Apply(ID3D12GraphicsCommandList* commandList, uint32_t srvIndex, uint32_t uavIndex, uint32_t dsvIndex)
 {
+	(void)uavIndex; // 未使用
+	(void)dsvIndex; // 未使用
+
 	commandList->SetPipelineState(graphicsPipelineState_.Get());
 	commandList->SetGraphicsRootSignature(rootSignature_.Get());
 

--- a/Project/EngineLayer/PostEffectManagement/NormalEffect/NormalEffect.h
+++ b/Project/EngineLayer/PostEffectManagement/NormalEffect/NormalEffect.h
@@ -21,7 +21,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	DirectXCommon* dxCommon_ = nullptr;
 
 	// パイプラインビルダー
-	PostEffectPipelineBuilder* pipelineBuilder_;
+	PostEffectPipelineBuilder* pipelineBuilder_ = nullptr;
 
 	// グラフィックスパイプラインステートオブジェクト
 	Microsoft::WRL::ComPtr<ID3D12PipelineState> graphicsPipelineState_;

--- a/Project/EngineLayer/PostEffectManagement/PostEffectManager/PostEffectManager.cpp
+++ b/Project/EngineLayer/PostEffectManagement/PostEffectManager/PostEffectManager.cpp
@@ -21,8 +21,8 @@
 #include <DepthOutlineEffect.h>
 #include <UAVManager.h>
 
-
-auto Transition = [&](PostEffectManager::RenderTarget& rt, D3D12_RESOURCE_STATES newState)
+/// リソース状態遷移のラムダ関数
+auto Transition = [](PostEffectManager::RenderTarget& rt, D3D12_RESOURCE_STATES newState)
 	{
 		auto dxCommon_ = DirectXCommon::GetInstance();
 		if (rt.state == newState) return;                    // 二重バリア防止
@@ -141,8 +141,6 @@ void PostEffectManager::BeginDraw()
 /// -------------------------------------------------------------
 void PostEffectManager::EndDraw()
 {
-	auto commandList = dxCommon_->GetCommandManager()->GetCommandList();
-
 	// 🔷 Outline等で使うために、depthResource を PIXEL_SHADER_RESOURCE に遷移
 	if (depthResource_ && depthState_ != D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE)
 	{
@@ -179,12 +177,12 @@ void PostEffectManager::RenderPostEffect()
 		ComPtr<ID3D12Resource> backBuffer = dxCommon_->GetBackBuffer(backBufferIndex);
 		D3D12_CPU_DESCRIPTOR_HANDLE backBufferRTV = dxCommon_->GetBackBufferRTV(backBufferIndex);
 
-		// ★ ①-1 PRESENT → RENDER_TARGET へ遷移
+		// PRESENT → RENDER_TARGET へ遷移
 		dxCommon_->ResourceTransition(backBuffer.Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET);
 
 		commandList->OMSetRenderTargets(1, &backBufferRTV, false, &dsvHandle);
 
-		// ① PSO / ルートシグネチャ
+		// PSO / ルートシグネチャ
 		commandList->SetPipelineState(pipelineBuilder_->GetCopyPipelineState().Get());
 		commandList->SetGraphicsRootSignature(pipelineBuilder_->GetCopyRootSignature().Get());
 		SRVManager::GetInstance()->SetGraphicsRootDescriptorTable(0, rt.srvIndex);
@@ -227,7 +225,7 @@ void PostEffectManager::RenderPostEffect()
 		}
 		else
 		{
-			// ★ SRVヒープをバインド（PSで使うため）
+			// SRVヒープをバインド（PSで使うため）
 			SRVManager::GetInstance()->PreDraw();
 
 			// 書き込み

--- a/Project/EngineLayer/PostEffectManagement/PostEffectManager/PostEffectManager.h
+++ b/Project/EngineLayer/PostEffectManagement/PostEffectManager/PostEffectManager.h
@@ -120,13 +120,12 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	// DSVのハンドル
 	ComPtr<ID3D12Resource> depthResource_;
-	D3D12_CPU_DESCRIPTOR_HANDLE dsvHandle;
+	D3D12_CPU_DESCRIPTOR_HANDLE dsvHandle = {};
 	D3D12_RESOURCE_STATES depthState_ = D3D12_RESOURCE_STATE_DEPTH_WRITE;
 	uint32_t dsvSrvIndex_ = 0;
 
 	static constexpr int kPostRTCount = 1; // ポストエフェクト用のレンダーテクスチャ数
 	std::vector<RenderTarget> renderTargets_; // レンダーテクスチャのリスト
-
 
 private: /// ---------- コピー禁止 ---------- ///
 

--- a/Project/EngineLayer/PostEffectManagement/RadialBlurEffect/RadialBlurEffect.cpp
+++ b/Project/EngineLayer/PostEffectManagement/RadialBlurEffect/RadialBlurEffect.cpp
@@ -43,6 +43,8 @@ void RadialBlurEffect::Initialize(DirectXCommon* dxCommon, PostEffectPipelineBui
 /// -------------------------------------------------------------
 void RadialBlurEffect::Apply(ID3D12GraphicsCommandList* commandList, uint32_t srvIndex, uint32_t uavIndex, uint32_t dsvIndex)
 {
+	(void)dsvIndex; // 未使用
+
 	// ① コンピュート用のルートシグネチャとPSOを設定
 	commandList->SetComputeRootSignature(computeRootSignature_.Get());
 	commandList->SetPipelineState(computePipelineState_.Get());

--- a/Project/EngineLayer/PostEffectManagement/RadialBlurEffect/RadialBlurEffect.h
+++ b/Project/EngineLayer/PostEffectManagement/RadialBlurEffect/RadialBlurEffect.h
@@ -35,7 +35,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	DirectXCommon* dxCommon_ = nullptr;
 
 	// パイプラインビルダー
-	PostEffectPipelineBuilder* pipelineBuilder_;
+	PostEffectPipelineBuilder* pipelineBuilder_ = nullptr;
 
 	// コンピュートパイプラインステートオブジェクト
 	Microsoft::WRL::ComPtr<ID3D12PipelineState> computePipelineState_;

--- a/Project/EngineLayer/PostEffectManagement/SmoothingEffect/SmoothingEffect.cpp
+++ b/Project/EngineLayer/PostEffectManagement/SmoothingEffect/SmoothingEffect.cpp
@@ -41,6 +41,8 @@ void SmoothingEffect::Initialize(DirectXCommon* dxCommon, PostEffectPipelineBuil
 /// -------------------------------------------------------------
 void SmoothingEffect::Apply(ID3D12GraphicsCommandList* commandList, uint32_t srvIndex, uint32_t uavIndex, uint32_t dsvIndex)
 {
+	(void)dsvIndex; // 未使用
+
 	// ① コンピュート用のルートシグネチャとPSOを設定
 	commandList->SetComputeRootSignature(computeRootSignature_.Get());
 	commandList->SetPipelineState(computePipelineState_.Get());

--- a/Project/EngineLayer/PostEffectManagement/SmoothingEffect/SmoothingEffect.h
+++ b/Project/EngineLayer/PostEffectManagement/SmoothingEffect/SmoothingEffect.h
@@ -32,7 +32,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	DirectXCommon* dxCommon_ = nullptr;
 
 	// パイプラインビルダー
-	PostEffectPipelineBuilder* pipelineBuilder_;
+	PostEffectPipelineBuilder* pipelineBuilder_ = nullptr;
 
 	// コンピュートパイプラインステートオブジェクト
 	Microsoft::WRL::ComPtr<ID3D12PipelineState> computePipelineState_;

--- a/Project/EngineLayer/PostEffectManagement/VignetteEffect/VignetteEffect.cpp
+++ b/Project/EngineLayer/PostEffectManagement/VignetteEffect/VignetteEffect.cpp
@@ -42,6 +42,8 @@ void VignetteEffect::Initialize(DirectXCommon* dxCommon, PostEffectPipelineBuild
 /// -------------------------------------------------------------
 void VignetteEffect::Apply(ID3D12GraphicsCommandList* commandList, uint32_t srvIndex, uint32_t uavIndex, uint32_t dsvIndex)
 {
+	(void)dsvIndex; // 未使用
+
 	// ① コンピュート用のルートシグネチャとPSOを設定
 	commandList->SetComputeRootSignature(computeRootSignature_.Get());
 	commandList->SetPipelineState(computePipelineState_.Get());

--- a/Project/EngineLayer/PostEffectManagement/VignetteEffect/VignetteEffect.h
+++ b/Project/EngineLayer/PostEffectManagement/VignetteEffect/VignetteEffect.h
@@ -34,7 +34,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	DirectXCommon* dxCommon_ = nullptr;
 
 	// パイプラインビルダー
-	PostEffectPipelineBuilder* pipelineBuilder_;
+	PostEffectPipelineBuilder* pipelineBuilder_ = nullptr;
 
 	// コンピュートパイプラインステートオブジェクト
 	Microsoft::WRL::ComPtr<ID3D12PipelineState> computePipelineState_;

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -55,7 +55,7 @@
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <SDLCheck>true</SDLCheck>
       <PreprocessorDefinitions>_DEBUG;_WINDOWS;USE_IMGUI;%(PreprocessorDefinitions)</PreprocessorDefinitions>
       <ConformanceMode>true</ConformanceMode>
@@ -85,7 +85,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <ClCompile>
-      <WarningLevel>Level3</WarningLevel>
+      <WarningLevel>Level4</WarningLevel>
       <FunctionLevelLinking>true</FunctionLevelLinking>
       <IntrinsicFunctions>true</IntrinsicFunctions>
       <SDLCheck>true</SDLCheck>


### PR DESCRIPTION
`Player` クラスの`forward`計算を修正し、`OnCollision`メソッドを追加。`Item`クラスの初期化処理を改善し、未使用引数の警告を回避。`GamePlayScene`のカットシーン処理をコメントアウト。`BaseWeapon`と`PistolWeapon`のメソッドを調整。`DirectX`関連のエフェクトクラスで未使用引数を回避し、メンバ変数の初期化を追加。`Ken4lowEngine.vcxproj`で警告レベルを引き上げ。