### PR TITLE
敵の死亡演出とゲームクリア処理を追加

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/Enemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Enemy.cpp
@@ -39,12 +39,20 @@ void Enemy::Initialize()
 	parts_[leftArmIndex_].transform.rotate_.x = idleRad;
 	parts_[rightArmIndex_].transform.rotate_.x = idleRad;
 
+	hp_ = maxHp_;                  // 体力満タンに
 	aiState_ = AIState::SpawnDelay; // 初期状態を出現待機に設定
 	stateTimer_ = 0.0f;           // 状態タイマーリセット
 	isActive_ = false;            // スポーン済みフラグリセット
 
 	hitFlashTimer_ = 0.0f;
 	ApplyColorToAll(baseColor_);
+
+	death_ = DeathEnemyState{};
+
+	// パーツの親も復元しておく（分解で parent_ を外している場合）
+	for (auto& part : parts_) {
+		part.transform.parent_ = &body_.transform;
+	}
 }
 
 /// -------------------------------------------------------------
@@ -52,6 +60,29 @@ void Enemy::Initialize()
 /// -------------------------------------------------------------
 void Enemy::Update(float deltaTime)
 {
+	// 死亡演出中ならそちらを優先
+	if (death_.active)
+	{
+		UpdateDeath(deltaTime);
+		BaseCharacter::Update(deltaTime);
+		return;
+	}
+
+	// まずスポーン待機中（SpawnDelay）は isActive_ が false でも進める
+	if (!isActive_)
+	{
+		if (aiState_ == AIState::SpawnDelay)
+		{
+			UpdateSpawnDelay(deltaTime);
+		}
+
+		// ここでまだアクティブ化してなければ何もしないで終了
+		if (!isActive_) {
+			return;
+		}
+		// isActive_ が true になったら、この下の通常処理に入る
+	}
+
 	// 攻撃クールダウンタイマーを進める
 	if (attackCooldownTimer_ > 0.0f)
 	{
@@ -119,7 +150,7 @@ void Enemy::Update(float deltaTime)
 void Enemy::Draw()
 {
 	// スポーン前（SpawnDelay状態）は描画しない
-	if (!isActive_) return;
+	if (!isActive_ && !death_.active) return;
 
 	// ベースキャラクター描画
 	BaseCharacter::Draw();
@@ -177,6 +208,9 @@ void Enemy::OnCollision(Collider* other)
 
 		hitFlashTimer_ = hitFlashDuration_;  // フラッシュ開始/延長
 		ApplyColorToAll(hitColor_);          // 即赤く（次フレームから徐々に戻る）
+
+		// ダメージ処理
+		TakeDamage(player_->GetWeaponManager()->GetCurrentConfig().damage); // ダメージ量取得
 
 		// 弾丸と衝突したときの処理
 		OutputDebugStringA("Enemy hit by bullet!\n");
@@ -338,10 +372,6 @@ void Enemy::UpdateChase(float deltaTime)
 		didHitThisAttack_ = false;
 		return;
 	}
-
-	if (distAfter > detectRadius_ * 1.5f) {
-		aiState_ = AIState::Wander; stateTimer_ = 0.0f; return;
-	}
 }
 
 /// -------------------------------------------------------------
@@ -480,9 +510,37 @@ void Enemy::UpdateDamaged(float deltaTime)
 /// -------------------------------------------------------------
 ///				　　　死亡状態の更新処理
 /// -------------------------------------------------------------
-void Enemy::UpdateDead(float deltaTime)
+void Enemy::UpdateDeath(float deltaTime)
 {
-	(void)deltaTime;
+	death_.timer += deltaTime;
+	float t = std::clamp(death_.timer / death_.duration, 0.0f, 1.0f);
+	const Vector3 gravity = { 0.0f, -9.8f * 3.0f, 0.0f };
+
+	// body も飛ばす
+	death_.bodyGib.velocity += gravity * deltaTime;
+	body_.transform.translate_ += death_.bodyGib.velocity * deltaTime;
+	body_.transform.rotate_ += death_.bodyGib.angularVelocity * deltaTime;
+
+	for (size_t i = 0; i < parts_.size() && i < death_.gibs.size(); ++i)
+	{
+		auto& part = parts_[i];
+		auto& gm = death_.gibs[i];
+
+		gm.velocity += gravity * deltaTime;
+		part.transform.translate_ += gm.velocity * deltaTime;
+		part.transform.rotate_ += gm.angularVelocity * deltaTime;
+
+		// だんだん消えていく（ディゾルブがあるならそこに繋ぐ）
+		float alpha = 1.0f - t;
+		part.object->SetColor({ colorModulate_.x,colorModulate_.y,colorModulate_.z,alpha });
+	}
+
+	if (death_.timer >= death_.duration)
+	{
+		death_.active = false;
+		death_.finished = true;
+		isActive_ = false; // ここで完全に消す
+	}
 }
 
 /// -------------------------------------------------------------
@@ -660,4 +718,77 @@ void Enemy::ApplyColorToAll(const Vector4& color)
 	for (auto& part : parts_) {
 		if (part.object) { part.object->SetColor(colorModulate_); }
 	}
+}
+
+/// -------------------------------------------------------------
+///				　　　ダメージ処理
+/// -------------------------------------------------------------
+void Enemy::TakeDamage(float amount)
+{
+	if (aiState_ == AIState::Dead) return;
+
+	hp_ -= amount;
+	if (hp_ <= 0.0f)
+	{
+		hp_ = 0.0f;
+		StartDeath();
+	}
+	else
+	{
+		// 簡単に「食らった」状態にしても良いし、
+		// 今回は演出最低限でスルーでもOK
+		aiState_ = AIState::Chase;
+		stateTimer_ = 0.0f;
+	}
+}
+
+/// -------------------------------------------------------------
+///				　　　死亡開始処理
+/// -------------------------------------------------------------
+void Enemy::StartDeath()
+{
+	if (death_.active) return;
+
+	death_.active = true;
+	death_.finished = false;
+	death_.timer = 0.0f;
+	death_.duration = 0.8f;
+
+	aiState_ = AIState::Dead;
+	isActive_ = true;
+
+	death_.gibs.clear();
+	death_.gibs.resize(parts_.size());
+
+	static thread_local std::mt19937 rng{ std::random_device{}() };
+	std::uniform_real_distribution<float> dirDist(-1.0f, 1.0f);
+	std::uniform_real_distribution<float> upDist(2.0f, 6.0f);
+	std::uniform_real_distribution<float> angDist(-6.0f, 6.0f);
+
+	for (size_t i = 0; i < parts_.size(); ++i)
+	{
+		auto& part = parts_[i];
+		GibMotion gm{};
+
+		// ランダム速度
+		Vector3 dir{ dirDist(rng), 0.0f, dirDist(rng) };
+		if (Vector3::Length(dir) < 0.001f) dir = { 0.0f, 0.0f, 1.0f };
+		dir = Vector3::Normalize(dir);
+		gm.velocity = dir * 3.0f;
+		gm.velocity.y += upDist(rng);
+		gm.angularVelocity = { angDist(rng), angDist(rng), angDist(rng) };
+		death_.gibs[i] = gm;
+
+		// 今までの translate_ は body_ からのローカル位置なので、
+		// 親を外す前に「ワールド位置」に焼き直す
+		Vector3 worldPos = part.transform.translate_;
+		if (part.transform.parent_ == &body_.transform) {
+			worldPos += body_.transform.translate_;
+		}
+
+		part.transform.parent_ = nullptr;
+		part.transform.translate_ = worldPos;
+	}
+
+	ApplyColorToAll({ 0.6f, 0.6f, 0.6f, 1.0f });
 }

