### PR TITLE
HRESULTの初期化とディレクトリ構造の改善

### DIFF
--- a/Project/ApplicationLayer/Scene/TitleScene/TitleScene.h
+++ b/Project/ApplicationLayer/Scene/TitleScene/TitleScene.h
@@ -112,7 +112,7 @@ private: /// ---------- 構造体 ---------- ///
 	struct Timers
 	{
 		float time = 0.0f;				   // シーン開始からの経過時間
-		float duration = 0.0f;			   // シーン全体の継続時間
+		float duration = 1.0f;			   // シーン全体の継続時間
 		float state = 0.0f;				   // 状態遷移用
 		float idle = 0.0f;				   // 無操作でタイトルに
 		float returnSeconds = 75.0f;	   // 無操作でタイトルに戻るまでの時間

--- a/Project/EngineLayer/3D/AnimationManagement/AnimationModel.cpp
+++ b/Project/EngineLayer/3D/AnimationManagement/AnimationModel.cpp
@@ -125,7 +125,8 @@ void AnimationModel::Initialize(const std::string& fileName, bool isSkinning)
 		D3D12_RESOURCE_DESC   bufDesc = CD3DX12_RESOURCE_DESC::Buffer(vbSize);
 
 		// 頂点バッファ本体
-		HRESULT hr = dxCommon_->GetDevice()->CreateCommittedResource(&defaultHeap, D3D12_HEAP_FLAG_NONE, &bufDesc, D3D12_RESOURCE_STATE_COMMON, nullptr, IID_PPV_ARGS(&staticVBDefault_));
+		HRESULT hr = S_FALSE;
+		hr = dxCommon_->GetDevice()->CreateCommittedResource(&defaultHeap, D3D12_HEAP_FLAG_NONE, &bufDesc, D3D12_RESOURCE_STATE_COMMON, nullptr, IID_PPV_ARGS(&staticVBDefault_));
 		assert(SUCCEEDED(hr));
 
 		// 一時UploadにCPUから詰める
@@ -178,7 +179,8 @@ void AnimationModel::Initialize(const std::string& fileName, bool isSkinning)
 	D3D12_RESOURCE_DESC   desc = CD3DX12_RESOURCE_DESC::Buffer(sizeof(VertexData) * flat.vertices.size(), D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
 
 	// スキン済み頂点バッファ作成
-	HRESULT hr = dxCommon_->GetDevice()->CreateCommittedResource(&heapProps, D3D12_HEAP_FLAG_NONE, &desc, D3D12_RESOURCE_STATE_COMMON, nullptr, IID_PPV_ARGS(&skinnedVB_));
+	HRESULT hr = S_FALSE;
+	hr = dxCommon_->GetDevice()->CreateCommittedResource(&heapProps, D3D12_HEAP_FLAG_NONE, &desc, D3D12_RESOURCE_STATE_COMMON, nullptr, IID_PPV_ARGS(&skinnedVB_));
 	assert(SUCCEEDED(hr));
 
 	// UAV（u0）作成（UAVヒープ）
@@ -641,7 +643,8 @@ void AnimationModel::InitializeLODs()
 			D3D12_RESOURCE_DESC   bufDesc = CD3DX12_RESOURCE_DESC::Buffer(vbSize);
 
 			// DEFAULTヒープに頂点バッファを作成
-			HRESULT hr = device->CreateCommittedResource(&heapDefault, D3D12_HEAP_FLAG_NONE, &bufDesc, D3D12_RESOURCE_STATE_COMMON, nullptr, IID_PPV_ARGS(&defaultVB));
+			HRESULT hr = S_FALSE;
+			hr = device->CreateCommittedResource(&heapDefault, D3D12_HEAP_FLAG_NONE, &bufDesc, D3D12_RESOURCE_STATE_COMMON, nullptr, IID_PPV_ARGS(&defaultVB));
 			assert(SUCCEEDED(hr));
 
 			// Upload 経由でコピー
@@ -676,7 +679,8 @@ void AnimationModel::InitializeLODs()
 			D3D12_RESOURCE_DESC   bufDesc = CD3DX12_RESOURCE_DESC::Buffer(ibSize);
 
 			// DEFAULTヒープに頂点バッファを作成
-			HRESULT hr = device->CreateCommittedResource(&heapDefault, D3D12_HEAP_FLAG_NONE, &bufDesc, D3D12_RESOURCE_STATE_COMMON, nullptr, IID_PPV_ARGS(&defaultIB));
+			HRESULT hr = S_FALSE;
+			hr = device->CreateCommittedResource(&heapDefault, D3D12_HEAP_FLAG_NONE, &bufDesc, D3D12_RESOURCE_STATE_COMMON, nullptr, IID_PPV_ARGS(&defaultIB));
 			assert(SUCCEEDED(hr));
 
 			// Upload 経由でコピー
@@ -708,7 +712,8 @@ void AnimationModel::InitializeLODs()
 			D3D12_RESOURCE_DESC   desc = CD3DX12_RESOURCE_DESC::Buffer(sizeof(VertexData) * flat.vertices.size(), D3D12_RESOURCE_FLAG_ALLOW_UNORDERED_ACCESS);
 
 			// スキン済み頂点バッファ作成
-			HRESULT hr = device->CreateCommittedResource(&heapDefault, D3D12_HEAP_FLAG_NONE, &desc, D3D12_RESOURCE_STATE_COMMON, nullptr, IID_PPV_ARGS(&skinnedVB));
+			HRESULT hr = S_FALSE;
+			hr = device->CreateCommittedResource(&heapDefault, D3D12_HEAP_FLAG_NONE, &desc, D3D12_RESOURCE_STATE_COMMON, nullptr, IID_PPV_ARGS(&skinnedVB));
 			assert(SUCCEEDED(hr));
 		}
 

--- a/Project/EngineLayer/3D/AnimationManagement/AnimationPipelineBuilder.cpp
+++ b/Project/EngineLayer/3D/AnimationManagement/AnimationPipelineBuilder.cpp
@@ -370,6 +370,7 @@ void AnimationPipelineBuilder::CreateComputePSO()
 	desc.pRootSignature = computeRootSignature_.Get();
 	desc.CS = { computeShader->GetBufferPointer(), computeShader->GetBufferSize() };
 
-	HRESULT hr = dxCommon_->GetDevice()->CreateComputePipelineState(&desc, IID_PPV_ARGS(&computePipelineState_));
+	HRESULT hr = S_FALSE;
+	hr = dxCommon_->GetDevice()->CreateComputePipelineState(&desc, IID_PPV_ARGS(&computePipelineState_));
 	assert(SUCCEEDED(hr) && "CreateComputePipelineState Failed");
 }

