### PR TITLE
Add Model Disintegration effect (CPU emitter, renderer, effect and DebugScene integration)

### DIFF
--- a/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationEmitter.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationEmitter.cpp
@@ -1,0 +1,121 @@
+#include "DisintegrationEmitter.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace
+{
+	K4E::Vector3 ToVector3(const K4E::Vector4& v)
+	{
+		return { v.x, v.y, v.z };
+	}
+
+	float TriangleArea(const K4E::Vector3& a, const K4E::Vector3& b, const K4E::Vector3& c)
+	{
+		return K4E::Vector3::Length(K4E::Vector3::Cross(b - a, c - a)) * 0.5f;
+	}
+}
+
+std::vector<DisintegrationParticle> DisintegrationEmitter::EmitFromModel(
+	const K4E::ModelData& modelData,
+	const K4E::Matrix4x4& worldMatrix,
+	const Settings& settings)
+{
+	std::vector<TriangleSample> triangles;
+	triangles.reserve(1024);
+
+	float totalArea = 0.0f;
+	for (const auto& subMesh : modelData.subMeshes)
+	{
+		if (subMesh.indices.size() >= 3)
+		{
+			for (size_t i = 0; i + 2 < subMesh.indices.size(); i += 3)
+			{
+				const uint32_t ia = subMesh.indices[i + 0];
+				const uint32_t ib = subMesh.indices[i + 1];
+				const uint32_t ic = subMesh.indices[i + 2];
+				if (ia >= subMesh.vertices.size() || ib >= subMesh.vertices.size() || ic >= subMesh.vertices.size()) { continue; }
+
+				const K4E::Vector3 a = ToVector3(subMesh.vertices[ia].position);
+				const K4E::Vector3 b = ToVector3(subMesh.vertices[ib].position);
+				const K4E::Vector3 c = ToVector3(subMesh.vertices[ic].position);
+				const float area = TriangleArea(a, b, c);
+				if (area <= 0.000001f) { continue; }
+
+				totalArea += area;
+				TriangleSample tri{};
+				tri.a = a;
+				tri.b = b;
+				tri.c = c;
+				tri.normal = K4E::Vector3::NormalizeSafe(K4E::Vector3::Cross(b - a, c - a), { 0.0f, 1.0f, 0.0f });
+				tri.cumulativeArea = totalArea;
+				triangles.push_back(tri);
+			}
+		}
+	}
+
+	std::vector<DisintegrationParticle> particles;
+	particles.reserve(static_cast<size_t>(std::max(0, settings.particleCount)));
+	if (triangles.empty() || settings.particleCount <= 0) { return particles; }
+
+	const K4E::Vector3 center = worldMatrix.GetTranslation();
+
+	for (int i = 0; i < settings.particleCount; ++i)
+	{
+		const float areaPick = RandomRange(0.0f, totalArea);
+		auto it = std::lower_bound(
+			triangles.begin(), triangles.end(), areaPick,
+			[](const TriangleSample& tri, float value) { return tri.cumulativeArea < value; });
+		if (it == triangles.end()) { it = triangles.end() - 1; }
+
+		float u = Random01();
+		float v = Random01();
+		if (u + v > 1.0f)
+		{
+			u = 1.0f - u;
+			v = 1.0f - v;
+		}
+
+		const K4E::Vector3 local = it->a + (it->b - it->a) * u + (it->c - it->a) * v;
+		const K4E::Vector3 world = K4E::Vector3::Transform(local, worldMatrix);
+		K4E::Vector3 outward = K4E::Vector3::NormalizeSafe(world - center, it->normal);
+		outward = K4E::Vector3::NormalizeSafe(outward + RandomUnitVector() * 0.35f, it->normal);
+
+		DisintegrationParticle particle{};
+		particle.initialPosition = world;
+		particle.position = world;
+		particle.outward = outward;
+		particle.velocity = outward * RandomRange(settings.spreadPower * 0.35f, settings.spreadPower);
+		particle.velocity.y += RandomRange(-settings.upwardPower * 0.35f, settings.upwardPower);
+		particle.life = RandomRange(settings.lifeTime * 0.75f, settings.lifeTime * 1.15f);
+		particle.startDelay = RandomRange(0.0f, settings.startDelay);
+		particle.size = settings.particleSize * RandomRange(0.55f, 1.35f);
+		particle.color = { RandomRange(0.55f, 0.78f), RandomRange(0.52f, 0.68f), RandomRange(0.46f, 0.58f), 1.0f };
+		particle.alpha = 1.0f;
+		particle.alive = true;
+		particles.push_back(particle);
+	}
+
+	return particles;
+}
+
+float DisintegrationEmitter::Random01()
+{
+	return unitDist_(rng_);
+}
+
+float DisintegrationEmitter::RandomRange(float minValue, float maxValue)
+{
+	return minValue + (maxValue - minValue) * Random01();
+}
+
+K4E::Vector3 DisintegrationEmitter::RandomUnitVector()
+{
+	K4E::Vector3 v{};
+	do
+	{
+		v = { RandomRange(-1.0f, 1.0f), RandomRange(-1.0f, 1.0f), RandomRange(-1.0f, 1.0f) };
+	} while (K4E::Vector3::LengthSquared(v) <= 0.000001f);
+
+	return K4E::Vector3::Normalize(v);
+}

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationEmitter.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationEmitter.h
@@ -1,0 +1,46 @@
+#pragma once
+#include "DisintegrationParticle.h"
+#include "Matrix4x4.h"
+#include "ModelData.h"
+
+#include <random>
+#include <vector>
+
+/// -------------------------------------------------------------
+/// モデル表面から崩壊粒子の初期配置を作る専用エミッター
+/// -------------------------------------------------------------
+class DisintegrationEmitter
+{
+public:
+	struct Settings
+	{
+		int particleCount = 1200;
+		float particleSize = 0.035f;
+		float lifeTime = 2.0f;
+		float spreadPower = 1.6f;
+		float upwardPower = 0.65f;
+		float startDelay = 0.35f;
+	};
+
+	std::vector<DisintegrationParticle> EmitFromModel(
+		const K4E::ModelData& modelData,
+		const K4E::Matrix4x4& worldMatrix,
+		const Settings& settings);
+
+private:
+	struct TriangleSample
+	{
+		K4E::Vector3 a{};
+		K4E::Vector3 b{};
+		K4E::Vector3 c{};
+		K4E::Vector3 normal{ 0.0f, 1.0f, 0.0f };
+		float cumulativeArea = 0.0f;
+	};
+
+	float Random01();
+	float RandomRange(float minValue, float maxValue);
+	K4E::Vector3 RandomUnitVector();
+
+	std::mt19937 rng_{ 0xD157E6A7u };
+	std::uniform_real_distribution<float> unitDist_{ 0.0f, 1.0f };
+};

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationParticle.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationParticle.h
@@ -1,0 +1,23 @@
+#pragma once
+#include "Vector3.h"
+#include "Vector4.h"
+
+namespace K4E = ::Ken4lowEngine;
+
+/// -------------------------------------------------------------
+/// モデル崩壊専用のCPU粒子データ
+/// -------------------------------------------------------------
+struct DisintegrationParticle
+{
+	K4E::Vector3 initialPosition{};
+	K4E::Vector3 position{};
+	K4E::Vector3 velocity{};
+	K4E::Vector3 outward{};
+	K4E::Vector4 color{ 0.72f, 0.66f, 0.55f, 1.0f };
+	float age = 0.0f;
+	float life = 1.0f;
+	float startDelay = 0.0f;
+	float size = 0.04f;
+	float alpha = 1.0f;
+	bool alive = false;
+};

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationRenderer.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationRenderer.cpp
@@ -1,0 +1,24 @@
+#include "DisintegrationRenderer.h"
+
+#include "Wireframe.h"
+
+void DisintegrationRenderer::Draw(const std::vector<DisintegrationParticle>& particles) const
+{
+	auto* wireframe = K4E::Wireframe::GetInstance();
+	if (!wireframe) { return; }
+
+	for (const auto& particle : particles)
+	{
+		if (!particle.alive || particle.alpha <= 0.0f) { continue; }
+
+		K4E::Vector4 color = particle.color;
+		color.w *= particle.alpha;
+
+		const float s = particle.size * 0.5f;
+		const K4E::Vector3& p = particle.position;
+
+		// 点群らしい細かな塵に見せるため、立方体ではなく短い交差線だけを描く。
+		wireframe->DrawLine({ p.x - s, p.y, p.z }, { p.x + s, p.y, p.z }, color);
+		wireframe->DrawLine({ p.x, p.y - s, p.z }, { p.x, p.y + s, p.z }, color);
+	}
+}

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationRenderer.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationRenderer.h
@@ -1,0 +1,13 @@
+#pragma once
+#include "DisintegrationParticle.h"
+
+#include <vector>
+
+/// -------------------------------------------------------------
+/// 既存Particleに依存しない崩壊エフェクト専用レンダラー
+/// -------------------------------------------------------------
+class DisintegrationRenderer
+{
+public:
+	void Draw(const std::vector<DisintegrationParticle>& particles) const;
+};

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelDisintegrationEffect.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelDisintegrationEffect.cpp
@@ -1,0 +1,129 @@
+#include "ModelDisintegrationEffect.h"
+
+#include "Model.h"
+#include "ModelManager.h"
+
+#include <algorithm>
+#include <cmath>
+#include <random>
+
+#ifdef USE_IMGUI
+#include <imgui.h>
+#endif
+
+namespace
+{
+	float Clamp01(float value)
+	{
+		return std::clamp(value, 0.0f, 1.0f);
+	}
+}
+
+void ModelDisintegrationEffect::Initialize()
+{
+	particles_.clear();
+	isActive_ = false;
+	elapsedTime_ = 0.0f;
+}
+
+void ModelDisintegrationEffect::PlayFromModel(const std::string& modelPath, const K4E::Matrix4x4& worldMatrix)
+{
+	auto model = K4E::ModelManager::GetInstance()->LoadModel(modelPath);
+	if (!model) { return; }
+
+	DisintegrationEmitter::Settings settings{};
+	settings.particleCount = parameters_.particleCount;
+	settings.particleSize = parameters_.particleSize;
+	settings.lifeTime = parameters_.lifeTime;
+	settings.spreadPower = parameters_.spreadPower;
+	settings.upwardPower = parameters_.upwardPower;
+	settings.startDelay = parameters_.startDelay;
+
+	particles_ = emitter_.EmitFromModel(model->GetModelData(), worldMatrix, settings);
+	isActive_ = !particles_.empty();
+	elapsedTime_ = 0.0f;
+}
+
+void ModelDisintegrationEffect::Update(float deltaTime)
+{
+	if (!isActive_) { return; }
+
+	elapsedTime_ += deltaTime;
+	bool anyAlive = false;
+
+	for (auto& particle : particles_)
+	{
+		if (!particle.alive) { continue; }
+
+		particle.age += deltaTime;
+		if (particle.age < particle.startDelay)
+		{
+			anyAlive = true;
+			continue;
+		}
+
+		const float activeAge = particle.age - particle.startDelay;
+		const float preserveRate = Clamp01(activeAge / std::max(parameters_.shapePreserveTime, 0.0001f));
+		const K4E::Vector3 noise = RandomNoiseVector() * parameters_.noisePower;
+
+		particle.velocity += (particle.outward * parameters_.spreadPower + noise) * (deltaTime * preserveRate);
+		particle.velocity.y += (parameters_.upwardPower + parameters_.gravity) * deltaTime;
+		particle.position += particle.velocity * (deltaTime * preserveRate);
+
+		const float lifeRate = Clamp01(activeAge / std::max(particle.life, 0.0001f));
+		particle.alpha = Clamp01(1.0f - lifeRate * parameters_.fadeSpeed);
+
+		if (activeAge >= particle.life || particle.alpha <= 0.0f)
+		{
+			particle.alive = false;
+			continue;
+		}
+
+		anyAlive = true;
+	}
+
+	if (!anyAlive)
+	{
+		StopIfFinished();
+	}
+}
+
+void ModelDisintegrationEffect::Draw() const
+{
+	if (!isActive_) { return; }
+	renderer_.Draw(particles_);
+}
+
+void ModelDisintegrationEffect::DrawImGui()
+{
+#ifdef USE_IMGUI
+	ImGui::Begin("Model Disintegration Effect");
+	ImGui::Text("Active: %s", isActive_ ? "true" : "false");
+	ImGui::Text("Particle Instances: %zu", particles_.size());
+	ImGui::SliderInt("particleCount", &parameters_.particleCount, 32, 8000);
+	ImGui::SliderFloat("particleSize", &parameters_.particleSize, 0.005f, 0.20f);
+	ImGui::SliderFloat("lifeTime", &parameters_.lifeTime, 0.10f, 8.0f);
+	ImGui::SliderFloat("spreadPower", &parameters_.spreadPower, 0.0f, 8.0f);
+	ImGui::SliderFloat("gravity", &parameters_.gravity, -10.0f, 10.0f);
+	ImGui::SliderFloat("noisePower", &parameters_.noisePower, 0.0f, 8.0f);
+	ImGui::SliderFloat("fadeSpeed", &parameters_.fadeSpeed, 0.1f, 4.0f);
+	ImGui::SliderFloat("upwardPower", &parameters_.upwardPower, -4.0f, 8.0f);
+	ImGui::SliderFloat("startDelay", &parameters_.startDelay, 0.0f, 3.0f);
+	ImGui::SliderFloat("shapePreserveTime", &parameters_.shapePreserveTime, 0.0f, 3.0f);
+	ImGui::Text("Debug Key: F9 plays Characters/body.gltf at the player position.");
+	ImGui::End();
+#endif
+}
+
+K4E::Vector3 ModelDisintegrationEffect::RandomNoiseVector()
+{
+	static std::mt19937 rng{ 0xA5A5D157u };
+	static std::uniform_real_distribution<float> dist{ -1.0f, 1.0f };
+	return K4E::Vector3::NormalizeSafe({ dist(rng), dist(rng), dist(rng) }, { 0.0f, 1.0f, 0.0f });
+}
+
+void ModelDisintegrationEffect::StopIfFinished()
+{
+	isActive_ = false;
+	particles_.clear();
+}

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelDisintegrationEffect.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelDisintegrationEffect.h
@@ -1,0 +1,49 @@
+#pragma once
+#include "DisintegrationEmitter.h"
+#include "DisintegrationRenderer.h"
+#include "Matrix4x4.h"
+
+#include <string>
+#include <vector>
+
+/// -------------------------------------------------------------
+/// モデル形状を砂・灰・霧状に分解して消す完全新規エフェクト
+/// -------------------------------------------------------------
+class ModelDisintegrationEffect
+{
+public:
+	struct Parameters
+	{
+		int particleCount = 1200;
+		float particleSize = 0.035f;
+		float lifeTime = 2.0f;
+		float spreadPower = 1.6f;
+		float gravity = -0.45f;
+		float noisePower = 0.8f;
+		float fadeSpeed = 1.0f;
+		float upwardPower = 0.65f;
+		float startDelay = 0.35f;
+		float shapePreserveTime = 0.35f;
+	};
+
+	void Initialize();
+	void PlayFromModel(const std::string& modelPath, const K4E::Matrix4x4& worldMatrix);
+	void Update(float deltaTime);
+	void Draw() const;
+	void DrawImGui();
+	bool IsActive() const { return isActive_; }
+
+	Parameters& GetParameters() { return parameters_; }
+	const Parameters& GetParameters() const { return parameters_; }
+
+private:
+	K4E::Vector3 RandomNoiseVector();
+	void StopIfFinished();
+
+	Parameters parameters_{};
+	DisintegrationEmitter emitter_{};
+	DisintegrationRenderer renderer_{};
+	std::vector<DisintegrationParticle> particles_{};
+	bool isActive_ = false;
+	float elapsedTime_ = 0.0f;
+};

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -119,6 +119,16 @@ void DebugScene::Initialize()
 	// 見やすい位置に置く
 	debugBoss_->SetPosition({ 0.0f, 2.25f, 30.0f });
 	debugBoss_->SetYaw(3.141592f); // 必要ならプレイヤー側へ向ける
