### PR TITLE
Fix GPU particle PS root signature mismatch for b2 CBV

### DIFF
--- a/Project/Engine/Graphics/Renderer/GpuParticle/Pipeline/GpuParticleSpritePipeline.cpp
+++ b/Project/Engine/Graphics/Renderer/GpuParticle/Pipeline/GpuParticleSpritePipeline.cpp
@@ -114,7 +114,7 @@ void GpuParticleSpritePipeline::CreateRootSignature()
 	srvRange[0].OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
 
 	// RootParameters
-	D3D12_ROOT_PARAMETER params[4]{};
+	D3D12_ROOT_PARAMETER params[5]{};
 
 	// b0 : PerView / シミュレーション定数（全部のシェーダ）
 	params[0].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
@@ -132,11 +132,16 @@ void GpuParticleSpritePipeline::CreateRootSignature()
 	params[2].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
 	params[2].Descriptor.ShaderRegister = 1;
 
-	// t0 : Texture SRV（PS）
-	params[3].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+	// b2 : Emitter（PS）
+	params[3].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
 	params[3].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
-	params[3].DescriptorTable.NumDescriptorRanges = _countof(srvRange);
-	params[3].DescriptorTable.pDescriptorRanges = srvRange;
+	params[3].Descriptor.ShaderRegister = 2;
+
+	// t0 : Texture SRV（PS）
+	params[4].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+	params[4].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+	params[4].DescriptorTable.NumDescriptorRanges = _countof(srvRange);
+	params[4].DescriptorTable.pDescriptorRanges = srvRange;
 
 	rsDesc.pParameters = params;
 	rsDesc.NumParameters = _countof(params);

--- a/Project/Engine/Graphics/Renderer/GpuParticle/Renderer/GpuParticleRenderer.cpp
+++ b/Project/Engine/Graphics/Renderer/GpuParticle/Renderer/GpuParticleRenderer.cpp
@@ -58,7 +58,9 @@ namespace Ken4lowEngine
 		// マテリアル設定
 		particleMaterial_->SetPipeline(2, slot);
 
-		TextureManager::GetInstance()->SetGraphicsRootDescriptorTable(commandList, 3, TextureManager::GetInstance()->GetSrvHandleGPU(textureFilePath_));
+		commandList->SetGraphicsRootConstantBufferView(3, gpuParticleBuffers_->GetEmitterCBAddress(slot));
+
+		TextureManager::GetInstance()->SetGraphicsRootDescriptorTable(commandList, 4, TextureManager::GetInstance()->GetSrvHandleGPU(textureFilePath_));
 
 		// インスタンス数分描画
 		if (particleMesh_->HasIndex())


### PR DESCRIPTION
### Motivation
- Resolve D3D12 `CREATEGRAPHICSPIPELINESTATE_PS_ROOT_SIGNATURE_MISMATCH` caused by a pixel shader requesting `register(b2)` while the root signature did not expose a matching CBV.
- Apply a minimal change that follows the repository's existing PSO / Root Signature design without altering shader register assignments.

### Description
- Added a pixel-visible CBV root parameter for `register(b2)` in `Project/Engine/Graphics/Renderer/GpuParticle/Pipeline/GpuParticleSpritePipeline.cpp` and increased root parameter array size from 4 to 5.
- Shifted the texture SRV descriptor table to the new root index to preserve the original layout semantics.
- Updated `Project/Engine/Graphics/Renderer/GpuParticle/Renderer/GpuParticleRenderer.cpp` to bind the emitter CBV with `SetGraphicsRootConstantBufferView(3, ...)` and to set the texture SRV at root index 4.
- Did not change shader `register(...)` assignments; the fix makes the Root Signature match the existing `GpuParticle.PS.hlsl` expectation (`gEmitter : register(b2)`).

### Testing
- Ran targeted code searches (`rg`) to locate `register(b2)` in `Project/Resources/Shaders/GpuParticle/GpuParticle.PS.hlsl` and to find the PSO / Root Signature creation sites, confirming the offending shader and pipeline.
- Verified the patch with `git diff` and created a local commit (`git commit`) on branch `codex/fix-ps-rootsignature-b2` successfully.
- Attempted to push but `git push` failed because the `origin` remote is not configured in this environment, and a full build/test was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1892b4dd4832da50ab2ff9881f3d3)