### PR TITLE
GPUパーティクルのImGuiパラメータオーバーライド追加と敵スポーン試作プリセット

### DIFF
--- a/Project/Engine/Graphics/Renderer/GpuParticle/Data/GpuParticleEmitterData.h
+++ b/Project/Engine/Graphics/Renderer/GpuParticle/Data/GpuParticleEmitterData.h
@@ -19,5 +19,13 @@ struct GpuEmitterCBData
 	uint32_t emit; 			// 発生フラグ
 	uint32_t type;			// エミッターの種類
 	uint32_t billboardMode; // ビルボードモード
+	float fadeInRatio;
+	float fadeOutRatio;
+	float emissiveBoost;
+	float convergence;
+	float divergence;
+	float floaty;
+	uint32_t spawnShapeOverride;
+	float _pad0;
 };
 } // namespace Ken4lowEngine

--- a/Project/Engine/Graphics/Renderer/GpuParticle/Emitter/GpuParticleEmitter.cpp
+++ b/Project/Engine/Graphics/Renderer/GpuParticle/Emitter/GpuParticleEmitter.cpp
@@ -50,6 +50,13 @@ bool GpuParticleEmitter::BuildCB(GpuEmitterCBData& out, float deltaTime)
 	// kindに応じた type / packed billboardMode
 	out.type = GetEffectiveType();
 	out.billboardMode = GetPackedBillboardMode();
+	out.fadeInRatio = info_.fadeInRatio;
+	out.fadeOutRatio = info_.fadeOutRatio;
+	out.emissiveBoost = info_.emissiveBoost;
+	out.convergence = info_.convergence;
+	out.divergence = info_.divergence;
+	out.floaty = info_.floaty;
+	out.spawnShapeOverride = info_.spawnShapeOverride;
 
 	// ------------------------------
 	// Emitしない

--- a/Project/Engine/Graphics/Renderer/GpuParticle/Emitter/GpuParticleEmitter.h
+++ b/Project/Engine/Graphics/Renderer/GpuParticle/Emitter/GpuParticleEmitter.h
@@ -41,6 +41,13 @@ public: /// ---------- 構造体 ---------- ///
 
 		// ★下位16bitのフラグ（Camera/YAxis など）
 		BillboardMode billboardFlags = BillboardMode::Camera;
+		float fadeInRatio = 0.10f;
+		float fadeOutRatio = 0.25f;
+		float emissiveBoost = 0.0f;
+		float convergence = 0.0f;
+		float divergence = 0.0f;
+		float floaty = 0.0f;
+		uint32_t spawnShapeOverride = 0;
 	};
 
 public: /// ---------- メンバ関数 ---------- ///

--- a/Project/Engine/Graphics/Renderer/GpuParticle/Manager/GpuParticleManager.cpp
+++ b/Project/Engine/Graphics/Renderer/GpuParticle/Manager/GpuParticleManager.cpp
@@ -377,6 +377,23 @@ namespace Ken4lowEngine
 		}
 
 		ImGui::SeparatorText("Emitters");
