### PR TITLE
Add ModelBlockEffectSequence and DebugScene ImGui controls

### DIFF
--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelBlockEffectSequence.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelBlockEffectSequence.cpp
@@ -1,0 +1,247 @@
+#define NOMINMAX
+#include "ModelBlockEffectSequence.h"
+
+#include "ModelDisintegrationEffect.h"
+#include "ModelReconstructionEffect.h"
+
+#include <algorithm>
+
+void ModelBlockEffectSequence::Initialize(ModelReconstructionEffect* reconstructionEffect, ModelDisintegrationEffect* disintegrationEffect)
+{
+	reconstructionEffect_ = reconstructionEffect;
+	disintegrationEffect_ = disintegrationEffect;
+	Reset();
+}
+
+void ModelBlockEffectSequence::PlaySpawnThenDisintegrate(const std::string& modelPath, const K4E::Matrix4x4& worldMatrix)
+{
+	Begin(modelPath, worldMatrix, SequenceMode::SpawnThenDisintegrate, parameters_.loopEnabled);
+	StartReconstruction();
+}
+
+void ModelBlockEffectSequence::PlayDisintegrateThenReconstruct(const std::string& modelPath, const K4E::Matrix4x4& worldMatrix)
+{
+	Begin(modelPath, worldMatrix, SequenceMode::DisintegrateThenReconstruct, parameters_.loopEnabled);
+	modelVisible_ = true;
+	StartDisintegration();
+}
+
+void ModelBlockEffectSequence::PlayLoop(const std::string& modelPath, const K4E::Matrix4x4& worldMatrix)
+{
+	Begin(modelPath, worldMatrix, SequenceMode::SpawnThenDisintegrate, true);
+	StartReconstruction();
+}
+
+void ModelBlockEffectSequence::Stop(bool showModelAfterStop)
+{
+	ResetEffects();
+	modelVisible_ = showModelAfterStop;
+	state_ = SequenceState::Idle;
+	waitingReason_ = WaitingReason::None;
+	sequenceElapsed_ = 0.0f;
+	stateElapsed_ = 0.0f;
+}
+
+void ModelBlockEffectSequence::Reset()
+{
+	ResetEffects();
+	modelVisible_ = true;
+	state_ = SequenceState::Idle;
+	mode_ = SequenceMode::SpawnThenDisintegrate;
+	waitingReason_ = WaitingReason::None;
+	sequenceElapsed_ = 0.0f;
+	stateElapsed_ = 0.0f;
+	reconstructionCompleted_ = false;
+	disintegrationCompleted_ = false;
+}
+
+void ModelBlockEffectSequence::Update(float deltaTime)
+{
+	if (state_ == SequenceState::Idle || state_ == SequenceState::Completed)
+	{
+		return;
+	}
+
+	sequenceElapsed_ += deltaTime;
+	stateElapsed_ += deltaTime;
+
+	if (reconstructionEffect_)
+	{
+		reconstructionEffect_->Update(deltaTime);
+	}
+	if (disintegrationEffect_)
+	{
+		disintegrationEffect_->Update(deltaTime);
+	}
+
+	switch (state_)
+	{
+	case SequenceState::Reconstructing:
+		if (reconstructionEffect_ && reconstructionEffect_->IsComplete())
+		{
+			reconstructionCompleted_ = true;
+			modelVisible_ = true;
+			if (mode_ == SequenceMode::DisintegrateThenReconstruct && !parameters_.loopEnabled)
+			{
+				ResetEffects();
+				EnterState(SequenceState::Completed);
+			}
+			else
+			{
+				EnterState(SequenceState::ShowingModel);
+			}
+		}
+		break;
+	case SequenceState::ShowingModel:
+		if (stateElapsed_ >= std::max(parameters_.showDuration, 0.0f))
+		{
+			StartDisintegration();
+		}
+		break;
+	case SequenceState::Disintegrating:
+		if (disintegrationEffect_ && !disintegrationEffect_->IsActive())
+		{
+			disintegrationCompleted_ = true;
+			modelVisible_ = false;
+			if (mode_ == SequenceMode::DisintegrateThenReconstruct)
+			{
+				waitingReason_ = WaitingReason::BeforeReconstruct;
+				EnterState(SequenceState::Waiting);
+			}
+			else
+			{
+				CompleteOrLoop();
+			}
+		}
+		break;
+	case SequenceState::Waiting:
+		if (stateElapsed_ >= std::max(parameters_.waitDuration, 0.0f))
+		{
+			if (waitingReason_ == WaitingReason::BeforeReconstruct)
+			{
+				StartReconstruction();
+			}
+			else if (waitingReason_ == WaitingReason::BeforeLoopRestart)
+			{
+				StartReconstruction();
+			}
+		}
+		break;
+	default:
+		break;
+	}
+}
+
+const char* ModelBlockEffectSequence::GetStateName() const
+{
+	switch (state_)
+	{
+	case SequenceState::Idle: return "Idle";
+	case SequenceState::Reconstructing: return "Reconstructing";
+	case SequenceState::ShowingModel: return "ShowingModel";
+	case SequenceState::Disintegrating: return "Disintegrating";
+	case SequenceState::Waiting: return "Waiting";
+	case SequenceState::Completed: return "Completed";
+	default: return "Unknown";
+	}
+}
+
+void ModelBlockEffectSequence::Begin(const std::string& modelPath, const K4E::Matrix4x4& worldMatrix, SequenceMode mode, bool loopEnabled)
+{
+	modelPath_ = modelPath;
+	worldMatrix_ = worldMatrix;
+	mode_ = mode;
+	parameters_.loopEnabled = loopEnabled;
+	sequenceElapsed_ = 0.0f;
+	stateElapsed_ = 0.0f;
+	reconstructionCompleted_ = false;
+	disintegrationCompleted_ = false;
+	waitingReason_ = WaitingReason::None;
+	ResetEffects();
+	ApplySharedParameters();
+	modelVisible_ = false;
+}
+
+void ModelBlockEffectSequence::ResetEffects()
+{
+	if (reconstructionEffect_)
+	{
+		reconstructionEffect_->Initialize();
+	}
+	if (disintegrationEffect_)
+	{
+		disintegrationEffect_->Initialize();
+	}
+}
+
+void ModelBlockEffectSequence::ApplySharedParameters()
+{
+	if (reconstructionEffect_)
+	{
+		auto& reconstructionParams = reconstructionEffect_->GetParameters();
+		reconstructionParams.blockCount = parameters_.blockCount;
+		reconstructionParams.blockSize = parameters_.blockSize;
+		reconstructionParams.surfaceSampling = parameters_.surfaceSampling;
+		reconstructionParams.showFinalModel = false;
+		reconstructionParams.autoHideBlocksAfterComplete = true;
+	}
+
+	if (disintegrationEffect_)
+	{
+		auto& disintegrationParams = disintegrationEffect_->GetParameters();
+		disintegrationParams.particleCount = parameters_.blockCount;
+		disintegrationParams.particleSize = parameters_.blockSize;
+		disintegrationParams.blockSize = parameters_.blockSize;
+		disintegrationParams.surfaceSampling = parameters_.surfaceSampling;
+	}
+}
+
+void ModelBlockEffectSequence::StartReconstruction()
+{
+	ResetEffects();
+	ApplySharedParameters();
+	modelVisible_ = false;
+	reconstructionCompleted_ = false;
+	waitingReason_ = WaitingReason::None;
+	EnterState(SequenceState::Reconstructing);
+	if (reconstructionEffect_)
+	{
+		// 再構築中は通常モデルを隠し、ブロックだけで登場演出を確認する。
+		reconstructionEffect_->PlayFromModel(modelPath_, worldMatrix_);
+	}
+}
+
+void ModelBlockEffectSequence::StartDisintegration()
+{
+	ResetEffects();
+	ApplySharedParameters();
+	modelVisible_ = false;
+	disintegrationCompleted_ = false;
+	waitingReason_ = WaitingReason::None;
+	EnterState(SequenceState::Disintegrating);
+	if (disintegrationEffect_)
+	{
+		disintegrationEffect_->PlayFromModel(modelPath_, worldMatrix_);
+	}
+}
+
+void ModelBlockEffectSequence::EnterState(SequenceState nextState)
+{
+	state_ = nextState;
+	stateElapsed_ = 0.0f;
+}
+
+void ModelBlockEffectSequence::CompleteOrLoop()
+{
+	if (parameters_.loopEnabled)
+	{
+		waitingReason_ = WaitingReason::BeforeLoopRestart;
+		EnterState(SequenceState::Waiting);
+		return;
+	}
+
+	ResetEffects();
+	modelVisible_ = false;
+	waitingReason_ = WaitingReason::None;
+	EnterState(SequenceState::Completed);
+}

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelBlockEffectSequence.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelBlockEffectSequence.h
@@ -1,0 +1,91 @@
+#pragma once
+#include "Matrix4x4.h"
+
+#include <string>
+
+namespace K4E = ::Ken4lowEngine;
+
+class ModelDisintegrationEffect;
+class ModelReconstructionEffect;
+
+/// -------------------------------------------------------------
+/// DebugSceneで崩壊/再構築ブロック演出を連続確認するための小さな管理クラス
+/// -------------------------------------------------------------
+class ModelBlockEffectSequence
+{
+public:
+	enum class SequenceState
+	{
+		Idle,
+		Reconstructing,
+		ShowingModel,
+		Disintegrating,
+		Waiting,
+		Completed,
+	};
+
+	struct Parameters
+	{
+		float showDuration = 1.2f;
+		float waitDuration = 0.8f;
+		bool loopEnabled = false;
+		int blockCount = 1200;
+		float blockSize = 0.045f;
+		bool surfaceSampling = true;
+	};
+
+	void Initialize(ModelReconstructionEffect* reconstructionEffect, ModelDisintegrationEffect* disintegrationEffect);
+	void PlaySpawnThenDisintegrate(const std::string& modelPath, const K4E::Matrix4x4& worldMatrix);
+	void PlayDisintegrateThenReconstruct(const std::string& modelPath, const K4E::Matrix4x4& worldMatrix);
+	void PlayLoop(const std::string& modelPath, const K4E::Matrix4x4& worldMatrix);
+	void Stop(bool showModelAfterStop = false);
+	void Reset();
+	void Update(float deltaTime);
+
+	Parameters& GetParameters() { return parameters_; }
+	const Parameters& GetParameters() const { return parameters_; }
+
+	SequenceState GetState() const { return state_; }
+	const char* GetStateName() const;
+	float GetSequenceElapsed() const { return sequenceElapsed_; }
+	bool IsModelVisible() const { return modelVisible_; }
+	bool IsRunning() const { return state_ != SequenceState::Idle && state_ != SequenceState::Completed; }
+	bool IsReconstructionCompleted() const { return reconstructionCompleted_; }
+	bool IsDisintegrationCompleted() const { return disintegrationCompleted_; }
+
+private:
+	enum class SequenceMode
+	{
+		SpawnThenDisintegrate,
+		DisintegrateThenReconstruct,
+	};
+
+	enum class WaitingReason
+	{
+		None,
+		BeforeReconstruct,
+		BeforeLoopRestart,
+	};
+
+	void Begin(const std::string& modelPath, const K4E::Matrix4x4& worldMatrix, SequenceMode mode, bool loopEnabled);
+	void ResetEffects();
+	void ApplySharedParameters();
+	void StartReconstruction();
+	void StartDisintegration();
+	void EnterState(SequenceState nextState);
+	void CompleteOrLoop();
+
+	ModelReconstructionEffect* reconstructionEffect_ = nullptr;
+	ModelDisintegrationEffect* disintegrationEffect_ = nullptr;
+	Parameters parameters_{};
+	SequenceState state_ = SequenceState::Idle;
+	SequenceMode mode_ = SequenceMode::SpawnThenDisintegrate;
+	WaitingReason waitingReason_ = WaitingReason::None;
+	std::string modelPath_;
+	K4E::Matrix4x4 worldMatrix_{};
+	float sequenceElapsed_ = 0.0f;
+	float stateElapsed_ = 0.0f;
+	bool modelVisible_ = true;
+	bool reconstructionCompleted_ = false;
+	bool disintegrationCompleted_ = false;
+};

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -18,6 +18,7 @@
 #include "WeaponMasterDataDatabase.h"
 #include "WeaponMasterDataEditor.h"
 #include "WeaponMasterDataWriter.h"
