### PR TITLE
GPU particle foundation: fade in/out, spawn shapes, behavior params, emissive boost

### DIFF
--- a/Project/Resources/Shaders/GpuParticle/GpuParticle.PS.hlsl
+++ b/Project/Resources/Shaders/GpuParticle/GpuParticle.PS.hlsl
@@ -1,5 +1,6 @@
 #include "GpuParticle.hlsli"
 #include "GpuParticleData.hlsli"
+#include "GpuParticleTypeParams.hlsli"
 
 struct Material
 {
@@ -77,6 +78,8 @@ float4 main(VertexShaderOutput input) : SV_TARGET0
     float4 textureColor = gTexture.Sample(gSampler, transformedUV.xy);
 
     float4 outColor = gMaterial.color * textureColor * input.color;
+    ParticleTypeParam param = GetParticleTypeParam(input.type);
+    outColor.rgb *= (1.0f + param.emissiveBoost);
 
     if (outColor.a < 0.001f)
     {

--- a/Project/Resources/Shaders/GpuParticle/GpuParticleEmit.CS.hlsl
+++ b/Project/Resources/Shaders/GpuParticle/GpuParticleEmit.CS.hlsl
@@ -162,6 +162,17 @@ float3 SampleSpawnOffset(float3 seed, uint spawnShape, float radius)
                 float r = radius * (0.10f + GPURand1(seed + 8.2f) * 0.90f);
                 return float3(cos(a) * r, 0.0f, sin(a) * r);
             }
+        case GPU_PARTICLE_SPAWN_SHAPE_BOX:
+        {
+                float3 r = GPURand3(seed) * 2.0f - 1.0f;
+                return r * radius;
+            }
+        case GPU_PARTICLE_SPAWN_SHAPE_CIRCLE:
+        {
+                float a = GPURand1(seed + 13.2f) * 6.2831853f;
+                float r = radius * sqrt(GPURand1(seed + 14.7f));
+                return float3(cos(a) * r, 0.0f, sin(a) * r);
+            }
 
         case GPU_PARTICLE_SPAWN_SHAPE_SPHERE:
         default:

--- a/Project/Resources/Shaders/GpuParticle/GpuParticleSpawnParams.hlsli
+++ b/Project/Resources/Shaders/GpuParticle/GpuParticleSpawnParams.hlsli
@@ -4,6 +4,8 @@ static const uint GPU_PARTICLE_SPAWN_SHAPE_POINT = 0;
 static const uint GPU_PARTICLE_SPAWN_SHAPE_SPHERE = 1;
 static const uint GPU_PARTICLE_SPAWN_SHAPE_HEMISPHERE = 2;
 static const uint GPU_PARTICLE_SPAWN_SHAPE_RING = 3;
+static const uint GPU_PARTICLE_SPAWN_SHAPE_BOX = 4;
+static const uint GPU_PARTICLE_SPAWN_SHAPE_CIRCLE = 5;
 
 static const uint GPU_PARTICLE_DIR_RANDOM = 0;
 static const uint GPU_PARTICLE_DIR_UPHEMI = 1;
@@ -36,6 +38,9 @@ struct ParticleSpawnParam
 
     float stretchScaleMin;
     float stretchScaleMax;
+
+    float coneInnerRatio;
+    float coneOuterRatio;
 };
 
 static const ParticleSpawnParam kDefaultSpawnParam =
@@ -49,7 +54,8 @@ static const ParticleSpawnParam kDefaultSpawnParam =
     GPU_PARTICLE_SPAWN_SHAPE_SPHERE,
     GPU_PARTICLE_DIR_RANDOM,
     GPU_PARTICLE_SCALE_UNIFORM,
-    1.0f, 1.0f
+    1.0f, 1.0f,
+    0.0f, 1.0f
 };
 
 static const uint kParticleSpawnParamCount = GPU_PARTICLE_TYPE_DEATH_BURST_CORE + 1;
@@ -67,7 +73,8 @@ static const ParticleSpawnParam kParticleSpawnParams[kParticleSpawnParamCount] =
         GPU_PARTICLE_SPAWN_SHAPE_SPHERE,
         GPU_PARTICLE_DIR_RANDOM,
         GPU_PARTICLE_SCALE_UNIFORM,
-        1.0f, 1.0f
+        1.0f, 1.0f,
+        0.0f, 1.0f
     },
 
     // 1: Blood
