### PR TITLE
Refactor gameplay stage objectives into mission classes

### DIFF
--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
@@ -4,6 +4,9 @@
 #include <SpriteManager.h>
 #include <SceneManager.h>
 #include <GameTimer.h>
+#ifdef USE_IMGUI
+#include <imgui.h>
+#endif
 
 #ifdef _DEBUG
 #include <DebugCamera.h>
@@ -95,6 +98,22 @@ void GamePlayScene::SetupNewGame(bool skipIntro)
 	{
 		return;
 	}
+
+	missionConfig_ = StageMissionConfig{};
+	missionConfig_.stageType = ResolveStageTypeFromStageIndex(stageContext_->GetCurrentStageIndex());
+	if (!stageContext_->GetGoalPoints().empty())
+	{
+		missionConfig_.clearPoint = stageContext_->GetGoalPoints().front().position;
+		missionConfig_.escapePoint = stageContext_->GetGoalPoints().front().position;
+	}
+	if (!stageContext_->GetDefenseTargetPoints().empty())
+	{
+		missionConfig_.clearPoint = stageContext_->GetDefenseTargetPoints().front().position;
+	}
+	missionConfig_.defenseTime = stageContext_->GetCurrentStageRule().defendTimeSec > 0.0f ? stageContext_->GetCurrentStageRule().defendTimeSec : 60.0f;
+	missionConfig_.timeLimit = stageContext_->GetCurrentStageRule().timeLimitSec;
+	stageMission_ = CreateStageMissionByType(missionConfig_.stageType);
+	if (stageMission_) { stageMission_->Initialize(world_.get(), *stageContext_, missionConfig_); }
 
 	introDirector_->Reset(*stageContext_, 2.5f);
 
@@ -350,6 +369,10 @@ void GamePlayScene::UpdateWorld(float deltaTime)
 	{
 		world_->Update(deltaTime);
 	}
+	if (stageMission_)
+	{
+		stageMission_->Update(deltaTime);
+	}
 }
 
 /// -------------------------------------------------------------
@@ -373,16 +396,24 @@ void GamePlayScene::CheckGameEnd()
 	}
 
 	// ステージ固有の失敗条件
-	if (world_->IsStageObjectiveFailed())
+	if (stageMission_ && stageMission_->IsFailed())
 	{
 		flow_->EnterGameOver(input_);
 		return;
 	}
 
 	// ステージ固有のクリア条件
-	if (world_->IsStageObjectiveCleared())
+	if (stageMission_ && stageMission_->IsCleared())
 	{
-		flow_->EnterGameClear(input_, nullptr);
+		if (stageContext_ && stageContext_->GetCurrentStageIndex() >= 4)
+		{
+			flow_->EnterGameClear(input_, nullptr);
+		}
+		else
+		{
+			if (stageContext_) { stageContext_->UnlockNextStage(); }
+			flow_->EnterGameClear(input_, nullptr);
+		}
 		return;
 	}
 }
@@ -524,6 +555,14 @@ void GamePlayScene::DrawImGui()
 	if (debugTools_)
 	{
 		debugTools_->DrawImGui(world_.get());
+	}
+	if (stageContext_ && stageMission_)
+	{
+		ImGui::Begin("StageMission");
+		ImGui::Text("Current Stage: %d", stageContext_->GetCurrentStageIndex() + 1);
+		ImGui::Text("StageType: %s", ToStageTypeName(stageMission_->GetStageType()));
+		stageMission_->DrawDebugImGui();
+		ImGui::End();
 	}
 #endif // USE_IMGUI
 }

--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.h
@@ -7,6 +7,7 @@
 #include "GamePlayIntroDirector.h"
 #include "GamePlayDebugTools.h"
 #include "FadeManager.h"
+#include "Mission/StageMission.h"
 
 #include <memory>
 