+#include <algorithm>
 #include <filesystem>
 #include <cstdio>
 
@@ -139,6 +140,20 @@ void DebugScene::Initialize()
 
 	debugReconstructionEffect_ = std::make_unique<ModelReconstructionEffect>();
 	debugReconstructionEffect_->Initialize();
+
+	debugModelBlockSequenceModel_ = std::make_unique<Object3D>();
+	debugModelBlockSequenceModel_->Initialize(debugModelBlockSequenceModelPath_);
+	debugModelBlockSequenceModel_->SetTranslate(debugModelBlockSequencePosition_);
+	debugModelBlockSequenceModel_->SetRotate(debugModelBlockSequenceRotation_);
+	debugModelBlockSequenceModel_->SetScale(debugModelBlockSequenceScale_);
+	debugModelBlockSequenceModel_->Update();
+
+	debugSequenceDisintegrationEffect_ = std::make_unique<ModelDisintegrationEffect>();
+	debugSequenceDisintegrationEffect_->Initialize();
+	debugSequenceReconstructionEffect_ = std::make_unique<ModelReconstructionEffect>();
+	debugSequenceReconstructionEffect_->Initialize();
+	debugModelBlockSequence_ = std::make_unique<ModelBlockEffectSequence>();
+	debugModelBlockSequence_->Initialize(debugSequenceReconstructionEffect_.get(), debugSequenceDisintegrationEffect_.get());
 }
 
 void DebugScene::Update()
