### PR TITLE
Implement StageType and StageMissionFactory definitions and add to project

### DIFF
--- a/Project/ApplicationLayer/Scene/GamePlayScene/Mission/StageMission.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/Mission/StageMission.cpp
@@ -1,60 +1,23 @@
 #include "StageMission.h"
-#include "GamePlayStageContext.h"
-#include "GamePlayWorld.h"
-#include "EnemyBase.h"
 
 #ifdef USE_IMGUI
 #include <imgui.h>
 #endif
 
-#include <algorithm>
-
-void StageMissionBase::Initialize(GamePlayWorld* world, const GamePlayStageContext& stageContext, const StageMissionConfig& config) {
-    world_ = world; stageContext_ = &stageContext; config_ = config; isCleared_ = false; isFailed_ = false;
+void StageMissionBase::Initialize(GamePlayWorld* world, const GamePlayStageContext& stageContext, const StageMissionConfig& config)
+{
+	world_ = world;
+	stageContext_ = &stageContext;
+	config_ = config;
+	isCleared_ = false;
+	isFailed_ = false;
 }
-void StageMissionBase::DrawDebugImGui() {
+
+void StageMissionBase::DrawDebugImGui()
+{
 #ifdef USE_IMGUI
-    ImGui::Text("Mission: %s", GetDebugName());
-    ImGui::Text("Cleared: %s", isCleared_ ? "true" : "false");
-    ImGui::Text("Failed : %s", isFailed_ ? "true" : "false");
+	ImGui::Text("Mission: %s", GetDebugName());
+	ImGui::Text("Cleared: %s", isCleared_ ? "true" : "false");
+	ImGui::Text("Failed : %s", isFailed_ ? "true" : "false");
 #endif
 }
-
-class WaveStageMission : public StageMissionBase { public: void Update(float) override { if (world_) { isCleared_ = world_->IsAllWavesCleared() && world_->GetCharacters().GetEnemyCount() == 0; } } const char* GetDebugName() const override { return "WaveStageMission"; } };
-class ExploreStageMission : public StageMissionBase { public: void Update(float) override; void DrawDebugImGui() override; const char* GetDebugName() const override { return "ExploreStageMission"; } private: float distance_ = 0.0f; };
-void ExploreStageMission::Update(float) { if (!world_) return; auto* p = world_->GetCharacters().GetPlayer(); if (!p || !p->GetWorldTransform()) return; distance_ = K4E::Vector3::Length(p->GetWorldTransform()->translate_ - config_.clearPoint); isCleared_ = distance_ <= config_.clearRadius; }
-void ExploreStageMission::DrawDebugImGui() { StageMissionBase::DrawDebugImGui();
-#ifdef USE_IMGUI
-    ImGui::Text("ExploreDist: %.2f / %.2f", distance_, config_.clearRadius);
-#endif
-}
-
-class DefenseStageMission : public StageMissionBase { public: void Initialize(GamePlayWorld* w, const GamePlayStageContext& c, const StageMissionConfig& cfg) override { StageMissionBase::Initialize(w, c, cfg); hp_ = cfg.defenseTargetHp; } void Update(float dt) override; void DrawDebugImGui() override; const char* GetDebugName() const override { return "DefenseStageMission"; } private: float elapsed_ = 0.0f; float hp_ = 0.0f; };
-void DefenseStageMission::Update(float dt) { if (!world_ || isFailed_) return; elapsed_ += dt; for (auto* e : world_->GetCharacters().GetEnemyRawList()) { if (!e || e->IsDead()) continue; if (K4E::Vector3::Length(e->GetCenterPosition() - config_.clearPoint) < 4.0f) { hp_ -= dt * 5.0f; } } if (hp_ <= 0.0f) { hp_ = 0.0f; isFailed_ = true; } isCleared_ = (elapsed_ >= config_.defenseTime) && !isFailed_; }
-void DefenseStageMission::DrawDebugImGui() { StageMissionBase::DrawDebugImGui();
-#ifdef USE_IMGUI
-    ImGui::Text("DefenseRemain: %.2f", std::max(0.0f, config_.defenseTime - elapsed_));
-    ImGui::Text("DefenseHP: %.1f", hp_);
-#endif
-}
-
-class EscapeStageMission : public StageMissionBase { public: void Update(float dt) override; void DrawDebugImGui() override; const char* GetDebugName() const override { return "EscapeStageMission"; } private: float elapsed_ = 0.0f; float distance_ = 0.0f; };
-void EscapeStageMission::Update(float dt) { if (!world_) return; elapsed_ += dt; auto* p = world_->GetCharacters().GetPlayer(); if (!p || !p->GetWorldTransform()) return; distance_ = K4E::Vector3::Length(p->GetWorldTransform()->translate_ - config_.escapePoint); isCleared_ = distance_ <= config_.escapeRadius; if (config_.timeLimit > 0.0f && elapsed_ >= config_.timeLimit && !isCleared_) isFailed_ = true; }
-void EscapeStageMission::DrawDebugImGui() { StageMissionBase::DrawDebugImGui();
-#ifdef USE_IMGUI
-    ImGui::Text("EscapeDist: %.2f / %.2f", distance_, config_.escapeRadius);
-    ImGui::Text("TimeLimit: %.2f / %.2f", elapsed_, config_.timeLimit);
-#endif
-}
-
-class BossStageMission : public StageMissionBase { public: void Update(float) override; void DrawDebugImGui() override; const char* GetDebugName() const override { return "BossStageMission"; } private: float bossHp_ = 0.0f; };
-void BossStageMission::Update(float) { if (!world_) return; auto enemies = world_->GetCharacters().GetEnemyRawList(); if (enemies.empty()) { isCleared_ = true; bossHp_ = 0.0f; return; } bossHp_ = static_cast<float>(enemies.front()->GetHp()); isCleared_ = std::all_of(enemies.begin(), enemies.end(), [](EnemyBase* e) { return !e || e->IsDead(); }); }
-void BossStageMission::DrawDebugImGui() { StageMissionBase::DrawDebugImGui();
-#ifdef USE_IMGUI
-    ImGui::Text("BossHP: %.1f", bossHp_);
-#endif
-}
-
-std::unique_ptr<IStageMission> CreateStageMissionByType(StageType t) { switch (t) { case StageType::Wave: return std::make_unique<WaveStageMission>(); case StageType::Explore: return std::make_unique<ExploreStageMission>(); case StageType::Defense: return std::make_unique<DefenseStageMission>(); case StageType::Escape: return std::make_unique<EscapeStageMission>(); case StageType::Boss: return std::make_unique<BossStageMission>(); } return std::make_unique<WaveStageMission>(); }
-StageType ResolveStageTypeFromStageIndex(int i) { switch (i) { case 0: return StageType::Wave; case 1: return StageType::Explore; case 2: return StageType::Defense; case 3: return StageType::Escape; case 4: return StageType::Boss; default: return StageType::Wave; } }
-const char* ToStageTypeName(StageType t) { switch (t) { case StageType::Wave: return "Wave"; case StageType::Explore: return "Explore"; case StageType::Defense: return "Defense"; case StageType::Escape: return "Escape"; case StageType::Boss: return "Boss"; } return "Unknown"; }

--- a/Project/ApplicationLayer/Scene/GamePlayScene/Mission/StageMission.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/Mission/StageMission.h
@@ -1,21 +1,13 @@
 #pragma once
 #include "Vector3.h"
-#include <memory>
+#include "StageMissionFactory.h"
+#include "StageType.h"
 #include <string>
 
 class GamePlayWorld;
 class GamePlayStageContext;
 
 namespace K4E = ::Ken4lowEngine;
-
-enum class StageType
-{
-	Wave,
-	Explore,
-	Defense,
-	Escape,
-	Boss
-};
 
 struct StageMissionConfig
 {
@@ -61,6 +53,3 @@ protected:
 	bool isFailed_ = false;
 };
 
-std::unique_ptr<IStageMission> CreateStageMissionByType(StageType stageType);
-StageType ResolveStageTypeFromStageIndex(int stageIndex);
-const char* ToStageTypeName(StageType stageType);

--- a/Project/ApplicationLayer/Scene/GamePlayScene/Mission/StageMissionFactory.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/Mission/StageMissionFactory.cpp
@@ -1,0 +1,63 @@
+#include "StageMissionFactory.h"
+
+#include "EnemyBase.h"
+#include "GamePlayStageContext.h"
+#include "GamePlayWorld.h"
+#include "StageMission.h"
+
+#ifdef USE_IMGUI
+#include <imgui.h>
+#endif
+
+#include <algorithm>
+#include <memory>
+
+namespace K4E = ::Ken4lowEngine;
+
+class WaveStageMission : public StageMissionBase { public: void Update(float) override { if (world_) { isCleared_ = world_->IsAllWavesCleared() && world_->GetCharacters().GetEnemyCount() == 0; } } const char* GetDebugName() const override { return "WaveStageMission"; } };
+class ExploreStageMission : public StageMissionBase { public: void Update(float) override; void DrawDebugImGui() override; const char* GetDebugName() const override { return "ExploreStageMission"; } private: float distance_ = 0.0f; };
+void ExploreStageMission::Update(float) { if (!world_) return; auto* p = world_->GetCharacters().GetPlayer(); if (!p || !p->GetWorldTransform()) return; distance_ = K4E::Vector3::Length(p->GetWorldTransform()->translate_ - config_.clearPoint); isCleared_ = distance_ <= config_.clearRadius; }
+void ExploreStageMission::DrawDebugImGui() { StageMissionBase::DrawDebugImGui();
+#ifdef USE_IMGUI
+	ImGui::Text("ExploreDist: %.2f / %.2f", distance_, config_.clearRadius);
+#endif
+}
+
+class DefenseStageMission : public StageMissionBase { public: void Initialize(GamePlayWorld* w, const GamePlayStageContext& c, const StageMissionConfig& cfg) override { StageMissionBase::Initialize(w, c, cfg); hp_ = cfg.defenseTargetHp; } void Update(float dt) override; void DrawDebugImGui() override; const char* GetDebugName() const override { return "DefenseStageMission"; } private: float elapsed_ = 0.0f; float hp_ = 0.0f; };
+void DefenseStageMission::Update(float dt) { if (!world_ || isFailed_) return; elapsed_ += dt; for (auto* e : world_->GetCharacters().GetEnemyRawList()) { if (!e || e->IsDead()) continue; if (K4E::Vector3::Length(e->GetCenterPosition() - config_.clearPoint) < 4.0f) { hp_ -= dt * 5.0f; } } if (hp_ <= 0.0f) { hp_ = 0.0f; isFailed_ = true; } isCleared_ = (elapsed_ >= config_.defenseTime) && !isFailed_; }
+void DefenseStageMission::DrawDebugImGui() { StageMissionBase::DrawDebugImGui();
+#ifdef USE_IMGUI
+	ImGui::Text("DefenseRemain: %.2f", std::max(0.0f, config_.defenseTime - elapsed_));
+	ImGui::Text("DefenseHP: %.1f", hp_);
+#endif
+}
+
+class EscapeStageMission : public StageMissionBase { public: void Update(float dt) override; void DrawDebugImGui() override; const char* GetDebugName() const override { return "EscapeStageMission"; } private: float elapsed_ = 0.0f; float distance_ = 0.0f; };
+void EscapeStageMission::Update(float dt) { if (!world_) return; elapsed_ += dt; auto* p = world_->GetCharacters().GetPlayer(); if (!p || !p->GetWorldTransform()) return; distance_ = K4E::Vector3::Length(p->GetWorldTransform()->translate_ - config_.escapePoint); isCleared_ = distance_ <= config_.escapeRadius; if (config_.timeLimit > 0.0f && elapsed_ >= config_.timeLimit && !isCleared_) isFailed_ = true; }
+void EscapeStageMission::DrawDebugImGui() { StageMissionBase::DrawDebugImGui();
+#ifdef USE_IMGUI
+	ImGui::Text("EscapeDist: %.2f / %.2f", distance_, config_.escapeRadius);
+	ImGui::Text("TimeLimit: %.2f / %.2f", elapsed_, config_.timeLimit);
+#endif
+}
+
+class BossStageMission : public StageMissionBase { public: void Update(float) override; void DrawDebugImGui() override; const char* GetDebugName() const override { return "BossStageMission"; } private: float bossHp_ = 0.0f; };
+void BossStageMission::Update(float) { if (!world_) return; auto enemies = world_->GetCharacters().GetEnemyRawList(); if (enemies.empty()) { isCleared_ = true; bossHp_ = 0.0f; return; } bossHp_ = static_cast<float>(enemies.front()->GetHp()); isCleared_ = std::all_of(enemies.begin(), enemies.end(), [](EnemyBase* e) { return !e || e->IsDead(); }); }
+void BossStageMission::DrawDebugImGui() { StageMissionBase::DrawDebugImGui();
+#ifdef USE_IMGUI
+	ImGui::Text("BossHP: %.1f", bossHp_);
+#endif
+}
+
+std::unique_ptr<IStageMission> CreateStageMissionByType(StageType stageType)
+{
+	switch (stageType)
+	{
+	case StageType::Wave: return std::make_unique<WaveStageMission>();
+	case StageType::Explore: return std::make_unique<ExploreStageMission>();
+	case StageType::Defense: return std::make_unique<DefenseStageMission>();
+	case StageType::Escape: return std::make_unique<EscapeStageMission>();
+	case StageType::Boss: return std::make_unique<BossStageMission>();
+	default: return std::make_unique<WaveStageMission>();
+	}
+}

--- a/Project/ApplicationLayer/Scene/GamePlayScene/Mission/StageMissionFactory.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/Mission/StageMissionFactory.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "StageType.h"
+#include <memory>
+
+class IStageMission;
+
+std::unique_ptr<IStageMission> CreateStageMissionByType(StageType stageType);

--- a/Project/ApplicationLayer/Scene/GamePlayScene/Mission/StageType.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/Mission/StageType.cpp
@@ -1,0 +1,27 @@
+#include "StageType.h"
+
+StageType ResolveStageTypeFromStageIndex(int stageIndex)
+{
+	switch (stageIndex)
+	{
+	case 0: return StageType::Wave;
+	case 1: return StageType::Explore;
+	case 2: return StageType::Defense;
+	case 3: return StageType::Escape;
+	case 4: return StageType::Boss;
+	default: return StageType::Wave;
+	}
+}
+
+const char* ToStageTypeName(StageType stageType)
+{
+	switch (stageType)
+	{
+	case StageType::Wave: return "Wave";
+	case StageType::Explore: return "Explore";
+	case StageType::Defense: return "Defense";
+	case StageType::Escape: return "Escape";
+	case StageType::Boss: return "Boss";
+	default: return "Unknown";
+	}
+}

--- a/Project/ApplicationLayer/Scene/GamePlayScene/Mission/StageType.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/Mission/StageType.h
@@ -1,0 +1,13 @@
+#pragma once
+
+enum class StageType
+{
+	Wave,
+	Explore,
+	Defense,
+	Escape,
+	Boss
+};
+
+StageType ResolveStageTypeFromStageIndex(int stageIndex);
+const char* ToStageTypeName(StageType stageType);

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -270,6 +270,9 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\Camera\GamePlayIntroDirector.cpp" />
     <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\Core\GamePlayStageContext.cpp" />
     <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\World\GamePlayWorld.cpp" />
+    <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\Mission\StageMission.cpp" />
+    <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\Mission\StageMissionFactory.cpp" />
+    <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\Mission\StageType.cpp" />
     <ClCompile Include="ApplicationLayer\Character\Boss\BehaviorTree\IBTNode.cpp" />
     <ClCompile Include="ApplicationLayer\Character\Boss\Derived\GuardianBoss\GuardianBoss.cpp" />
     <ClCompile Include="ApplicationLayer\Character\Boss\BaseTypes\HumanoidBossBase.cpp" />
@@ -845,6 +848,9 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\Camera\GamePlayIntroDirector.h" />
     <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\Core\GamePlayStageContext.h" />
     <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\World\GamePlayWorld.h" />
+    <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\Mission\StageMission.h" />
+    <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\Mission\StageMissionFactory.h" />
+    <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\Mission\StageType.h" />
     <ClInclude Include="ApplicationLayer\Character\Boss\Attacks\IBossAttack.h" />
     <ClInclude Include="ApplicationLayer\Character\Boss\BehaviorTree\IBTNode.h" />
     <ClInclude Include="ApplicationLayer\Character\Boss\Derived\GuardianBoss\GuardianBoss.h" />


### PR DESCRIPTION
### Motivation
- Provide concrete definitions for `ToStageTypeName`, `ResolveStageTypeFromStageIndex` and `CreateStageMissionByType` which were referenced from `GamePlayScene.cpp` but missing at link time.
- Move factory and stage-type utilities out of header/inline contexts to avoid duplicated/distributed definitions and linker errors.
- Ensure Visual Studio project lists the new source files so the linker can find the implementations.

### Description
- Added `Project/ApplicationLayer/Scene/GamePlayScene/Mission/StageType.h` and `StageType.cpp` implementing `ResolveStageTypeFromStageIndex(int)` and `ToStageTypeName(StageType)`.
- Added `Project/ApplicationLayer/Scene/GamePlayScene/Mission/StageMissionFactory.h` and `StageMissionFactory.cpp` implementing `CreateStageMissionByType(StageType)` which returns `std::unique_ptr<IStageMission>` and constructs concrete missions with `std::make_unique`.
- Refactored `StageMission.cpp` to retain only `StageMissionBase` implementation and moved concrete mission class definitions into `StageMissionFactory.cpp` to centralize factory logic.
- Updated `Project/Ken4lowEngine.vcxproj` to include the new `.cpp` files under `ClCompile` and the new headers under `ClInclude`.

### Testing
- Ran `rg`/file inspections to locate usages of `ToStageTypeName`, `CreateStageMissionByType`, and `ResolveStageTypeFromStageIndex` and confirmed the new files contain the expected definitions.
- Verified `Project/Ken4lowEngine.vcxproj` contains `StageMission.cpp`, `StageMissionFactory.cpp`, and `StageType.cpp` entries via project file inspection.
- Attempted to run `msbuild Ken4lowEngine.vcxproj /p:Configuration=Debug /p:Platform=x64`, but the build could not be executed in this environment because `msbuild` is not installed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f1a76482b4832d835a34b19410a851)