### PR TITLE
雑魚敵AI最終調整：スタック回復・遮蔽物ピーク改善・撤退ヒステリシス導入

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/AI/EnemyAimController.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/AI/EnemyAimController.cpp
@@ -48,12 +48,14 @@ Vector3 EnemyAimController::BuildAimPoint(const Input& input) const
 	Vector3 up = NormalizeSafe(Vector3::Cross(right, targetDir));
 
 	const float distanceFactor = Clamp(input.distanceToTarget / 24.0f, 0.0f, 1.2f) * input.distanceSpreadWeight;
+	const float closeBonus = Clamp(1.0f - (input.distanceToTarget / 8.0f), 0.0f, 1.0f);
+	const float farPenalty = Clamp((input.distanceToTarget - 14.0f) / 14.0f, 0.0f, 1.0f);
 	const float speedFactor = Clamp(input.movementSpeed / 4.2f, 0.0f, 1.0f) * input.moveSpreadWeight;
 	const float stress = (input.lowHp ? 0.35f : 0.0f) + (input.inHitReaction ? 0.5f : 0.0f);
 	const float traitStability = input.traits ? input.traits->aimStability : 0.5f;
 	const float stabilityScale = Clamp(1.0f - (traitStability * input.stableBonusWeight), 0.55f, 1.2f);
 	const float spread = Clamp(
-		input.baseSpreadRad + (distanceFactor + speedFactor + stress * input.stressSpreadWeight) * 0.08f,
+		input.baseSpreadRad + (distanceFactor + farPenalty * 0.5f + speedFactor + stress * input.stressSpreadWeight - closeBonus * 0.3f) * 0.08f,
 		input.baseSpreadRad,
 		input.maxSpreadRad) * stabilityScale;
 

--- a/Project/ApplicationLayer/Character/Enemy/AI/EnemyCoverController.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/AI/EnemyCoverController.cpp
@@ -32,6 +32,13 @@ namespace
 		std::uniform_real_distribution<float> dist(minValue, maxValue);
 		return dist(engine);
 	}
+
+	bool RandomChance(float probability)
+	{
+		thread_local std::mt19937 engine{ std::random_device{}() };
+		std::bernoulli_distribution dist(std::clamp(static_cast<double>(probability), 0.0, 1.0));
+		return dist(engine);
+	}
 }
 
 void EnemyCoverController::Reset()
