### PR TITLE
Add stuck-detection/recovery for enemies and tune movement/aim behavior

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/AI/EnemyAimController.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/AI/EnemyAimController.cpp
@@ -47,13 +47,14 @@ Vector3 EnemyAimController::BuildAimPoint(const Input& input) const
 	right = NormalizeSafe(right);
 	Vector3 up = NormalizeSafe(Vector3::Cross(right, targetDir));
 
-	const float distanceFactor = Clamp(input.distanceToTarget / 24.0f, 0.0f, 1.2f) * input.distanceSpreadWeight;
+	const float distanceNorm = Clamp((input.distanceToTarget - 5.0f) / 26.0f, 0.0f, 1.2f);
+	const float distanceFactor = (distanceNorm * distanceNorm + distanceNorm * 0.2f) * input.distanceSpreadWeight;
 	const float speedFactor = Clamp(input.movementSpeed / 4.2f, 0.0f, 1.0f) * input.moveSpreadWeight;
 	const float stress = (input.lowHp ? 0.35f : 0.0f) + (input.inHitReaction ? 0.5f : 0.0f);
 	const float traitStability = input.traits ? input.traits->aimStability : 0.5f;
 	const float stabilityScale = Clamp(1.0f - (traitStability * input.stableBonusWeight), 0.55f, 1.2f);
 	const float spread = Clamp(
-		input.baseSpreadRad + (distanceFactor + speedFactor + stress * input.stressSpreadWeight) * 0.08f,
+		input.baseSpreadRad + (distanceFactor + speedFactor + stress * input.stressSpreadWeight) * 0.075f,
 		input.baseSpreadRad,
 		input.maxSpreadRad) * stabilityScale;
 

--- a/Project/ApplicationLayer/Character/Enemy/AI/EnemyStuckController.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/AI/EnemyStuckController.cpp
@@ -1,0 +1,77 @@
+#include "EnemyStuckController.h"
+
+#include <algorithm>
+#include <cmath>
+
+using namespace Ken4lowEngine;
+
+namespace
+{
+	float LengthXZ(const Vector3& value)
+	{
+		return std::sqrt(value.x * value.x + value.z * value.z);
+	}
+}
+
+void EnemyStuckController::Reset(const Vector3& startPos)
+{
+	probePosition_ = startPos;
+	probeTimer_ = config_.checkIntervalSec;
+	stuckAccumSec_ = 0.0f;
+	repathCooldownTimer_ = 0.0f;
+	unstuckTimer_ = 0.0f;
+	jumpRetryTimer_ = 0.0f;
+	initialized_ = true;
+}
+
+EnemyStuckController::Output EnemyStuckController::Update(const UpdateInput& input)
+{
+	if (!initialized_)
+	{
+		Reset(input.selfPos);
+	}
+
+	Output output{};
+	repathCooldownTimer_ = std::max(0.0f, repathCooldownTimer_ - input.dt);
+	unstuckTimer_ = std::max(0.0f, unstuckTimer_ - input.dt);
+	jumpRetryTimer_ = std::max(0.0f, jumpRetryTimer_ - input.dt);
+
+	probeTimer_ -= input.dt;
+	if (probeTimer_ <= 0.0f)
+	{
+		probeTimer_ = config_.checkIntervalSec;
+
+		const float moved = LengthXZ(input.selfPos - probePosition_);
+		probePosition_ = input.selfPos;
+
+		if (input.moveCommanded && moved < config_.minProgressDistance)
+		{
+			stuckAccumSec_ += config_.checkIntervalSec;
+		}
+		else
+		{
+			stuckAccumSec_ = std::max(0.0f, stuckAccumSec_ - config_.checkIntervalSec * 1.25f);
+		}
+	}
+
+	const bool stuckDetected = stuckAccumSec_ >= config_.stuckThresholdSec;
+	if (stuckDetected)
+	{
+		if (repathCooldownTimer_ <= 0.0f)
+		{
+			output.shouldRepath = true;
+			repathCooldownTimer_ = config_.repathCooldownSec;
+		}
+		if (input.grounded && jumpRetryTimer_ <= 0.0f)
+		{
+			output.shouldRetryJump = true;
+			jumpRetryTimer_ = config_.jumpRetryMinIntervalSec;
+		}
+
+		unstuckTimer_ = std::max(unstuckTimer_, config_.unstuckDurationSec);
+		stuckAccumSec_ = config_.stuckThresholdSec * 0.5f;
+	}
+
+	output.isRecovering = (unstuckTimer_ > 0.0f);
+	return output;
+}