--- a/Project/EngineLayer/3D/AnimationManagement/SkinCluster.cpp
+++ b/Project/EngineLayer/3D/AnimationManagement/SkinCluster.cpp
@@ -73,7 +73,8 @@ void SkinCluster::Initialize(const ModelData& modelData, Skeleton& skeleton)
 		D3D12_RESOURCE_DESC    bufDesc = CD3DX12_RESOURCE_DESC::Buffer(sizeof(WellForGPU) * joints.size());
 
 		// 初期ステートは COMMON にする（警告回避）
-		HRESULT hr = device->CreateCommittedResource(&heapDefault, D3D12_HEAP_FLAG_NONE, &bufDesc, D3D12_RESOURCE_STATE_COMMON, nullptr, IID_PPV_ARGS(&paletteResourceDefault_));
+		HRESULT hr = S_FALSE;
+		hr = device->CreateCommittedResource(&heapDefault, D3D12_HEAP_FLAG_NONE, &bufDesc, D3D12_RESOURCE_STATE_COMMON, nullptr, IID_PPV_ARGS(&paletteResourceDefault_));
 		assert(SUCCEEDED(hr));
 
 		// COMMON → COPY_DEST に明示遷移してからコピー
@@ -138,7 +139,8 @@ void SkinCluster::Initialize(const ModelData& modelData, Skeleton& skeleton)
 		D3D12_RESOURCE_DESC    bufDesc = CD3DX12_RESOURCE_DESC::Buffer(infSize);
 
 		// 初期ステートは COMMON
-		HRESULT hr = device->CreateCommittedResource(&heapDefault, D3D12_HEAP_FLAG_NONE, &bufDesc, D3D12_RESOURCE_STATE_COMMON, nullptr, IID_PPV_ARGS(&influenceResourceDefault_));
+		HRESULT hr = S_FALSE;
+		hr = device->CreateCommittedResource(&heapDefault, D3D12_HEAP_FLAG_NONE, &bufDesc, D3D12_RESOURCE_STATE_COMMON, nullptr, IID_PPV_ARGS(&influenceResourceDefault_));
 		assert(SUCCEEDED(hr));
 
 		// COMMON → COPY_DEST に明示遷移

