### PR TITLE
Stabilize enemy spawn positions and prevent tunneling

### DIFF
--- a/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.cpp
+++ b/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.cpp
@@ -14,29 +14,63 @@ using namespace Ken4lowEngine;
 
 namespace
 {
-	Vector3 ClampToAABB(const Vector3& p, const AABB& aabb)
+	constexpr float kSpawnPaddingXZ = 0.35f;
+	constexpr float kSpawnLiftY = 0.05f;
+	constexpr float kSpawnSpreadStep = 1.5f;
+
+	Vector3 ClampToAABB(const Vector3& p, const AABB& aabb, float paddingXZ = 0.0f)
 	{
+		const float minX = aabb.min.x + paddingXZ;
+		const float maxX = aabb.max.x - paddingXZ;
+		const float minZ = aabb.min.z + paddingXZ;
+		const float maxZ = aabb.max.z - paddingXZ;
 		return {
-			std::clamp(p.x, aabb.min.x, aabb.max.x),
+			std::clamp(p.x, std::min(minX, maxX), std::max(minX, maxX)),
 			std::clamp(p.y, aabb.min.y, aabb.max.y),
-			std::clamp(p.z, aabb.min.z, aabb.max.z)
+			std::clamp(p.z, std::min(minZ, maxZ), std::max(minZ, maxZ))
 		};
 	}
 
-	Vector3 StabilizeSpawnPosition(const Vector3& requested, Enemy& enemy)
+	Vector3 BuildSpawnSpreadOffset(size_t spawnSerial)
+	{
+		if (spawnSerial == 0) { return {0.0f, 0.0f, 0.0f}; }
+		const int layer = static_cast<int>((spawnSerial - 1) / 8) + 1;
+		const int dir = static_cast<int>((spawnSerial - 1) % 8);
+		const float d = static_cast<float>(layer) * kSpawnSpreadStep;
+		switch (dir)
+		{
+		case 0: return { d,0,0};
+		case 1: return {-d,0,0};
+		case 2: return {0,0,d};
+		case 3: return {0,0,-d};
+		case 4: return { d,0,d};
+		case 5: return {-d,0,d};
+		case 6: return { d,0,-d};
+		default:return {-d,0,-d};
+		}
+	}
+
+	Vector3 StabilizeSpawnPosition(const Vector3& requested, Enemy& enemy, size_t spawnSerial, bool* outInside)
 	{
 		const auto* worldAabbs = enemy.GetResolvedWorldAABBs();
 		if (!worldAabbs || worldAabbs->empty())
 		{
+			if (outInside) { *outInside = false; }
 			return requested;
 		}
-
+		const Vector3 spreadRequested = requested + BuildSpawnSpreadOffset(spawnSerial);
 		float bestDistSq = std::numeric_limits<float>::max();
-		Vector3 bestPos = requested;
+		Vector3 bestPos = spreadRequested;
+		bool insideAny = false;
 		for (const auto& aabb : *worldAabbs)
 		{
-			const Vector3 clamped = ClampToAABB(requested, aabb);
-			const Vector3 diff = requested - clamped;
+			const bool inside = (spreadRequested.x >= aabb.min.x && spreadRequested.x <= aabb.max.x &&
+				spreadRequested.y >= aabb.min.y && spreadRequested.y <= aabb.max.y &&
+				spreadRequested.z >= aabb.min.z && spreadRequested.z <= aabb.max.z);
+			insideAny = insideAny || inside;
+			Vector3 clamped = ClampToAABB(spreadRequested, aabb, kSpawnPaddingXZ);
+			clamped.y = aabb.max.y + kSpawnLiftY;
+			const Vector3 diff = spreadRequested - clamped;
 			const float distSq = Vector3::Dot(diff, diff);
 			if (distSq < bestDistSq)
 			{
@@ -44,7 +78,7 @@ namespace
 				bestPos = clamped;
 			}
 		}
-
+		if (outInside) { *outInside = insideAny; }
 		return bestPos;
 	}
 }
@@ -141,13 +175,19 @@ Enemy& CharacterWorld::SpawnEnemy(const EnemySpawnRequest& request)
 	auto e = std::make_unique<Enemy>();
 	InjectEnemyDeps(*e);
 	e->Initialize();
-	const Vector3 stabilizedSpawn = StabilizeSpawnPosition(request.position, *e);
+	bool wasInsideStage = false;
+	const size_t spawnSerial = enemies_.size();
+	const Vector3 stabilizedSpawn = StabilizeSpawnPosition(request.position, *e, spawnSerial, &wasInsideStage);
 	e->SetPosition(stabilizedSpawn);
+	e->SetVelocity({ 0.0f, 0.0f, 0.0f });
 
 #ifdef _DEBUG
 	std::ostringstream oss;
 	oss << "[Spawn] requested=(" << request.position.x << "," << request.position.y << "," << request.position.z
-		<< ") stabilized=(" << stabilizedSpawn.x << "," << stabilizedSpawn.y << "," << stabilizedSpawn.z << ")\n";
+		<< ") stabilized=(" << stabilizedSpawn.x << "," << stabilizedSpawn.y << "," << stabilizedSpawn.z
+		<< ") insideStage=" << (wasInsideStage ? 1 : 0)
+		<< " waveSpawnSerial=" << spawnSerial
+		<< "\n";
 	std::cout << oss.str();
 #endif
 


### PR DESCRIPTION
### Motivation
- 敵がレベル読み込み位置のままスポーンするとステージ外やジオメトリへのめり込み、物理トンネリング、複数体の重なりが発生していたため、安全にステージ内へ出現させる基盤を優先して修正する。
- スポーン演出は後回しにし、まず位置・初期速度・重なり対策で安定して出ることを最優先とする。

### Description
- `Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.cpp` にスポーン補正ロジックを導入し、`kSpawnPaddingXZ` / `kSpawnLiftY` / `kSpawnSpreadStep` を追加して XZ パディング、Y をステージ上面 + オフセットへ揃えるようにした。
- 同一スポーン地点からの多体生成に対して決定論的な分散オフセットを与える `BuildSpawnSpreadOffset` を追加し、`StabilizeSpawnPosition` を拡張して `spawnSerial` と `outInside` フラグを受け取り最短の安全位置を返すようにした。
- `SpawnEnemy` 側でスポーン直後に初期 `velocity` を `0` にリセットし、デバッグ出力を拡張して `requested` / `stabilized` / `insideStage` / `waveSpawnSerial` を出力するようにした（`_DEBUG` ログ、後で削除しやすい）。
- Enemy/Collider の責務は大きく変えず、変更は `CharacterWorld` 側の補正と初期化順まわりに限定している（既存の `CollisionManager` 登録処理は維持）。

### Testing
- 新ブランチ `codex/fix-safe-enemy-spawn` を作成して変更を `git commit` する操作は成功した（ローカルコミット完了）。
- `git push -u origin codex/fix-safe-enemy-spawn` はこの環境で `origin` が設定されていないため失敗し、リモートへのプッシュ/PR は未完了であることを確認した。 
- 自動ビルド／ユニットテストはこの環境では実行しておらず、マージ前に CI ビルドとランタイムでの衝突解決（ステージ上でのスポーン挙動）検証を推奨する。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f16161bc50832da919ecc8a9536c83)