--- a/Project/ApplicationLayer/Character/Enemy/AI/EnemyStuckController.h
+++ b/Project/ApplicationLayer/Character/Enemy/AI/EnemyStuckController.h
@@ -1,0 +1,45 @@
+#pragma once
+
+#include <Vector3.h>
+
+class EnemyStuckController
+{
+public:
+	struct Config
+	{
+		float checkIntervalSec = 0.28f;
+		float minProgressDistance = 0.18f;
+		float stuckThresholdSec = 0.84f;
+		float repathCooldownSec = 0.75f;
+		float unstuckDurationSec = 0.7f;
+		float jumpRetryMinIntervalSec = 0.28f;
+	};
+
+	struct UpdateInput
+	{
+		Ken4lowEngine::Vector3 selfPos{ 0.0f, 0.0f, 0.0f };
+		float dt = 0.0f;
+		bool moveCommanded = false;
+		bool grounded = false;
+	};
+
+	struct Output
+	{
+		bool isRecovering = false;
+		bool shouldRepath = false;
+		bool shouldRetryJump = false;
+	};
+
+	void Reset(const Ken4lowEngine::Vector3& startPos);
+	[[nodiscard]] Output Update(const UpdateInput& input);
+
+private:
+	Config config_{};
+	Ken4lowEngine::Vector3 probePosition_{ 0.0f, 0.0f, 0.0f };
+	float probeTimer_ = 0.0f;
+	float stuckAccumSec_ = 0.0f;
+	float repathCooldownTimer_ = 0.0f;
+	float unstuckTimer_ = 0.0f;
+	float jumpRetryTimer_ = 0.0f;
+	bool initialized_ = false;
+};

--- a/Project/ApplicationLayer/Character/Enemy/Core/Enemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/Enemy.cpp
@@ -122,6 +122,12 @@ void Enemy::Initialize()
 	jumpCooldownTimer_ = 0.0f;
 	hitChainTimer_ = 0.0f;
 	consecutiveHitCount_ = 0;
+	moveCommandedThisFrame_ = false;
+	isMovementRecovering_ = false;
+	lastMoveDirection_ = { 0.0f, 0.0f, 0.0f };
+	coverPreferenceTimer_ = 0.0f;
+	coverPreferenceDecision_ = false;
+	stuckController_.Reset(GetCenterPosition());
 
 	animState_ = AnimState::Idle;
 	animTime_ = 0.0f;
@@ -133,6 +139,8 @@ void Enemy::Initialize()
 void Enemy::Update(float deltaTime)
 {
 	UpdateNavigatorSource();
+	moveCommandedThisFrame_ = false;
+	RefreshCoverPreferenceDecision(deltaTime);
 
 	if (memory_.timeSinceSeen < 9999.0f) memory_.timeSinceSeen += deltaTime;
 
@@ -164,6 +172,24 @@ void Enemy::Update(float deltaTime)
 	}
 
 	if (state_) state_->Update(*this, deltaTime);
+
+	EnemyStuckController::UpdateInput stuckInput{};
+	stuckInput.selfPos = GetCenterPosition();
+	stuckInput.dt = deltaTime;
+	stuckInput.moveCommanded = moveCommandedThisFrame_;
+	stuckInput.grounded = grounded_;
+	const auto stuckOutput = stuckController_.Update(stuckInput);
+	isMovementRecovering_ = stuckOutput.isRecovering;
+	if (stuckOutput.shouldRepath)
+	{
+		navigator_.Reset();
+		UpdateStrafeDecision(999.0f);
+		currentStrafeSign_ *= -1.0f;
+	}
+	if (stuckOutput.shouldRetryJump)
+	{
+		TryStepJump(lastMoveDirection_);
+	}
 
 	if (IsDead()) PlayDeadAnimation();
 