@@ -168,6 +183,8 @@ void DebugScene::Update()
 
 	UpdateDebugReconstructionTest(deltaTime);
 
+	UpdateDebugModelBlockSequence(deltaTime);
+
 	collisionManager_->Update();
 	collisionManager_->CheckAllCollisions();
 
@@ -195,6 +212,21 @@ void DebugScene::Draw3DObjects()
 		debugReconstructionEffect_->Draw();
 	}
 
+	if (debugModelBlockSequence_ && debugModelBlockSequence_->IsModelVisible() && debugModelBlockSequenceModel_)
+	{
+		debugModelBlockSequenceModel_->Draw();
+	}
+
+	if (debugSequenceReconstructionEffect_)
+	{
+		debugSequenceReconstructionEffect_->Draw();
+	}
+
+	if (debugSequenceDisintegrationEffect_)
+	{
+		debugSequenceDisintegrationEffect_->Draw();
+	}
+
 	// ボス描画
 	if (debugBoss_)
 	{
@@ -219,6 +251,11 @@ void DebugScene::DrawShadowObjects()
 	if (debugReconstructionModelVisible_ && debugReconstructionModel_)
 	{
 		debugReconstructionModel_->DrawShadow();
+	}
+
+	if (debugModelBlockSequence_ && debugModelBlockSequence_->IsModelVisible() && debugModelBlockSequenceModel_)
+	{
+		debugModelBlockSequenceModel_->DrawShadow();
 	}
 
 	if (debugBoss_)
@@ -252,6 +289,10 @@ void DebugScene::Finalize()
 	input_->SetLockCursor(false);
 	input_->SetCursorVisible(true);
 
+	debugModelBlockSequence_.reset();
+	debugSequenceReconstructionEffect_.reset();
+	debugSequenceDisintegrationEffect_.reset();
+	debugModelBlockSequenceModel_.reset();
 	debugReconstructionEffect_.reset();
 	debugReconstructionModel_.reset();
 	debugDisintegrationEffect_.reset();
@@ -514,6 +555,90 @@ void DebugScene::DrawImGui()
 		debugReconstructionEffect_->DrawImGui();
 	}
 
