### PR TITLE
Improve Enemy AI: unstuck handling, cover usage, jump traversal, and retreat behavior

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/AI/EnemyStuckController.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/AI/EnemyStuckController.cpp
@@ -1,0 +1,68 @@
+#include "EnemyStuckController.h"
+
+#include <algorithm>
+#include <cmath>
+
+using namespace Ken4lowEngine;
+
+namespace
+{
+	float LengthXZ(const Vector3& value)
+	{
+		return std::sqrt(value.x * value.x + value.z * value.z);
+	}
+}
+
+void EnemyStuckController::Reset(const Vector3& startPos)
+{
+	probePosition_ = startPos;
+	probeTimer_ = config_.checkIntervalSec;
+	stuckAccumSec_ = 0.0f;
+	unstuckTimer_ = 0.0f;
+	initialized_ = true;
+}
+
+EnemyStuckController::Output EnemyStuckController::Update(const UpdateInput& input)
+{
+	if (!initialized_)
+	{
+		Reset(input.selfPos);
+	}
+
+	Output output{};
+	if (unstuckTimer_ > 0.0f)
+	{
+		unstuckTimer_ = std::max(0.0f, unstuckTimer_ - input.dt);
+	}
+
+	probeTimer_ -= input.dt;
+	if (probeTimer_ > 0.0f)
+	{
+		output.isStuck = (unstuckTimer_ > 0.0f);
+		return output;
+	}
+
+	probeTimer_ = config_.checkIntervalSec;
+
+	const float moved = LengthXZ(input.selfPos - probePosition_);
+	probePosition_ = input.selfPos;
+
+	if (input.moveCommanded && moved < config_.minProgressDistance)
+	{
+		stuckAccumSec_ += config_.checkIntervalSec;
+	}
+	else
+	{
+		stuckAccumSec_ = std::max(0.0f, stuckAccumSec_ - config_.checkIntervalSec * 1.5f);
+	}
+
+	if (stuckAccumSec_ >= config_.stuckThresholdSec)
+	{
+		output.shouldRepath = true;
+		stuckAccumSec_ = 0.0f;
+		unstuckTimer_ = config_.unstuckDurationSec;
+	}
+
+	output.isStuck = (unstuckTimer_ > 0.0f);
+	return output;
+}

--- a/Project/ApplicationLayer/Character/Enemy/AI/EnemyStuckController.h
+++ b/Project/ApplicationLayer/Character/Enemy/AI/EnemyStuckController.h
@@ -1,0 +1,40 @@
+#pragma once
+
+#include <Vector3.h>
+
+class EnemyStuckController
+{
+public:
+	struct Config
+	{
+		float checkIntervalSec = 0.3f;
+		float minProgressDistance = 0.2f;
+		float stuckThresholdSec = 0.9f;
+		float unstuckDurationSec = 0.7f;
+	};
+
+	struct UpdateInput
+	{
+		Ken4lowEngine::Vector3 selfPos{ 0.0f, 0.0f, 0.0f };
+		float dt = 0.0f;
+		bool moveCommanded = false;
+	};
+
+	struct Output
+	{
+		bool isStuck = false;
+		bool shouldRepath = false;
+	};
+
+	void Reset(const Ken4lowEngine::Vector3& startPos);
+	[[nodiscard]] Output Update(const UpdateInput& input);
+	[[nodiscard]] bool IsUnstucking() const { return unstuckTimer_ > 0.0f; }
+
+private:
+	Config config_{};
+	Ken4lowEngine::Vector3 probePosition_{ 0.0f, 0.0f, 0.0f };
+	float probeTimer_ = 0.0f;
+	float stuckAccumSec_ = 0.0f;
+	float unstuckTimer_ = 0.0f;
+	bool initialized_ = false;
+};

--- a/Project/ApplicationLayer/Character/Enemy/Core/Enemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/Enemy.cpp
@@ -122,6 +122,9 @@ void Enemy::Initialize()
 	jumpCooldownTimer_ = 0.0f;
 	hitChainTimer_ = 0.0f;
 	consecutiveHitCount_ = 0;
+	moveCommandedThisFrame_ = false;
+	isMovementStuck_ = false;
+	stuckController_.Reset(GetCenterPosition());
 
 	animState_ = AnimState::Idle;
 	animTime_ = 0.0f;
@@ -133,6 +136,7 @@ void Enemy::Initialize()
 void Enemy::Update(float deltaTime)
 {
 	UpdateNavigatorSource();
+	moveCommandedThisFrame_ = false;
 
 	if (memory_.timeSinceSeen < 9999.0f) memory_.timeSinceSeen += deltaTime;
 
@@ -164,6 +168,19 @@ void Enemy::Update(float deltaTime)
 	}
 
 	if (state_) state_->Update(*this, deltaTime);