+
+	debugDisintegrationModel_ = std::make_unique<Object3D>();
+	debugDisintegrationModel_->Initialize(debugDisintegrationModelPath_);
+	debugDisintegrationModel_->SetTranslate(debugDisintegrationPosition_);
+	debugDisintegrationModel_->SetRotate(debugDisintegrationRotation_);
+	debugDisintegrationModel_->SetScale(debugDisintegrationScale_);
+	debugDisintegrationModel_->Update();
+
+	debugDisintegrationEffect_ = std::make_unique<ModelDisintegrationEffect>();
+	debugDisintegrationEffect_->Initialize();
 }
 
 void DebugScene::Update()
@@ -144,6 +154,8 @@ void DebugScene::Update()
 
 	UpdateDebugParticleTest();
 
+	UpdateDebugDisintegrationTest(deltaTime);
+
 	collisionManager_->Update();
 	collisionManager_->CheckAllCollisions();
 
@@ -151,6 +163,16 @@ void DebugScene::Update()
 
 void DebugScene::Draw3DObjects()
 {
+	if (debugDisintegrationModelVisible_ && debugDisintegrationModel_)
+	{
+		debugDisintegrationModel_->Draw();
+	}
+
+	if (debugDisintegrationEffect_)
+	{
+		debugDisintegrationEffect_->Draw();
+	}
+
 	// ボス描画
 	if (debugBoss_)
 	{
@@ -167,6 +189,11 @@ void DebugScene::Draw3DObjects()
 
 void DebugScene::DrawShadowObjects()
 {
+	if (debugDisintegrationModelVisible_ && debugDisintegrationModel_)
+	{
+		debugDisintegrationModel_->DrawShadow();
+	}
+
 	if (debugBoss_)
 	{
 		debugBoss_->DrawShadow();
@@ -198,6 +225,8 @@ void DebugScene::Finalize()
 	input_->SetLockCursor(false);
 	input_->SetCursorVisible(true);
 
+	debugDisintegrationEffect_.reset();
+	debugDisintegrationModel_.reset();
 	debugBoss_.reset();
 	collisionManager_.reset();
 
@@ -381,6 +410,44 @@ void DebugScene::DrawImGui()
 		ImGui::Text("Mesh position:   %.2f, %.2f, %.2f", meshPos.x, meshPos.y, meshPos.z);
 		ImGui::TextWrapped("%s", debugParticleLog_.c_str());
 		ImGui::End();
+	}
+
+
+	/// ---------- モデル崩壊エフェクト単体テスト ---------- ///
+	{
+		static char modelPathBuffer[256] = "Characters/body.gltf";
+
+		ImGui::Begin("Model Disintegration DebugScene Test");
+		ImGui::TextWrapped("DebugScene-only test. F9 or the button samples the displayed model surface and plays the disintegration effect.");
+		ImGui::InputText("Model Path", modelPathBuffer, IM_ARRAYSIZE(modelPathBuffer));
+		ImGui::DragFloat3("Position", &debugDisintegrationPosition_.x, 0.05f);
+		ImGui::DragFloat3("Rotation", &debugDisintegrationRotation_.x, 0.01f);
+		ImGui::DragFloat3("Scale", &debugDisintegrationScale_.x, 0.01f, 0.01f, 10.0f);
+
+		if (ImGui::Button("Reload Test Model"))
+		{
+			debugDisintegrationModelPath_ = modelPathBuffer;
+			debugDisintegrationModel_ = std::make_unique<Object3D>();
+			debugDisintegrationModel_->Initialize(debugDisintegrationModelPath_);
+			debugDisintegrationLog_ = "Reloaded test model: " + debugDisintegrationModelPath_;
+			DebugLog(debugDisintegrationLog_);
+		}
+
+		ImGui::SameLine();
+		if (ImGui::Button("Play Disintegration"))
+		{
+			debugDisintegrationModelPath_ = modelPathBuffer;
+			PlayDebugDisintegrationEffect();
+		}
+
+		ImGui::Text("Model Visible: %s", debugDisintegrationModelVisible_ ? "true" : "false");
+		ImGui::TextWrapped("%s", debugDisintegrationLog_.c_str());
+		ImGui::End();
+	}
+
+	if (debugDisintegrationEffect_)
+	{
+		debugDisintegrationEffect_->DrawImGui();
 	}
 
 	/// ---------- 武器マスターデータエディタ ---------- ///
@@ -627,4 +694,46 @@ void DebugScene::UpdateDebugParticleTest()
 		debugParticleLog_ = "Spawn: Boss_Appear_Dust";
 		DebugLog(debugParticleLog_);
 	}
+}
+
+
+void DebugScene::UpdateDebugDisintegrationTest(float deltaTime)
+{
+	if (input_ && input_->TriggerKey(DIK_F9))
+	{
+		PlayDebugDisintegrationEffect();
+	}
+
+	if (debugDisintegrationModel_)
+	{
+		debugDisintegrationModel_->SetTranslate(debugDisintegrationPosition_);
+		debugDisintegrationModel_->SetRotate(debugDisintegrationRotation_);
+		debugDisintegrationModel_->SetScale(debugDisintegrationScale_);
+		debugDisintegrationModel_->Update();
+	}
+
+	if (debugDisintegrationEffect_)
+	{
+		debugDisintegrationEffect_->Update(deltaTime);
+		debugDisintegrationModelVisible_ = !debugDisintegrationEffect_->IsActive();
+	}
+}
+
+void DebugScene::PlayDebugDisintegrationEffect()
+{
+	if (!debugDisintegrationEffect_)
+	{
+		return;
+	}
+
+	const Matrix4x4 worldMatrix = Matrix4x4::MakeAffineMatrix(
+		debugDisintegrationScale_,
+		debugDisintegrationRotation_,
+		debugDisintegrationPosition_);
+
+	// 表示中のテストモデルと同じ行列から生成し、形状サンプリングのずれを確認しやすくする。
+	debugDisintegrationEffect_->PlayFromModel(debugDisintegrationModelPath_, worldMatrix);
+	debugDisintegrationModelVisible_ = !debugDisintegrationEffect_->IsActive();
+	debugDisintegrationLog_ = "Play: " + debugDisintegrationModelPath_;
+	DebugLog(debugDisintegrationLog_);
 }

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
@@ -5,6 +5,8 @@
 #include "Enemy.h"
 #include "Player.h"
 #include "Derived/GuardianBoss/GuardianBoss.h"
+#include "Disintegration/ModelDisintegrationEffect.h"
+#include "Object3D.h"
 
 #include <memory>
 #include <string>
@@ -57,6 +59,12 @@ private: /// ---------- メンバ関数 ---------- ///
 	/// テスト用GPUパーティクル発火
 	void UpdateDebugParticleTest();
 
+	/// モデル崩壊エフェクトの単体検証更新
+	void UpdateDebugDisintegrationTest(float deltaTime);
+
+	/// モデル崩壊エフェクトをデバッグ位置で再生
+	void PlayDebugDisintegrationEffect();
+
 	/// -------------------------------------------------------------
 	/// BossHitPart を文字列へ変換
 	/// ログ確認用
@@ -83,5 +91,15 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	// --- GPUパーティクルテスト用 ---
 	std::string debugParticleLog_ = "Press 1/2/3 to test GPU particles.";
+
+	// --- モデル崩壊エフェクト単体テスト用 ---
+	std::unique_ptr<K4E::Object3D> debugDisintegrationModel_;
+	std::unique_ptr<ModelDisintegrationEffect> debugDisintegrationEffect_;
+	K4E::Vector3 debugDisintegrationPosition_{ -4.0f, 2.25f, 18.0f };
+	K4E::Vector3 debugDisintegrationRotation_{ 0.0f, 0.0f, 0.0f };
+	K4E::Vector3 debugDisintegrationScale_{ 1.0f, 1.0f, 1.0f };
+	std::string debugDisintegrationModelPath_ = "Characters/body.gltf";
+	std::string debugDisintegrationLog_ = "Press F9 or the ImGui button to play.";
+	bool debugDisintegrationModelVisible_ = true;
 };
 

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -179,6 +179,9 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="ApplicationLayer\EffectLayer\Disintegration\DisintegrationEmitter.cpp" />
+    <ClCompile Include="ApplicationLayer\EffectLayer\Disintegration\DisintegrationRenderer.cpp" />
+    <ClCompile Include="ApplicationLayer\EffectLayer\Disintegration\ModelDisintegrationEffect.cpp" />
     <ClCompile Include="ApplicationLayer\EffectLayer\ParticleEmitter.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</ExcludedFromBuild>