+	/// ---------- モデルブロック演出シーケンステスト ---------- ///
+	{
+		static char sequenceModelPathBuffer[256] = "Characters/body.gltf";
+
+		ImGui::Begin("Model Block Effect Sequence");
+		ImGui::TextWrapped("DebugScene-only sequence test for Reconstruction -> Model -> Disintegration and Disintegration -> Reconstruction flows.");
+		ImGui::InputText("Model Path##BlockSequence", sequenceModelPathBuffer, IM_ARRAYSIZE(sequenceModelPathBuffer));
+		ImGui::DragFloat3("Position##BlockSequence", &debugModelBlockSequencePosition_.x, 0.05f);
+		ImGui::DragFloat3("Rotation##BlockSequence", &debugModelBlockSequenceRotation_.x, 0.01f);
+		ImGui::DragFloat3("Scale##BlockSequence", &debugModelBlockSequenceScale_.x, 0.01f, 0.01f, 10.0f);
+
+		if (debugModelBlockSequence_)
+		{
+			auto& sequenceParams = debugModelBlockSequence_->GetParameters();
+			ImGui::DragFloat("showDuration", &sequenceParams.showDuration, 0.05f, 0.0f, 10.0f);
+			ImGui::DragFloat("waitDuration", &sequenceParams.waitDuration, 0.05f, 0.0f, 10.0f);
+			ImGui::Checkbox("loopEnabled", &sequenceParams.loopEnabled);
+			ImGui::SliderInt("blockCount##BlockSequence", &sequenceParams.blockCount, 32, 8000);
+			if (ImGui::SliderFloat("blockSize##BlockSequence", &sequenceParams.blockSize, 0.005f, 0.30f))
+			{
+				sequenceParams.blockSize = std::max(sequenceParams.blockSize, 0.005f);
+			}
+			ImGui::Checkbox("surfaceSampling##BlockSequence", &sequenceParams.surfaceSampling);
+
+			if (ImGui::Button("Reload Model##BlockSequence"))
+			{
+				debugModelBlockSequenceModelPath_ = sequenceModelPathBuffer;
+				ReloadDebugModelBlockSequenceModel();
+			}
+
+			if (ImGui::Button("Play Spawn Then Disintegrate"))
+			{
+				debugModelBlockSequenceModelPath_ = sequenceModelPathBuffer;
+				ReloadDebugModelBlockSequenceModel();
+				debugModelBlockSequence_->PlaySpawnThenDisintegrate(debugModelBlockSequenceModelPath_, MakeDebugModelBlockSequenceWorldMatrix());
+				debugModelBlockSequenceLog_ = "Play Spawn Then Disintegrate: " + debugModelBlockSequenceModelPath_;
+				DebugLog(debugModelBlockSequenceLog_);
+			}
+
+			if (ImGui::Button("Play Disintegrate Then Reconstruct"))
+			{
+				debugModelBlockSequenceModelPath_ = sequenceModelPathBuffer;
+				ReloadDebugModelBlockSequenceModel();
+				debugModelBlockSequence_->PlayDisintegrateThenReconstruct(debugModelBlockSequenceModelPath_, MakeDebugModelBlockSequenceWorldMatrix());
+				debugModelBlockSequenceLog_ = "Play Disintegrate Then Reconstruct: " + debugModelBlockSequenceModelPath_;
+				DebugLog(debugModelBlockSequenceLog_);
+			}
+
+			if (ImGui::Button("Play Loop"))
+			{
+				debugModelBlockSequenceModelPath_ = sequenceModelPathBuffer;
+				ReloadDebugModelBlockSequenceModel();
+				debugModelBlockSequence_->PlayLoop(debugModelBlockSequenceModelPath_, MakeDebugModelBlockSequenceWorldMatrix());
+				debugModelBlockSequenceLog_ = "Play Loop: " + debugModelBlockSequenceModelPath_;
+				DebugLog(debugModelBlockSequenceLog_);
+			}
+
+			ImGui::SameLine();
+			if (ImGui::Button("Stop"))
+			{
+				debugModelBlockSequence_->Stop(false);
+				debugModelBlockSequenceLog_ = "Sequence stopped.";
+				DebugLog(debugModelBlockSequenceLog_);
+			}
+
+			ImGui::SameLine();
+			if (ImGui::Button("Reset"))
+			{
+				debugModelBlockSequence_->Reset();
+				debugModelBlockSequenceLog_ = "Sequence reset.";
+				DebugLog(debugModelBlockSequenceLog_);
+			}
+
+			ImGui::Separator();
+			ImGui::Text("currentState: %s", debugModelBlockSequence_->GetStateName());
+			ImGui::Text("sequenceElapsed: %.2f", debugModelBlockSequence_->GetSequenceElapsed());
+			ImGui::Text("reconstructionCompleted: %s", debugModelBlockSequence_->IsReconstructionCompleted() ? "true" : "false");
+			ImGui::Text("disintegrationCompleted: %s", debugModelBlockSequence_->IsDisintegrationCompleted() ? "true" : "false");
+			ImGui::Text("Model Visible: %s", debugModelBlockSequence_->IsModelVisible() ? "true" : "false");
+		}
+		ImGui::TextWrapped("%s", debugModelBlockSequenceLog_.c_str());
+		ImGui::End();
+	}
+
 	/// ---------- 武器マスターデータエディタ ---------- ///
 	static WeaponMasterDataDatabase weaponDB;
 	static WeaponMasterDataEditor weaponEditor;
