### PR TITLE
DebugScene: GPU particle lab with ImGui presets and burst controls

### DIFF
--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -19,6 +19,7 @@
 #include "WeaponMasterDataEditor.h"
 #include "WeaponMasterDataWriter.h"
 #include <filesystem>
+#include <algorithm>
 
 using namespace Ken4lowEngine;
 
@@ -58,6 +59,8 @@ void DebugScene::Initialize()
 	// 見やすい位置に置く
 	debugBoss_->SetPosition({ 0.0f, 2.25f, 30.0f });
 	debugBoss_->SetYaw(3.141592f); // 必要ならプレイヤー側へ向ける
+
+	ApplyDebugParticlePreset(0);
 }
 
 void DebugScene::Update()
@@ -231,11 +234,44 @@ void DebugScene::DrawImGui()
 	ImGui::Text("Press H to test hit.");
 	ImGui::TextWrapped("%s", debugHitLog_.c_str());
 
-	ImGui::Separator();
-	ImGui::Text("Particle Test");
-	ImGui::Text("1 : HitSpark");
-	ImGui::Text("2 : Heal_Effect");
-	ImGui::Text("3 : Boss_Appear_Dust");
+	ImGui::SeparatorText("DebugScene GPU Particle Lab");
+	if (ImGui::BeginCombo("Spawn Preset", kDebugParticlePresets_[debugParticlePresetIndex_].label))
+	{
+		for (uint32_t i = 0; i < static_cast<uint32_t>(kDebugParticlePresets_.size()); ++i)
+		{
+			const bool selected = (debugParticlePresetIndex_ == i);
+			if (ImGui::Selectable(kDebugParticlePresets_[i].label, selected))
+			{
+				ApplyDebugParticlePreset(i);
+			}
+			if (selected) { ImGui::SetItemDefaultFocus(); }
+		}
+		ImGui::EndCombo();
+	}
+	ImGui::SameLine();
+	if (ImGui::Button("Apply Preset"))
+	{
+		ApplyDebugParticlePreset(debugParticlePresetIndex_);
+	}
+
+	ImGui::DragFloat3("Spawn Position", &debugParticleSpawnPosition_.x, 0.05f);
+	ImGui::DragInt("Burst Count", &debugParticleBurstCount_, 1.0f, 1, 2048);
+	ImGui::Checkbox("Auto Loop", &debugParticleAutoLoop_);
+	ImGui::DragFloat("Auto Interval", &debugParticleAutoInterval_, 0.01f, 0.05f, 8.0f);
+
+	debugParticleDirty_ |= ImGui::SliderFloat("fadeInRatio", &debugFadeInRatio_, 0.0f, 1.0f);
+	debugParticleDirty_ |= ImGui::SliderFloat("fadeOutRatio", &debugFadeOutRatio_, 0.0f, 1.0f);
+	debugParticleDirty_ |= ImGui::SliderFloat("emissiveBoost", &debugEmissiveBoost_, 0.0f, 8.0f);
+	debugParticleDirty_ |= ImGui::SliderFloat("convergence", &debugConvergence_, 0.0f, 1.0f);
+	debugParticleDirty_ |= ImGui::SliderFloat("divergence", &debugDivergence_, 0.0f, 1.0f);
+	debugParticleDirty_ |= ImGui::SliderFloat("floaty", &debugFloaty_, 0.0f, 2.0f);
+	{ int shape = static_cast<int>(debugSpawnShapeOverride_); if (ImGui::SliderInt("spawnShapeOverride", &shape, 0, 4)) { debugSpawnShapeOverride_ = static_cast<uint32_t>(shape); debugParticleDirty_ = true; } }
+
+	if (ImGui::Button("Trigger Burst") || ImGui::IsKeyPressed(ImGuiKey_P))
+	{
+		TriggerDebugParticleBurst();
+	}
+
 	ImGui::TextWrapped("%s", debugParticleLog_.c_str());
 
 	ImGui::End();
@@ -344,72 +380,104 @@ void DebugScene::UpdateDebugBossHitTest()
 	}
 }
 