@@ -146,6 +147,8 @@ private: /// ---------- メンバ変数 ---------- ///
 	std::unique_ptr<GamePlayIntroDirector> introDirector_;
 	std::unique_ptr<GamePlayDebugTools> debugTools_;
 	std::unique_ptr<FadeManager> fadeManager_;
+	std::unique_ptr<IStageMission> stageMission_;
+	StageMissionConfig missionConfig_{};
 
 	// リトライ遷移制御
 	bool isRetryTransitionActive_ = false; // リトライ演出中か

--- a/Project/ApplicationLayer/Scene/GamePlayScene/Mission/StageMission.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/Mission/StageMission.cpp
@@ -1,0 +1,60 @@
+#include "StageMission.h"
+#include "GamePlayStageContext.h"
+#include "GamePlayWorld.h"
+#include "EnemyBase.h"
+
+#ifdef USE_IMGUI
+#include <imgui.h>
+#endif
+
+#include <algorithm>
+
+void StageMissionBase::Initialize(GamePlayWorld* world, const GamePlayStageContext& stageContext, const StageMissionConfig& config) {
+    world_ = world; stageContext_ = &stageContext; config_ = config; isCleared_ = false; isFailed_ = false;
+}
+void StageMissionBase::DrawDebugImGui() {
+#ifdef USE_IMGUI
+    ImGui::Text("Mission: %s", GetDebugName());
+    ImGui::Text("Cleared: %s", isCleared_ ? "true" : "false");
+    ImGui::Text("Failed : %s", isFailed_ ? "true" : "false");
+#endif
+}
+
+class WaveStageMission : public StageMissionBase { public: void Update(float) override { if (world_) { isCleared_ = world_->IsAllWavesCleared() && world_->GetCharacters().GetEnemyCount() == 0; } } const char* GetDebugName() const override { return "WaveStageMission"; } };
+class ExploreStageMission : public StageMissionBase { public: void Update(float) override; void DrawDebugImGui() override; const char* GetDebugName() const override { return "ExploreStageMission"; } private: float distance_ = 0.0f; };
+void ExploreStageMission::Update(float) { if (!world_) return; auto* p = world_->GetCharacters().GetPlayer(); if (!p || !p->GetWorldTransform()) return; distance_ = K4E::Vector3::Length(p->GetWorldTransform()->translate_ - config_.clearPoint); isCleared_ = distance_ <= config_.clearRadius; }
+void ExploreStageMission::DrawDebugImGui() { StageMissionBase::DrawDebugImGui();
+#ifdef USE_IMGUI
+    ImGui::Text("ExploreDist: %.2f / %.2f", distance_, config_.clearRadius);
+#endif
+}
+
+class DefenseStageMission : public StageMissionBase { public: void Initialize(GamePlayWorld* w, const GamePlayStageContext& c, const StageMissionConfig& cfg) override { StageMissionBase::Initialize(w, c, cfg); hp_ = cfg.defenseTargetHp; } void Update(float dt) override; void DrawDebugImGui() override; const char* GetDebugName() const override { return "DefenseStageMission"; } private: float elapsed_ = 0.0f; float hp_ = 0.0f; };
+void DefenseStageMission::Update(float dt) { if (!world_ || isFailed_) return; elapsed_ += dt; for (auto* e : world_->GetCharacters().GetEnemyRawList()) { if (!e || e->IsDead()) continue; if (K4E::Vector3::Length(e->GetCenterPosition() - config_.clearPoint) < 4.0f) { hp_ -= dt * 5.0f; } } if (hp_ <= 0.0f) { hp_ = 0.0f; isFailed_ = true; } isCleared_ = (elapsed_ >= config_.defenseTime) && !isFailed_; }
+void DefenseStageMission::DrawDebugImGui() { StageMissionBase::DrawDebugImGui();
+#ifdef USE_IMGUI
+    ImGui::Text("DefenseRemain: %.2f", std::max(0.0f, config_.defenseTime - elapsed_));
+    ImGui::Text("DefenseHP: %.1f", hp_);
+#endif
+}
+
+class EscapeStageMission : public StageMissionBase { public: void Update(float dt) override; void DrawDebugImGui() override; const char* GetDebugName() const override { return "EscapeStageMission"; } private: float elapsed_ = 0.0f; float distance_ = 0.0f; };
+void EscapeStageMission::Update(float dt) { if (!world_) return; elapsed_ += dt; auto* p = world_->GetCharacters().GetPlayer(); if (!p || !p->GetWorldTransform()) return; distance_ = K4E::Vector3::Length(p->GetWorldTransform()->translate_ - config_.escapePoint); isCleared_ = distance_ <= config_.escapeRadius; if (config_.timeLimit > 0.0f && elapsed_ >= config_.timeLimit && !isCleared_) isFailed_ = true; }
+void EscapeStageMission::DrawDebugImGui() { StageMissionBase::DrawDebugImGui();
+#ifdef USE_IMGUI
+    ImGui::Text("EscapeDist: %.2f / %.2f", distance_, config_.escapeRadius);
+    ImGui::Text("TimeLimit: %.2f / %.2f", elapsed_, config_.timeLimit);
+#endif
+}
+
+class BossStageMission : public StageMissionBase { public: void Update(float) override; void DrawDebugImGui() override; const char* GetDebugName() const override { return "BossStageMission"; } private: float bossHp_ = 0.0f; };
+void BossStageMission::Update(float) { if (!world_) return; auto enemies = world_->GetCharacters().GetEnemyRawList(); if (enemies.empty()) { isCleared_ = true; bossHp_ = 0.0f; return; } bossHp_ = static_cast<float>(enemies.front()->GetHp()); isCleared_ = std::all_of(enemies.begin(), enemies.end(), [](EnemyBase* e) { return !e || e->IsDead(); }); }
+void BossStageMission::DrawDebugImGui() { StageMissionBase::DrawDebugImGui();
+#ifdef USE_IMGUI
+    ImGui::Text("BossHP: %.1f", bossHp_);
+#endif
+}
+
+std::unique_ptr<IStageMission> CreateStageMissionByType(StageType t) { switch (t) { case StageType::Wave: return std::make_unique<WaveStageMission>(); case StageType::Explore: return std::make_unique<ExploreStageMission>(); case StageType::Defense: return std::make_unique<DefenseStageMission>(); case StageType::Escape: return std::make_unique<EscapeStageMission>(); case StageType::Boss: return std::make_unique<BossStageMission>(); } return std::make_unique<WaveStageMission>(); }
+StageType ResolveStageTypeFromStageIndex(int i) { switch (i) { case 0: return StageType::Wave; case 1: return StageType::Explore; case 2: return StageType::Defense; case 3: return StageType::Escape; case 4: return StageType::Boss; default: return StageType::Wave; } }
+const char* ToStageTypeName(StageType t) { switch (t) { case StageType::Wave: return "Wave"; case StageType::Explore: return "Explore"; case StageType::Defense: return "Defense"; case StageType::Escape: return "Escape"; case StageType::Boss: return "Boss"; } return "Unknown"; }

