### PR TITLE
Add ModelReconstructionEffect + shared ModelSurfaceSampler and DebugScene controls

### DIFF
--- a/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationEmitter.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationEmitter.cpp
@@ -6,25 +6,6 @@
 
 namespace
 {
-	K4E::Vector3 ToVector3(const K4E::Vector4& v)
-	{
-		return { v.x, v.y, v.z };
-	}
-
-	float TriangleArea(const K4E::Vector3& a, const K4E::Vector3& b, const K4E::Vector3& c)
-	{
-		return K4E::Vector3::Length(K4E::Vector3::Cross(b - a, c - a)) * 0.5f;
-	}
-
-	K4E::Vector3 TransformDirection(const K4E::Vector3& direction, const K4E::Matrix4x4& matrix)
-	{
-		return {
-			direction.x * matrix.m[0][0] + direction.y * matrix.m[1][0] + direction.z * matrix.m[2][0],
-			direction.x * matrix.m[0][1] + direction.y * matrix.m[1][1] + direction.z * matrix.m[2][1],
-			direction.x * matrix.m[0][2] + direction.y * matrix.m[1][2] + direction.z * matrix.m[2][2],
-		};
-	}
-
 	K4E::Vector4 ClampColor(const K4E::Vector4& color)
 	{
 		return {
@@ -41,109 +22,23 @@ std::vector<DisintegrationParticle> DisintegrationEmitter::EmitFromModel(
 	const K4E::Matrix4x4& worldMatrix,
 	const Settings& settings)
 {
-	std::vector<TriangleSample> triangles;
-	std::vector<VertexSample> vertices;
-	triangles.reserve(1024);
-	vertices.reserve(1024);
-
-	float totalArea = 0.0f;
-	for (const auto& subMesh : modelData.subMeshes)
-	{
-		for (const auto& vertex : subMesh.vertices)
-		{
-			vertices.push_back({ ToVector3(vertex.position), K4E::Vector3::NormalizeSafe(vertex.normal, { 0.0f, 1.0f, 0.0f }) });
-		}
-
-		if (subMesh.indices.size() >= 3)
-		{
-			for (size_t i = 0; i + 2 < subMesh.indices.size(); i += 3)
-			{
-				const uint32_t ia = subMesh.indices[i + 0];
-				const uint32_t ib = subMesh.indices[i + 1];
-				const uint32_t ic = subMesh.indices[i + 2];
-				if (ia >= subMesh.vertices.size() || ib >= subMesh.vertices.size() || ic >= subMesh.vertices.size()) { continue; }
-
-				const K4E::Vector3 a = ToVector3(subMesh.vertices[ia].position);
-				const K4E::Vector3 b = ToVector3(subMesh.vertices[ib].position);
-				const K4E::Vector3 c = ToVector3(subMesh.vertices[ic].position);
-				const float area = TriangleArea(a, b, c);
-				if (area <= 0.000001f) { continue; }
-
-				totalArea += area;
-				TriangleSample tri{};
-				tri.a = a;
-				tri.b = b;
-				tri.c = c;
-				tri.normal = K4E::Vector3::NormalizeSafe(K4E::Vector3::Cross(b - a, c - a), { 0.0f, 1.0f, 0.0f });
-				tri.cumulativeArea = totalArea;
-				triangles.push_back(tri);
-			}
-		}
-		else if (subMesh.vertices.size() >= 3)
-		{
-			for (size_t i = 0; i + 2 < subMesh.vertices.size(); i += 3)
-			{
-				const K4E::Vector3 a = ToVector3(subMesh.vertices[i + 0].position);
-				const K4E::Vector3 b = ToVector3(subMesh.vertices[i + 1].position);
-				const K4E::Vector3 c = ToVector3(subMesh.vertices[i + 2].position);
-				const float area = TriangleArea(a, b, c);
-				if (area <= 0.000001f) { continue; }
-
-				// Boundsではなく三角形表面の面積重みによって初期粒子位置を選ぶ。
-				totalArea += area;
-				TriangleSample tri{};
-				tri.a = a;
-				tri.b = b;
-				tri.c = c;
-				tri.normal = K4E::Vector3::NormalizeSafe(K4E::Vector3::Cross(b - a, c - a), { 0.0f, 1.0f, 0.0f });
-				tri.cumulativeArea = totalArea;
-				triangles.push_back(tri);
-			}
-		}
-	}
+	ModelSurfaceSampler sampler;
+	const std::vector<DisintegrationSamplePoint> samples = sampler.SampleFromModel(
+		modelData,
+		worldMatrix,
+		settings.particleCount,
+		settings.surfaceSampling,
+		settings.particleSize * 1.5f);
 
 	std::vector<DisintegrationParticle> particles;
-	particles.reserve(static_cast<size_t>(std::max(0, settings.particleCount)));
-	if ((triangles.empty() && vertices.empty()) || settings.particleCount <= 0) { return particles; }
+	particles.reserve(samples.size());
+	if (samples.empty()) { return particles; }
 
 	const K4E::Vector3 center = worldMatrix.GetTranslation();
-
-	for (int i = 0; i < settings.particleCount; ++i)
+	for (const auto& sample : samples)
 	{
-		K4E::Vector3 local{};
-		K4E::Vector3 localNormal{ 0.0f, 1.0f, 0.0f };
-
-		if (settings.surfaceSampling && !triangles.empty())
-		{
-			const float areaPick = RandomRange(0.0f, totalArea);
-			auto it = std::lower_bound(
-				triangles.begin(), triangles.end(), areaPick,
-				[](const TriangleSample& tri, float value) { return tri.cumulativeArea < value; });
-			if (it == triangles.end()) { it = triangles.end() - 1; }
-
-			float u = Random01();
-			float v = Random01();
-			if (u + v > 1.0f)
-			{
-				u = 1.0f - u;
-				v = 1.0f - v;
-			}
-
-			local = it->a + (it->b - it->a) * u + (it->c - it->a) * v;
-			localNormal = it->normal;
-		}
-		else
-		{
-			const size_t sampleIndex = std::min(static_cast<size_t>(Random01() * static_cast<float>(vertices.size())), vertices.size() - 1);
-			const VertexSample& sample = vertices[sampleIndex];
-			local = sample.position + RandomUnitVector() * RandomRange(0.0f, settings.particleSize * 1.5f);
-			localNormal = sample.normal;
-		}
-
-		const K4E::Vector3 world = K4E::Vector3::Transform(local, worldMatrix);
-		const K4E::Vector3 worldNormal = K4E::Vector3::NormalizeSafe(TransformDirection(localNormal, worldMatrix), { 0.0f, 1.0f, 0.0f });
-		K4E::Vector3 outward = K4E::Vector3::NormalizeSafe(world - center, worldNormal);
-		outward = K4E::Vector3::NormalizeSafe(outward * 0.70f + worldNormal * 0.25f + RandomUnitVector() * 0.20f, worldNormal);
+		K4E::Vector3 outward = K4E::Vector3::NormalizeSafe(sample.position - center, sample.normal);
+		outward = K4E::Vector3::NormalizeSafe(outward * 0.70f + sample.normal * 0.25f + RandomUnitVector() * 0.20f, sample.normal);
 
 		const float brightness = RandomRange(1.0f - settings.colorVariation, 1.0f + settings.colorVariation);
 		K4E::Vector4 color = ClampColor({
@@ -154,8 +49,8 @@ std::vector<DisintegrationParticle> DisintegrationEmitter::EmitFromModel(
 		});
 
 		DisintegrationParticle particle{};
-		particle.initialPosition = world;
-		particle.position = world;
+		particle.initialPosition = sample.position;
+		particle.position = sample.position;
 		particle.outward = outward;
 		particle.rotation = {
 			RandomRange(-settings.blockRotationRandomness, settings.blockRotationRandomness),

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelReconstructionEffect.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelReconstructionEffect.cpp
@@ -1,0 +1,138 @@
+#define NOMINMAX
+#include "ModelReconstructionEffect.h"
+
+#include "Model.h"
+#include "ModelManager.h"
+
+#include <algorithm>
+#include <cmath>
+
+#ifdef USE_IMGUI
+#include <imgui.h>
+#endif
+
+void ModelReconstructionEffect::Initialize()
+{
+	blocks_.clear();
+	isActive_ = false;
+	isComplete_ = false;
+	elapsedTime_ = 0.0f;
+}
+
+void ModelReconstructionEffect::PlayFromModel(const std::string& modelPath, const K4E::Matrix4x4& worldMatrix)
+{
+	auto model = K4E::ModelManager::GetInstance()->LoadModel(modelPath);
+	if (!model) { return; }
+
+	ReconstructionEmitter::Settings settings{};
+	settings.blockCount = parameters_.blockCount;
+	settings.blockSize = parameters_.blockSize;
+	settings.startScatterRadius = parameters_.startScatterRadius;
+	settings.startHeight = parameters_.startHeight;
+	settings.startDelayRange = parameters_.startDelayRange;
+	settings.rotationRandomness = parameters_.rotationRandomness;
+	settings.surfaceSampling = parameters_.surfaceSampling;
+	settings.color = parameters_.color;
+	settings.colorVariation = parameters_.colorVariation;
+
+	blocks_ = emitter_.EmitFromModel(model->GetModelData(), worldMatrix, settings);
+	isActive_ = !blocks_.empty();
+	isComplete_ = false;
+	elapsedTime_ = 0.0f;
+}
+
+void ModelReconstructionEffect::Update(float deltaTime)
+{
+	if (!isActive_ && parameters_.autoHideBlocksAfterComplete) { return; }
+	if (blocks_.empty()) { return; }
+
+	elapsedTime_ += deltaTime;
+	bool allArrived = true;
+
+	for (auto& block : blocks_)
+	{
+		if (!block.alive) { continue; }
+
+		block.age += deltaTime;
+		if (block.age < block.startDelay)
+		{
+			block.position = block.startPosition;
+			allArrived = false;
+			continue;
+		}
+
+		const float localT = Clamp01((block.age - block.startDelay) / std::max(parameters_.duration, 0.0001f));
+		const float easedT = EaseOut(localT);
+
+		// 到着直前で回転速度を弱め、最終的には表面サンプル位置に静止させる。
+		block.position = block.startPosition + (block.targetPosition - block.startPosition) * easedT;
+		block.rotation = block.startRotation + block.rotationVelocity * ((1.0f - easedT) * block.age);
+		block.arrived = localT >= 1.0f;
+		if (block.arrived)
+		{
+			block.position = block.targetPosition;
+			block.rotation = { 0.0f, 0.0f, 0.0f };
+		}
+		else
+		{
+			allArrived = false;
+		}
+	}
+
+	const float totalTime = parameters_.startDelayRange + parameters_.duration + parameters_.holdTime;
+	if (allArrived && elapsedTime_ >= totalTime)
+	{
+		isComplete_ = true;
+	}
+
+	if (isComplete_ && parameters_.autoHideBlocksAfterComplete)
+	{
+		isActive_ = false;
+		for (auto& block : blocks_)
+		{
+			block.alive = false;
+		}
+	}
+}
+
+void ModelReconstructionEffect::Draw()
+{
+	if (!ShouldDrawBlocks()) { return; }
+	renderer_.Draw(blocks_);
+}
+
+void ModelReconstructionEffect::DrawImGui()
+{
+#ifdef USE_IMGUI
+	ImGui::Begin("Model Reconstruction Effect");
+	ImGui::Text("Active: %s", isActive_ ? "true" : "false");
+	ImGui::Text("Complete: %s", isComplete_ ? "true" : "false");
+	ImGui::Text("Block Instances: %zu", blocks_.size());
+	ImGui::SliderInt("blockCount", &parameters_.blockCount, 32, 8000);
+	ImGui::SliderFloat("blockSize", &parameters_.blockSize, 0.005f, 0.30f);
+	ImGui::SliderFloat("duration", &parameters_.duration, 0.05f, 8.0f);
+	ImGui::SliderFloat("startScatterRadius", &parameters_.startScatterRadius, 0.0f, 12.0f);
+	ImGui::SliderFloat("startHeight", &parameters_.startHeight, -2.0f, 10.0f);
+	ImGui::SliderFloat("startDelayRange", &parameters_.startDelayRange, 0.0f, 3.0f);
+	ImGui::SliderFloat("rotationRandomness", &parameters_.rotationRandomness, 0.0f, 12.0f);
+	ImGui::SliderFloat("easePower", &parameters_.easePower, 1.0f, 8.0f);
+	ImGui::ColorEdit4("color", &parameters_.color.x);
+	ImGui::SliderFloat("colorVariation", &parameters_.colorVariation, 0.0f, 0.8f);
+	ImGui::SliderFloat("holdTime", &parameters_.holdTime, 0.0f, 5.0f);
+	ImGui::Checkbox("showFinalModel", &parameters_.showFinalModel);
+	ImGui::Checkbox("autoHideBlocksAfterComplete", &parameters_.autoHideBlocksAfterComplete);
+	ImGui::Checkbox("surfaceSampling", &parameters_.surfaceSampling);
+	ImGui::End();
+#endif
+}
+
+float ModelReconstructionEffect::Clamp01(float value) const
+{
+	return std::clamp(value, 0.0f, 1.0f);
+}
+
+float ModelReconstructionEffect::EaseOut(float value) const
+{
+	const float t = Clamp01(value);
+	return 1.0f - std::pow(1.0f - t, std::max(parameters_.easePower, 1.0f));
+}

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelReconstructionEffect.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelReconstructionEffect.h
@@ -1,0 +1,58 @@
+#pragma once
+#include "ReconstructionEmitter.h"
+#include "ReconstructionRenderer.h"
+#include "Matrix4x4.h"
+#include "Vector4.h"
+
+#include <string>
+#include <vector>
+
+/// -------------------------------------------------------------
+/// モデル登場時に散らばったブロックを表面サンプル位置へ集める再構築エフェクト
+/// -------------------------------------------------------------
+class ModelReconstructionEffect
+{
+public:
+	struct Parameters
+	{
+		int blockCount = 1200;
+		float blockSize = 0.045f;
+		float duration = 1.8f;
+		float startScatterRadius = 3.0f;
+		float startHeight = 2.5f;
+		float startDelayRange = 0.45f;
+		float rotationRandomness = 4.0f;
+		float easePower = 3.0f;
+		K4E::Vector4 color{ 0.64f, 0.72f, 0.86f, 1.0f };
+		float colorVariation = 0.18f;
+		float holdTime = 0.60f;
+		bool showFinalModel = true;
+		bool autoHideBlocksAfterComplete = true;
+		bool surfaceSampling = true;
+	};
+
+	void Initialize();
+	void PlayFromModel(const std::string& modelPath, const K4E::Matrix4x4& worldMatrix);
+	void Update(float deltaTime);
+	void Draw();
+	void DrawImGui();
+	bool IsActive() const { return isActive_; }
+	bool IsComplete() const { return isComplete_; }
+	bool ShouldShowFinalModel() const { return isComplete_ && parameters_.showFinalModel; }
+	bool ShouldDrawBlocks() const { return isActive_ || (!parameters_.autoHideBlocksAfterComplete && !blocks_.empty()); }
+
+	Parameters& GetParameters() { return parameters_; }
+	const Parameters& GetParameters() const { return parameters_; }
+
+private:
+	float Clamp01(float value) const;
+	float EaseOut(float value) const;
+
+	Parameters parameters_{};
+	ReconstructionEmitter emitter_{};
+	ReconstructionRenderer renderer_{};
+	std::vector<ReconstructionBlock> blocks_{};
+	bool isActive_ = false;
+	bool isComplete_ = false;
+	float elapsedTime_ = 0.0f;
+};

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelSurfaceSampler.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelSurfaceSampler.cpp
@@ -1,0 +1,149 @@
+#define NOMINMAX
+#include "ModelSurfaceSampler.h"
+
+#include <algorithm>
+#include <cmath>
+
+namespace
+{
+	K4E::Vector3 ToVector3(const K4E::Vector4& v)
+	{
+		return { v.x, v.y, v.z };
+	}
+
+	float TriangleArea(const K4E::Vector3& a, const K4E::Vector3& b, const K4E::Vector3& c)
+	{
+		return K4E::Vector3::Length(K4E::Vector3::Cross(b - a, c - a)) * 0.5f;
+	}
+
+	K4E::Vector3 TransformDirection(const K4E::Vector3& direction, const K4E::Matrix4x4& matrix)
+	{
+		return {
+			direction.x * matrix.m[0][0] + direction.y * matrix.m[1][0] + direction.z * matrix.m[2][0],
+			direction.x * matrix.m[0][1] + direction.y * matrix.m[1][1] + direction.z * matrix.m[2][1],
+			direction.x * matrix.m[0][2] + direction.y * matrix.m[1][2] + direction.z * matrix.m[2][2],
+		};
+	}
+}
+
+std::vector<DisintegrationSamplePoint> ModelSurfaceSampler::SampleFromModel(
+	const K4E::ModelData& modelData,
+	const K4E::Matrix4x4& worldMatrix,
+	int sampleCount,
+	bool surfaceSampling,
+	float vertexJitterRadius)
+{
+	std::vector<TriangleSample> triangles;
+	std::vector<VertexSample> vertices;
+	triangles.reserve(1024);
+	vertices.reserve(1024);
+
+	float totalArea = 0.0f;
+	for (const auto& subMesh : modelData.subMeshes)
+	{
+		for (const auto& vertex : subMesh.vertices)
+		{
+			vertices.push_back({ ToVector3(vertex.position), K4E::Vector3::NormalizeSafe(vertex.normal, { 0.0f, 1.0f, 0.0f }) });
+		}
+
+		if (subMesh.indices.size() >= 3)
+		{
+			for (size_t i = 0; i + 2 < subMesh.indices.size(); i += 3)
+			{
+				const uint32_t ia = subMesh.indices[i + 0];
+				const uint32_t ib = subMesh.indices[i + 1];
+				const uint32_t ic = subMesh.indices[i + 2];
+				if (ia >= subMesh.vertices.size() || ib >= subMesh.vertices.size() || ic >= subMesh.vertices.size()) { continue; }
+
+				const K4E::Vector3 a = ToVector3(subMesh.vertices[ia].position);
+				const K4E::Vector3 b = ToVector3(subMesh.vertices[ib].position);
+				const K4E::Vector3 c = ToVector3(subMesh.vertices[ic].position);
+				const float area = TriangleArea(a, b, c);
+				if (area <= 0.000001f) { continue; }
+
+				totalArea += area;
+				triangles.push_back({ a, b, c, K4E::Vector3::NormalizeSafe(K4E::Vector3::Cross(b - a, c - a), { 0.0f, 1.0f, 0.0f }), totalArea });
+			}
+		}
+		else if (subMesh.vertices.size() >= 3)
+		{
+			for (size_t i = 0; i + 2 < subMesh.vertices.size(); i += 3)
+			{
+				const K4E::Vector3 a = ToVector3(subMesh.vertices[i + 0].position);
+				const K4E::Vector3 b = ToVector3(subMesh.vertices[i + 1].position);
+				const K4E::Vector3 c = ToVector3(subMesh.vertices[i + 2].position);
+				const float area = TriangleArea(a, b, c);
+				if (area <= 0.000001f) { continue; }
+
+				// Boundsではなく三角形表面の面積重みによってモデル形状を復元する点を選ぶ。
+				totalArea += area;
+				triangles.push_back({ a, b, c, K4E::Vector3::NormalizeSafe(K4E::Vector3::Cross(b - a, c - a), { 0.0f, 1.0f, 0.0f }), totalArea });
+			}
+		}
+	}
+
+	std::vector<DisintegrationSamplePoint> samples;
+	samples.reserve(static_cast<size_t>(std::max(0, sampleCount)));
+	if ((triangles.empty() && vertices.empty()) || sampleCount <= 0) { return samples; }
+
+	for (int i = 0; i < sampleCount; ++i)
+	{
+		K4E::Vector3 local{};
+		K4E::Vector3 localNormal{ 0.0f, 1.0f, 0.0f };
+
+		if (surfaceSampling && !triangles.empty())
+		{
+			const float areaPick = RandomRange(0.0f, totalArea);
+			auto it = std::lower_bound(
+				triangles.begin(), triangles.end(), areaPick,
+				[](const TriangleSample& tri, float value) { return tri.cumulativeArea < value; });
+			if (it == triangles.end()) { it = triangles.end() - 1; }
+
+			float u = Random01();
+			float v = Random01();
+			if (u + v > 1.0f)
+			{
+				u = 1.0f - u;
+				v = 1.0f - v;
+			}
+
+			local = it->a + (it->b - it->a) * u + (it->c - it->a) * v;
+			localNormal = it->normal;
+		}
+		else
+		{
+			const size_t sampleIndex = std::min(static_cast<size_t>(Random01() * static_cast<float>(vertices.size())), vertices.size() - 1);
+			const VertexSample& sample = vertices[sampleIndex];
+			local = sample.position + RandomUnitVector() * RandomRange(0.0f, vertexJitterRadius);
+			localNormal = sample.normal;
+		}
+
+		DisintegrationSamplePoint sample{};
+		sample.position = K4E::Vector3::Transform(local, worldMatrix);
+		sample.normal = K4E::Vector3::NormalizeSafe(TransformDirection(localNormal, worldMatrix), { 0.0f, 1.0f, 0.0f });
+		samples.push_back(sample);
+	}
+
+	return samples;
+}
+
+float ModelSurfaceSampler::Random01()
+{
+	return unitDist_(rng_);
+}
+
+float ModelSurfaceSampler::RandomRange(float minValue, float maxValue)
+{
+	return minValue + (maxValue - minValue) * Random01();
+}
+
+K4E::Vector3 ModelSurfaceSampler::RandomUnitVector()
+{
+	K4E::Vector3 v{};
+	do
+	{
+		v = { RandomRange(-1.0f, 1.0f), RandomRange(-1.0f, 1.0f), RandomRange(-1.0f, 1.0f) };
+	} while (K4E::Vector3::LengthSquared(v) <= 0.000001f);
+
+	return K4E::Vector3::Normalize(v);
+}

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelSurfaceSampler.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelSurfaceSampler.h
@@ -1,0 +1,55 @@
+#pragma once
+#include "Matrix4x4.h"
+#include "ModelData.h"
+#include "Vector3.h"
+
+#include <random>
+#include <vector>
+
+namespace K4E = ::Ken4lowEngine;
+
+/// -------------------------------------------------------------
+/// 崩壊・再構築エフェクトで共有するモデル表面サンプル点
+/// -------------------------------------------------------------
+struct DisintegrationSamplePoint
+{
+	K4E::Vector3 position{};
+	K4E::Vector3 normal{ 0.0f, 1.0f, 0.0f };
+};
+
+/// -------------------------------------------------------------
+/// AABBグリッドではなく三角形表面または頂点から形状点を生成するサンプラー
+/// -------------------------------------------------------------
+class ModelSurfaceSampler
+{
+public:
+	std::vector<DisintegrationSamplePoint> SampleFromModel(
+		const K4E::ModelData& modelData,
+		const K4E::Matrix4x4& worldMatrix,
+		int sampleCount,
+		bool surfaceSampling,
+		float vertexJitterRadius = 0.0f);
+
+private:
+	struct TriangleSample
+	{
+		K4E::Vector3 a{};
+		K4E::Vector3 b{};
+		K4E::Vector3 c{};
+		K4E::Vector3 normal{ 0.0f, 1.0f, 0.0f };
+		float cumulativeArea = 0.0f;
+	};
+
+	struct VertexSample
+	{
+		K4E::Vector3 position{};
+		K4E::Vector3 normal{ 0.0f, 1.0f, 0.0f };
+	};
+
+	float Random01();
+	float RandomRange(float minValue, float maxValue);
+	K4E::Vector3 RandomUnitVector();
+
+	std::mt19937 rng_{ 0x51A7F00Du };
+	std::uniform_real_distribution<float> unitDist_{ 0.0f, 1.0f };
+};

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionBlock.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionBlock.h
@@ -1,0 +1,26 @@
+#pragma once
+#include "Vector3.h"
+#include "Vector4.h"
+
+namespace K4E = ::Ken4lowEngine;
+
+/// -------------------------------------------------------------
+/// モデル再構築専用のCPUブロックデータ
+/// -------------------------------------------------------------
+struct ReconstructionBlock
+{
+	K4E::Vector3 startPosition{};
+	K4E::Vector3 targetPosition{};
+	K4E::Vector3 position{};
+	K4E::Vector3 rotation{};
+	K4E::Vector3 startRotation{};
+	K4E::Vector3 rotationVelocity{};
+	K4E::Vector3 scale{ 1.0f, 1.0f, 1.0f };
+	K4E::Vector4 color{ 0.64f, 0.72f, 0.86f, 1.0f };
+	float age = 0.0f;
+	float startDelay = 0.0f;
+	float size = 0.04f;
+	float alpha = 1.0f;
+	bool alive = false;
+	bool arrived = false;
+};

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionEmitter.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionEmitter.cpp
@@ -1,0 +1,94 @@
+#define NOMINMAX
+#include "ReconstructionEmitter.h"
+
+#include <algorithm>
+#include <cmath>
+
+std::vector<ReconstructionBlock> ReconstructionEmitter::EmitFromModel(
+	const K4E::ModelData& modelData,
+	const K4E::Matrix4x4& worldMatrix,
+	const Settings& settings)
+{
+	ModelSurfaceSampler sampler;
+	const std::vector<DisintegrationSamplePoint> targets = sampler.SampleFromModel(
+		modelData,
+		worldMatrix,
+		settings.blockCount,
+		settings.surfaceSampling,
+		settings.blockSize * 1.5f);
+
+	std::vector<ReconstructionBlock> blocks;
+	blocks.reserve(targets.size());
+	if (targets.empty()) { return blocks; }
+
+	const K4E::Vector3 center = worldMatrix.GetTranslation();
+	for (const auto& target : targets)
+	{
+		const K4E::Vector3 radial = K4E::Vector3::NormalizeSafe(target.position - center, RandomUnitVector());
+		K4E::Vector3 scatter = radial * RandomRange(settings.startScatterRadius * 0.35f, settings.startScatterRadius);
+		scatter += RandomUnitVector() * RandomRange(0.0f, settings.startScatterRadius * 0.35f);
+		scatter.y += RandomRange(-0.25f, settings.startHeight);
+
+		ReconstructionBlock block{};
+		block.startPosition = target.position + scatter;
+		block.targetPosition = target.position;
+		block.position = block.startPosition;
+		block.startRotation = {
+			RandomRange(-settings.rotationRandomness, settings.rotationRandomness),
+			RandomRange(-settings.rotationRandomness, settings.rotationRandomness),
+			RandomRange(-settings.rotationRandomness, settings.rotationRandomness),
+		};
+		block.rotation = block.startRotation;
+		block.rotationVelocity = {
+			RandomRange(-settings.rotationRandomness, settings.rotationRandomness),
+			RandomRange(-settings.rotationRandomness, settings.rotationRandomness),
+			RandomRange(-settings.rotationRandomness, settings.rotationRandomness),
+		};
+		block.scale = {
+			RandomRange(0.86f, 1.12f),
+			RandomRange(0.86f, 1.12f),
+			RandomRange(0.86f, 1.12f),
+		};
+		block.color = MakeColor(settings);
+		block.startDelay = RandomRange(0.0f, settings.startDelayRange);
+		block.size = settings.blockSize * RandomRange(0.86f, 1.12f);
+		block.alpha = 1.0f;
+		block.alive = true;
+		blocks.push_back(block);
+	}
+
+	return blocks;
+}
+
+float ReconstructionEmitter::Random01()
+{
+	return unitDist_(rng_);
+}
+
+float ReconstructionEmitter::RandomRange(float minValue, float maxValue)
+{
+	return minValue + (maxValue - minValue) * Random01();
+}
+
+K4E::Vector3 ReconstructionEmitter::RandomUnitVector()
+{
+	K4E::Vector3 v{};
+	do
+	{
+		v = { RandomRange(-1.0f, 1.0f), RandomRange(-1.0f, 1.0f), RandomRange(-1.0f, 1.0f) };
+	} while (K4E::Vector3::LengthSquared(v) <= 0.000001f);
+
+	return K4E::Vector3::Normalize(v);
+}
+
+K4E::Vector4 ReconstructionEmitter::MakeColor(const Settings& settings)
+{
+	const float variation = settings.colorVariation;
+	const float brightness = RandomRange(1.0f - variation, 1.0f + variation);
+	return {
+		std::clamp(settings.color.x * brightness + RandomRange(-variation, variation) * 0.25f, 0.0f, 1.0f),
+		std::clamp(settings.color.y * brightness + RandomRange(-variation, variation) * 0.25f, 0.0f, 1.0f),
+		std::clamp(settings.color.z * brightness + RandomRange(-variation, variation) * 0.25f, 0.0f, 1.0f),
+		std::clamp(settings.color.w, 0.0f, 1.0f),
+	};
+}

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionEmitter.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionEmitter.h
@@ -1,6 +1,6 @@
 #pragma once
-#include "DisintegrationParticle.h"
 #include "ModelSurfaceSampler.h"
+#include "ReconstructionBlock.h"
 #include "Matrix4x4.h"
 #include "ModelData.h"
 #include "Vector4.h"
@@ -9,26 +9,25 @@
 #include <vector>
 
 /// -------------------------------------------------------------
-/// モデル表面から崩壊粒子の初期配置を作る専用エミッター
+/// モデル表面サンプルを目標位置にした再構築ブロックを生成する
 /// -------------------------------------------------------------
-class DisintegrationEmitter
+class ReconstructionEmitter
 {
 public:
 	struct Settings
 	{
-		int particleCount = 1200;
-		float particleSize = 0.045f;
-		float blockRotationRandomness = 1.2f;
+		int blockCount = 1200;
+		float blockSize = 0.045f;
+		float startScatterRadius = 3.0f;
+		float startHeight = 2.5f;
+		float startDelayRange = 0.45f;
+		float rotationRandomness = 4.0f;
 		bool surfaceSampling = true;
-		float lifeTime = 2.0f;
-		float spreadPower = 1.6f;
-		float upwardPower = 0.65f;
-		float startDelay = 0.20f;
-		K4E::Vector4 baseColor{ 0.64f, 0.61f, 0.56f, 1.0f };
-		float colorVariation = 0.16f;
+		K4E::Vector4 color{ 0.64f, 0.72f, 0.86f, 1.0f };
+		float colorVariation = 0.18f;
 	};
 
-	std::vector<DisintegrationParticle> EmitFromModel(
+	std::vector<ReconstructionBlock> EmitFromModel(
 		const K4E::ModelData& modelData,
 		const K4E::Matrix4x4& worldMatrix,
 		const Settings& settings);
@@ -37,7 +36,8 @@ private:
 	float Random01();
 	float RandomRange(float minValue, float maxValue);
 	K4E::Vector3 RandomUnitVector();
+	K4E::Vector4 MakeColor(const Settings& settings);
 
-	std::mt19937 rng_{ 0xD157E6A7u };
+	std::mt19937 rng_{ 0xC0DE2026u };
 	std::uniform_real_distribution<float> unitDist_{ 0.0f, 1.0f };
 };

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionRenderer.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionRenderer.cpp
@@ -1,0 +1,223 @@
+#define NOMINMAX
+#include "ReconstructionRenderer.h"
+
+#include "BlendStateFactory.h"
+#include "CameraManager.h"
+#include "DebugCamera.h"
+#include "DirectXCommon.h"
+#include "PipelineStatePresets.h"
+#include "BlendModeType.h"
+#include "ResourceManager.h"
+#include "SRVManager.h"
+#include "ShaderCompiler.h"
+
+#include <algorithm>
+#include <array>
+#include <cassert>
+#include <cstring>
+
+namespace
+{
+	constexpr UINT kRootViewProjection = 0;
+	constexpr UINT kRootInstances = 1;
+
+	K4E::Matrix4x4 MakeWorldMatrix(const ReconstructionBlock& particle)
+	{
+		const K4E::Vector3 scale = particle.scale * particle.size;
+		return K4E::Matrix4x4::MakeAffineMatrix(scale, particle.rotation, particle.position);
+	}
+}
+
+ReconstructionRenderer::~ReconstructionRenderer()
+{
+	ReleaseSrv();
+}
+
+void ReconstructionRenderer::Draw(const std::vector<ReconstructionBlock>& particles)
+{
+	if (particles.empty()) { return; }
+	if (!initialized_) { Initialize(); }
+
+	size_t visibleCount = 0;
+	for (const auto& particle : particles)
+	{
+		if (particle.alive && particle.alpha > 0.0f) { ++visibleCount; }
+	}
+	if (visibleCount == 0) { return; }
+
+	EnsureInstanceCapacity(visibleCount);
+	UpdateViewProjection();
+
+	size_t writeIndex = 0;
+	for (const auto& particle : particles)
+	{
+		if (!particle.alive || particle.alpha <= 0.0f) { continue; }
+
+		K4E::Vector4 color = particle.color;
+		color.w *= particle.alpha;
+		instanceData_[writeIndex].world = MakeWorldMatrix(particle);
+		instanceData_[writeIndex].color = color;
+		++writeIndex;
+	}
+
+	auto* dxCommon = K4E::DirectXCommon::GetInstance();
+	auto* commandList = dxCommon->GetCommandManager()->GetCommandList();
+	K4E::SRVManager::GetInstance()->PreDraw();
+
+	commandList->SetGraphicsRootSignature(rootSignature_.Get());
+	commandList->SetPipelineState(pipelineState_.Get());
+	commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+	commandList->IASetVertexBuffers(0, 1, &vertexBufferView_);
+	commandList->IASetIndexBuffer(&indexBufferView_);
+	commandList->SetGraphicsRootConstantBufferView(kRootViewProjection, viewProjectionBuffer_->GetGPUVirtualAddress());
+	K4E::SRVManager::GetInstance()->SetGraphicsRootDescriptorTable(kRootInstances, srvIndex_);
+	commandList->DrawIndexedInstanced(indexCount_, static_cast<UINT>(visibleCount), 0, 0, 0);
+}
+
+void ReconstructionRenderer::Initialize()
+{
+	CreatePipeline();
+	CreateCubeMesh();
+
+	auto* device = K4E::DirectXCommon::GetInstance()->GetDevice();
+	viewProjectionBuffer_ = K4E::ResourceManager::CreateBufferResource(device, sizeof(ViewProjectionData));
+	viewProjectionBuffer_->SetName(L"ReconstructionRenderer_ViewProjectionBuffer");
+	viewProjectionBuffer_->Map(0, nullptr, reinterpret_cast<void**>(&viewProjectionData_));
+
+	EnsureInstanceCapacity(1);
+	initialized_ = true;
+}
+
+void ReconstructionRenderer::CreatePipeline()
+{
+	auto* dxCommon = K4E::DirectXCommon::GetInstance();
+	auto* device = dxCommon->GetDevice();
+
+	std::array<D3D12_DESCRIPTOR_RANGE, 1> ranges{};
+	ranges[0].BaseShaderRegister = 0;
+	ranges[0].NumDescriptors = 1;
+	ranges[0].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
+	ranges[0].OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
+
+	std::array<D3D12_ROOT_PARAMETER, 2> rootParameters{};
+	rootParameters[kRootViewProjection].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
+	rootParameters[kRootViewProjection].ShaderVisibility = D3D12_SHADER_VISIBILITY_VERTEX;
+	rootParameters[kRootViewProjection].Descriptor.ShaderRegister = 0;
+
+	rootParameters[kRootInstances].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+	rootParameters[kRootInstances].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
+	rootParameters[kRootInstances].DescriptorTable.pDescriptorRanges = ranges.data();
+	rootParameters[kRootInstances].DescriptorTable.NumDescriptorRanges = 1;
+
+	D3D12_ROOT_SIGNATURE_DESC rootSignatureDesc{};
+	rootSignatureDesc.Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
+	rootSignatureDesc.NumParameters = static_cast<UINT>(rootParameters.size());
+	rootSignatureDesc.pParameters = rootParameters.data();
+
+	Microsoft::WRL::ComPtr<ID3DBlob> signatureBlob;
+	Microsoft::WRL::ComPtr<ID3DBlob> errorBlob;
+	HRESULT hr = D3D12SerializeRootSignature(&rootSignatureDesc, D3D_ROOT_SIGNATURE_VERSION_1, &signatureBlob, &errorBlob);
+	assert(SUCCEEDED(hr));
+	hr = device->CreateRootSignature(0, signatureBlob->GetBufferPointer(), signatureBlob->GetBufferSize(), IID_PPV_ARGS(&rootSignature_));
+	assert(SUCCEEDED(hr));
+
+	const K4E::ShaderDescriptor vsDesc{ L"ReconstructionBlockVS", L"Resources/Shaders/Disintegration/DisintegrationBlock.VS.hlsl", L"main", L"vs_6_0", K4E::ShaderStage::Vertex, K4E::RootSignatureType::Object3D };
+	const K4E::ShaderDescriptor psDesc{ L"ReconstructionBlockPS", L"Resources/Shaders/Disintegration/DisintegrationBlock.PS.hlsl", L"main", L"ps_6_0", K4E::ShaderStage::Pixel, K4E::RootSignatureType::Object3D };
+	auto vertexShader = K4E::ShaderCompiler::CompileShader(vsDesc, dxCommon->GetDXCCompilerManager());
+	auto pixelShader = K4E::ShaderCompiler::CompileShader(psDesc, dxCommon->GetDXCCompilerManager());
+
+	D3D12_INPUT_ELEMENT_DESC inputElement{};
+	inputElement.SemanticName = "POSITION";
+	inputElement.SemanticIndex = 0;
+	inputElement.Format = DXGI_FORMAT_R32G32B32_FLOAT;
+	inputElement.InputSlot = 0;
+	inputElement.AlignedByteOffset = D3D12_APPEND_ALIGNED_ELEMENT;
+	inputElement.InputSlotClass = D3D12_INPUT_CLASSIFICATION_PER_VERTEX_DATA;
+
+	D3D12_GRAPHICS_PIPELINE_STATE_DESC psoDesc{};
+	psoDesc.pRootSignature = rootSignature_.Get();
+	psoDesc.InputLayout = { &inputElement, 1 };
+	psoDesc.VS = { vertexShader->GetBufferPointer(), vertexShader->GetBufferSize() };
+	psoDesc.PS = { pixelShader->GetBufferPointer(), pixelShader->GetBufferSize() };
+	psoDesc.BlendState.RenderTarget[0] = K4E::BlendStateFactory::GetInstance()->GetBlendDesc(K4E::BlendMode::kBlendModeNormal);
+	psoDesc.RasterizerState = K4E::PipelineStatePresets::MakeRasterizerCullNone();
+	psoDesc.DepthStencilState = K4E::PipelineStatePresets::MakeDepthReadOnly();
+	psoDesc.SampleMask = D3D12_DEFAULT_SAMPLE_MASK;
+	psoDesc.PrimitiveTopologyType = D3D12_PRIMITIVE_TOPOLOGY_TYPE_TRIANGLE;
+	psoDesc.NumRenderTargets = 1;
+	psoDesc.RTVFormats[0] = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
+	psoDesc.DSVFormat = DXGI_FORMAT_D24_UNORM_S8_UINT;
+	psoDesc.SampleDesc.Count = 1;
+
+	hr = device->CreateGraphicsPipelineState(&psoDesc, IID_PPV_ARGS(&pipelineState_));
+	assert(SUCCEEDED(hr));
+}
+
+void ReconstructionRenderer::CreateCubeMesh()
+{
+	static const std::array<CubeVertex, 8> vertices{
+		CubeVertex{ { -0.5f, -0.5f, -0.5f } }, CubeVertex{ { -0.5f,  0.5f, -0.5f } },
+		CubeVertex{ {  0.5f,  0.5f, -0.5f } }, CubeVertex{ {  0.5f, -0.5f, -0.5f } },
+		CubeVertex{ { -0.5f, -0.5f,  0.5f } }, CubeVertex{ { -0.5f,  0.5f,  0.5f } },
+		CubeVertex{ {  0.5f,  0.5f,  0.5f } }, CubeVertex{ {  0.5f, -0.5f,  0.5f } },
+	};
+	static const std::array<uint32_t, 36> indices{
+		0, 1, 2, 0, 2, 3, 4, 6, 5, 4, 7, 6,
+		4, 5, 1, 4, 1, 0, 3, 2, 6, 3, 6, 7,
+		1, 5, 6, 1, 6, 2, 4, 0, 3, 4, 3, 7,
+	};
+
+	auto* device = K4E::DirectXCommon::GetInstance()->GetDevice();
+	vertexBuffer_ = K4E::ResourceManager::CreateBufferResource(device, sizeof(CubeVertex) * vertices.size());
+	vertexBuffer_->SetName(L"ReconstructionRenderer_CubeVertexBuffer");
+	void* vertexMapped = nullptr;
+	vertexBuffer_->Map(0, nullptr, &vertexMapped);
+	std::memcpy(vertexMapped, vertices.data(), sizeof(CubeVertex) * vertices.size());
+
+	vertexBufferView_.BufferLocation = vertexBuffer_->GetGPUVirtualAddress();
+	vertexBufferView_.SizeInBytes = static_cast<UINT>(sizeof(CubeVertex) * vertices.size());
+	vertexBufferView_.StrideInBytes = sizeof(CubeVertex);
+
+	indexBuffer_ = K4E::ResourceManager::CreateBufferResource(device, sizeof(uint32_t) * indices.size());
+	indexBuffer_->SetName(L"ReconstructionRenderer_CubeIndexBuffer");
+	void* indexMapped = nullptr;
+	indexBuffer_->Map(0, nullptr, &indexMapped);
+	std::memcpy(indexMapped, indices.data(), sizeof(uint32_t) * indices.size());
+
+	indexBufferView_.BufferLocation = indexBuffer_->GetGPUVirtualAddress();
+	indexBufferView_.SizeInBytes = static_cast<UINT>(sizeof(uint32_t) * indices.size());
+	indexBufferView_.Format = DXGI_FORMAT_R32_UINT;
+	indexCount_ = static_cast<UINT>(indices.size());
+}
+
+void ReconstructionRenderer::EnsureInstanceCapacity(size_t requiredCapacity)
+{
+	if (requiredCapacity <= instanceCapacity_) { return; }
+
+	ReleaseSrv();
+	instanceCapacity_ = std::max(requiredCapacity, instanceCapacity_ * 2 + 1);
+	auto* device = K4E::DirectXCommon::GetInstance()->GetDevice();
+	instanceBuffer_ = K4E::ResourceManager::CreateBufferResource(device, sizeof(InstanceData) * instanceCapacity_);
+	instanceBuffer_->SetName(L"ReconstructionRenderer_InstanceBuffer");
+	instanceBuffer_->Map(0, nullptr, reinterpret_cast<void**>(&instanceData_));
+
+	srvIndex_ = K4E::SRVManager::GetInstance()->Allocate();
+	K4E::SRVManager::GetInstance()->CreateSRVForStructureBuffer(srvIndex_, instanceBuffer_.Get(), static_cast<UINT>(instanceCapacity_), sizeof(InstanceData));
+}
+
+void ReconstructionRenderer::UpdateViewProjection()
+{
+	viewProjectionData_->viewProjection = K4E::CameraManager::GetInstance()->GetActiveViewProjectionMatrix();
+}
+
+void ReconstructionRenderer::ReleaseSrv()
+{
+	if (srvIndex_ != UINT32_MAX)
+	{
+		K4E::SRVManager::GetInstance()->Free(srvIndex_);
+		srvIndex_ = UINT32_MAX;
+	}
+	instanceData_ = nullptr;
+	instanceBuffer_.Reset();
+	instanceCapacity_ = 0;
+}

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionRenderer.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionRenderer.h
@@ -1,0 +1,56 @@
+#pragma once
+#include "ReconstructionBlock.h"
+#include "DX12Include.h"
+#include "Matrix4x4.h"
+
+#include <vector>
+
+/// -------------------------------------------------------------
+/// 既存Particleに依存しない再構築エフェクト専用レンダラー
+/// -------------------------------------------------------------
+class ReconstructionRenderer
+{
+public:
+	~ReconstructionRenderer();
+
+	void Draw(const std::vector<ReconstructionBlock>& particles);
+
+private:
+	struct CubeVertex
+	{
+		K4E::Vector3 position{};
+	};
+
+	struct InstanceData
+	{
+		K4E::Matrix4x4 world{};
+		K4E::Vector4 color{};
+	};
+
+	struct ViewProjectionData
+	{
+		K4E::Matrix4x4 viewProjection{};
+	};
+
+	void Initialize();
+	void CreatePipeline();
+	void CreateCubeMesh();
+	void EnsureInstanceCapacity(size_t requiredCapacity);
+	void UpdateViewProjection();
+	void ReleaseSrv();
+
+	bool initialized_ = false;
+	uint32_t srvIndex_ = UINT32_MAX;
+	Microsoft::WRL::ComPtr<ID3D12RootSignature> rootSignature_;
+	Microsoft::WRL::ComPtr<ID3D12PipelineState> pipelineState_;
+	Microsoft::WRL::ComPtr<ID3D12Resource> vertexBuffer_;
+	Microsoft::WRL::ComPtr<ID3D12Resource> indexBuffer_;
+	Microsoft::WRL::ComPtr<ID3D12Resource> instanceBuffer_;
+	Microsoft::WRL::ComPtr<ID3D12Resource> viewProjectionBuffer_;
+	D3D12_VERTEX_BUFFER_VIEW vertexBufferView_{};
+	D3D12_INDEX_BUFFER_VIEW indexBufferView_{};
+	InstanceData* instanceData_ = nullptr;
+	ViewProjectionData* viewProjectionData_ = nullptr;
+	size_t instanceCapacity_ = 0;
+	UINT indexCount_ = 0;
+};

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -129,6 +129,16 @@ void DebugScene::Initialize()
 
 	debugDisintegrationEffect_ = std::make_unique<ModelDisintegrationEffect>();
 	debugDisintegrationEffect_->Initialize();
+
+	debugReconstructionModel_ = std::make_unique<Object3D>();
+	debugReconstructionModel_->Initialize(debugReconstructionModelPath_);
+	debugReconstructionModel_->SetTranslate(debugReconstructionPosition_);
+	debugReconstructionModel_->SetRotate(debugReconstructionRotation_);
+	debugReconstructionModel_->SetScale(debugReconstructionScale_);
+	debugReconstructionModel_->Update();
+
+	debugReconstructionEffect_ = std::make_unique<ModelReconstructionEffect>();
+	debugReconstructionEffect_->Initialize();
 }
 
 void DebugScene::Update()
@@ -156,6 +166,8 @@ void DebugScene::Update()
 
 	UpdateDebugDisintegrationTest(deltaTime);
 
+	UpdateDebugReconstructionTest(deltaTime);
+
 	collisionManager_->Update();
 	collisionManager_->CheckAllCollisions();
 
@@ -171,6 +183,16 @@ void DebugScene::Draw3DObjects()
 	if (debugDisintegrationEffect_)
 	{
 		debugDisintegrationEffect_->Draw();
+	}
+
+	if (debugReconstructionModelVisible_ && debugReconstructionModel_)
+	{
+		debugReconstructionModel_->Draw();
+	}
+
+	if (debugReconstructionEffect_)
+	{
+		debugReconstructionEffect_->Draw();
 	}
 
 	// ボス描画
@@ -192,6 +214,11 @@ void DebugScene::DrawShadowObjects()
 	if (debugDisintegrationModelVisible_ && debugDisintegrationModel_)
 	{
 		debugDisintegrationModel_->DrawShadow();
+	}
+
+	if (debugReconstructionModelVisible_ && debugReconstructionModel_)
+	{
+		debugReconstructionModel_->DrawShadow();
 	}
 
 	if (debugBoss_)
@@ -225,6 +252,8 @@ void DebugScene::Finalize()
 	input_->SetLockCursor(false);
 	input_->SetCursorVisible(true);
 
+	debugReconstructionEffect_.reset();
+	debugReconstructionModel_.reset();
 	debugDisintegrationEffect_.reset();
 	debugDisintegrationModel_.reset();
 	debugBoss_.reset();
@@ -450,6 +479,41 @@ void DebugScene::DrawImGui()
 		debugDisintegrationEffect_->DrawImGui();
 	}
 
+
+	/// ---------- モデル再構築エフェクト単体テスト ---------- ///
+	{
+		static char reconstructionModelPathBuffer[256] = "Characters/body.gltf";
+
+		ImGui::Begin("Model Reconstruction Debug");
+		ImGui::TextWrapped("DebugScene-only test. F10 or the button gathers scattered CPU cube blocks into sampled model-surface positions.");
+		ImGui::InputText("Test Model Path", reconstructionModelPathBuffer, IM_ARRAYSIZE(reconstructionModelPathBuffer));
+		ImGui::DragFloat3("Position", &debugReconstructionPosition_.x, 0.05f);
+		ImGui::DragFloat3("Rotation", &debugReconstructionRotation_.x, 0.01f);
+		ImGui::DragFloat3("Scale", &debugReconstructionScale_.x, 0.01f, 0.01f, 10.0f);
+
+		if (ImGui::Button("Reload Test Model##Reconstruction"))
+		{
+			debugReconstructionModelPath_ = reconstructionModelPathBuffer;
+			ReloadDebugReconstructionModel();
+		}
+
+		ImGui::SameLine();
+		if (ImGui::Button("Play Reconstruction"))
+		{
+			debugReconstructionModelPath_ = reconstructionModelPathBuffer;
+			PlayDebugReconstructionEffect();
+		}
+
+		ImGui::Text("Model Visible: %s", debugReconstructionModelVisible_ ? "true" : "false");
+		ImGui::TextWrapped("%s", debugReconstructionLog_.c_str());
+		ImGui::End();
+	}
+
+	if (debugReconstructionEffect_)
+	{
+		debugReconstructionEffect_->DrawImGui();
+	}
+
 	/// ---------- 武器マスターデータエディタ ---------- ///
 	static WeaponMasterDataDatabase weaponDB;
 	static WeaponMasterDataEditor weaponEditor;
@@ -538,6 +602,67 @@ void DebugScene::UpdateDebug()
 		/*input_->SetLockCursor(!isDebugCamera_);
 		input_->SetCursorVisible(isDebugCamera_);*/
 	}
+}
+
+void DebugScene::UpdateDebugReconstructionTest(float deltaTime)
+{
+	if (input_ && input_->TriggerKey(DIK_F10))
+	{
+		PlayDebugReconstructionEffect();
+	}
+
+	if (debugReconstructionModel_)
+	{
+		debugReconstructionModel_->SetTranslate(debugReconstructionPosition_);
+		debugReconstructionModel_->SetRotate(debugReconstructionRotation_);
+		debugReconstructionModel_->SetScale(debugReconstructionScale_);
+		debugReconstructionModel_->Update();
+	}
+
+	if (debugReconstructionEffect_)
+	{
+		debugReconstructionEffect_->Update(deltaTime);
+		if (debugReconstructionEffect_->IsActive())
+		{
+			debugReconstructionModelVisible_ = debugReconstructionEffect_->ShouldShowFinalModel();
+		}
+		else if (debugReconstructionEffect_->IsComplete())
+		{
+			debugReconstructionModelVisible_ = debugReconstructionEffect_->ShouldShowFinalModel();
+		}
+	}
+}
+
+void DebugScene::PlayDebugReconstructionEffect()
+{
+	if (!debugReconstructionEffect_)
+	{
+		return;
+	}
+
+	const Matrix4x4 worldMatrix = Matrix4x4::MakeAffineMatrix(
+		debugReconstructionScale_,
+		debugReconstructionRotation_,
+		debugReconstructionPosition_);
+
+	// 表面サンプルを最終到達位置にして、散らばったブロックをモデル形状へ集める。
+	debugReconstructionEffect_->PlayFromModel(debugReconstructionModelPath_, worldMatrix);
+	debugReconstructionModelVisible_ = debugReconstructionEffect_->ShouldShowFinalModel();
+	debugReconstructionLog_ = "Play Reconstruction: " + debugReconstructionModelPath_;
+	DebugLog(debugReconstructionLog_);
+}
+
+void DebugScene::ReloadDebugReconstructionModel()
+{
+	debugReconstructionModel_ = std::make_unique<Object3D>();
+	debugReconstructionModel_->Initialize(debugReconstructionModelPath_);
+	debugReconstructionModel_->SetTranslate(debugReconstructionPosition_);
+	debugReconstructionModel_->SetRotate(debugReconstructionRotation_);
+	debugReconstructionModel_->SetScale(debugReconstructionScale_);
+	debugReconstructionModel_->Update();
+	debugReconstructionModelVisible_ = true;
+	debugReconstructionLog_ = "Reloaded reconstruction test model: " + debugReconstructionModelPath_;
+	DebugLog(debugReconstructionLog_);
 }
 
 /// -------------------------------------------------------------

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
@@ -6,6 +6,7 @@
 #include "Player.h"
 #include "Derived/GuardianBoss/GuardianBoss.h"
 #include "Disintegration/ModelDisintegrationEffect.h"
+#include "Disintegration/ModelReconstructionEffect.h"
 #include "Object3D.h"
 
 #include <memory>
@@ -65,6 +66,15 @@ private: /// ---------- メンバ関数 ---------- ///
 	/// モデル崩壊エフェクトをデバッグ位置で再生
 	void PlayDebugDisintegrationEffect();
 
+	/// モデル再構築エフェクトの単体検証更新
+	void UpdateDebugReconstructionTest(float deltaTime);
+
+	/// モデル再構築エフェクトをデバッグ位置で再生
+	void PlayDebugReconstructionEffect();
+
+	/// モデル再構築テスト用モデルを読み直す
+	void ReloadDebugReconstructionModel();
+
 	/// -------------------------------------------------------------
 	/// BossHitPart を文字列へ変換
 	/// ログ確認用
@@ -101,5 +111,15 @@ private: /// ---------- メンバ変数 ---------- ///
 	std::string debugDisintegrationModelPath_ = "Characters/body.gltf";
 	std::string debugDisintegrationLog_ = "Press F9 or the ImGui button to play.";
 	bool debugDisintegrationModelVisible_ = true;
+
+	// --- モデル再構築エフェクト単体テスト用 ---
+	std::unique_ptr<K4E::Object3D> debugReconstructionModel_;
+	std::unique_ptr<ModelReconstructionEffect> debugReconstructionEffect_;
+	K4E::Vector3 debugReconstructionPosition_{ 4.0f, 2.25f, 18.0f };
+	K4E::Vector3 debugReconstructionRotation_{ 0.0f, 0.0f, 0.0f };
+	K4E::Vector3 debugReconstructionScale_{ 1.0f, 1.0f, 1.0f };
+	std::string debugReconstructionModelPath_ = "Characters/body.gltf";
+	std::string debugReconstructionLog_ = "Press F10 or the ImGui button to play.";
+	bool debugReconstructionModelVisible_ = true;
 };
 

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -182,6 +182,10 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="ApplicationLayer\EffectLayer\Disintegration\DisintegrationEmitter.cpp" />
     <ClCompile Include="ApplicationLayer\EffectLayer\Disintegration\DisintegrationRenderer.cpp" />
     <ClCompile Include="ApplicationLayer\EffectLayer\Disintegration\ModelDisintegrationEffect.cpp" />
+    <ClCompile Include="ApplicationLayer\EffectLayer\Disintegration\ModelReconstructionEffect.cpp" />
+    <ClCompile Include="ApplicationLayer\EffectLayer\Disintegration\ReconstructionRenderer.cpp" />
+    <ClCompile Include="ApplicationLayer\EffectLayer\Disintegration\ReconstructionEmitter.cpp" />
+    <ClCompile Include="ApplicationLayer\EffectLayer\Disintegration\ModelSurfaceSampler.cpp" />
     <ClCompile Include="ApplicationLayer\EffectLayer\ParticleEmitter.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</ExcludedFromBuild>
@@ -817,6 +821,11 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\DisintegrationParticle.h" />
     <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\DisintegrationRenderer.h" />
     <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\ModelDisintegrationEffect.h" />
+    <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\ModelReconstructionEffect.h" />
+    <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\ReconstructionRenderer.h" />
+    <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\ReconstructionEmitter.h" />
+    <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\ReconstructionBlock.h" />
+    <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\ModelSurfaceSampler.h" />
     <ClInclude Include="ApplicationLayer\EffectLayer\ModelParticle.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</ExcludedFromBuild>

--- a/Project/Ken4lowEngine.vcxproj.filters
+++ b/Project/Ken4lowEngine.vcxproj.filters
@@ -178,6 +178,18 @@
     <ClCompile Include="ApplicationLayer\EffectLayer\Disintegration\ModelDisintegrationEffect.cpp">
       <Filter>ApplicationLayer\EffectLayer</Filter>
     </ClCompile>
+    <ClCompile Include="ApplicationLayer\EffectLayer\Disintegration\ModelSurfaceSampler.cpp">
+      <Filter>ApplicationLayer\EffectLayer</Filter>
+    </ClCompile>
+    <ClCompile Include="ApplicationLayer\EffectLayer\Disintegration\ReconstructionEmitter.cpp">
+      <Filter>ApplicationLayer\EffectLayer</Filter>
+    </ClCompile>
+    <ClCompile Include="ApplicationLayer\EffectLayer\Disintegration\ReconstructionRenderer.cpp">
+      <Filter>ApplicationLayer\EffectLayer</Filter>
+    </ClCompile>
+    <ClCompile Include="ApplicationLayer\EffectLayer\Disintegration\ModelReconstructionEffect.cpp">
+      <Filter>ApplicationLayer\EffectLayer</Filter>
+    </ClCompile>
     <ClCompile Include="ApplicationLayer\Scene\StageSelectScene\State\StageSelectSelectingState.cpp">
       <Filter>ApplicationLayer\Scene\StageSelectScene\State</Filter>
     </ClCompile>
@@ -892,6 +904,21 @@
       <Filter>ApplicationLayer\EffectLayer</Filter>
     </ClInclude>
     <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\ModelDisintegrationEffect.h">
+      <Filter>ApplicationLayer\EffectLayer</Filter>
+    </ClInclude>
+    <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\ModelSurfaceSampler.h">
+      <Filter>ApplicationLayer\EffectLayer</Filter>
+    </ClInclude>
+    <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\ReconstructionBlock.h">
+      <Filter>ApplicationLayer\EffectLayer</Filter>
+    </ClInclude>
+    <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\ReconstructionEmitter.h">
+      <Filter>ApplicationLayer\EffectLayer</Filter>
+    </ClInclude>
+    <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\ReconstructionRenderer.h">
+      <Filter>ApplicationLayer\EffectLayer</Filter>
+    </ClInclude>
+    <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\ModelReconstructionEffect.h">
       <Filter>ApplicationLayer\EffectLayer</Filter>
     </ClInclude>
     <ClInclude Include="ApplicationLayer\Scene\StageSelectScene\State\IStageSelectSceneState.h">


### PR DESCRIPTION
### Motivation
- 実装意図は既存のモデル崩壊（ModelDisintegrationEffect）の逆パターンとして、散らばった小ブロックが集まってモデル形状を作る再構築エフェクトを追加し、DebugScene で検証できるようにすることです。
- モデル形状の再現は単純な AABB グリッドではなく三角形表面または頂点サンプリングに基づく方法で行い、崩壊と再構築でサンプリング処理を共通化することを目指しました。

### Description
- 新規クラスを追加して CPU ベースの再構築エフェクトを実装しました: `ModelReconstructionEffect`、`ReconstructionBlock`、`ReconstructionEmitter`、`ReconstructionRenderer`（ブロックは `startPosition`/`targetPosition` を持ち、イーズ付きで到達する挙動）。
- 三角形面積重みまたは頂点ジッタによるサンプリング処理を共通化する `ModelSurfaceSampler` を追加し、既存の `DisintegrationEmitter` をこのサンプラーに切り替えて共通化しました。
- `DebugScene` に再構築向けの ImGui パネルを追加して、モデルパス入力、`Reload Test Model`、`Play Reconstruction` ボタン、および `F10` による再生トリガーを実装し、再生中／完了後の通常モデル表示切替制御を行えるようにしました（GamePlayScene / Enemy へは接続していません）。
- Visual Studio プロジェクト定義（`Project/Ken4lowEngine.vcxproj` と `.filters`）へ新規ファイル群を登録しました（`ModelReconstructionEffect.*`、`Reconstruction*`、`ModelSurfaceSampler.*` 等）。

### Testing
- 実行した自動チェック: `git diff --check` は問題なしでした（成功）。
- Visual Studio プロジェクト XML 構文チェックとして `xml.etree.ElementTree.parse` を用いたパースは `Project/Ken4lowEngine.vcxproj` と `Project/Ken4lowEngine.vcxproj.filters` ともに成功しました（成功）。
- ビルド確認: `msbuild Project/Ken4lowEngine.sln /p:Configuration=Debug /p:Platform=x64 /m` はこの実行環境に `msbuild` が無いため実行できませんでした（未実行）。
- ヘッダ依存の静的構文チェック: `g++ -std=c++20 -fsyntax-only ...` を試行しましたが、Windows の DirectX ヘッダ（例: `d3d12.h`）がこの環境に無いため実行できませんでした（未完了）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe0bc22044832d8544eb8782c16af1)