+void DebugScene::EnsureDebugParticleEmitter()
+{
+	GpuParticleManager* gpuParticleManager = GpuParticleManager::GetInstance();
+	if (!gpuParticleManager) { return; }
+
+	auto* emitter = gpuParticleManager->FindEmitter(debugParticleEmitterName_);
+	if (!emitter)
+	{
+		emitter = gpuParticleManager->CreateEmitter(
+			debugParticleEmitterName_,
+			kDebugParticlePresets_[debugParticlePresetIndex_].type,
+			debugParticleSpawnPosition_);
+		debugParticleDirty_ = true;
+	}
+
+	if (emitter)
+	{
+		emitter->SetPosition(debugParticleSpawnPosition_);
+	}
+}
+
+void DebugScene::ApplyDebugParticlePreset(uint32_t presetIndex)
+{
+	debugParticlePresetIndex_ = std::min<uint32_t>(presetIndex, static_cast<uint32_t>(kDebugParticlePresets_.size() - 1));
+	const DebugParticlePreset& preset = kDebugParticlePresets_[debugParticlePresetIndex_];
+
+	debugFadeInRatio_ = preset.fadeInRatio;
+	debugFadeOutRatio_ = preset.fadeOutRatio;
+	debugEmissiveBoost_ = preset.emissiveBoost;
+	debugConvergence_ = preset.convergence;
+	debugDivergence_ = preset.divergence;
+	debugFloaty_ = preset.floaty;
+	debugSpawnShapeOverride_ = preset.spawnShapeOverride;
+	debugParticleBurstCount_ = static_cast<int>(preset.burstCount);
+	debugParticleDirty_ = true;
+
+	debugParticleLog_ = std::string("Applied preset: ") + preset.label;
+}
+
+void DebugScene::UpdateDebugParticleEmitterParams()
+{
+	GpuParticleManager* gpuParticleManager = GpuParticleManager::GetInstance();
+	auto* emitter = gpuParticleManager ? gpuParticleManager->FindEmitter(debugParticleEmitterName_) : nullptr;
+	if (!emitter) { return; }
+
+	emitter->SetPosition(debugParticleSpawnPosition_);
+	auto& info = emitter->GetInfoMutable();
+	info.fadeInRatio = debugFadeInRatio_;
+	info.fadeOutRatio = debugFadeOutRatio_;
+	info.emissiveBoost = debugEmissiveBoost_;
+	info.convergence = debugConvergence_;
+	info.divergence = debugDivergence_;
+	info.floaty = debugFloaty_;
+	info.spawnShapeOverride = debugSpawnShapeOverride_;
+	info.spriteType = kDebugParticlePresets_[debugParticlePresetIndex_].type;
+}
+
+void DebugScene::TriggerDebugParticleBurst()
+{
+	GpuParticleManager* gpuParticleManager = GpuParticleManager::GetInstance();
+	auto* emitter = gpuParticleManager ? gpuParticleManager->FindEmitter(debugParticleEmitterName_) : nullptr;
+	if (!emitter) { return; }
+
+	emitter->RequestEmit(static_cast<uint32_t>(std::max(debugParticleBurstCount_, 1)));
+	debugParticleLog_ = std::string("Burst: ") + kDebugParticlePresets_[debugParticlePresetIndex_].label;
+}
+
 void DebugScene::UpdateDebugParticleTest()
 {
-	if (!debugBoss_)
+	EnsureDebugParticleEmitter();
+
+	if (debugParticleDirty_)
 	{
-		return;
+		UpdateDebugParticleEmitterParams();
+		debugParticleDirty_ = false;
 	}
 
-	GpuParticleManager* gpuParticleManager = GpuParticleManager::GetInstance();
-	if (!gpuParticleManager)
+	if (input_->TriggerKey(DIK_1)) { ApplyDebugParticlePreset(0); TriggerDebugParticleBurst(); }
+	if (input_->TriggerKey(DIK_2)) { ApplyDebugParticlePreset(1); TriggerDebugParticleBurst(); }
+	if (input_->TriggerKey(DIK_3)) { ApplyDebugParticlePreset(2); TriggerDebugParticleBurst(); }
+	if (input_->TriggerKey(DIK_4)) { ApplyDebugParticlePreset(3); TriggerDebugParticleBurst(); }
+
+	if (input_->TriggerKey(DIK_P))
 	{
-		debugParticleLog_ = "GpuParticleManager is null.";
-		return;
+		TriggerDebugParticleBurst();
 	}
 
-	const Vector3 bossCenter = debugBoss_->GetCenterPosition();
-
-	// ---------------------------------------------------------
-	// 1キー: ヒット火花
-	// ---------------------------------------------------------
-	if (input_->TriggerKey(DIK_1))
+	if (debugParticleAutoLoop_)
 	{
-		Vector3 pos = bossCenter;
-		pos.y += 1.0f;
-
-		gpuParticleManager->EmitBurst(
-			"Debug_HitSpark",
-			GpuParticleType::Spark,
-			pos,
-			20);
-
-		debugParticleLog_ = "Spawn: HitSpark";
-		DebugLog(debugParticleLog_);
+		debugParticleAutoTimer_ += K4E::GameTimer::GetInstance()->GetDeltaTime();
+		if (debugParticleAutoTimer_ >= std::max(debugParticleAutoInterval_, 0.05f))
+		{
+			debugParticleAutoTimer_ = 0.0f;
+			TriggerDebugParticleBurst();
+		}
 	}
-
-	// ---------------------------------------------------------
-	// 2キー: 回復エフェクト
-	// ---------------------------------------------------------
-	if (input_->TriggerKey(DIK_2))
+	else
 	{
-		Vector3 pos = bossCenter;
-		pos.y += 1.5f;
-
-		gpuParticleManager->EmitBurst(
-			"Debug_Heal",
-			GpuParticleType::Heal,
-			pos,
-			24);
-
-		debugParticleLog_ = "Spawn: Heal_Effect";
-		DebugLog(debugParticleLog_);
-	}
-
-	// ---------------------------------------------------------
-	// 3キー: ボス登場砂埃
-	// ---------------------------------------------------------
-	if (input_->TriggerKey(DIK_3))
-	{
-		Vector3 pos = bossCenter;
-
-		gpuParticleManager->EmitBurst(
-			"Debug_BossAppear",
-			GpuParticleType::Default,
-			pos,
-			48);
-
-		debugParticleLog_ = "Spawn: Boss_Appear_Dust";
-		DebugLog(debugParticleLog_);
+		debugParticleAutoTimer_ = 0.0f;
 	}
 }

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
@@ -7,6 +7,8 @@
 #include "Derived/GuardianBoss/GuardianBoss.h"
 
 #include <memory>