@@ -58,12 +65,14 @@ EnemyCoverController::Output EnemyCoverController::Update(const UpdateInput& inp
 		exposing_ = !exposing_;
 		if (input.dangerMode && exposing_)
 		{
-			exposing_ = false;
+			exposing_ = RandomChance(0.32f);
 		}
 
 		if (exposing_)
 		{
-			phaseTimer_ = RandomRange(config_.peekExposeMinSec, config_.peekExposeMaxSec);
+			const float exposeMin = input.dangerMode ? config_.peekExposeMinSec * 0.55f : config_.peekExposeMinSec;
+			const float exposeMax = input.dangerMode ? config_.peekExposeMaxSec * 0.7f : config_.peekExposeMaxSec;
+			phaseTimer_ = RandomRange(exposeMin, exposeMax);
 		}
 		else
 		{

--- a/Project/ApplicationLayer/Character/Enemy/AI/EnemyRetreatDecisionMemory.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/AI/EnemyRetreatDecisionMemory.cpp
@@ -1,0 +1,66 @@
+#include "EnemyRetreatDecisionMemory.h"
+
+#include <algorithm>
+
+void EnemyRetreatDecisionMemory::Reset()
+{
+	retreating_ = false;
+	evalTimer_ = 0.0f;
+	retreatHoldTimer_ = 0.0f;
+	safeTimer_ = 0.0f;
+}
+
+bool EnemyRetreatDecisionMemory::Update(const Input& input)
+{
+	if (retreatHoldTimer_ > 0.0f)
+	{
+		retreatHoldTimer_ = std::max(0.0f, retreatHoldTimer_ - input.dt);
+	}
+
+	evalTimer_ -= input.dt;
+	if (evalTimer_ > 0.0f)
+	{
+		return retreating_;
+	}
+	evalTimer_ = std::max(0.05f, input.decisionInterval);
+
+	const bool veryLowHp = input.hpRate <= config_.hpThreshold;
+	const bool pressuredByHits = input.inHitReaction && input.consecutiveHits >= 2;
+	const bool closeThreat = input.distanceToTarget <= (input.retreatDistance + config_.engageDistanceBias);
+	const bool shouldEnterRetreat = veryLowHp && (closeThreat || pressuredByHits);
+
+	if (!retreating_ && shouldEnterRetreat)
+	{
+		retreating_ = true;
+		retreatHoldTimer_ = config_.minRetreatHoldSec;
+		safeTimer_ = 0.0f;
+		return retreating_;
+	}
+
+	if (!retreating_)
+	{
+		return retreating_;
+	}
+
+	const bool hpRecovered = input.hpRate >= config_.hpRecoverThreshold;
+	const bool safeDistance = input.distanceToTarget >= input.returnDistance;
+	const bool notPressured = !input.inHitReaction && input.consecutiveHits == 0;
+	const bool hasShots = input.canShoot;
+
+	if (safeDistance && hasShots && notPressured)
+	{
+		safeTimer_ += input.decisionInterval;
+	}
+	else
+	{
+		safeTimer_ = 0.0f;
+	}
+
+	if (retreatHoldTimer_ <= 0.0f && (hpRecovered || safeTimer_ >= config_.safeTimeToReleaseSec))
+	{
+		retreating_ = false;
+		safeTimer_ = 0.0f;
+	}
+
+	return retreating_;
+}

--- a/Project/ApplicationLayer/Character/Enemy/AI/EnemyRetreatDecisionMemory.h
+++ b/Project/ApplicationLayer/Character/Enemy/AI/EnemyRetreatDecisionMemory.h
@@ -1,0 +1,39 @@
+#pragma once
+
+class EnemyRetreatDecisionMemory
+{
+public:
+	struct Config
+	{
+		float hpThreshold = 0.5f;
+		float hpRecoverThreshold = 0.62f;
+		float engageDistanceBias = 2.0f;
+		float minRetreatHoldSec = 1.1f;
+		float safeTimeToReleaseSec = 1.4f;
+	};
+
+	struct Input
+	{
+		float dt = 0.0f;
+		float hpRate = 1.0f;
+		float distanceToTarget = 9999.0f;
+		float retreatDistance = 18.0f;
+		float returnDistance = 28.0f;
+		float decisionInterval = 0.2f;
+		bool inHitReaction = false;
+		bool canShoot = true;
+		int consecutiveHits = 0;
+	};
+
+	void Reset();
+	void SetConfig(const Config& config) { config_ = config; }
+	[[nodiscard]] bool Update(const Input& input);
+	[[nodiscard]] bool IsRetreating() const { return retreating_; }
+
+private:
+	Config config_{};
+	bool retreating_ = false;
+	float evalTimer_ = 0.0f;
+	float retreatHoldTimer_ = 0.0f;
+	float safeTimer_ = 0.0f;
+};

--- a/Project/ApplicationLayer/Character/Enemy/AI/EnemyStuckController.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/AI/EnemyStuckController.cpp
@@ -19,6 +19,8 @@ void EnemyStuckController::Reset(const Vector3& startPos)
 	probeTimer_ = config_.checkIntervalSec;
 	stuckAccumSec_ = 0.0f;
 	unstuckTimer_ = 0.0f;
+	jumpRetryCooldownSec_ = 0.0f;
+	consecutiveStuckEvents_ = 0;
 	initialized_ = true;
 }
 
@@ -33,6 +35,10 @@ EnemyStuckController::Output EnemyStuckController::Update(const UpdateInput& inp
 	if (unstuckTimer_ > 0.0f)
 	{
 		unstuckTimer_ = std::max(0.0f, unstuckTimer_ - input.dt);
+	}
+	if (jumpRetryCooldownSec_ > 0.0f)
+	{
+		jumpRetryCooldownSec_ = std::max(0.0f, jumpRetryCooldownSec_ - input.dt);
 	}
 
 	probeTimer_ -= input.dt;
@@ -54,6 +60,10 @@ EnemyStuckController::Output EnemyStuckController::Update(const UpdateInput& inp
 	else
 	{
 		stuckAccumSec_ = std::max(0.0f, stuckAccumSec_ - config_.checkIntervalSec * 1.5f);
+		if (moved >= config_.minProgressDistance * 1.2f)
+		{
+			consecutiveStuckEvents_ = 0;
+		}
 	}
 
 	if (stuckAccumSec_ >= config_.stuckThresholdSec)
@@ -61,6 +71,12 @@ EnemyStuckController::Output EnemyStuckController::Update(const UpdateInput& inp
 		output.shouldRepath = true;
 		stuckAccumSec_ = 0.0f;
 		unstuckTimer_ = config_.unstuckDurationSec;
+		++consecutiveStuckEvents_;
+		if (jumpRetryCooldownSec_ <= 0.0f || consecutiveStuckEvents_ >= 2)
+		{
+			output.shouldRetryJump = true;
+			jumpRetryCooldownSec_ = 0.45f;
+		}
 	}
 
 	output.isStuck = (unstuckTimer_ > 0.0f);

--- a/Project/ApplicationLayer/Character/Enemy/AI/EnemyStuckController.h
+++ b/Project/ApplicationLayer/Character/Enemy/AI/EnemyStuckController.h
@@ -24,6 +24,7 @@ public:
 	{
 		bool isStuck = false;
 		bool shouldRepath = false;
+		bool shouldRetryJump = false;
 	};
 
 	void Reset(const Ken4lowEngine::Vector3& startPos);
@@ -36,5 +37,7 @@ private:
 	float probeTimer_ = 0.0f;
 	float stuckAccumSec_ = 0.0f;
 	float unstuckTimer_ = 0.0f;
+	float jumpRetryCooldownSec_ = 0.0f;
+	int consecutiveStuckEvents_ = 0;
 	bool initialized_ = false;
 };

--- a/Project/ApplicationLayer/Character/Enemy/Core/Enemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/Enemy.cpp
@@ -125,6 +125,7 @@ void Enemy::Initialize()
 	moveCommandedThisFrame_ = false;
 	isMovementStuck_ = false;
 	stuckController_.Reset(GetCenterPosition());
+	retreatDecision_.Reset();
 
 	animState_ = AnimState::Idle;
 	animTime_ = 0.0f;
@@ -180,6 +181,16 @@ void Enemy::Update(float deltaTime)
 		navigator_.Reset();
 		UpdateStrafeDecision(999.0f);
 		currentStrafeSign_ *= -1.0f;
+	}
+	if (stuckOutput.shouldRetryJump)
+	{
+		Vector3 recoverDir = GetVelocity();
+		recoverDir.y = 0.0f;
+		if (LengthSqXZ(recoverDir) <= kEpsilon)
+		{
+			recoverDir = memory_.lastSeenPos - GetCenterPosition();
+		}
+		TryStepJump(recoverDir);
 	}
 
 	if (IsDead()) PlayDeadAnimation();
@@ -535,7 +546,7 @@ bool Enemy::CanShootTarget(const K4E::Vector3& targetPos) const
 	return HasLineOfSight(muzzle, targetEye);
 }
 