@@ -218,6 +244,8 @@ void Enemy::MoveInDirectionXZ(const K4E::Vector3& direction, float speed)
 		StopMove();
 		return; // 方向がほとんどない場合は移動しない
 	}
+	moveCommandedThisFrame_ = (speed > 0.05f);
+	lastMoveDirection_ = normDir;
 
 	Vector3 v = GetVelocity();
 	v.x = normDir.x * speed;
@@ -243,7 +271,19 @@ void Enemy::MoveTowardsPath(const K4E::Vector3& targetPos, float speed, float de
 {
 	Vector3 waypoint = targetPos;
 	const float sampleY = GetCenterPosition().y + 1.0f;
+	if (isMovementRecovering_)
+	{
+		navigator_.Reset();
+	}
 	navigator_.GetNextWaypoint(GetCenterPosition(), targetPos, sampleY, deltaTime, waypoint);
+	if (isMovementRecovering_)
+	{
+		Vector3 toTarget = targetPos - GetCenterPosition();
+		toTarget.y = 0.0f;
+		Vector3 side{ toTarget.z, 0.0f, -toTarget.x };
+		side = NormalizeXZ(side);
+		waypoint += side * (movement_.losProbeDistance * currentStrafeSign_);
+	}
 
 	Vector3 direction = waypoint - GetCenterPosition();
 	direction.y = 0.0f; // 水平方向のみ
@@ -354,11 +394,12 @@ void Enemy::FireAt(const K4E::Vector3& targetPos)
 	aimInput.movementSpeed = LengthXZ(GetVelocity());
 	aimInput.lowHp = IsLowHp();
 	aimInput.inHitReaction = IsInHitReaction();
-	aimInput.baseSpreadRad = 0.008f;
-	aimInput.maxSpreadRad = 0.12f;
-	aimInput.distanceSpreadWeight = 0.95f;
-	aimInput.moveSpreadWeight = 0.85f;
-	aimInput.stressSpreadWeight = 0.7f;
+	const float distanceFactor = Clamp((aimInput.distanceToTarget - 6.0f) / 26.0f, 0.0f, 1.0f);
+	aimInput.baseSpreadRad = 0.0065f + distanceFactor * 0.0055f;
+	aimInput.maxSpreadRad = 0.105f + distanceFactor * 0.045f;
+	aimInput.distanceSpreadWeight = 1.08f;
+	aimInput.moveSpreadWeight = 0.82f;
+	aimInput.stressSpreadWeight = 0.62f;
 	aimInput.stableBonusWeight = 0.55f;
 	aimInput.traits = &traits_;
 	const Vector3 aim = aimController_.BuildAimPoint(aimInput);
@@ -517,7 +558,7 @@ EnemyRetreatController::Plan Enemy::EvaluateRetreatPlan(float distToTarget, bool
 	input.lowHpRetreatSpeedScale = survival_.lowHpRetreatSpeedScale;
 	input.hitReactionMoveWeight = reaction_.hitReactionMoveWeight + (1.0f - traits_.aggression) * 0.25f;
 	input.isLowHp = IsLowHp();
-	input.inHitReaction = IsInHitReaction();
+	input.inHitReaction = IsInHitReaction() && consecutiveHitCount_ >= 2;
 	input.canShoot = canShoot;
 	return retreatController_.EvaluatePlan(input);
 }
@@ -621,12 +662,25 @@ void Enemy::TryStepJump(const K4E::Vector3& moveDirection)
 
 void Enemy::UpdateTraitProfile()
 {
-	traits_.reactionDelayScale = RandomRange(0.85f, 1.2f);
-	traits_.strafeSwitchScale = RandomRange(0.8f, 1.35f);
-	traits_.fireIntervalScale = RandomRange(0.82f, 1.3f);
-	traits_.aggression = RandomRange(0.35f, 0.85f);
-	traits_.coverPreference = RandomRange(0.3f, 0.9f);
-	traits_.aimStability = RandomRange(0.25f, 0.9f);
+	traits_.reactionDelayScale = RandomRange(0.9f, 1.12f);
+	traits_.strafeSwitchScale = RandomRange(0.9f, 1.2f);
+	traits_.fireIntervalScale = RandomRange(0.9f, 1.18f);
+	traits_.aggression = RandomRange(0.42f, 0.74f);
+	traits_.coverPreference = RandomRange(0.38f, 0.76f);
+	traits_.aimStability = RandomRange(0.4f, 0.78f);
+}
+
+void Enemy::RefreshCoverPreferenceDecision(float deltaTime)
+{
+	coverPreferenceTimer_ -= deltaTime;
+	if (coverPreferenceTimer_ > 0.0f)
+	{
+		return;
+	}
+
+	coverPreferenceTimer_ = RandomRange(0.8f, 1.7f);
+	const float willingness = Clamp(traits_.coverPreference * 0.9f + (1.0f - traits_.aggression) * 0.15f, 0.2f, 0.9f);
+	coverPreferenceDecision_ = Random01() < willingness;
 }
 
 void Enemy::PickNextWanderTarget()

--- a/Project/ApplicationLayer/Character/Enemy/Core/Enemy.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/Enemy.h
@@ -8,6 +8,7 @@
 #include <EnemyCoverSelector.h>
 #include <EnemyEvadeController.h>
 #include <EnemyRetreatController.h>
+#include <EnemyStuckController.h>
 #include <EnemyTraitProfile.h>
 
 #include <memory>
@@ -74,13 +75,13 @@ private: /// ---------- 構造体 ---------- ///
 	// 低HP時の生存行動の設定
 	struct EnemySurvivalConfig
 	{
-		float lowHpThresholdRate = 0.4f;
+		float lowHpThresholdRate = 0.5f;
 		float lowHpRetreatDistance = 20.0f;
-		float lowHpReturnDistance = 28.0f;
-		float lowHpRetreatSpeedScale = 1.45f;
+		float lowHpReturnDistance = 24.0f;
+		float lowHpRetreatSpeedScale = 1.25f;
 		float lowHpShootRange = 15.0f;
 		float lowHpShootStaySec = 0.35f;
-		float retreatDecisionInterval = 0.18f;
+		float retreatDecisionInterval = 0.12f;
 	};
 
 	struct EnemyReactionConfig
@@ -119,9 +120,9 @@ private: /// ---------- 構造体 ---------- ///
 		float tacticalBlend = 0.45f;
 		float shootMicroStrafeSpeed = 1.35f;
 		float jumpProbeDistance = 1.05f;
-		float jumpStepHeight = 0.95f;
-		float jumpVelocity = 5.3f;
-		float jumpCooldown = 0.9f;
+		float jumpStepHeight = 1.08f;
+		float jumpVelocity = 6.2f;
+		float jumpCooldown = 0.72f;
 	};
 
 	// 通常時の徘徊設定
@@ -250,6 +251,8 @@ public: /// ---------- アクセサ ---------- ///
 	[[nodiscard]] EnemyCoverController::Output EvaluateCoverAction(const K4E::Vector3& targetPos, const K4E::Vector3& coverPos, bool dangerMode, bool hasCover, float deltaTime);
 	void ResetCoverAction();
 	bool ShouldShootFromCover(const EnemyCoverController::Output& coverAction) const;
+	bool IsMovementRecovering() const { return isMovementRecovering_; }
+	bool ShouldPreferCoverNow() const { return coverPreferenceDecision_; }
 
 	void UpdateStrafeDecision(float dt);
 	float GetCurrentStrafeSign() const { return currentStrafeSign_; }
@@ -284,6 +287,7 @@ private: /// ---------- 内部処理 ---------- ///
 	void PickNextWanderTarget();
 	void TryStepJump(const K4E::Vector3& moveDirection);
 	void UpdateTraitProfile();
+	void RefreshCoverPreferenceDecision(float deltaTime);
 
 private: /// ---------- メンバ変数 ---------- ///
 
@@ -317,6 +321,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	EnemyCoverController coverController_{};
 
 	EnemyRetreatController retreatController_{};
+	EnemyStuckController stuckController_{};
 
 	EnemyEvadeController evadeController_{};
 	
@@ -338,6 +343,11 @@ private: /// ---------- メンバ変数 ---------- ///
 	float jumpCooldownTimer_ = 0.0f;
 	float hitChainTimer_ = 0.0f;
 	int consecutiveHitCount_ = 0;
+	bool moveCommandedThisFrame_ = false;
+	bool isMovementRecovering_ = false;
+	K4E::Vector3 lastMoveDirection_{ 0.0f, 0.0f, 0.0f };
+	float coverPreferenceTimer_ = 0.0f;
+	bool coverPreferenceDecision_ = false;
 
 	AnimState animState_ = AnimState::Idle;
 	float animTime_ = 0.0f;

--- a/Project/ApplicationLayer/Character/Enemy/State/EnemyCombatMoveState.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/State/EnemyCombatMoveState.cpp
@@ -77,12 +77,20 @@ void EnemyCombatMoveState::Update(Enemy& enemy, float deltaTime)
 	}
 
 	const bool shouldPrioritizeCover = forceRetreat || (dangerMode && coverStayTimer_ <= 0.0f) || (evadePlan.mode == EnemyEvadeController::Mode::ToCover);