+#include <array>
+#include <cstdint>
 #include <string>
 
 namespace K4E = ::Ken4lowEngine;
@@ -57,6 +59,25 @@ private: /// ---------- メンバ関数 ---------- ///
 	/// テスト用GPUパーティクル発火
 	void UpdateDebugParticleTest();
 
+	struct DebugParticlePreset
+	{
+		const char* label = "";
+		K4E::GpuParticleType type = K4E::GpuParticleType::Default;
+		float fadeInRatio = 0.1f;
+		float fadeOutRatio = 0.25f;
+		float emissiveBoost = 0.0f;
+		float convergence = 0.0f;
+		float divergence = 0.0f;
+		float floaty = 0.0f;
+		uint32_t spawnShapeOverride = 0;
+		uint32_t burstCount = 32;
+	};
+
+	void EnsureDebugParticleEmitter();
+	void ApplyDebugParticlePreset(uint32_t presetIndex);
+	void TriggerDebugParticleBurst();
+	void UpdateDebugParticleEmitterParams();
+
 	/// -------------------------------------------------------------
 	/// BossHitPart を文字列へ変換
 	/// ログ確認用
@@ -82,6 +103,30 @@ private: /// ---------- メンバ変数 ---------- ///
 	std::string debugHitLog_ = "Press H to test hit.";
 
 	// --- GPUパーティクルテスト用 ---