--- a/Project/ApplicationLayer/Scene/GamePlayScene/Mission/StageMission.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/Mission/StageMission.h
@@ -1,0 +1,66 @@
+#pragma once
+#include "Vector3.h"
+#include <memory>
+#include <string>
+
+class GamePlayWorld;
+class GamePlayStageContext;
+
+namespace K4E = ::Ken4lowEngine;
+
+enum class StageType
+{
+	Wave,
+	Explore,
+	Defense,
+	Escape,
+	Boss
+};
+
+struct StageMissionConfig
+{
+	StageType stageType = StageType::Wave;
+	K4E::Vector3 clearPoint{ 0.0f, 0.0f, 0.0f };
+	float clearRadius = 3.0f;
+	float defenseTime = 60.0f;
+	float defenseTargetHp = 100.0f;
+	K4E::Vector3 escapePoint{ 0.0f, 0.0f, 0.0f };
+	float escapeRadius = 3.0f;
+	float timeLimit = 0.0f;
+	std::string bossSpawnName;
+	int bossEnemyId = -1;
+};
+
+class IStageMission
+{
+public:
+	virtual ~IStageMission() = default;
+	virtual void Initialize(GamePlayWorld* world, const GamePlayStageContext& stageContext, const StageMissionConfig& config) = 0;
+	virtual void Update(float dt) = 0;
+	virtual void DrawDebugImGui() = 0;
+	virtual bool IsCleared() const = 0;
+	virtual bool IsFailed() const = 0;
+	virtual const char* GetDebugName() const = 0;
+	virtual StageType GetStageType() const = 0;
+};
+
+class StageMissionBase : public IStageMission
+{
+public:
+	void Initialize(GamePlayWorld* world, const GamePlayStageContext& stageContext, const StageMissionConfig& config) override;
+	void DrawDebugImGui() override;
+	bool IsCleared() const override { return isCleared_; }
+	bool IsFailed() const override { return isFailed_; }
+	StageType GetStageType() const override { return config_.stageType; }
+
+protected:
+	GamePlayWorld* world_ = nullptr;
+	const GamePlayStageContext* stageContext_ = nullptr;
+	StageMissionConfig config_{};
+	bool isCleared_ = false;
+	bool isFailed_ = false;
+};
+
+std::unique_ptr<IStageMission> CreateStageMissionByType(StageType stageType);
+StageType ResolveStageTypeFromStageIndex(int stageIndex);
+const char* ToStageTypeName(StageType stageType);


