### PR TITLE
Staged GPU particle spawn sequence (Telegraph → Converge → Materialize) with enemy presentation gating

### DIFF
--- a/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.cpp
+++ b/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.cpp
@@ -5,6 +5,7 @@
 
 #include "WorldCollisionResolver.h"
 #include "AudioManager.h"
+#include <imgui.h>
 
 using namespace Ken4lowEngine;
 
@@ -29,6 +30,7 @@ void CharacterWorld::Initialize(GameContext& ctx)
 	}
 
 	enemies_.clear();
+	spawnSequences_.clear();
 }
 
 void CharacterWorld::Finalize()
@@ -111,11 +113,19 @@ Enemy& CharacterWorld::SpawnEnemy(const EnemySpawnRequest& request)
 	return *enemies_.back();
 }
 
-Enemy& CharacterWorld::SpawnEnemyAt(const K4E::Vector3& position)
+Enemy& CharacterWorld::SpawnEnemyAt(const K4E::Vector3& position, int spawnPointIndex, int waveNumber)
 {
 	EnemySpawnRequest request{};
 	request.position = position;
-	return SpawnEnemy(request);
+	request.spawnPointIndex = spawnPointIndex;
+	request.waveNumber = waveNumber;
+	Enemy& enemy = SpawnEnemy(request);
+	enemy.SetSpawnPresentationActive(true, 0.0f);
+	EnemySpawnSequenceState state{};
+	state.request = request;
+	state.enemy = &enemy;
+	spawnSequences_.push_back(state);
+	return enemy;
 }
 
 void CharacterWorld::ClearEnemies()
@@ -137,6 +147,31 @@ void CharacterWorld::Update(float dt)
 	for (auto& e : enemies_)
 	{
 		e->Update(dt);
+	}
+	auto* pm = K4E::GpuParticleManager::GetInstance();
+	for (auto& seq : spawnSequences_)
+	{
+		seq.timer += dt;
+		if (!seq.telegraphPlayed && seq.timer >= 0.0f)
+		{
+			if (auto* e = pm->GetEmitter("Spawn_Telegraph_Ground")) { e->SetPosition(seq.request.position); e->RequestEmit(1); }
+			seq.telegraphPlayed = true;
+		}
+		if (!seq.convergePlayed && seq.timer >= 0.1f)
+		{
+			if (auto* e = pm->GetEmitter("Spawn_Converge")) { e->SetPosition(seq.request.position); e->RequestEmit(1); }
+			seq.convergePlayed = true;
+		}
+		if (!seq.materializePlayed && seq.timer >= 0.35f)
+		{
+			if (auto* e = pm->GetEmitter("Spawn_Materialize")) { e->SetPosition(seq.request.position); e->RequestEmit(1); }
+			seq.materializePlayed = true;
+		}
+		if (seq.enemy)
+		{
+			const float fadeT = (seq.timer - 0.35f) / 0.45f;
+			seq.enemy->SetSpawnPresentationActive(seq.timer < 0.8f, fadeT);
+		}
 	}
 
 	if (ctx_.collisionManager_)
@@ -176,6 +211,16 @@ void CharacterWorld::DrawImGui()
 	// - EnemyTuningEditor は出さない
 	// --------------------------------------------------------
 	for (auto& e : enemies_) { e->DrawImGui(); }
+	if (ImGui::Begin("Enemy Spawn Sequence"))
+	{
+		for (size_t i = 0; i < spawnSequences_.size(); ++i)
+		{
+			const auto& s = spawnSequences_[i];
+			ImGui::Text("Seq[%d] wave=%d spawnPoint=%d pos=(%.2f, %.2f, %.2f) timer=%.2f", static_cast<int>(i), s.request.waveNumber, s.request.spawnPointIndex, s.request.position.x, s.request.position.y, s.request.position.z, s.timer);
+			ImGui::Text("  telegraph=%d converge=%d materialize=%d", s.telegraphPlayed ? 1 : 0, s.convergePlayed ? 1 : 0, s.materializePlayed ? 1 : 0);
+		}
+	}
+	ImGui::End();
 
 	// --------------------------------------------------------
 	// 3) EnemyTuningEditor は 1回だけ描画する