+		ImGui::SeparatorText("Prototype Preset");
+		if (ImGui::Button("Create Enemy Spawn Prototype"))
+		{
+			auto makeSpawnEmitter = [&](const std::string& name, GpuParticleType type, const Vector3& pos, float radius, uint32_t loopCount)
+				{
+					auto info = GpuParticleEmitterPresetTable::MakeEmitterInfo(type);
+					info.radius = radius;
+					info.loopCount = loopCount;
+					info.loopFrequency = 0.04f;
+					CreateEmitter(name, info);
+					if (auto* se = GetEmitter(name)) { se->SetPosition(pos); }
+				};
+			makeSpawnEmitter("Spawn_Telegraph_Ground", GpuParticleType::Shockwave, { 0.0f, 0.05f, 0.0f }, 1.6f, 4);
+			makeSpawnEmitter("Spawn_Converge", GpuParticleType::DeathBurstCore, { 0.0f, 0.6f, 0.0f }, 1.2f, 8);
+			makeSpawnEmitter("Spawn_Materialize", GpuParticleType::Heal, { 0.0f, 0.9f, 0.0f }, 0.7f, 6);
+			makeSpawnEmitter("Spawn_Finish_Flash", GpuParticleType::Spark, { 0.0f, 1.0f, 0.0f }, 0.9f, 2);
+		}
 		if (ImGui::BeginListBox("Emitters"))
 		{
 			std::vector<std::string> emitterNames;
@@ -415,6 +432,8 @@ namespace Ken4lowEngine
 
 				ImGui::SeparatorText("Selected Emitter");
 				ImGui::Text("Name: %s", selected.c_str());
+				ImGui::TextColored(ImVec4(0.8f, 1.0f, 0.6f, 1.0f), "Editing Type: %s",
+					GpuParticleEmitterPresetTable::GetSpriteDisplayName(info.spriteType));
 
 				ImGui::SameLine();
 				if (ImGui::Button("Delete"))
@@ -569,6 +588,13 @@ namespace Ken4lowEngine
 						info.loopFrequency = presetInfo.loopFrequency;
 						info.drawType = presetInfo.drawType;
 						info.billboardFlags = presetInfo.billboardFlags;
+						info.fadeInRatio = presetInfo.fadeInRatio;
+						info.fadeOutRatio = presetInfo.fadeOutRatio;
+						info.emissiveBoost = presetInfo.emissiveBoost;
+						info.convergence = presetInfo.convergence;
+						info.divergence = presetInfo.divergence;
+						info.floaty = presetInfo.floaty;
+						info.spawnShapeOverride = presetInfo.spawnShapeOverride;
 
 						std::snprintf(textureBuf, sizeof(textureBuf), "%s", info.textureFilePath.c_str());
 					}
@@ -618,6 +644,23 @@ namespace Ken4lowEngine
 				if (ImGui::Button("Apply Texture"))
 				{
 					info.textureFilePath = textureBuf;
+				}
+
+				ImGui::SeparatorText("Type Param Overrides");
+				ImGui::DragFloat("fadeInRatio", &info.fadeInRatio, 0.005f, 0.0f, 1.0f, "%.3f");
+				ImGui::DragFloat("fadeOutRatio", &info.fadeOutRatio, 0.005f, 0.0f, 1.0f, "%.3f");
+				ImGui::DragFloat("emissiveBoost", &info.emissiveBoost, 0.01f, 0.0f, 8.0f, "%.2f");
+				ImGui::DragFloat("convergence", &info.convergence, 0.01f, -10.0f, 10.0f, "%.2f");
+				ImGui::DragFloat("divergence", &info.divergence, 0.01f, -10.0f, 10.0f, "%.2f");
+				ImGui::DragFloat("floaty", &info.floaty, 0.01f, 0.0f, 10.0f, "%.2f");
+
+				const char* kSpawnShapeItems[] = { "UseTypeDefault", "Box", "Circle" };
+				int spawnShapeUi = 0;
+				if (info.spawnShapeOverride == 3u) { spawnShapeUi = 1; }
+				else if (info.spawnShapeOverride == 4u) { spawnShapeUi = 2; }
+				if (ImGui::Combo("Spawn Shape", &spawnShapeUi, kSpawnShapeItems, IM_ARRAYSIZE(kSpawnShapeItems)))
+				{
+					info.spawnShapeOverride = (spawnShapeUi == 1) ? 3u : (spawnShapeUi == 2) ? 4u : 0u;
 				}
 
 				uint32_t effectiveType = 0;

--- a/Project/Engine/Graphics/Renderer/GpuParticle/Preset/GpuParticleEmitterPreset.cpp
+++ b/Project/Engine/Graphics/Renderer/GpuParticle/Preset/GpuParticleEmitterPreset.cpp
@@ -211,6 +211,13 @@ namespace Ken4lowEngine
 		info.spriteType = preset.spriteType;
 		info.ribbonType = preset.ribbonType;
 		info.billboardFlags = preset.billboardFlags;