@@ -81,7 +88,8 @@ static const ParticleSpawnParam kParticleSpawnParams[kParticleSpawnParamCount] =
         GPU_PARTICLE_SPAWN_SHAPE_HEMISPHERE,
         GPU_PARTICLE_DIR_UPHEMI,
         GPU_PARTICLE_SCALE_UNIFORM,
-        1.0f, 1.0f
+        1.0f, 1.0f,
+        0.0f, 1.0f
     },
 
     // 2: Dust
@@ -95,7 +103,8 @@ static const ParticleSpawnParam kParticleSpawnParams[kParticleSpawnParamCount] =
         GPU_PARTICLE_SPAWN_SHAPE_HEMISPHERE,
         GPU_PARTICLE_DIR_UPHEMI,
         GPU_PARTICLE_SCALE_UNIFORM,
-        1.0f, 1.0f
+        1.0f, 1.0f,
+        0.0f, 1.0f
     },
 
     // 3: Debris
@@ -109,7 +118,8 @@ static const ParticleSpawnParam kParticleSpawnParams[kParticleSpawnParamCount] =
         GPU_PARTICLE_SPAWN_SHAPE_HEMISPHERE,
         GPU_PARTICLE_DIR_RANDOM,
         GPU_PARTICLE_SCALE_UNIFORM,
-        1.0f, 1.0f
+        1.0f, 1.0f,
+        0.0f, 1.0f
     },
 
     // 4: Smoke
@@ -123,7 +133,8 @@ static const ParticleSpawnParam kParticleSpawnParams[kParticleSpawnParamCount] =
         GPU_PARTICLE_SPAWN_SHAPE_SPHERE,
         GPU_PARTICLE_DIR_UPHEMI,
         GPU_PARTICLE_SCALE_UNIFORM,
-        1.0f, 1.0f
+        1.0f, 1.0f,
+        0.0f, 1.0f
     },
 
     // 5: Ambient
@@ -137,7 +148,8 @@ static const ParticleSpawnParam kParticleSpawnParams[kParticleSpawnParamCount] =
         GPU_PARTICLE_SPAWN_SHAPE_SPHERE,
         GPU_PARTICLE_DIR_RANDOM,
         GPU_PARTICLE_SCALE_UNIFORM,
-        1.0f, 1.0f
+        1.0f, 1.0f,
+        0.0f, 1.0f
     },
 
     // 6: Spark
@@ -151,7 +163,8 @@ static const ParticleSpawnParam kParticleSpawnParams[kParticleSpawnParamCount] =
         GPU_PARTICLE_SPAWN_SHAPE_HEMISPHERE,
         GPU_PARTICLE_DIR_RANDOM,
         GPU_PARTICLE_SCALE_UNIFORM,
-        1.0f, 1.0f
+        1.0f, 1.0f,
+        0.0f, 1.0f
     },
 
     // 7: Shockwave
@@ -165,7 +178,8 @@ static const ParticleSpawnParam kParticleSpawnParams[kParticleSpawnParamCount] =
         GPU_PARTICLE_SPAWN_SHAPE_RING,
         GPU_PARTICLE_DIR_RADIAL,
         GPU_PARTICLE_SCALE_UNIFORM,
-        1.0f, 1.0f
+        1.0f, 1.0f,
+        0.0f, 1.0f
     },
 
     // 8: Heal
@@ -179,7 +193,8 @@ static const ParticleSpawnParam kParticleSpawnParams[kParticleSpawnParamCount] =
         GPU_PARTICLE_SPAWN_SHAPE_RING,
         GPU_PARTICLE_DIR_UP,
         GPU_PARTICLE_SCALE_UNIFORM,
-        1.0f, 1.0f
+        1.0f, 1.0f,
+        0.0f, 1.0f
     },
 
     // 9: Trail
@@ -193,7 +208,8 @@ static const ParticleSpawnParam kParticleSpawnParams[kParticleSpawnParamCount] =
         GPU_PARTICLE_SPAWN_SHAPE_SPHERE,
         GPU_PARTICLE_DIR_TANGENT,
         GPU_PARTICLE_SCALE_UNIFORM,
-        1.0f, 1.0f
+        1.0f, 1.0f,
+        0.0f, 1.0f
     },
     
      // 10: DeathBurstCore
@@ -207,7 +223,8 @@ static const ParticleSpawnParam kParticleSpawnParams[kParticleSpawnParamCount] =
         GPU_PARTICLE_SPAWN_SHAPE_SPHERE, // spawnShape
         GPU_PARTICLE_DIR_RANDOM, // dirType
         GPU_PARTICLE_SCALE_UNIFORM, // scaleMode
-        1.0f, 1.0f
+        1.0f, 1.0f,
+        0.0f, 1.0f
     },
 };
 