@@ -798,6 +801,10 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</ExcludedFromBuild>
     </ClInclude>
+    <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\DisintegrationEmitter.h" />
+    <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\DisintegrationParticle.h" />
+    <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\DisintegrationRenderer.h" />
+    <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\ModelDisintegrationEffect.h" />
     <ClInclude Include="ApplicationLayer\EffectLayer\ModelParticle.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</ExcludedFromBuild>

--- a/Project/Ken4lowEngine.vcxproj.filters
+++ b/Project/Ken4lowEngine.vcxproj.filters
@@ -163,6 +163,15 @@
     <ClCompile Include="ApplicationLayer\EffectLayer\ModelParticle.cpp">
       <Filter>ApplicationLayer\EffectLayer</Filter>
     </ClCompile>
+    <ClCompile Include="ApplicationLayer\EffectLayer\Disintegration\DisintegrationEmitter.cpp">
+      <Filter>ApplicationLayer\EffectLayer</Filter>
+    </ClCompile>
+    <ClCompile Include="ApplicationLayer\EffectLayer\Disintegration\DisintegrationRenderer.cpp">
+      <Filter>ApplicationLayer\EffectLayer</Filter>
+    </ClCompile>
+    <ClCompile Include="ApplicationLayer\EffectLayer\Disintegration\ModelDisintegrationEffect.cpp">
+      <Filter>ApplicationLayer\EffectLayer</Filter>
+    </ClCompile>
     <ClCompile Include="ApplicationLayer\Scene\StageSelectScene\State\StageSelectSelectingState.cpp">
       <Filter>ApplicationLayer\Scene\StageSelectScene\State</Filter>
     </ClCompile>