-	if (shouldPrioritizeCover)
+	const bool shouldUseOpportunisticCover =
+		!dangerMode &&
+		!canShoot &&
+		coverStayTimer_ <= 0.0f &&
+		distToTarget <= enemy.GetFireRange() * 1.2f &&
+		enemy.ShouldPreferCoverNow();
+	const bool useCover = shouldPrioritizeCover || shouldUseOpportunisticCover;
+	if (useCover)
 	{
 		if (!hasRetreatTarget_ || retreatRepathTimer_ <= 0.0f)
 		{
 			Ken4lowEngine::Vector3 cover{};
-			hasRetreatTarget_ = enemy.TryFindCoverPosition(targetPos, true, cover);
+			const bool preferRetreat = dangerMode || forceRetreat;
+			hasRetreatTarget_ = enemy.TryFindCoverPosition(targetPos, preferRetreat, cover);
 			if (hasRetreatTarget_)
 			{
 				retreatTarget_ = cover;
@@ -112,6 +120,10 @@ void EnemyCombatMoveState::Update(Enemy& enemy, float deltaTime)
 	else
 	{
 		enemy.ResetCoverAction();
+		if (enemy.IsMovementRecovering())
+		{
+			enemy.ForceStrafeSign(-enemy.GetCurrentStrafeSign());
+		}
 		enemy.MoveTacticalAround(targetPos, enemy.GetCurrentStrafeSign(), radialBias, speed);
 	}
 	enemy.PlayMoveAnimation(speed);

--- a/Project/ApplicationLayer/Character/Enemy/State/EnemyShootState.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/State/EnemyShootState.cpp
@@ -39,9 +39,9 @@ void EnemyShootState::Update(Enemy& enemy, float deltaTime)
 		return;
 	}
 
-	// 被弾直後や低HP時は射撃状態に留まらず、すぐ生存行動へ移る
-	if (((inHitReaction && enemy.GetConsecutiveHitCount() >= 2) && stayTimer_ > 0.03f) ||
-		(inHitReaction && stayTimer_ > 0.08f) || (lowHp && distToTarget < enemy.GetLowHpRetreatDistance()))
+	// 単発被弾だけでは即離脱せず、低HPまたは連続被弾時に生存行動へ移る
+	if ((inHitReaction && enemy.GetConsecutiveHitCount() >= 2 && stayTimer_ > 0.05f) ||
+		(lowHp && distToTarget < enemy.GetLowHpRetreatDistance()))
 	{
 		enemy.ChangeStateToCombatMove();
 		return;

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -292,6 +292,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="ApplicationLayer\Character\Enemy\AI\EnemyRetreatController.cpp" />
     <ClCompile Include="ApplicationLayer\Character\Enemy\AI\EnemyAimController.cpp" />
     <ClCompile Include="ApplicationLayer\Character\Enemy\AI\EnemyCoverController.cpp" />
+    <ClCompile Include="ApplicationLayer\Character\Enemy\AI\EnemyStuckController.cpp" />
     <ClCompile Include="ApplicationLayer\Character\Enemy\AI\EnemyEvadeController.cpp" />
     <ClCompile Include="Engine\Graphics\Camera\Manager\CameraManager.cpp" />
     <ClCompile Include="Engine\Core\Application\Framework.cpp" />
@@ -867,6 +868,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="ApplicationLayer\Character\Enemy\AI\EnemyRetreatController.h" />
     <ClInclude Include="ApplicationLayer\Character\Enemy\AI\EnemyAimController.h" />
     <ClInclude Include="ApplicationLayer\Character\Enemy\AI\EnemyCoverController.h" />
+    <ClInclude Include="ApplicationLayer\Character\Enemy\AI\EnemyStuckController.h" />
     <ClInclude Include="ApplicationLayer\Character\Enemy\AI\EnemyEvadeController.h" />
     <ClInclude Include="ApplicationLayer\Character\Enemy\AI\EnemyTraitProfile.h" />
     <ClInclude Include="Engine\Graphics\Camera\Manager\CameraManager.h" />

--- a/Project/Ken4lowEngine.vcxproj.filters
+++ b/Project/Ken4lowEngine.vcxproj.filters
@@ -778,6 +778,9 @@
     <ClCompile Include="ApplicationLayer\Character\Enemy\AI\EnemyCoverController.cpp">
       <Filter>ApplicationLayer\Character\Enemy\AI</Filter>
     </ClCompile>
+    <ClCompile Include="ApplicationLayer\Character\Enemy\AI\EnemyStuckController.cpp">
+      <Filter>ApplicationLayer\Character\Enemy\AI</Filter>
+    </ClCompile>
     <ClCompile Include="ApplicationLayer\Character\Enemy\AI\EnemyEvadeController.cpp">
       <Filter>ApplicationLayer\Character\Enemy\AI</Filter>
     </ClCompile>
@@ -1630,6 +1633,9 @@
       <Filter>ApplicationLayer\Character\Enemy\AI</Filter>
     </ClInclude>
     <ClInclude Include="ApplicationLayer\Character\Enemy\AI\EnemyCoverController.h">
+      <Filter>ApplicationLayer\Character\Enemy\AI</Filter>
+    </ClInclude>
+    <ClInclude Include="ApplicationLayer\Character\Enemy\AI\EnemyStuckController.h">
       <Filter>ApplicationLayer\Character\Enemy\AI</Filter>
     </ClInclude>
     <ClInclude Include="ApplicationLayer\Character\Enemy\AI\EnemyEvadeController.h">


### PR DESCRIPTION
### Motivation
- Detect and recover enemies that become stuck during navigation to avoid frozen or looping movement and improve combat flow.
- Adjust aiming, movement, and trait parameters to make enemy combat behavior more stable and better balanced.

### Description
- Add `EnemyStuckController` (`EnemyStuckController.h/.cpp`) that probes positional progress, accumulates stuck time, and emits `shouldRepath` and `shouldRetryJump` signals; include it in the build files.
- Integrate stuck handling into `Enemy`: add members (`moveCommandedThisFrame_`, `isMovementRecovering_`, `lastMoveDirection_`, cover preference state), set command flags in `MoveInDirectionXZ`, call `stuckController_.Update` in `Update`, and trigger `navigator_.Reset()` or `TryStepJump()` when requested.
- Change path following to aid recovery by resetting the navigator when recovering and offsetting waypoints sideways to escape, and flip strafe sign when recovering in combat movement state.
- Tune aim/spread calculation and combat/movement parameters by updating `EnemyAimController::BuildAimPoint` and `Enemy::FireAt` spread math, adjusting trait randomization ranges, jump and survival thresholds, and refining retreat/cover decision logic in combat and shoot states.

### Testing
- Built the `Ken4lowEngine` solution (Debug/x64) with the new sources and project updates and the compilation succeeded.
- Ran the existing automated test/smoke suite and engine integration checks, and no failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f09d3272a0832dac48ae9da832b255)