--- a/Project/Resources/Shaders/GpuParticle/GpuParticleTypeParams.hlsli
+++ b/Project/Resources/Shaders/GpuParticle/GpuParticleTypeParams.hlsli
@@ -8,6 +8,12 @@ struct ParticleTypeParam
     float drag;
     float scaleGrow;
     float scaleShrink;
+    float fadeInRatio;
+    float fadeOutRatio;
+    float emissiveBoost;
+    float convergence;
+    float divergence;
+    float floaty;
 };
 
 static const ParticleTypeParam kDefaultParticleTypeParam =
@@ -17,6 +23,12 @@ static const ParticleTypeParam kDefaultParticleTypeParam =
     0.0f,
     0.6f,
     0.0f,
+    0.0f,
+    0.08f,
+    0.25f,
+    0.0f,
+    0.0f,
+    0.0f,
     0.0f
 };
 
@@ -25,37 +37,37 @@ static const uint kParticleTypeParamCount = GPU_PARTICLE_TYPE_DEATH_BURST_CORE +
 static const ParticleTypeParam kParticleTypeParams[kParticleTypeParamCount] =
 {
     // 0: Default
-    { 1.00f, 1.20f, 0.0f, 0.6f, 0.0f, 0.0f },
+    { 1.00f, 1.20f, 0.0f, 0.6f, 0.0f, 0.0f, 0.10f, 0.25f, 0.0f, 0.0f, 0.0f, 0.0f },
 
     // 1: Blood
-    { 0.95f, 1.10f, -9.8f, 0.8f, 0.0f, 0.0f },
+    { 0.95f, 1.10f, -9.8f, 0.8f, 0.0f, 0.0f, 0.00f, 0.20f, 0.1f, 0.0f, 0.2f, 0.0f },
 
     // 2: Dust
-    { 0.40f, 1.00f, 0.6f, 2.0f, 0.6f, 0.0f },
+    { 0.40f, 1.00f, 0.6f, 2.0f, 0.6f, 0.0f, 0.10f, 0.35f, 0.0f, 0.0f, 0.15f, 0.45f },
 
     // 3: Debris
-    { 0.75f, 1.20f, -5.0f, 1.2f, 0.0f, 0.0f },
+    { 0.75f, 1.20f, -5.0f, 1.2f, 0.0f, 0.0f, 0.02f, 0.20f, 0.2f, 0.0f, 0.25f, 0.0f },
 
     // 4: Smoke
-    { 0.35f, 0.85f, 0.8f, 1.0f, 0.9f, 0.0f },
+    { 0.35f, 0.85f, 0.8f, 1.0f, 0.9f, 0.0f, 0.12f, 0.40f, 0.0f, 0.0f, 0.10f, 0.30f },
 
     // 5: Ambient
-    { 0.12f, 0.60f, 0.0f, 0.2f, 0.0f, 0.0f },
+    { 0.12f, 0.60f, 0.0f, 0.2f, 0.0f, 0.0f, 0.08f, 0.20f, 0.4f, 0.35f, 0.0f, 0.25f },
 
     // 6: Spark
-    { 1.00f, 2.20f, -2.0f, 0.6f, 0.0f, 8.0f },
+    { 1.00f, 2.20f, -2.0f, 0.6f, 0.0f, 8.0f, 0.00f, 0.25f, 1.2f, 0.0f, 0.35f, 0.0f },
 
     // 7: Shockwave
-    { 0.85f, 1.30f, 0.0f, 0.4f, 0.0f, 0.0f },
+    { 0.85f, 1.30f, 0.0f, 0.4f, 0.0f, 0.0f, 0.02f, 0.35f, 0.8f, 0.0f, 0.55f, 0.0f },
 
     // 8: Heal
-    { 0.55f, 1.10f, 0.8f, 0.6f, 0.4f, 0.0f },
+    { 0.55f, 1.10f, 0.8f, 0.6f, 0.4f, 0.0f, 0.10f, 0.35f, 0.9f, 0.45f, 0.0f, 0.35f },
 
     // 9: Trail
-    { 0.55f, 1.50f, 0.0f, 0.5f, 0.0f, 0.0f },
+    { 0.55f, 1.50f, 0.0f, 0.5f, 0.0f, 0.0f, 0.00f, 0.20f, 0.2f, 0.25f, 0.0f, 0.0f },
     
     // 10: DeathBurstCore
-    { 0.95f, 1.80f, 0.4f, 3.8f, 2.8f, 0.0f },
+    { 0.95f, 1.80f, 0.4f, 3.8f, 2.8f, 0.0f, 0.01f, 0.30f, 1.0f, 0.85f, 0.0f, 0.45f },
 };
 
 ParticleTypeParam GetParticleTypeParam(uint type)

