### PR TITLE
Fix GPU particle spawn shape UI mapping (Box/Circle)

### DIFF
--- a/Project/Engine/Graphics/Renderer/GpuParticle/Manager/GpuParticleManager.cpp
+++ b/Project/Engine/Graphics/Renderer/GpuParticle/Manager/GpuParticleManager.cpp
@@ -656,11 +656,11 @@ namespace Ken4lowEngine
 
 				const char* kSpawnShapeItems[] = { "UseTypeDefault", "Box", "Circle" };
 				int spawnShapeUi = 0;
-				if (info.spawnShapeOverride == 3u) { spawnShapeUi = 1; }
-				else if (info.spawnShapeOverride == 4u) { spawnShapeUi = 2; }
+				if (info.spawnShapeOverride == 4u) { spawnShapeUi = 1; }
+				else if (info.spawnShapeOverride == 5u) { spawnShapeUi = 2; }
 				if (ImGui::Combo("Spawn Shape", &spawnShapeUi, kSpawnShapeItems, IM_ARRAYSIZE(kSpawnShapeItems)))
 				{
-					info.spawnShapeOverride = (spawnShapeUi == 1) ? 3u : (spawnShapeUi == 2) ? 4u : 0u;
+					info.spawnShapeOverride = (spawnShapeUi == 1) ? 4u : (spawnShapeUi == 2) ? 5u : 0u;
 				}
 
 				uint32_t effectiveType = 0;


### PR DESCRIPTION
### Motivation
- Fix a mismatch where the ImGui `Spawn Shape` selection mapped `Box` and `Circle` to wrong internal IDs, causing the displayed shape to be different from the actual GPU spawn shape while keeping DebugScene verification intact.

### Description
- Update `Project/Engine/Graphics/Renderer/GpuParticle/Manager/GpuParticleManager.cpp` so the ImGui selection maps to the shader-aligned constants `GPU_PARTICLE_SPAWN_SHAPE_BOX = 4` and `GPU_PARTICLE_SPAWN_SHAPE_CIRCLE = 5` in both directions, without modifying HLSL or DebugBoss-related code.

### Testing
- No automated tests were run; static verification was performed by inspecting `Project/Resources/Shaders/GpuParticle/GpuParticleSpawnParams.hlsli` and `Project/Resources/Shaders/GpuParticle/GpuParticleEmit.CS.hlsl`, and repository checks (`rg`, `git diff`, `git commit`) succeeded while `git push` failed due to a missing `origin` remote in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f18ddfd844832db8eaf8cbc381fea3)