--- a/Project/ApplicationLayer/Character/Enemy/Enemy.h
+++ b/Project/ApplicationLayer/Character/Enemy/Enemy.h
@@ -8,6 +8,23 @@
 class Player;
 class LevelObjectManager;
 
+struct GibMotion
+{
+	Vector3 velocity; // 初速度
+	Vector3 angularVelocity; // 角速度（ラジアン）
+};
+
+struct DeathEnemyState
+{
+	bool  active = false;     // 死亡演出中
+	bool  finished = false;   // 完了（クリア判定用）
+	float timer = 0.0f;
+	float duration = 1.2f;    // 分解が終わるまでの時間
+	std::vector<GibMotion> gibs; // 各部位の分解運動データ
+	GibMotion bodyGib; // 体幹部位の分解運動データ
+};
+
+
 /// -------------------------------------------------------------
 ///					　敵キャラクタークラス
 /// -------------------------------------------------------------
@@ -64,6 +81,11 @@ public: /// ---------- メンバ関数 ---------- ///
 	// スポーン済みかどうか取得
 	bool IsActive() const { return isActive_; }
 
+	// 死亡状態かどうか取得
+	bool IsDead() const { return aiState_ == AIState::Dead; }
+
+	bool IsDeadNow() const { return death_.finished; }
+
 private: /// ---------- メンバ関数 ---------- ///
 
 	// 状態遷移処理