--- a/Project/Resources/Shaders/GpuParticle/GpuParticleUpdate.CS.hlsl
+++ b/Project/Resources/Shaders/GpuParticle/GpuParticleUpdate.CS.hlsl
@@ -54,6 +54,10 @@ void main(uint3 DTid : SV_DispatchThreadID)
     p.velocity.y += param.accelY * dt;
 
     p.translate += p.velocity * dt;
+    float3 centerDir = normalize(-p.translate + float3(1e-4f, 1e-4f, 1e-4f));
+    p.velocity += centerDir * param.convergence * dt;
+    p.velocity += normalize(p.translate + float3(1e-4f, 1e-4f, 1e-4f)) * param.divergence * dt;
+    p.velocity.y += sin(p.currentTime * 12.0f + particleIndex * 0.13f) * param.floaty * dt;
 
     if (param.scaleGrow > 0.0f)
     {
@@ -74,7 +78,10 @@ void main(uint3 DTid : SV_DispatchThreadID)
         p.scale *= s;
     }
 
-    float a = pow(1.0f - t, param.alphaPow) * param.baseAlpha;
+    float fadeIn = (param.fadeInRatio <= 0.0f) ? 1.0f : saturate(t / max(param.fadeInRatio, 1e-4f));
+    float fadeOutStart = 1.0f - saturate(param.fadeOutRatio);
+    float fadeOut = (t <= fadeOutStart) ? 1.0f : saturate((1.0f - t) / max(1.0f - fadeOutStart, 1e-4f));
+    float a = pow(1.0f - t, param.alphaPow) * param.baseAlpha * fadeIn * fadeOut;
     p.color.a = saturate(a);
 
     gParticles[particleIndex] = p;


### PR DESCRIPTION
### Motivation
- Stabilize and improve expressiveness of the existing GPU particle base so spawn effects are reliable and visually suitable for future 3D/digital spawn effects. 
- Reduce visible instability (particles not showing / inconsistent alpha/scale/lifetime) by smoothing lifetime/alpha progression and adding type-driven behaviour controls. 
- Provide a broader set of spawn patterns (box/circle) and type parameters to make data-driven tuning and future ImGui controls straightforward.

### Description
- Added new spawn shapes `GPU_PARTICLE_SPAWN_SHAPE_BOX` and `GPU_PARTICLE_SPAWN_SHAPE_CIRCLE` and extended `ParticleSpawnParam` with `coneInnerRatio`/`coneOuterRatio` for future use (`Project/Resources/Shaders/GpuParticle/GpuParticleSpawnParams.hlsli`).
- Extended `ParticleTypeParam` with `fadeInRatio`, `fadeOutRatio`, `emissiveBoost`, `convergence`, `divergence`, and `floaty` and populated the type table so behaviours are data-driven per particle type (`Project/Resources/Shaders/GpuParticle/GpuParticleTypeParams.hlsli`).
- Updated update compute shader to apply smoother alpha progression (fade-in / fade-out), and to add convergence/divergence/floaty velocity adjustments to support center attraction, spread and subtle floating drift (`Project/Resources/Shaders/GpuParticle/GpuParticleUpdate.CS.hlsl`).
- Updated emit compute shader to support Box and Circle spawn offsets used by the above spawn shapes (`Project/Resources/Shaders/GpuParticle/GpuParticleEmit.CS.hlsl`).
- Updated pixel shader to apply per-type `emissiveBoost` so particles can appear more glowing/digital when needed (`Project/Resources/Shaders/GpuParticle/GpuParticle.PS.hlsl`).
- Work done on branch `codex/gpu-particle-foundation-0136` and committed as part of this PR; changes are limited to shader-side foundation so existing CPU-side emitters/UI remain compatible.

### Testing
- Created and committed the changes on branch `codex/gpu-particle-foundation-0136` with `git commit` (succeeded). 
- Attempted to push with `git push -u origin codex/gpu-particle-foundation-0136` but the push failed because `origin` remote is not configured in this environment. 
- Patch application and local diffs were validated (`git diff` / file inspection) and all modified files applied cleanly. 
- No automated engine build or runtime shader validation was executed in this environment due to missing build/DirectX runtime; visual verification and ImGui sliders for the new parameters are recommended in a follow-up.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f16c237404832dbc42c9cb6d8735d8)