-EnemyRetreatController::Plan Enemy::EvaluateRetreatPlan(float distToTarget, bool canShoot) const
+EnemyRetreatController::Plan Enemy::EvaluateRetreatPlan(float distToTarget, bool canShoot)
 {
 	EnemyRetreatController::Input input{};
 	input.distanceToTarget = distToTarget;
@@ -550,7 +561,18 @@ EnemyRetreatController::Plan Enemy::EvaluateRetreatPlan(float distToTarget, bool
 	input.strafeSpeed = movement_.strafeSpeed;
 	input.lowHpRetreatSpeedScale = survival_.lowHpRetreatSpeedScale;
 	input.hitReactionMoveWeight = reaction_.hitReactionMoveWeight + (1.0f - traits_.aggression) * 0.25f;
-	input.isLowHp = IsLowHp();
+	EnemyRetreatDecisionMemory::Input retreatInput{};
+	retreatInput.dt = 0.0f;
+	retreatInput.hpRate = GetHpRate();
+	retreatInput.distanceToTarget = distToTarget;
+	retreatInput.retreatDistance = survival_.lowHpRetreatDistance;
+	retreatInput.returnDistance = survival_.lowHpReturnDistance;
+	retreatInput.decisionInterval = survival_.retreatDecisionInterval;
+	retreatInput.inHitReaction = IsInHitReaction();
+	retreatInput.canShoot = canShoot;
+	retreatInput.consecutiveHits = consecutiveHitCount_;
+	const bool retreating = retreatDecision_.Update(retreatInput);
+	input.isLowHp = retreating;
 	input.inHitReaction = IsInHitReaction();
 	if (consecutiveHitCount_ < 2)
 	{
@@ -659,12 +681,19 @@ void Enemy::TryStepJump(const K4E::Vector3& moveDirection)
 
 void Enemy::UpdateTraitProfile()
 {
-	traits_.reactionDelayScale = RandomRange(0.85f, 1.2f);
-	traits_.strafeSwitchScale = RandomRange(0.8f, 1.35f);
-	traits_.fireIntervalScale = RandomRange(0.82f, 1.3f);
-	traits_.aggression = RandomRange(0.35f, 0.85f);
-	traits_.coverPreference = RandomRange(0.3f, 0.9f);
-	traits_.aimStability = RandomRange(0.25f, 0.9f);
+	traits_.reactionDelayScale = RandomRange(0.9f, 1.12f);
+	traits_.strafeSwitchScale = RandomRange(0.88f, 1.2f);
+	traits_.fireIntervalScale = RandomRange(0.9f, 1.18f);
+	traits_.aggression = RandomRange(0.4f, 0.72f);
+	traits_.coverPreference = RandomRange(0.38f, 0.78f);
+	traits_.aimStability = RandomRange(0.35f, 0.76f);
+
+	const float cautiousness = 1.0f - traits_.aggression;
+	movement_.strafeSwitchMinSec *= RandomRange(0.92f, 1.08f);
+	movement_.strafeSwitchMaxSec *= RandomRange(0.94f, 1.14f);
+	combat_.fireInterval *= (0.95f + cautiousness * 0.08f);
+	reaction_.coverBias = Clamp(reaction_.coverBias + (traits_.coverPreference - 0.5f) * 0.25f, 0.45f, 0.82f);
+	reaction_.evadeWeight = Clamp(reaction_.evadeWeight + cautiousness * 0.08f, 0.58f, 0.84f);
 }
 
 void Enemy::PickNextWanderTarget()

--- a/Project/ApplicationLayer/Character/Enemy/Core/Enemy.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/Enemy.h
@@ -8,6 +8,7 @@
 #include <EnemyCoverSelector.h>
 #include <EnemyEvadeController.h>
 #include <EnemyRetreatController.h>
+#include <EnemyRetreatDecisionMemory.h>
 #include <EnemyStuckController.h>
 #include <EnemyTraitProfile.h>
 
@@ -238,6 +239,7 @@ public: /// ---------- アクセサ ---------- ///
 	float GetCoverRepathInterval() const { return cover_.coverRepathInterval; }
 	float GetCoverStayTime() const { return cover_.coverStayTime; }
 	bool IsLowHp() const { return GetHpRate() <= survival_.lowHpThresholdRate; }
+	bool IsRetreating() const { return retreatDecision_.IsRetreating(); }
 	bool IsInHitReaction() const { return hitReactionTimer_ > 0.0f; }
 	float GetHitReactionMoveWeight() const { return reaction_.hitReactionMoveWeight; }
 	float GetEvadeWeight() const { return reaction_.evadeWeight; }
@@ -245,7 +247,7 @@ public: /// ---------- アクセサ ---------- ///
 	float GetCoverPreference() const { return traits_.coverPreference; }
 	float GetAggression() const { return traits_.aggression; }
 	int GetConsecutiveHitCount() const { return consecutiveHitCount_; }
-	EnemyRetreatController::Plan EvaluateRetreatPlan(float distToTarget, bool canShoot) const;
+	EnemyRetreatController::Plan EvaluateRetreatPlan(float distToTarget, bool canShoot);
 	EnemyEvadeController::Plan EvaluateEvadePlan(bool canShoot) const;
 	[[nodiscard]] bool TryFindCoverPosition(const K4E::Vector3& targetPos, bool preferRetreat, K4E::Vector3& outPosition) const;
 	[[nodiscard]] EnemyCoverController::Output EvaluateCoverAction(const K4E::Vector3& targetPos, const K4E::Vector3& coverPos, bool dangerMode, bool hasCover, float deltaTime);
@@ -319,6 +321,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	EnemyCoverController coverController_{};
 
 	EnemyRetreatController retreatController_{};
+	EnemyRetreatDecisionMemory retreatDecision_{};
 	EnemyStuckController stuckController_{};
 
 	EnemyEvadeController evadeController_{};

--- a/Project/ApplicationLayer/Character/Enemy/State/EnemyCombatMoveState.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/State/EnemyCombatMoveState.cpp
@@ -81,7 +81,7 @@ void EnemyCombatMoveState::Update(Enemy& enemy, float deltaTime)
 		!dangerMode &&
 		!canShoot &&
 		coverStayTimer_ <= 0.0f &&
-		distToTarget <= enemy.GetFireRange() * 1.15f;
+		distToTarget <= enemy.GetFireRange() * (1.05f + enemy.GetCoverPreference() * 0.2f);
 	const bool useCover = shouldPrioritizeCover || shouldUseOpportunisticCover;
 	if (useCover)
 	{

--- a/Project/ApplicationLayer/Character/Enemy/State/EnemyShootState.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/State/EnemyShootState.cpp
@@ -26,7 +26,7 @@ void EnemyShootState::Update(Enemy& enemy, float deltaTime)
 	const Vector3 targetPos = enemy.GetTargetPosition();
 	const float distToTarget = enemy.GetDistanceToTarget();
 	const bool inHitReaction = enemy.IsInHitReaction();
-	const bool lowHp = enemy.IsLowHp();
+	const bool lowHp = enemy.IsRetreating();
 	const bool canSee = enemy.CanSeeTargetPublic(targetPos, distToTarget);
 
 	if (canSee)

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -290,6 +290,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="ApplicationLayer\Character\Enemy\Navigation\EnemyAStarNavigator.cpp" />
     <ClCompile Include="ApplicationLayer\Character\Enemy\AI\EnemyCoverSelector.cpp" />
     <ClCompile Include="ApplicationLayer\Character\Enemy\AI\EnemyRetreatController.cpp" />
+    <ClCompile Include="ApplicationLayer\Character\Enemy\AI\EnemyRetreatDecisionMemory.cpp" />
     <ClCompile Include="ApplicationLayer\Character\Enemy\AI\EnemyAimController.cpp" />
     <ClCompile Include="ApplicationLayer\Character\Enemy\AI\EnemyCoverController.cpp" />
     <ClCompile Include="ApplicationLayer\Character\Enemy\AI\EnemyStuckController.cpp" />
@@ -866,6 +867,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="ApplicationLayer\Character\Enemy\Navigation\EnemyAStarNavigator.h" />
     <ClInclude Include="ApplicationLayer\Character\Enemy\AI\EnemyCoverSelector.h" />
     <ClInclude Include="ApplicationLayer\Character\Enemy\AI\EnemyRetreatController.h" />
+    <ClInclude Include="ApplicationLayer\Character\Enemy\AI\EnemyRetreatDecisionMemory.h" />
     <ClInclude Include="ApplicationLayer\Character\Enemy\AI\EnemyAimController.h" />
     <ClInclude Include="ApplicationLayer\Character\Enemy\AI\EnemyCoverController.h" />
     <ClInclude Include="ApplicationLayer\Character\Enemy\AI\EnemyStuckController.h" />

--- a/Project/Ken4lowEngine.vcxproj.filters
+++ b/Project/Ken4lowEngine.vcxproj.filters
@@ -772,6 +772,9 @@
     <ClCompile Include="ApplicationLayer\Character\Enemy\AI\EnemyRetreatController.cpp">
       <Filter>ApplicationLayer\Character\Enemy\AI</Filter>
     </ClCompile>
+    <ClCompile Include="ApplicationLayer\Character\Enemy\AI\EnemyRetreatDecisionMemory.cpp">
+      <Filter>ApplicationLayer\Character\Enemy\AI</Filter>
+    </ClCompile>
     <ClCompile Include="ApplicationLayer\Character\Enemy\AI\EnemyAimController.cpp">
       <Filter>ApplicationLayer\Character\Enemy\AI</Filter>
     </ClCompile>
@@ -1627,6 +1630,9 @@
       <Filter>ApplicationLayer\Character\Enemy\AI</Filter>
     </ClInclude>
     <ClInclude Include="ApplicationLayer\Character\Enemy\AI\EnemyRetreatController.h">
+      <Filter>ApplicationLayer\Character\Enemy\AI</Filter>
+    </ClInclude>
+    <ClInclude Include="ApplicationLayer\Character\Enemy\AI\EnemyRetreatDecisionMemory.h">
       <Filter>ApplicationLayer\Character\Enemy\AI</Filter>
     </ClInclude>
     <ClInclude Include="ApplicationLayer\Character\Enemy\AI\EnemyAimController.h">


### PR DESCRIPTION
### Motivation

- 障害物や段差での不自然な停止を減らし、無意味な棒立ちをなくすためにスタック回復を強化しました。 
- 遮蔽物を使った戦闘挙動を自然に見せつつ隠れっぱなしを避けるため、カバー挙動を調整しました。 
- HPベースの即時撤退を抑え、撤退開始／保持／解除にヒステリシスを導入して往復行動の発生を緩和しました。

### Description

- スタック回復：`EnemyStuckController` に `shouldRetryJump` 出力、連続スタックイベントカウント、ジャンプ再試行クールダウンを追加し、`Enemy` 側で受け取って `TryStepJump` を再評価するようにしました（段差や小障害物の突破改善）。
- 撤退ヒステリシス：新規 `EnemyRetreatDecisionMemory` を追加して撤退判断を状態化し、HP閾値(0.5) を基準に距離・被弾等で開始・最短保持・安全条件で解除するロジックを分離して `EvaluateRetreatPlan` で利用するようにしました。 
- 遮蔽物/ピーク挙動：`EnemyCoverController` の露出ロジックを調整し、danger 時でも一定確率で短時間だけ顔を出す（確率 ≈ 0.32）ようにして露出時間を短縮しました。 `EnemyCombatMoveState` は `coverPreference` を反映して通常戦闘でのカバー使用判定を柔軟化しました。 
- 精度・個体差：`EnemyAimController` に近距離ボーナス／遠距離ペナルティを追加して距離依存の散布を改善し、`Enemy::UpdateTraitProfile` のレンジを狭めつつ微調整し個体差を軽く付与しました（反応速度／ストレイフ頻度／射撃間隔／攻撃/回避傾向／遮蔽物志向／照準安定性）。
- その他：プロジェクトファイルに新規ソースを登録しました。 
- 主な変更ファイル：
  - 新規追加：`Project/ApplicationLayer/Character/Enemy/AI/EnemyRetreatDecisionMemory.h`、`EnemyRetreatDecisionMemory.cpp`
  - 修正：`Project/ApplicationLayer/Character/Enemy/Core/Enemy.h`、`Enemy.cpp`、`EnemyAimController.cpp`、`EnemyCoverController.cpp`、`EnemyStuckController.h`、`EnemyStuckController.cpp`、`EnemyCombatMoveState.cpp`、`EnemyShootState.cpp`、`Project/Ken4lowEngine.vcxproj`、`Project/Ken4lowEngine.vcxproj.filters`

### Testing

- コード整合チェックとして `git diff --check` と `git status --short` を実行し差分はコミット可能な状態であることを確認しました。 
- 変更はローカルで `git commit -m "Tune grunt enemy AI: stuck recovery, cover peeking, retreat hysteresis"` によりコミットされ、ブランチ `codex/ai-final-tuning-0.13.5` を作成しました。 
- `git push -u origin codex/ai-final-tuning-0.13.5` を試行しましたが、リポジトリに `origin` が設定されていないためプッシュは失敗しました（リモート設定後にプッシュをお願いします）。 
- ビルド／単体テストはこの作業内では実行しておらず、コンパイル確認や実プレイでの挙動確認をリポジトリの CI もしくはローカルで実行してください。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f0ac6fdf20832d926b4a291a6490ef)