+		info.fadeInRatio = preset.fadeInRatio;
+		info.fadeOutRatio = preset.fadeOutRatio;
+		info.emissiveBoost = preset.emissiveBoost;
+		info.convergence = preset.convergence;
+		info.divergence = preset.divergence;
+		info.floaty = preset.floaty;
+		info.spawnShapeOverride = preset.spawnShapeOverride;
 		return info;
 	}
 

--- a/Project/Engine/Graphics/Renderer/GpuParticle/Preset/GpuParticleEmitterPreset.h
+++ b/Project/Engine/Graphics/Renderer/GpuParticle/Preset/GpuParticleEmitterPreset.h
@@ -16,6 +16,13 @@ namespace Ken4lowEngine
 		GpuParticleType spriteType = GpuParticleType::Default;
 		GpuRibbonType ribbonType = GpuRibbonType::Trail;
 		BillboardMode billboardFlags = BillboardMode::Camera;
+		float fadeInRatio = 0.10f;
+		float fadeOutRatio = 0.25f;
+		float emissiveBoost = 0.0f;
+		float convergence = 0.0f;
+		float divergence = 0.0f;
+		float floaty = 0.0f;
+		uint32_t spawnShapeOverride = 0;
 	};
 
 	class GpuParticleEmitterPresetTable

--- a/Project/Resources/Shaders/GpuParticle/GpuParticle.PS.hlsl
+++ b/Project/Resources/Shaders/GpuParticle/GpuParticle.PS.hlsl
@@ -11,6 +11,7 @@ struct Material
 };
 
 ConstantBuffer<Material> gMaterial : register(b1);
+ConstantBuffer<EmitterCBData> gEmitter : register(b2);
 Texture2D<float4> gTexture : register(t0);
 SamplerState gSampler : register(s0);
 
@@ -78,7 +79,7 @@ float4 main(VertexShaderOutput input) : SV_TARGET0
     float4 textureColor = gTexture.Sample(gSampler, transformedUV.xy);
 
     float4 outColor = gMaterial.color * textureColor * input.color;
-    ParticleTypeParam param = GetParticleTypeParam(input.type);
+    ParticleTypeParam param = ApplyEmitterOverrides(GetParticleTypeParam(input.type), gEmitter);
     outColor.rgb *= (1.0f + param.emissiveBoost);
 
     if (outColor.a < 0.001f)

--- a/Project/Resources/Shaders/GpuParticle/GpuParticleData.hlsli
+++ b/Project/Resources/Shaders/GpuParticle/GpuParticleData.hlsli
@@ -90,6 +90,14 @@ struct EmitterCBData
     uint emit;
     uint type;
     uint billboardMode;
+    float fadeInRatio;
+    float fadeOutRatio;
+    float emissiveBoost;
+    float convergence;
+    float divergence;
+    float floaty;
+    uint spawnShapeOverride;
+    float _pad0;
 };
 
 /// ---------- 時間制御 ---------- ///

--- a/Project/Resources/Shaders/GpuParticle/GpuParticleEmit.CS.hlsl
+++ b/Project/Resources/Shaders/GpuParticle/GpuParticleEmit.CS.hlsl
@@ -207,7 +207,8 @@ float3 SampleSpawnDirection(float3 seed, uint dirType, float3 offset)
 
 void InitParticleCommon(uint i, float3 seed, ParticleSpawnParam param, inout Particle p)
 {
-    float3 offset = SampleSpawnOffset(seed, param.spawnShape, gEmitter.radius);
+    uint spawnShape = (gEmitter.spawnShapeOverride == 0u) ? param.spawnShape : gEmitter.spawnShapeOverride;
+    float3 offset = SampleSpawnOffset(seed, spawnShape, gEmitter.radius);
     float3 dir = SampleSpawnDirection(seed + 11.3f, param.dirType, offset);
 
     // DeathBurstCore 用の方向補正

--- a/Project/Resources/Shaders/GpuParticle/GpuParticleTypeParams.hlsli
+++ b/Project/Resources/Shaders/GpuParticle/GpuParticleTypeParams.hlsli
@@ -79,3 +79,14 @@ ParticleTypeParam GetParticleTypeParam(uint type)
 
     return kDefaultParticleTypeParam;
 }