@@ -663,6 +788,42 @@ void DebugScene::ReloadDebugReconstructionModel()
 	debugReconstructionModelVisible_ = true;
 	debugReconstructionLog_ = "Reloaded reconstruction test model: " + debugReconstructionModelPath_;
 	DebugLog(debugReconstructionLog_);
+}
+
+void DebugScene::UpdateDebugModelBlockSequence(float deltaTime)
+{
+	if (debugModelBlockSequenceModel_)
+	{
+		debugModelBlockSequenceModel_->SetTranslate(debugModelBlockSequencePosition_);
+		debugModelBlockSequenceModel_->SetRotate(debugModelBlockSequenceRotation_);
+		debugModelBlockSequenceModel_->SetScale(debugModelBlockSequenceScale_);
+		debugModelBlockSequenceModel_->Update();
+	}
+
+	if (debugModelBlockSequence_)
+	{
+		debugModelBlockSequence_->Update(deltaTime);
+	}
+}
+
+void DebugScene::ReloadDebugModelBlockSequenceModel()
+{
+	debugModelBlockSequenceModel_ = std::make_unique<Object3D>();
+	debugModelBlockSequenceModel_->Initialize(debugModelBlockSequenceModelPath_);
+	debugModelBlockSequenceModel_->SetTranslate(debugModelBlockSequencePosition_);
+	debugModelBlockSequenceModel_->SetRotate(debugModelBlockSequenceRotation_);
+	debugModelBlockSequenceModel_->SetScale(debugModelBlockSequenceScale_);
+	debugModelBlockSequenceModel_->Update();
+	debugModelBlockSequenceLog_ = "Reloaded sequence test model: " + debugModelBlockSequenceModelPath_;
+	DebugLog(debugModelBlockSequenceLog_);
+}
+
+Matrix4x4 DebugScene::MakeDebugModelBlockSequenceWorldMatrix() const
+{
+	return Matrix4x4::MakeAffineMatrix(
+		debugModelBlockSequenceScale_,
+		debugModelBlockSequenceRotation_,
+		debugModelBlockSequencePosition_);
 }
 
 /// -------------------------------------------------------------

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
@@ -5,6 +5,7 @@
 #include "Enemy.h"
 #include "Player.h"
 #include "Derived/GuardianBoss/GuardianBoss.h"