--- a/Project/EngineLayer/Base/DX12SwapChain/DX12SwapChain.h
+++ b/Project/EngineLayer/Base/DX12SwapChain/DX12SwapChain.h
@@ -44,6 +44,6 @@ private: /// ---------- メンバ変数 ---------- ///
 	Microsoft::WRL::ComPtr <IDXGISwapChain4> swapChain;
 	Microsoft::WRL::ComPtr <ID3D12Resource> swapChainResources[2];
 	DXGI_SWAP_CHAIN_DESC1 swapChainDesc{};
-	D3D12_RESOURCE_STATES backBufferStates[2];  // 2つのバックバッファの状態を記録
+	D3D12_RESOURCE_STATES backBufferStates[2] = {};  // 2つのバックバッファの状態を記録
 };
 

--- a/Project/EngineLayer/Base/DirectXCommon/DirectXCommon.cpp
+++ b/Project/EngineLayer/Base/DirectXCommon/DirectXCommon.cpp
@@ -148,7 +148,8 @@ void DirectXCommon::Finalize()
 ComPtr<ID3D12Resource> DirectXCommon::GetBackBuffer(uint32_t index)
 {
 	ComPtr<ID3D12Resource> backBuffer = nullptr;
-	HRESULT hr = swapChain_->GetSwapChain()->GetBuffer(index, IID_PPV_ARGS(&backBuffer));
+	HRESULT hr = S_FALSE;
+	hr = swapChain_->GetSwapChain()->GetBuffer(index, IID_PPV_ARGS(&backBuffer));
 	assert(SUCCEEDED(hr));
 	return backBuffer.Get();
 }