+
+ParticleTypeParam ApplyEmitterOverrides(ParticleTypeParam param, EmitterCBData emitter)
+{
+    param.fadeInRatio = emitter.fadeInRatio;
+    param.fadeOutRatio = emitter.fadeOutRatio;
+    param.emissiveBoost = emitter.emissiveBoost;
+    param.convergence = emitter.convergence;
+    param.divergence = emitter.divergence;
+    param.floaty = emitter.floaty;
+    return param;
+}

--- a/Project/Resources/Shaders/GpuParticle/GpuParticleUpdate.CS.hlsl
+++ b/Project/Resources/Shaders/GpuParticle/GpuParticleUpdate.CS.hlsl
@@ -5,6 +5,7 @@ RWStructuredBuffer<Particle> gParticles : register(u0);
 RWStructuredBuffer<int> gFreeListIndex : register(u1);
 RWStructuredBuffer<uint> gFreeList : register(u2);
 
+ConstantBuffer<EmitterCBData> gEmitter : register(b1);
 ConstantBuffer<PerFrame> gPerFrame : register(b2);
 
 [numthreads(1024, 1, 1)]
@@ -47,7 +48,7 @@ void main(uint3 DTid : SV_DispatchThreadID)
     }
 
     float t = saturate(p.currentTime / max(p.lifeTime, 1e-5f));
-    ParticleTypeParam param = GetParticleTypeParam(p.type);
+    ParticleTypeParam param = ApplyEmitterOverrides(GetParticleTypeParam(p.type), gEmitter);
 
     float damp = max(0.0f, 1.0f - param.drag * dt);
     p.velocity *= damp;


### PR DESCRIPTION
### Motivation
- GPUパーティクルの新パラメータをリアルタイムに調整しやすくして、スポーン演出の試作を素早く行えるようにするため。 
- エミッター単位でfade/emissive/収束系の動作を上書きできるようにして、既存基盤を大きく改修せずに見た目の差分確認を優先するため。 
- スポーン演出で使う複数段のプリセットをワンクリックで用意して、演出の確認フローを短縮するため。 

### Description
- `GpuParticleEmitter::EmitterInfo` に `fadeInRatio` / `fadeOutRatio` / `emissiveBoost` / `convergence` / `divergence` / `floaty` / `spawnShapeOverride` を追加して ImGui で保持できるようにしました。 
- `GpuEmitterCBData`（CPU側構造体／HLSLの `EmitterCBData`）に同フィールドを追加し、`BuildCB` で GPU に転送するようにしました。 
- シェーダー側に `ApplyEmitterOverrides` を追加してタイプ既定値にエミッターオーバーライドを適用し、Update/PS に反映すると同時に Emit 側で `spawnShapeOverride` が設定されている場合は発生形状を上書きするようにしました。 
- ImGui（`GpuParticle` デバッグウィンドウ）を拡張し、編集中のタイプ表示・`fadeInRatio` 等の `DragFloat` コントロール・Spawn Shape コンボを追加し、さらに「Create Enemy Spawn Prototype」ボタンで4つの試作エミッター（地面予兆／収束／実体化補助／完了フラッシュ）を生成する機能を追加しました。 

### Testing
- 自動化されたテスト（ユニットテスト／CIビルド）はこの変更に対して実行していません。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f17e56c458832d973f3196d71e2f57)