+#include "Disintegration/ModelBlockEffectSequence.h"
 #include "Disintegration/ModelDisintegrationEffect.h"
 #include "Disintegration/ModelReconstructionEffect.h"
 #include "Object3D.h"
@@ -75,6 +76,15 @@ private: /// ---------- メンバ関数 ---------- ///
 	/// モデル再構築テスト用モデルを読み直す
 	void ReloadDebugReconstructionModel();
 
+	/// モデルブロック演出シーケンスの更新
+	void UpdateDebugModelBlockSequence(float deltaTime);
+
+	/// モデルブロック演出シーケンス用モデルを読み直す
+	void ReloadDebugModelBlockSequenceModel();
+
+	/// モデルブロック演出シーケンスのワールド行列を作成
+	K4E::Matrix4x4 MakeDebugModelBlockSequenceWorldMatrix() const;
+
 	/// -------------------------------------------------------------
 	/// BossHitPart を文字列へ変換
 	/// ログ確認用
@@ -121,5 +131,16 @@ private: /// ---------- メンバ変数 ---------- ///
 	std::string debugReconstructionModelPath_ = "Characters/body.gltf";
 	std::string debugReconstructionLog_ = "Press F10 or the ImGui button to play.";
 	bool debugReconstructionModelVisible_ = true;