--- a/Project/EngineLayer/Base/DirectXCommon/DirectXCommon.h
+++ b/Project/EngineLayer/Base/DirectXCommon/DirectXCommon.h
@@ -22,8 +22,8 @@ class WinApp;
 /// -------------------------------------------------------------
 class DirectXCommon
 {
-	uint32_t kClientWidth;
-	uint32_t kClientHeight;
+	uint32_t kClientWidth = 0;
+	uint32_t kClientHeight = 0;
 
 public: /// ---------- メンバ関数 ---------- ///
 
@@ -98,9 +98,9 @@ private: /// ---------- メンバ変数 ---------- ///
 	D3D12_RECT scissorRect{};
 
 	UINT backBufferIndex = 0;
-	uint32_t dsvIndex_ = 0; // 🔹 DSVのインデックス
+	uint32_t dsvIndex_ = 0; // DSVのインデックス
 
-	ComPtr<ID3D12Resource> depthStencilResource; // 🔹 深度バッファ
+	ComPtr<ID3D12Resource> depthStencilResource; // 深度バッファ
 
 private: /// ---------- コピー禁止 ---------- ///
 

--- a/Project/EngineLayer/Base/MultipleStructs/ModelData.h
+++ b/Project/EngineLayer/Base/MultipleStructs/ModelData.h
@@ -31,7 +31,7 @@ template <typename T>
 struct Keyframe
 {
 	float time = 0.0f; // 時刻
-	T value;	// 値
+	T value{};	// 値
 };
 
 using KeyframeVector3 = Keyframe<Vector3>;		 // Vector3のキーフレーム

--- a/Project/EngineLayer/Managers/ResourceManager/ResourceManager.cpp
+++ b/Project/EngineLayer/Managers/ResourceManager/ResourceManager.cpp
@@ -32,7 +32,8 @@ ComPtr<ID3D12Resource> ResourceManager::CreateBufferResource(ID3D12Device* devic
 
 	//実際に頂点リソースを作る
 	ComPtr <ID3D12Resource> vertexResource = nullptr;
-	HRESULT hr = device->CreateCommittedResource(&uploadHeapProperties, D3D12_HEAP_FLAG_NONE,
+	HRESULT hr = S_FALSE;
+	hr = device->CreateCommittedResource(&uploadHeapProperties, D3D12_HEAP_FLAG_NONE,
 		&vertexResourceDesc, D3D12_RESOURCE_STATE_GENERIC_READ, nullptr,
 		IID_PPV_ARGS(&vertexResource));
 	assert(SUCCEEDED(hr));

--- a/Project/EngineLayer/Managers/SRVManager/SRVManager.cpp
+++ b/Project/EngineLayer/Managers/SRVManager/SRVManager.cpp
@@ -184,7 +184,8 @@ ComPtr<ID3D12DescriptorHeap> SRVManager::CreateDescriptorHeap(ID3D12Device* devi
 	descriptorHeapDesc.Type = heapType;	//レンダーターゲットビュー用
 	descriptorHeapDesc.NumDescriptors = numDescriptors;						//ダブルバッファ用に2つ。多くても別に構わない
 	descriptorHeapDesc.Flags = shadervisible ? D3D12_DESCRIPTOR_HEAP_FLAG_SHADER_VISIBLE : D3D12_DESCRIPTOR_HEAP_FLAG_NONE;
-	HRESULT hr = device->CreateDescriptorHeap(&descriptorHeapDesc, IID_PPV_ARGS(&descriptorHeap));
+	HRESULT hr = S_FALSE;
+	hr = device->CreateDescriptorHeap(&descriptorHeapDesc, IID_PPV_ARGS(&descriptorHeap));
 	//ディスクリプタヒープが作れなかったので起動できない
 	assert(SUCCEEDED(hr));
 

--- a/Project/EngineLayer/Managers/TextureManager/TextureManager.cpp
+++ b/Project/EngineLayer/Managers/TextureManager/TextureManager.cpp
@@ -52,7 +52,8 @@ ComPtr<ID3D12Resource> TextureManager::CreateTextureResource(ID3D12Device* devic
 
 	//3. Resourceを生成する
 	ComPtr <ID3D12Resource> resource = nullptr;
-	HRESULT hr = device->CreateCommittedResource(
+	HRESULT hr = S_FALSE;
+	hr = device->CreateCommittedResource(
 		&heapProperties,														// Heapの設定
 		D3D12_HEAP_FLAG_NONE,													// Heapの特殊な設定。特になし。
 		&resourceDesc,															// /Resourceの設定

--- a/Project/EngineLayer/Managers/TextureManager/TextureManager.h
+++ b/Project/EngineLayer/Managers/TextureManager/TextureManager.h
@@ -21,7 +21,7 @@ private: /// ---------- テクスチャデータの構造体 ---------- ///
 	// テクスチャ１枚分のデータ
 	struct TextureData
 	{
-		DirectX::TexMetadata metaData;			    // 画像の幅や高さなどの情報
+		DirectX::TexMetadata metaData = {};			// 画像の幅や高さなどの情報
 		ComPtr<ID3D12Resource> resource;		    // テクスチャリソース
 		uint32_t srvIndex = 0;
 		D3D12_CPU_DESCRIPTOR_HANDLE srvHandleCPU{}; // SRV作成時に必要なCPUハンドル
@@ -33,6 +33,7 @@ public: /// ---------- メンバ関数 ---------- ///
 	// シングルトンインスタンス
 	static TextureManager* GetInstance();
 
+	// 初期化処理
 	void Initialize(DirectXCommon* dxCommon);
 
 	// DirectX12のTextureResourceを作る

--- a/Project/EngineLayer/PostEffectManagement/PostEffectManager/PostEffectManager.cpp
+++ b/Project/EngineLayer/PostEffectManagement/PostEffectManager/PostEffectManager.cpp
@@ -365,7 +365,8 @@ ComPtr<ID3D12Resource> PostEffectManager::CreateDepthBufferResource(uint32_t wid
 		D3D12_MEMORY_POOL_UNKNOWN, 1, 1 };
 
 	ComPtr<ID3D12Resource> depth;
-	HRESULT hr = dxCommon_->GetDevice()->CreateCommittedResource(
+	HRESULT hr = S_FALSE;
+	hr = dxCommon_->GetDevice()->CreateCommittedResource(
 		&heapProp,
 		D3D12_HEAP_FLAG_NONE,
 		&desc,

--- a/Project/EngineLayer/PostEffectManagement/PostEffectPipelineBuilder/PostEffectPipelineBuilder.cpp
+++ b/Project/EngineLayer/PostEffectManagement/PostEffectPipelineBuilder/PostEffectPipelineBuilder.cpp
@@ -155,7 +155,8 @@ ComPtr<ID3D12PipelineState> PostEffectPipelineBuilder::CreateGraphicsPipeline(co
 	}
 
 	ComPtr<ID3D12PipelineState> pso;
-	HRESULT hr = dxCommon_->GetDevice()->CreateGraphicsPipelineState(&desc, IID_PPV_ARGS(&pso));
+	HRESULT hr = S_FALSE;
+	hr = dxCommon_->GetDevice()->CreateGraphicsPipelineState(&desc, IID_PPV_ARGS(&pso));
 	assert(SUCCEEDED(hr));
 	return pso;
 }

--- a/Project/Externals/DirectXTex/DirectXTex_Desktop_2022_Win10.vcxproj
+++ b/Project/Externals/DirectXTex/DirectXTex_Desktop_2022_Win10.vcxproj
@@ -40,14 +40,14 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|X64'">
-    <OutDir>Bin\Desktop_2022_Win10\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Desktop_2022_Win10\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)..\Generated\outputs\lib\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\Generated\obj\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
     <TargetName>DirectXTex</TargetName>
     <GenerateManifest>true</GenerateManifest>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|X64'">
-    <OutDir>Bin\Desktop_2022_Win10\$(Platform)\$(Configuration)\</OutDir>
-    <IntDir>Bin\Desktop_2022_Win10\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)..\Generated\outputs\lib\$(Platform)\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\Generated\obj\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
     <TargetName>DirectXTex</TargetName>
     <GenerateManifest>true</GenerateManifest>
   </PropertyGroup>

--- a/Project/Externals/imgui/imgui.vcxproj
+++ b/Project/Externals/imgui/imgui.vcxproj
@@ -71,20 +71,20 @@
   </ImportGroup>
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
-    <IntDir>$(SolutionDir)..\Generated\obj\$(ProjectName)\$(Configuration)\</IntDir>
-    <OutDir>$(SolutionDir)..\Generated\outputs\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\Generated\obj\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)..\Generated\outputs\lib\$(Platform)\$(Configuration)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
-    <IntDir>$(SolutionDir)..\Generated\obj\$(ProjectName)\$(Configuration)\</IntDir>
-    <OutDir>$(SolutionDir)..\Generated\outputs\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\Generated\obj\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)..\Generated\outputs\lib\$(Platform)\$(Configuration)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
-    <IntDir>$(SolutionDir)..\Generated\obj\$(ProjectName)\$(Configuration)\</IntDir>
-    <OutDir>$(SolutionDir)..\Generated\outputs\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\Generated\obj\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)..\Generated\outputs\lib\$(Platform)\$(Configuration)\</OutDir>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
-    <IntDir>$(SolutionDir)..\Generated\obj\$(ProjectName)\$(Configuration)\</IntDir>
-    <OutDir>$(SolutionDir)..\Generated\outputs\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\Generated\obj\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)..\Generated\outputs\lib\$(Platform)\$(Configuration)\</OutDir>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|Win32'">
     <ClCompile>

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -45,14 +45,14 @@
   <PropertyGroup Label="UserMacros" />
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
     <IncludePath>$(SolutionDir)Externals\Audio\minimp3;$(SolutionDir)Externals\imgui;$(SolutionDir)Externals\nlohmann;$(SolutionDir)Externals\DirectXTex;$(IncludePath)</IncludePath>
-    <IntDir>$(SolutionDir)..\Generated\obj\$(ProjectName)\$(Configuration)\</IntDir>
-    <OutDir>$(SolutionDir)..\Generated\outputs\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\Generated\obj\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)..\Generated\outputs\$(Platform)\$(Configuration)\</OutDir>
     <ExternalIncludePath>$(ExternalIncludePath)</ExternalIncludePath>
   </PropertyGroup>
   <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <IncludePath>$(SolutionDir)Externals\Audio\minimp3;$(SolutionDir)Externals\imgui;$(SolutionDir)Externals\nlohmann;$(SolutionDir)Externals\DirectXTex;$(IncludePath)</IncludePath>
-    <IntDir>$(SolutionDir)..\Generated\obj\$(ProjectName)\$(Configuration)\</IntDir>
-    <OutDir>$(SolutionDir)..\Generated\outputs\$(Configuration)\</OutDir>
+    <IntDir>$(SolutionDir)..\Generated\obj\$(ProjectName)\$(Platform)\$(Configuration)\</IntDir>
+    <OutDir>$(SolutionDir)..\Generated\outputs\$(Platform)\$(Configuration)\</OutDir>
     <ExternalIncludePath>$(ExternalIncludePath)</ExternalIncludePath>
   </PropertyGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">


### PR DESCRIPTION
`HRESULT`の初期化を明示的に行う変更を多数のファイルに適用し、コードの安全性を向上。未初期化変数によるバグを防止。 また、ビルド成果物の出力ディレクトリを`Generated`ディレクトリに統一し、成果物管理を明確化。 その他、構造体や変数の初期化方法を改善し、安定性を向上。