@@ -76,7 +98,7 @@ private: /// ---------- メンバ関数 ---------- ///
 	void UpdateChase(float deltaTime);		// 追跡
 	void UpdateAttack(float deltaTime);		// 攻撃
 	void UpdateDamaged(float deltaTime);	// ダメージ
-	void UpdateDead(float deltaTime);		// 死亡
+	void UpdateDeath(float deltaTime);		// 死亡
 
 	// ワールド衝突解決処理
 	void SolveWorldCollision(const Vector3& oldTranslate);
@@ -85,6 +107,12 @@ private: /// ---------- メンバ関数 ---------- ///
 	void PickNewWanderDirection();
 
 	void ApplyColorToAll(const Vector4& color); // body_ と parts_ に一括適用
+
+	// ダメージを受ける
+	void TakeDamage(float amount);
+
+	// 死亡処理開始
+	void StartDeath();
 
 private: /// ---------- メンバ関数 ---------- ///
 
@@ -158,5 +186,12 @@ private: /// ---------- 定数 ---------- ///
 	Vector4 baseColor_ = { 1.0f,1.0f,1.0f,1.0f }; // 元の色
 	Vector4 hitColor_ = { 1.0f,0.0f,0.0f,1.0f };  // ヒット時の色
 	Vector4 colorModulate_ = { 1.0f,1.0f,1.0f,1.0f }; // 現在の色補正
+
+private: /// ---------- 定数 ---------- ///
+
+	float maxHp_ = 100.0f; // 最大体力
+	float hp_ = maxHp_;    // 現在体力
+
+	DeathEnemyState death_;
 };
 

--- a/Project/ApplicationLayer/Character/Player/Player.h
+++ b/Project/ApplicationLayer/Character/Player/Player.h
@@ -168,6 +168,9 @@ public: /// ---------- アクセサー関数 ---------- ///
 	// 死亡中かどうか取得
 	bool IsDeadNow() const { return deathState_.isDead || deathState_.inDeathSeq; }
 
+	// 武器マネージャー取得
+	WeaponManager* GetWeaponManager() const { return weaponManager_.get(); }
+
 private: /// ---------- メンバ関数 ---------- ///
 
 	// 移動処理

--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
@@ -12,7 +12,7 @@
 #include "LevelLoader.h"
 #include "LinearInterpolation.h"
 
-#include "GpuParticleManager.h"
+#include "StageRepository.h"
 
 #ifdef _DEBUG
 #include <DebugCamera.h>
@@ -156,6 +156,11 @@ void GamePlayScene::Update()
 	// デルタタイムの取得
 	const float deltaTime = dxCommon_->GetFPSCounter().GetDeltaTime();
 
+	// ここで毎フレームフェード更新
+	if (fadeController_) {
+		fadeController_->Update(deltaTime);
+	}
+
 	// デバッグカメラの更新
 	UpdateDebug();
 
@@ -191,7 +196,6 @@ void GamePlayScene::Update()
 
 		// 画的に必要な更新だけ許可
 		skyBox_->Update();
-		fadeController_->Update(deltaTime);
 		itemManager_->Update(player_.get(), deltaTime);
 		levelObjectManager_->Update();
 
@@ -217,16 +221,27 @@ void GamePlayScene::Update()
 		// プレイヤー死亡チェック
 		if (player_->IsDeadNow())
 		{
-			gameState_ = GameState::Result;
+			gameState_ = GameState::GameOver;
 
 			// ゲームオーバー中はマウスを解放してUI操作できるようにする
 			Input::GetInstance()->SetLockCursor(false);
 			ShowCursor(true);
 		}
+
+		// エネミー死亡チェック
+		if (enemy_ && enemy_->IsDeadNow())
+		{
+			Input::GetInstance()->SetLockCursor(false);
+			ShowCursor(true);
+
+			// ステージクリア処理
+			OnStageClear();
+		}
+
 		break;
 	case GameState::Paused:
 		break;
-	case GameState::Result:
+	case GameState::GameOver:
 		// 死亡演出を最後まで回すためにプレイヤーだけは更新
 		player_->Update(deltaTime);
 
@@ -237,6 +252,10 @@ void GamePlayScene::Update()
 		itemManager_->Update(player_.get(), deltaTime);
 		retryButtonSprite_->Update();
 		retireButtonSprite_->Update();
+
+		if (fadeController_) {
+			fadeController_->Update(deltaTime);
+		}
 
 		// キー操作でもまだ残しておく（デバッグ用）
 		if (input_->TriggerKey(DIK_R))