+
+	EnemyStuckController::UpdateInput stuckInput{};
+	stuckInput.selfPos = GetCenterPosition();
+	stuckInput.dt = deltaTime;
+	stuckInput.moveCommanded = moveCommandedThisFrame_;
+	const auto stuckOutput = stuckController_.Update(stuckInput);
+	isMovementStuck_ = stuckOutput.isStuck;
+	if (stuckOutput.shouldRepath)
+	{
+		navigator_.Reset();
+		UpdateStrafeDecision(999.0f);
+		currentStrafeSign_ *= -1.0f;
+	}
 
 	if (IsDead()) PlayDeadAnimation();
 
@@ -218,6 +235,7 @@ void Enemy::MoveInDirectionXZ(const K4E::Vector3& direction, float speed)
 		StopMove();
 		return; // 方向がほとんどない場合は移動しない
 	}
+	moveCommandedThisFrame_ = (speed > 0.05f);
 
 	Vector3 v = GetVelocity();
 	v.x = normDir.x * speed;
@@ -243,7 +261,23 @@ void Enemy::MoveTowardsPath(const K4E::Vector3& targetPos, float speed, float de
 {
 	Vector3 waypoint = targetPos;
 	const float sampleY = GetCenterPosition().y + 1.0f;
+	if (isMovementStuck_)
+	{
+		navigator_.Reset();
+	}
 	navigator_.GetNextWaypoint(GetCenterPosition(), targetPos, sampleY, deltaTime, waypoint);
+
+	if (isMovementStuck_)
+	{
+		Vector3 toTarget = targetPos - GetCenterPosition();
+		toTarget.y = 0.0f;
+		Vector3 side{ toTarget.z, 0.0f, -toTarget.x };
+		side = NormalizeXZ(side);
+		if (LengthSqXZ(side) > kEpsilon)
+		{
+			waypoint += side * movement_.losProbeDistance * currentStrafeSign_;
+		}
+	}
 
 	Vector3 direction = waypoint - GetCenterPosition();
 	direction.y = 0.0f; // 水平方向のみ
@@ -518,6 +552,10 @@ EnemyRetreatController::Plan Enemy::EvaluateRetreatPlan(float distToTarget, bool
 	input.hitReactionMoveWeight = reaction_.hitReactionMoveWeight + (1.0f - traits_.aggression) * 0.25f;
 	input.isLowHp = IsLowHp();
 	input.inHitReaction = IsInHitReaction();
+	if (consecutiveHitCount_ < 2)
+	{
+		input.inHitReaction = false;
+	}
 	input.canShoot = canShoot;
 	return retreatController_.EvaluatePlan(input);
 }

--- a/Project/ApplicationLayer/Character/Enemy/Core/Enemy.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/Enemy.h
@@ -8,6 +8,7 @@
 #include <EnemyCoverSelector.h>
 #include <EnemyEvadeController.h>
 #include <EnemyRetreatController.h>
+#include <EnemyStuckController.h>
 #include <EnemyTraitProfile.h>
 
 #include <memory>
@@ -74,7 +75,7 @@ private: /// ---------- 構造体 ---------- ///
 	// 低HP時の生存行動の設定
 	struct EnemySurvivalConfig
 	{
-		float lowHpThresholdRate = 0.4f;
+		float lowHpThresholdRate = 0.5f;
 		float lowHpRetreatDistance = 20.0f;
 		float lowHpReturnDistance = 28.0f;
 		float lowHpRetreatSpeedScale = 1.45f;
@@ -119,9 +120,9 @@ private: /// ---------- 構造体 ---------- ///
 		float tacticalBlend = 0.45f;
 		float shootMicroStrafeSpeed = 1.35f;
 		float jumpProbeDistance = 1.05f;
-		float jumpStepHeight = 0.95f;
-		float jumpVelocity = 5.3f;
-		float jumpCooldown = 0.9f;
+		float jumpStepHeight = 1.05f;
+		float jumpVelocity = 6.2f;
+		float jumpCooldown = 0.72f;
 	};
 
 	// 通常時の徘徊設定
@@ -250,6 +251,7 @@ public: /// ---------- アクセサ ---------- ///
 	[[nodiscard]] EnemyCoverController::Output EvaluateCoverAction(const K4E::Vector3& targetPos, const K4E::Vector3& coverPos, bool dangerMode, bool hasCover, float deltaTime);
 	void ResetCoverAction();
 	bool ShouldShootFromCover(const EnemyCoverController::Output& coverAction) const;
+	bool IsMovementStuck() const { return isMovementStuck_; }
 
 	void UpdateStrafeDecision(float dt);
 	float GetCurrentStrafeSign() const { return currentStrafeSign_; }
@@ -317,6 +319,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	EnemyCoverController coverController_{};
 
 	EnemyRetreatController retreatController_{};
+	EnemyStuckController stuckController_{};
 
 	EnemyEvadeController evadeController_{};
 	
@@ -338,6 +341,8 @@ private: /// ---------- メンバ変数 ---------- ///
 	float jumpCooldownTimer_ = 0.0f;
 	float hitChainTimer_ = 0.0f;
 	int consecutiveHitCount_ = 0;
+	bool moveCommandedThisFrame_ = false;
+	bool isMovementStuck_ = false;
 
 	AnimState animState_ = AnimState::Idle;
 	float animTime_ = 0.0f;

--- a/Project/ApplicationLayer/Character/Enemy/State/EnemyCombatMoveState.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/State/EnemyCombatMoveState.cpp
@@ -77,12 +77,19 @@ void EnemyCombatMoveState::Update(Enemy& enemy, float deltaTime)
 	}
 
 	const bool shouldPrioritizeCover = forceRetreat || (dangerMode && coverStayTimer_ <= 0.0f) || (evadePlan.mode == EnemyEvadeController::Mode::ToCover);
-	if (shouldPrioritizeCover)
+	const bool shouldUseOpportunisticCover =
+		!dangerMode &&
+		!canShoot &&
+		coverStayTimer_ <= 0.0f &&
+		distToTarget <= enemy.GetFireRange() * 1.15f;
+	const bool useCover = shouldPrioritizeCover || shouldUseOpportunisticCover;
+	if (useCover)
 	{
 		if (!hasRetreatTarget_ || retreatRepathTimer_ <= 0.0f)
 		{
 			Ken4lowEngine::Vector3 cover{};
-			hasRetreatTarget_ = enemy.TryFindCoverPosition(targetPos, true, cover);
+			const bool preferRetreat = dangerMode || forceRetreat;
+			hasRetreatTarget_ = enemy.TryFindCoverPosition(targetPos, preferRetreat, cover);
 			if (hasRetreatTarget_)
 			{
 				retreatTarget_ = cover;
@@ -112,6 +119,10 @@ void EnemyCombatMoveState::Update(Enemy& enemy, float deltaTime)
 	else
 	{
 		enemy.ResetCoverAction();
+		if (enemy.IsMovementStuck())
+		{
+			enemy.ForceStrafeSign(-enemy.GetCurrentStrafeSign());
+		}
 		enemy.MoveTacticalAround(targetPos, enemy.GetCurrentStrafeSign(), radialBias, speed);
 	}
 	enemy.PlayMoveAnimation(speed);

--- a/Project/ApplicationLayer/Character/Enemy/State/EnemyShootState.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/State/EnemyShootState.cpp
@@ -39,9 +39,9 @@ void EnemyShootState::Update(Enemy& enemy, float deltaTime)
 		return;
 	}
 
-	// 被弾直後や低HP時は射撃状態に留まらず、すぐ生存行動へ移る
-	if (((inHitReaction && enemy.GetConsecutiveHitCount() >= 2) && stayTimer_ > 0.03f) ||
-		(inHitReaction && stayTimer_ > 0.08f) || (lowHp && distToTarget < enemy.GetLowHpRetreatDistance()))
+	// 低HP時は早めに離脱。単発被弾だけでは即撤退しない。
+	if ((inHitReaction && enemy.GetConsecutiveHitCount() >= 2 && stayTimer_ > 0.05f) ||
+		(lowHp && distToTarget < enemy.GetLowHpRetreatDistance()))
 	{
 		enemy.ChangeStateToCombatMove();
 		return;

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -292,6 +292,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="ApplicationLayer\Character\Enemy\AI\EnemyRetreatController.cpp" />
     <ClCompile Include="ApplicationLayer\Character\Enemy\AI\EnemyAimController.cpp" />
     <ClCompile Include="ApplicationLayer\Character\Enemy\AI\EnemyCoverController.cpp" />
+    <ClCompile Include="ApplicationLayer\Character\Enemy\AI\EnemyStuckController.cpp" />
     <ClCompile Include="ApplicationLayer\Character\Enemy\AI\EnemyEvadeController.cpp" />
     <ClCompile Include="Engine\Graphics\Camera\Manager\CameraManager.cpp" />
     <ClCompile Include="Engine\Core\Application\Framework.cpp" />
@@ -867,6 +868,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="ApplicationLayer\Character\Enemy\AI\EnemyRetreatController.h" />
     <ClInclude Include="ApplicationLayer\Character\Enemy\AI\EnemyAimController.h" />
     <ClInclude Include="ApplicationLayer\Character\Enemy\AI\EnemyCoverController.h" />
+    <ClInclude Include="ApplicationLayer\Character\Enemy\AI\EnemyStuckController.h" />
     <ClInclude Include="ApplicationLayer\Character\Enemy\AI\EnemyEvadeController.h" />
     <ClInclude Include="ApplicationLayer\Character\Enemy\AI\EnemyTraitProfile.h" />
     <ClInclude Include="Engine\Graphics\Camera\Manager\CameraManager.h" />

--- a/Project/Ken4lowEngine.vcxproj.filters
+++ b/Project/Ken4lowEngine.vcxproj.filters
@@ -778,6 +778,9 @@
     <ClCompile Include="ApplicationLayer\Character\Enemy\AI\EnemyCoverController.cpp">
       <Filter>ApplicationLayer\Character\Enemy\AI</Filter>
     </ClCompile>
+    <ClCompile Include="ApplicationLayer\Character\Enemy\AI\EnemyStuckController.cpp">
+      <Filter>ApplicationLayer\Character\Enemy\AI</Filter>
+    </ClCompile>
     <ClCompile Include="ApplicationLayer\Character\Enemy\AI\EnemyEvadeController.cpp">
       <Filter>ApplicationLayer\Character\Enemy\AI</Filter>
     </ClCompile>
@@ -1630,6 +1633,9 @@
       <Filter>ApplicationLayer\Character\Enemy\AI</Filter>
     </ClInclude>
     <ClInclude Include="ApplicationLayer\Character\Enemy\AI\EnemyCoverController.h">
+      <Filter>ApplicationLayer\Character\Enemy\AI</Filter>
+    </ClInclude>
+    <ClInclude Include="ApplicationLayer\Character\Enemy\AI\EnemyStuckController.h">
       <Filter>ApplicationLayer\Character\Enemy\AI</Filter>
     </ClInclude>
     <ClInclude Include="ApplicationLayer\Character\Enemy\AI\EnemyEvadeController.h">


### PR DESCRIPTION
### Motivation
- Fix enemies getting permanently stuck on obstacles by adding periodic progress checks and automatic replan/unstuck behavior.
- Allow enemies to reliably overcome small steps/obstacles by tuning jump traversal while avoiding needless jump spam.
- Make combat use of cover more visibly during normal engagements (not only in panic/low-HP), and reduce overreaction to a single hit so enemies don’t flee too early.

### Description
- Added a new helper `EnemyStuckController` (`Project/ApplicationLayer/Character/Enemy/AI/EnemyStuckController.{h,cpp}`) that detects movement stalls, triggers repath resets and temporary unstuck windows, and is integrated into `Enemy` as `stuckController_`.
- Integrated stuck detection into `Enemy` (`Project/ApplicationLayer/Character/Enemy/Core/Enemy.{h,cpp}`) and set a `moveCommandedThisFrame_` flag so movement commands are evaluated for progress, with a fallback where a lateral offset is applied to waypoint selection when stuck.
- Tuned jump traversal parameters in `Enemy` (`jumpStepHeight`, `jumpVelocity`, `jumpCooldown`) to better clear small steps while keeping the existing probe checks and cooldown to avoid excessive jumping.
- Improved cover behavior in combat (`Project/ApplicationLayer/Character/Enemy/State/EnemyCombatMoveState.cpp`) by adding opportunistic cover selection when LOS is poor, and adjusted retreat logic and thresholds so `lowHpThresholdRate` is `0.5` and hit-reaction-driven retreats require consecutive hits to avoid immediate flee on light damage.
- Updated Visual Studio project files to include the new AI files (`Project/Ken4lowEngine.vcxproj` and `Project/Ken4lowEngine.vcxproj.filters`).

### Testing
- Ran `git diff --check` which completed without reported style errors.
- Attempted to run a full build with `msbuild Project/Ken4lowEngine.sln /t:Build /p:Configuration=Debug /p:Platform=x64`, but the environment lacks `msbuild` so the build could not be executed (failure recorded).
- Attempted to push the feature branch but the environment has no configured `origin` remote, so remote push was not possible (failure recorded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f09d3272a0832dac48ae9da832b255)