-	std::string debugParticleLog_ = "Press 1/2/3 to test GPU particles.";
+	std::string debugParticleLog_ = "DebugScene GPU particle lab ready.";
+
+	std::string debugParticleEmitterName_ = "DebugScene_SpawnPrototype";
+	Vector3 debugParticleSpawnPosition_{ 0.0f, 0.25f, 24.0f };
+	int debugParticleBurstCount_ = 64;
+	bool debugParticleAutoLoop_ = false;
+	float debugParticleAutoInterval_ = 0.75f;
+	float debugParticleAutoTimer_ = 0.0f;
+	uint32_t debugParticlePresetIndex_ = 0;
+	bool debugParticleDirty_ = true;
+
+	float debugFadeInRatio_ = 0.08f;
+	float debugFadeOutRatio_ = 0.20f;
+	float debugEmissiveBoost_ = 1.5f;
+	float debugConvergence_ = 0.0f;
+	float debugDivergence_ = 0.0f;
+	float debugFloaty_ = 0.0f;
+	uint32_t debugSpawnShapeOverride_ = 0;
+
+	static constexpr std::array<DebugParticlePreset, 4> kDebugParticlePresets_ = {{
+		{ "Ground Telegragh", K4E::GpuParticleType::Dust, 0.08f, 0.35f, 0.4f, 0.0f, 0.7f, 0.15f, 4u, 56u },
+		{ "Convergence", K4E::GpuParticleType::Ambient, 0.04f, 0.28f, 1.2f, 1.0f, 0.0f, 0.10f, 1u, 72u },
+		{ "Materialize Assist", K4E::GpuParticleType::Smoke, 0.10f, 0.32f, 0.7f, 0.45f, 0.15f, 0.55f, 3u, 64u },
+		{ "Completion Flash", K4E::GpuParticleType::Spark, 0.01f, 0.14f, 2.7f, 0.0f, 1.0f, 0.02f, 0u, 96u },
+	}};
 };
 


### PR DESCRIPTION
### Motivation
- Provide a quick, low-risk in-editor lab in `DebugScene` to spawn, preview and tune GPU particle effects before integrating into spawn logic. 
- Allow designers/devs to switch presets, trigger bursts and tweak visual parameters (`fadeInRatio`, `fadeOutRatio`, `emissiveBoost`, `convergence`, `divergence`, `floaty`, and spawn shape) interactively via ImGui. 
- Keep changes localized to `DebugScene` and reuse existing `GpuParticleManager` APIs so the GPU particle foundation is not modified for production behavior. 

### Description
- Added a `DebugParticlePreset` struct and a small `kDebugParticlePresets_` array and state members to `DebugScene` for preset selection and runtime overrides in `DebugScene.h`.
- Implemented emitter management and control helpers in `DebugScene.cpp`: `EnsureDebugParticleEmitter()`, `ApplyDebugParticlePreset()`, `UpdateDebugParticleEmitterParams()`, `TriggerDebugParticleBurst()`, and integrated them into the existing `UpdateDebugParticleTest()` flow so a persistent debug emitter (`DebugScene_SpawnPrototype`) is created/updated and can be triggered.
- Extended the ImGui UI inside `DebugScene::DrawImGui()` to add a `DebugScene GPU Particle Lab` section with a `Spawn Preset` combo, `Apply Preset` button, `Spawn Position`, `Burst Count`, `Auto Loop`/`Auto Interval`, sliders for the visual parameters, a `Trigger Burst` button and keyboard shortcuts (`1/2/3/4` for presets, `P` to trigger).
- Changes are localized to `DebugScene` and call into the existing `GpuParticleManager` (`FindEmitter`, `CreateEmitter`, `RequestEmit`, `GetInfoMutable`) so production systems are not directly altered.

### Testing
- Performed static code checks and repository inspections (searches for the new helper names and usages) and verified the new functions are referenced: `EnsureDebugParticleEmitter`, `ApplyDebugParticlePreset`, `UpdateDebugParticleEmitterParams`, `TriggerDebugParticleBurst` (succeeded).
- Created and committed the local changes and verified the diff includes only `DebugScene.h` and `DebugScene.cpp` (local commit succeeded); pushing to remote failed in this environment because the `origin` remote is not configured. 
- No automated build or CI run was executed in this environment, so a full compile/test should be run in CI or locally to confirm integration with the GPU particle pipelines and rendering runtime.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f182e5dde8832dbe17d713f51682e8)