@@ -369,7 +388,7 @@ void GamePlayScene::Draw2DSprites()
 	fadeController_->Draw();
 
 	// ---------- Result(ゲームオーバー)時のUI ----------
-	if (gameState_ == GameState::Result)
+	if (gameState_ == GameState::GameOver)
 	{
 		// 左下(リタイア)
 		if (retireButtonSprite_)
@@ -662,5 +681,40 @@ void GamePlayScene::CheckAllCollisions()
 
 	// 衝突判定と応答
 	collisionManager_->CheckAllCollisions();
+}
+
+/// -------------------------------------------------------------
+///				　			ステージクリア時の処理
+/// -------------------------------------------------------------
+void GamePlayScene::OnStageClear()
+{
+	gameState_ = GameState::GameClear;
+
+	auto& repo = StageRepository::GetInstance();
+	auto stages = repo.GetStages();
+	auto startIndexOpt = repo.GetStartIndex();
+
+	if (startIndexOpt && !stages.empty())
+	{
+		int idx = *startIndexOpt;
+		if (idx + 1 < (int)stages.size())
+		{
+			stages[idx + 1].locked = false; // 次ステージ解放
+			repo.SetStages(stages);
+		}
+	}
+
+	// クリア後はステージセレクトへ戻る想定
+	if (fadeController_)
+	{
+		fadeController_->SetOnComplete([this]() {
+			if (sceneManager_) sceneManager_->ChangeScene("StageSelectScene");
+			});
+		fadeController_->StartFadeOut(0.8f);
+	}
+	else
+	{
+		if (sceneManager_) sceneManager_->ChangeScene("StageSelectScene");
+	}
 }
 

--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.h
@@ -31,8 +31,9 @@ enum class GameState
 {
 	Playing, // プレイ中
 	Paused, // ポーズ中
-	Result, // 結果画面
-	CutScene // カットシーン中
+	GameClear, // ゲームクリア
+	GameOver, // ゲームオーバー
+	CutScene, // カットシーン中
 };
 
 /// -------------------------------------------------------------
@@ -97,6 +98,9 @@ private: /// ---------- メンバ関数 ---------- ///
 
 	// 衝突判定と応答
 	void CheckAllCollisions();
+
+	// ステージクリア時の処理
+	void OnStageClear();
 
 private: /// ---------- メンバ変数 ---------- ///
 

--- a/Project/ApplicationLayer/Scene/StageSelectScene/StageSelectScene.cpp
+++ b/Project/ApplicationLayer/Scene/StageSelectScene/StageSelectScene.cpp
@@ -22,6 +22,13 @@ void StageSelectScene::Initialize()
 	stages_.push_back({ 3u, "朽ちた果てた街", "white.png", true,  0u, { 0.37f, 0.35f, 0.49f, 1.0f } });
 	stages_.push_back({ 4u, "港湾ターミナル", "white.png", true,  0u, { 0.08f, 0.40f, 0.75f, 1.0f } });
 
+	// リポジトリから保存済みステージ情報を取得
+	const auto& saved = StageRepository::GetInstance().GetStages();
+	if (!saved.empty() && saved.size() == stages_.size())
+	{
+		stages_ = saved;
+	}
+
 	// フェードコントローラーの初期化
 	fadeController_ = std::make_unique<FadeController>();
 	float screenWidth = static_cast<float>(dxCommon_->GetSwapChainDesc().Width);

--- a/Project/EngineLayer/FrameworkLayer/Framework/GameEngine.cpp
+++ b/Project/EngineLayer/FrameworkLayer/Framework/GameEngine.cpp
@@ -30,7 +30,7 @@ void GameEngine::Initialize()
 	SceneManager::GetInstance()->SetAbstractSceneFactory(std::move(sceneFactory));
 
 	// 最初のシーンを設定
-	SceneManager::GetInstance()->SetNextScene(std::make_unique<GamePlayScene>());
+	SceneManager::GetInstance()->SetNextScene(std::make_unique<TitleScene>());
 }
 
 


### PR DESCRIPTION
- Enemyクラスに死亡演出処理（UpdateDeath, StartDeath）を追加
- ダメージ処理（TakeDamage）を実装し、体力管理を導入
- GamePlaySceneにゲームオーバーとゲームクリア状態を追加
- ステージクリア時の次ステージ解放と遷移処理を実装
- フェード処理を強化し、シーン遷移をスムーズに
- StageSelectSceneでステージ情報の保存・復元を追加
- 初期シーンをTitleSceneに変更