+
+	// --- モデルブロック演出シーケンステスト用 ---
+	std::unique_ptr<K4E::Object3D> debugModelBlockSequenceModel_;
+	std::unique_ptr<ModelDisintegrationEffect> debugSequenceDisintegrationEffect_;
+	std::unique_ptr<ModelReconstructionEffect> debugSequenceReconstructionEffect_;
+	std::unique_ptr<ModelBlockEffectSequence> debugModelBlockSequence_;
+	K4E::Vector3 debugModelBlockSequencePosition_{ 0.0f, 2.25f, 18.0f };
+	K4E::Vector3 debugModelBlockSequenceRotation_{ 0.0f, 0.0f, 0.0f };
+	K4E::Vector3 debugModelBlockSequenceScale_{ 1.0f, 1.0f, 1.0f };
+	std::string debugModelBlockSequenceModelPath_ = "Characters/body.gltf";
+	std::string debugModelBlockSequenceLog_ = "Use the ImGui sequence buttons to play.";
 };
 

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -181,6 +181,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     </ClCompile>
     <ClCompile Include="ApplicationLayer\EffectLayer\Disintegration\DisintegrationEmitter.cpp" />
     <ClCompile Include="ApplicationLayer\EffectLayer\Disintegration\DisintegrationRenderer.cpp" />
+    <ClCompile Include="ApplicationLayer\EffectLayer\Disintegration\ModelBlockEffectSequence.cpp" />
     <ClCompile Include="ApplicationLayer\EffectLayer\Disintegration\ModelDisintegrationEffect.cpp" />
     <ClCompile Include="ApplicationLayer\EffectLayer\Disintegration\ModelReconstructionEffect.cpp" />
     <ClCompile Include="ApplicationLayer\EffectLayer\Disintegration\ReconstructionRenderer.cpp" />
@@ -820,6 +821,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\DisintegrationEmitter.h" />
     <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\DisintegrationParticle.h" />
     <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\DisintegrationRenderer.h" />
+    <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\ModelBlockEffectSequence.h" />
     <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\ModelDisintegrationEffect.h" />
     <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\ModelReconstructionEffect.h" />
     <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\ReconstructionRenderer.h" />