--- a/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.h
+++ b/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.h
@@ -6,6 +6,7 @@
 #include "Player.h"
 #include "Enemy.h"
 #include "EnemyParticleEffectSystem.h"
+#include <GpuParticleManager.h>
 
 // 前方宣言
 class CollisionManager;
@@ -31,6 +32,18 @@ private: /// ---------- 構造体 ---------- ///
 		K4E::Vector3 position = {};
 		float yawRad = 0.0f;
 		float maxHp = 240.0f;
+		int spawnPointIndex = -1;
+		int waveNumber = -1;
+	};
+	struct EnemySpawnSequenceState
+	{
+		EnemySpawnRequest request{};
+		float timer = 0.0f;
+		bool telegraphPlayed = false;
+		bool convergePlayed = false;
+		bool materializePlayed = false;
+		bool enemySpawned = false;
+		Enemy* enemy = nullptr;
 	};
 
 public: /// ---------- メンバ関数 ---------- ///
@@ -55,7 +68,7 @@ public: /// ---------- メンバ関数 ---------- ///
 
 	// 生成
 	Enemy& SpawnEnemy(const EnemySpawnRequest& request);
-	Enemy& SpawnEnemyAt(const K4E::Vector3& position);
+	Enemy& SpawnEnemyAt(const K4E::Vector3& position, int spawnPointIndex = -1, int waveNumber = -1);
 
 	// 全消し
 	void ClearEnemies();
@@ -81,6 +94,7 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	// 敵の被弾エフェクトシステム
 	EnemyParticleEffectSystem enemyParticleEffectSystem_;
+	std::vector<EnemySpawnSequenceState> spawnSequences_;
 
 private: /// ---------- デバッグ用 ---------- ///
 

--- a/Project/ApplicationLayer/Character/Enemy/Core/Enemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/Enemy.cpp
@@ -136,6 +136,12 @@ void Enemy::Initialize()
 
 void Enemy::Update(float deltaTime)
 {
+	if (spawnPresentationActive_)
+	{
+		StopMove();
+		EnemyBase::Update(deltaTime);
+		return;
+	}
 	UpdateNavigatorSource();
 	moveCommandedThisFrame_ = false;
 
@@ -197,6 +203,13 @@ void Enemy::Update(float deltaTime)
 
 	UpdateAnimation(deltaTime);
 	EnemyBase::Update(deltaTime);
+}
+
+void Enemy::SetSpawnPresentationActive(bool active, float normalizedTime)
+{
+	spawnPresentationActive_ = active;
+	const float t = std::clamp(normalizedTime, 0.0f, 1.0f);
+	SetColor({ 1.0f, 1.0f, 1.0f, active ? t : 1.0f });
 }
 
 void Enemy::ChangeState(std::unique_ptr<IEnemyState> nextState)

--- a/Project/ApplicationLayer/Character/Enemy/Core/Enemy.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/Enemy.h
@@ -159,6 +159,8 @@ public: /// ---------- メンバ関数 ---------- ///
 	void Initialize() override;
 
 	void Update(float deltaTime) override;
+	void SetSpawnPresentationActive(bool active, float normalizedTime = 1.0f);
+	bool IsSpawnPresentationActive() const { return spawnPresentationActive_; }
 
 public: /// ---------- 外部からのアクセス ---------- ///
 
@@ -348,6 +350,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	bool isMovementStuck_ = false;
 
 	AnimState animState_ = AnimState::Idle;
+	bool spawnPresentationActive_ = false;
 	float animTime_ = 0.0f;
 	float animMoveRate_ = 1.0f;
 };

--- a/Project/ApplicationLayer/Scene/GamePlayScene/Core/GamePlayStageContext.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/Core/GamePlayStageContext.cpp
@@ -347,12 +347,14 @@ void GamePlayStageContext::SetupWaves(WaveManager* waveManager) const
 			else { waves[static_cast<size_t>(i)].delayBeforeSpawnSec = 2.5f; }
 		}
 