### PR DESCRIPTION
### Motivation
- Separate stage-specific rules from `GamePlayScene` so the scene only manages mission lifecycle and transitions.
- Provide a flexible, JSON-friendly mission configuration surface (clear points/radii, defense timers/HP, escape params, boss identifiers) for future expansion.
- Preserve existing `WaveManager` behavior while enabling other stage types (Explore/Defense/Escape/Boss) without adding large switch blocks into the scene.

### Description
- Added a mission abstraction with `StageType` and `StageMissionConfig` and a mission contract via `IStageMission` and `StageMissionBase` to standardize initialization, update, debug draw, and clear/fail queries.
- Implemented per-stage missions `WaveStageMission`, `ExploreStageMission`, `DefenseStageMission`, `EscapeStageMission`, and `BossStageMission` and a small factory `CreateStageMissionByType` to instantiate them by `StageType`.
- Integrated mission lifecycle into `GamePlayScene` by adding `stageMission_` and `missionConfig_`, creating/initializing the appropriate mission in `SetupNewGame`, calling `stageMission_->Update` from `UpdateWorld`, and using `IsCleared`/`IsFailed` in `CheckGameEnd` to drive transitions.
- Added ImGui debug output for mission information and progress and introduced these new files and edits: `Project/ApplicationLayer/Scene/GamePlayScene/Mission/StageMission.h`, `.../Mission/StageMission.cpp`, and updates to `GamePlayScene.h` and `GamePlayScene.cpp` to wire everything together.

### Testing
- Performed static repository inspections and file content verification of the new and changed files (`StageMission.h`, `StageMission.cpp`, `GamePlayScene.h`, `GamePlayScene.cpp`), and the changes are present and consistent with the new mission API.
- Verified integration points in `GamePlayScene` (mission creation in `SetupNewGame`, `stageMission_->Update` in `UpdateWorld`, and mission-based checks in `CheckGameEnd`) using diffs and file listings, with no merge or compilation errors observed at the source level.
- No automated runtime unit tests or full project build were executed in this change set, so runtime validation and tuning should be performed in the next step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1a07a1b14832dad19960cccf650da)