@@ -865,6 +874,18 @@
       <Filter>ApplicationLayer\Character\BaseCharacter</Filter>
     </ClInclude>
     <ClInclude Include="ApplicationLayer\EffectLayer\ModelParticle.h">
+      <Filter>ApplicationLayer\EffectLayer</Filter>
+    </ClInclude>
+    <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\DisintegrationEmitter.h">
+      <Filter>ApplicationLayer\EffectLayer</Filter>
+    </ClInclude>
+    <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\DisintegrationParticle.h">
+      <Filter>ApplicationLayer\EffectLayer</Filter>
+    </ClInclude>
+    <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\DisintegrationRenderer.h">
+      <Filter>ApplicationLayer\EffectLayer</Filter>
+    </ClInclude>
+    <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\ModelDisintegrationEffect.h">
       <Filter>ApplicationLayer\EffectLayer</Filter>
     </ClInclude>
     <ClInclude Include="ApplicationLayer\Scene\StageSelectScene\State\IStageSelectSceneState.h">


### PR DESCRIPTION
### Motivation

- Implement a new CPU-driven model disintegration effect that samples a model's surface and spawns particle fragments to reproduce a sand/ash/mist style dissolve. 
- Provide a lightweight renderer and test harness in the DebugScene so artists and developers can preview and tune parameters interactively.

### Description

- Add `DisintegrationEmitter`, `DisintegrationParticle`, and `DisintegrationRenderer` to sample mesh triangles, generate particle initial state (position, outward vector, velocity, color, life, etc.), and draw simple wireframe-cross particles. 
- Add `ModelDisintegrationEffect` to manage particle lifecycle, update physics/noise/preserve-shape behavior, fading, and expose tunable `Parameters` with an ImGui panel. 
- Integrate the effect into `DebugScene` with an inspectable test model, ImGui controls, F9 hotkey and functions to play the effect at a transform-matched world matrix, and hide the preview model while the effect is active. 
- Update project files (`.vcxproj` and `.filters`) to include the new sources and headers.

### Testing

- Built the solution in `Debug|x64` with the added files and project updates and the build completed successfully. 
- No automated unit tests were added for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fdfe693d30832dac427590bcfba93b)