-		for (const auto& spawn : enemySpawnInfos_)
+		for (size_t spawnInfoIndex = 0; spawnInfoIndex < enemySpawnInfos_.size(); ++spawnInfoIndex)
 		{
+			const auto& spawn = enemySpawnInfos_[spawnInfoIndex];
 			const int waveIndex = std::max(0, spawn.wave - 1);
 
 			WaveSpawnEntry entry{};
 			entry.position = spawn.position;
+			entry.spawnPointIndex = static_cast<int>(spawnInfoIndex);
 
 			const int spawnCount = std::max(1, spawn.count);
 			for (int i = 0; i < spawnCount; ++i)

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/WaveManager.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/WaveManager.cpp
@@ -81,7 +81,7 @@ int WaveManager::SpawnWave(CharacterWorld& characters, const WaveDefinition& wav
 
 	for (const auto& entry : wave.enemies)
 	{
-		characters.SpawnEnemyAt(entry.position);
+		characters.SpawnEnemyAt(entry.position, entry.spawnPointIndex, currentWaveIndex_ + 1);
 		++spawnedCount;
 	}
 

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/WaveManager.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/WaveManager.h
@@ -12,6 +12,7 @@ class CharacterWorld;
 struct WaveSpawnEntry
 {
 	K4E::Vector3 position = { 0.0f, 0.0f, 0.0f }; // スポーン位置
+	int spawnPointIndex = -1;
 };
 
 /// ---------- 1ウェーブ分の定義 ---------- ///
@@ -83,4 +84,3 @@ private: /// ---------- メンバ変数 ---------- ///
 	bool allWavesCleared_ = false; // すべてのウェーブがクリアされたかどうか
 	int currentWaveSpawnedCount_ = 0; // 現在のウェーブでスポーンした敵の数
 };
-


### PR DESCRIPTION
### Motivation
- Implement a clear, stage-based enemy spawn presentation using existing GPU particle emitters so players see: ground telegraph → particle converge → materialize, then AI activation. 
- Keep spawn world XZ position intact (use LevelData spawn positions) and avoid adding unrelated debug/boss logic.

### Description
- Added `spawnPointIndex` to `WaveSpawnEntry` and populated it when building waves so spawn metadata is propagated from stage data to the spawn flow (`GamePlayStageContext`, `WaveManager`).
- Introduced a per-spawn sequence state in `CharacterWorld` (`EnemySpawnSequenceState`) and a timed sequencer that triggers GPU emitters `Spawn_Telegraph_Ground`, `Spawn_Converge`, `Spawn_Materialize` at ~0.0s / 0.1s / 0.35s and drives a short materialize fade until ~0.8s.
- Added a spawn presentation flag and simple fade in on `Enemy` so normal AI/state updates are suppressed during the materialization window and the visual body fades in naturally.
- Exposed an ImGui panel in `CharacterWorld::DrawImGui` for debugging per-spawn information including wave number, spawnPoint index, spawn world position, sequence timer, and per-effect played flags.
- Modified files (key changes):
  - Project/ApplicationLayer/Scene/GamePlayScene/Core/GamePlayStageContext.cpp (attach spawnPointIndex)
  - Project/ApplicationLayer/Scene/GamePlayScene/World/WaveManager.h/.cpp (pass spawnPointIndex into spawn requests)
  - Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.h/.cpp (spawn sequence state, timed emitter requests, ImGui)
  - Project/ApplicationLayer/Character/Enemy/Core/Enemy.h/.cpp (spawn presentation flag, AI gating, fade-in color)

### Testing
- Performed project-wide code inspection to verify new emitter calls and spawn-sequence wiring (search and diffs), and these inspections succeeded.  
- Changes were recorded in a local workspace branch named `codex/spawn-sequence`; pushing to remote was not performed in this environment because the requested base branch was not available.  
- Attempt to create the requested start branch `Develop_Ver.0.13.6` in this environment failed because that branch/commit was not present here.  
- No full build or automated unit/runtime tests were executed in this environment, so a full build + in-editor/playtest is recommended to confirm emitter names exist, Y-ground snapping (if desired), damage/HP-bar gating, and visual timing on real hardware.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f191af6f48832dba03cce9cc6541d8)