--- a/Project/Ken4lowEngine.vcxproj.filters
+++ b/Project/Ken4lowEngine.vcxproj.filters
@@ -175,6 +175,9 @@
     <ClCompile Include="ApplicationLayer\EffectLayer\Disintegration\DisintegrationRenderer.cpp">
       <Filter>ApplicationLayer\EffectLayer</Filter>
     </ClCompile>
+    <ClCompile Include="ApplicationLayer\EffectLayer\Disintegration\ModelBlockEffectSequence.cpp">
+      <Filter>ApplicationLayer\EffectLayer</Filter>
+    </ClCompile>
     <ClCompile Include="ApplicationLayer\EffectLayer\Disintegration\ModelDisintegrationEffect.cpp">
       <Filter>ApplicationLayer\EffectLayer</Filter>
     </ClCompile>
@@ -901,6 +904,9 @@
       <Filter>ApplicationLayer\EffectLayer</Filter>
     </ClInclude>
     <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\DisintegrationRenderer.h">
+      <Filter>ApplicationLayer\EffectLayer</Filter>
+    </ClInclude>
+    <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\ModelBlockEffectSequence.h">
       <Filter>ApplicationLayer\EffectLayer</Filter>
     </ClInclude>
     <ClInclude Include="ApplicationLayer\EffectLayer\Disintegration\ModelDisintegrationEffect.h">


### PR DESCRIPTION
### Motivation
- Provide a DebugScene-only sequence controller to play `ModelReconstructionEffect` and `ModelDisintegrationEffect` back-to-back so flows like “Spawn → Show → Disintegrate” and “Disintegrate → Wait → Reconstruct” can be validated.
- Allow loop testing, adjustable wait/show durations, current-phase display, and stop/reset controls while avoiding interference with existing single-effect debug buttons.
- Keep the change local to `DebugScene` and do not connect to `GamePlayScene` or enemy/gameplay logic.

### Description
- Add `ModelBlockEffectSequence` (`Project/ApplicationLayer/EffectLayer/Disintegration/ModelBlockEffectSequence.h/.cpp`) that implements `SequenceState`, `Parameters`, `PlaySpawnThenDisintegrate`, `PlayDisintegrateThenReconstruct`, `PlayLoop`, `Stop`, `Reset`, and `Update`, and propagates shared `blockCount/blockSize/surfaceSampling` to both effects.
- Integrate the sequence into `DebugScene` by adding separate instances `debugModelBlockSequence_`, `debugSequenceReconstructionEffect_`, `debugSequenceDisintegrationEffect_` and a dedicated `debugModelBlockSequenceModel_`, and wire them into initialization, `Update`, `Draw3DObjects`/`DrawShadowObjects`, and finalization so single-effect tests remain independent.
- Add an ImGui panel `Model Block Effect Sequence` in `DebugScene::DrawImGui` with controls and buttons for `showDuration`, `waitDuration`, `loopEnabled`, `blockCount`, `blockSize`, `surfaceSampling`, `Play Spawn Then Disintegrate`, `Play Disintegrate Then Reconstruct`, `Play Loop`, `Stop`, `Reset`, and diagnostic displays for `currentState`, `sequenceElapsed`, `reconstructionCompleted`, `disintegrationCompleted`, and model visibility.
- Register the new source and header in Visual Studio project files (`Project/Ken4lowEngine.vcxproj` and `Project/Ken4lowEngine.vcxproj.filters`) and ensure the sequence resets both effects on start/stop to avoid concurrent-play conflicts.

### Testing
- Ran `git diff --check` to catch whitespace and diff errors and it succeeded with no reported issues.
- Parsed `Project/Ken4lowEngine.vcxproj` and `Project/Ken4lowEngine.vcxproj.filters` using Python `xml.etree.ElementTree` to validate the modified project files and parsing completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe0ee0b4a0832d9edfd028bdaad1d9)