### PR TITLE
Defer Debug ImGui actions to Update; avoid releasing SRVs during draw

### DIFF
--- a/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationRenderer.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationRenderer.cpp
@@ -194,7 +194,15 @@ void DisintegrationRenderer::EnsureInstanceCapacity(size_t requiredCapacity)
 {
 	if (requiredCapacity <= instanceCapacity_) { return; }
 
-	ReleaseSrv();
+	if (instanceBuffer_)
+	{
+		retiredInstanceBuffers_.push_back(instanceBuffer_);
+	}
+	if (srvIndex_ != UINT32_MAX)
+	{
+		retiredSrvIndices_.push_back(srvIndex_);
+		srvIndex_ = UINT32_MAX;
+	}
 	instanceCapacity_ = std::max(requiredCapacity, instanceCapacity_ * 2 + 1);
 	auto* device = K4E::DirectXCommon::GetInstance()->GetDevice();
 	instanceBuffer_ = K4E::ResourceManager::CreateBufferResource(device, sizeof(InstanceData) * instanceCapacity_);
@@ -217,6 +225,12 @@ void DisintegrationRenderer::ReleaseSrv()
 		K4E::SRVManager::GetInstance()->Free(srvIndex_);
 		srvIndex_ = UINT32_MAX;
 	}
+	for (uint32_t retiredSrvIndex : retiredSrvIndices_)
+	{
+		K4E::SRVManager::GetInstance()->Free(retiredSrvIndex);
+	}
+	retiredSrvIndices_.clear();
+	retiredInstanceBuffers_.clear();
 	instanceData_ = nullptr;
 	instanceBuffer_.Reset();
 	instanceCapacity_ = 0;

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationRenderer.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationRenderer.h
@@ -47,6 +47,8 @@ private:
 	Microsoft::WRL::ComPtr<ID3D12Resource> indexBuffer_;
 	Microsoft::WRL::ComPtr<ID3D12Resource> instanceBuffer_;
 	Microsoft::WRL::ComPtr<ID3D12Resource> viewProjectionBuffer_;
+	std::vector<Microsoft::WRL::ComPtr<ID3D12Resource>> retiredInstanceBuffers_;
+	std::vector<uint32_t> retiredSrvIndices_;
 	D3D12_VERTEX_BUFFER_VIEW vertexBufferView_{};
 	D3D12_INDEX_BUFFER_VIEW indexBufferView_{};
 	InstanceData* instanceData_ = nullptr;

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionRenderer.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionRenderer.cpp
@@ -194,7 +194,15 @@ void ReconstructionRenderer::EnsureInstanceCapacity(size_t requiredCapacity)
 {
 	if (requiredCapacity <= instanceCapacity_) { return; }
 
-	ReleaseSrv();
+	if (instanceBuffer_)
+	{
+		retiredInstanceBuffers_.push_back(instanceBuffer_);
+	}
+	if (srvIndex_ != UINT32_MAX)
+	{
+		retiredSrvIndices_.push_back(srvIndex_);
+		srvIndex_ = UINT32_MAX;
+	}
 	instanceCapacity_ = std::max(requiredCapacity, instanceCapacity_ * 2 + 1);
 	auto* device = K4E::DirectXCommon::GetInstance()->GetDevice();
 	instanceBuffer_ = K4E::ResourceManager::CreateBufferResource(device, sizeof(InstanceData) * instanceCapacity_);
@@ -217,6 +225,12 @@ void ReconstructionRenderer::ReleaseSrv()
 		K4E::SRVManager::GetInstance()->Free(srvIndex_);
 		srvIndex_ = UINT32_MAX;
 	}
+	for (uint32_t retiredSrvIndex : retiredSrvIndices_)
+	{
+		K4E::SRVManager::GetInstance()->Free(retiredSrvIndex);
+	}
+	retiredSrvIndices_.clear();
+	retiredInstanceBuffers_.clear();
 	instanceData_ = nullptr;
 	instanceBuffer_.Reset();
 	instanceCapacity_ = 0;

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionRenderer.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionRenderer.h
@@ -47,6 +47,8 @@ private:
 	Microsoft::WRL::ComPtr<ID3D12Resource> indexBuffer_;
 	Microsoft::WRL::ComPtr<ID3D12Resource> instanceBuffer_;
 	Microsoft::WRL::ComPtr<ID3D12Resource> viewProjectionBuffer_;
+	std::vector<Microsoft::WRL::ComPtr<ID3D12Resource>> retiredInstanceBuffers_;
+	std::vector<uint32_t> retiredSrvIndices_;
 	D3D12_VERTEX_BUFFER_VIEW vertexBufferView_{};
 	D3D12_INDEX_BUFFER_VIEW indexBufferView_{};
 	InstanceData* instanceData_ = nullptr;

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -496,18 +496,17 @@ void DebugScene::DrawImGui()
 
 		if (ImGui::Button("Reload Test Model"))
 		{
-			debugDisintegrationModelPath_ = modelPathBuffer;
-			debugDisintegrationModel_ = std::make_unique<Object3D>();
-			debugDisintegrationModel_->Initialize(debugDisintegrationModelPath_);
-			debugDisintegrationLog_ = "Reloaded test model: " + debugDisintegrationModelPath_;
-			DebugLog(debugDisintegrationLog_);
+			pendingDebugDisintegrationPath_ = modelPathBuffer;
+			pendingDebugDisintegrationReload_ = true;
+			debugDisintegrationLog_ = "Queued reload test model: " + pendingDebugDisintegrationPath_;
 		}
 
 		ImGui::SameLine();
 		if (ImGui::Button("Play Disintegration"))
 		{
-			debugDisintegrationModelPath_ = modelPathBuffer;
-			PlayDebugDisintegrationEffect();
+			pendingDebugDisintegrationPath_ = modelPathBuffer;
+			pendingDebugDisintegrationPlay_ = true;
+			debugDisintegrationLog_ = "Queued play: " + pendingDebugDisintegrationPath_;
 		}
 
 		ImGui::Text("Model Visible: %s", debugDisintegrationModelVisible_ ? "true" : "false");
@@ -534,15 +533,17 @@ void DebugScene::DrawImGui()
 
 		if (ImGui::Button("Reload Test Model##Reconstruction"))
 		{
-			debugReconstructionModelPath_ = reconstructionModelPathBuffer;
-			ReloadDebugReconstructionModel();
+			pendingDebugReconstructionPath_ = reconstructionModelPathBuffer;
+			pendingDebugReconstructionReload_ = true;
+			debugReconstructionLog_ = "Queued reload reconstruction test model: " + pendingDebugReconstructionPath_;
 		}
 
 		ImGui::SameLine();
 		if (ImGui::Button("Play Reconstruction"))
 		{
-			debugReconstructionModelPath_ = reconstructionModelPathBuffer;
-			PlayDebugReconstructionEffect();
+			pendingDebugReconstructionPath_ = reconstructionModelPathBuffer;
+			pendingDebugReconstructionPlay_ = true;
+			debugReconstructionLog_ = "Queued play reconstruction: " + pendingDebugReconstructionPath_;
 		}
 
 		ImGui::Text("Model Visible: %s", debugReconstructionModelVisible_ ? "true" : "false");
@@ -581,51 +582,44 @@ void DebugScene::DrawImGui()
 
 			if (ImGui::Button("Reload Model##BlockSequence"))
 			{
-				debugModelBlockSequenceModelPath_ = sequenceModelPathBuffer;
-				ReloadDebugModelBlockSequenceModel();
+				pendingDebugModelBlockSequencePath_ = sequenceModelPathBuffer;
+				debugModelBlockSequenceRequest_ = DebugModelBlockSequenceRequest::Reload;
+				debugModelBlockSequenceLog_ = "Queued sequence model reload: " + pendingDebugModelBlockSequencePath_;
 			}
 
 			if (ImGui::Button("Play Spawn Then Disintegrate"))
 			{
-				debugModelBlockSequenceModelPath_ = sequenceModelPathBuffer;
-				ReloadDebugModelBlockSequenceModel();
-				debugModelBlockSequence_->PlaySpawnThenDisintegrate(debugModelBlockSequenceModelPath_, MakeDebugModelBlockSequenceWorldMatrix());
-				debugModelBlockSequenceLog_ = "Play Spawn Then Disintegrate: " + debugModelBlockSequenceModelPath_;
-				DebugLog(debugModelBlockSequenceLog_);
+				pendingDebugModelBlockSequencePath_ = sequenceModelPathBuffer;
+				debugModelBlockSequenceRequest_ = DebugModelBlockSequenceRequest::PlaySpawnThenDisintegrate;
+				debugModelBlockSequenceLog_ = "Queued Spawn Then Disintegrate: " + pendingDebugModelBlockSequencePath_;
 			}
 
 			if (ImGui::Button("Play Disintegrate Then Reconstruct"))
 			{
-				debugModelBlockSequenceModelPath_ = sequenceModelPathBuffer;
-				ReloadDebugModelBlockSequenceModel();
-				debugModelBlockSequence_->PlayDisintegrateThenReconstruct(debugModelBlockSequenceModelPath_, MakeDebugModelBlockSequenceWorldMatrix());
-				debugModelBlockSequenceLog_ = "Play Disintegrate Then Reconstruct: " + debugModelBlockSequenceModelPath_;
-				DebugLog(debugModelBlockSequenceLog_);
+				pendingDebugModelBlockSequencePath_ = sequenceModelPathBuffer;
+				debugModelBlockSequenceRequest_ = DebugModelBlockSequenceRequest::PlayDisintegrateThenReconstruct;
+				debugModelBlockSequenceLog_ = "Queued Disintegrate Then Reconstruct: " + pendingDebugModelBlockSequencePath_;
 			}
 
 			if (ImGui::Button("Play Loop"))
 			{
-				debugModelBlockSequenceModelPath_ = sequenceModelPathBuffer;
-				ReloadDebugModelBlockSequenceModel();
-				debugModelBlockSequence_->PlayLoop(debugModelBlockSequenceModelPath_, MakeDebugModelBlockSequenceWorldMatrix());
-				debugModelBlockSequenceLog_ = "Play Loop: " + debugModelBlockSequenceModelPath_;
-				DebugLog(debugModelBlockSequenceLog_);
+				pendingDebugModelBlockSequencePath_ = sequenceModelPathBuffer;
+				debugModelBlockSequenceRequest_ = DebugModelBlockSequenceRequest::PlayLoop;
+				debugModelBlockSequenceLog_ = "Queued Loop: " + pendingDebugModelBlockSequencePath_;
 			}
 
 			ImGui::SameLine();
 			if (ImGui::Button("Stop"))
 			{
-				debugModelBlockSequence_->Stop(false);
-				debugModelBlockSequenceLog_ = "Sequence stopped.";
-				DebugLog(debugModelBlockSequenceLog_);
+				debugModelBlockSequenceRequest_ = DebugModelBlockSequenceRequest::Stop;
+				debugModelBlockSequenceLog_ = "Queued sequence stop.";
 			}
 
 			ImGui::SameLine();
 			if (ImGui::Button("Reset"))
 			{
-				debugModelBlockSequence_->Reset();
-				debugModelBlockSequenceLog_ = "Sequence reset.";
-				DebugLog(debugModelBlockSequenceLog_);
+				debugModelBlockSequenceRequest_ = DebugModelBlockSequenceRequest::Reset;
+				debugModelBlockSequenceLog_ = "Queued sequence reset.";
 			}
 
 			ImGui::Separator();
@@ -733,8 +727,10 @@ void DebugScene::UpdateDebugReconstructionTest(float deltaTime)
 {
 	if (input_ && input_->TriggerKey(DIK_F10))
 	{
-		PlayDebugReconstructionEffect();
+		pendingDebugReconstructionPlay_ = true;
 	}
+
+	ProcessDebugReconstructionRequest();
 
 	if (debugReconstructionModel_)
 	{
@@ -790,8 +786,38 @@ void DebugScene::ReloadDebugReconstructionModel()
 	DebugLog(debugReconstructionLog_);
 }
 
+void DebugScene::ProcessDebugReconstructionRequest()
+{
+	if (!pendingDebugReconstructionReload_ && !pendingDebugReconstructionPlay_)
+	{
+		return;
+	}
+
+	// ImGui からのGPUリソース更新要求は、コマンドリスト記録前のUpdateでだけ実行する。
+	if (!pendingDebugReconstructionPath_.empty())
+	{
+		debugReconstructionModelPath_ = pendingDebugReconstructionPath_;
+	}
+
+	if (pendingDebugReconstructionReload_)
+	{
+		ReloadDebugReconstructionModel();
+	}
+
+	if (pendingDebugReconstructionPlay_)
+	{
+		PlayDebugReconstructionEffect();
+	}
+
+	pendingDebugReconstructionReload_ = false;
+	pendingDebugReconstructionPlay_ = false;
+	pendingDebugReconstructionPath_.clear();
+}
+
 void DebugScene::UpdateDebugModelBlockSequence(float deltaTime)
 {
+	ProcessDebugModelBlockSequenceRequest();
+
 	if (debugModelBlockSequenceModel_)
 	{
 		debugModelBlockSequenceModel_->SetTranslate(debugModelBlockSequencePosition_);
@@ -816,6 +842,66 @@ void DebugScene::ReloadDebugModelBlockSequenceModel()
 	debugModelBlockSequenceModel_->Update();
 	debugModelBlockSequenceLog_ = "Reloaded sequence test model: " + debugModelBlockSequenceModelPath_;
 	DebugLog(debugModelBlockSequenceLog_);
+}
+
+void DebugScene::ProcessDebugModelBlockSequenceRequest()
+{
+	if (debugModelBlockSequenceRequest_ == DebugModelBlockSequenceRequest::None)
+	{
+		return;
+	}
+
+	if (!pendingDebugModelBlockSequencePath_.empty())
+	{
+		debugModelBlockSequenceModelPath_ = pendingDebugModelBlockSequencePath_;
+	}
+
+	const DebugModelBlockSequenceRequest request = debugModelBlockSequenceRequest_;
+	debugModelBlockSequenceRequest_ = DebugModelBlockSequenceRequest::None;
+	pendingDebugModelBlockSequencePath_.clear();
+
+	if (!debugModelBlockSequence_)
+	{
+		return;
+	}
+
+	switch (request)
+	{
+	case DebugModelBlockSequenceRequest::Reload:
+		ReloadDebugModelBlockSequenceModel();
+		break;
+	case DebugModelBlockSequenceRequest::PlaySpawnThenDisintegrate:
+		ReloadDebugModelBlockSequenceModel();
+		debugModelBlockSequence_->PlaySpawnThenDisintegrate(debugModelBlockSequenceModelPath_, MakeDebugModelBlockSequenceWorldMatrix());
+		debugModelBlockSequenceLog_ = "Play Spawn Then Disintegrate: " + debugModelBlockSequenceModelPath_;
+		DebugLog(debugModelBlockSequenceLog_);
+		break;
+	case DebugModelBlockSequenceRequest::PlayDisintegrateThenReconstruct:
+		ReloadDebugModelBlockSequenceModel();
+		debugModelBlockSequence_->PlayDisintegrateThenReconstruct(debugModelBlockSequenceModelPath_, MakeDebugModelBlockSequenceWorldMatrix());
+		debugModelBlockSequenceLog_ = "Play Disintegrate Then Reconstruct: " + debugModelBlockSequenceModelPath_;
+		DebugLog(debugModelBlockSequenceLog_);
+		break;
+	case DebugModelBlockSequenceRequest::PlayLoop:
+		ReloadDebugModelBlockSequenceModel();
+		debugModelBlockSequence_->PlayLoop(debugModelBlockSequenceModelPath_, MakeDebugModelBlockSequenceWorldMatrix());
+		debugModelBlockSequenceLog_ = "Play Loop: " + debugModelBlockSequenceModelPath_;
+		DebugLog(debugModelBlockSequenceLog_);
+		break;
+	case DebugModelBlockSequenceRequest::Stop:
+		debugModelBlockSequence_->Stop(false);
+		debugModelBlockSequenceLog_ = "Sequence stopped.";
+		DebugLog(debugModelBlockSequenceLog_);
+		break;
+	case DebugModelBlockSequenceRequest::Reset:
+		debugModelBlockSequence_->Reset();
+		debugModelBlockSequenceLog_ = "Sequence reset.";
+		DebugLog(debugModelBlockSequenceLog_);
+		break;
+	case DebugModelBlockSequenceRequest::None:
+	default:
+		break;
+	}
 }
 
 Matrix4x4 DebugScene::MakeDebugModelBlockSequenceWorldMatrix() const
@@ -987,8 +1073,10 @@ void DebugScene::UpdateDebugDisintegrationTest(float deltaTime)
 {
 	if (input_ && input_->TriggerKey(DIK_F9))
 	{
-		PlayDebugDisintegrationEffect();
+		pendingDebugDisintegrationPlay_ = true;
 	}
+
+	ProcessDebugDisintegrationRequest();
 
 	if (debugDisintegrationModel_)
 	{
@@ -1003,6 +1091,46 @@ void DebugScene::UpdateDebugDisintegrationTest(float deltaTime)
 		debugDisintegrationEffect_->Update(deltaTime);
 		debugDisintegrationModelVisible_ = !debugDisintegrationEffect_->IsActive();
 	}
+}
+
+void DebugScene::ReloadDebugDisintegrationModel()
+{
+	debugDisintegrationModel_ = std::make_unique<Object3D>();
+	debugDisintegrationModel_->Initialize(debugDisintegrationModelPath_);
+	debugDisintegrationModel_->SetTranslate(debugDisintegrationPosition_);
+	debugDisintegrationModel_->SetRotate(debugDisintegrationRotation_);
+	debugDisintegrationModel_->SetScale(debugDisintegrationScale_);
+	debugDisintegrationModel_->Update();
+	debugDisintegrationModelVisible_ = true;
+	debugDisintegrationLog_ = "Reloaded test model: " + debugDisintegrationModelPath_;
+	DebugLog(debugDisintegrationLog_);
+}
+
+void DebugScene::ProcessDebugDisintegrationRequest()
+{
+	if (!pendingDebugDisintegrationReload_ && !pendingDebugDisintegrationPlay_)
+	{
+		return;
+	}
+
+	if (!pendingDebugDisintegrationPath_.empty())
+	{
+		debugDisintegrationModelPath_ = pendingDebugDisintegrationPath_;
+	}
+
+	if (pendingDebugDisintegrationReload_)
+	{
+		ReloadDebugDisintegrationModel();
+	}
+
+	if (pendingDebugDisintegrationPlay_)
+	{
+		PlayDebugDisintegrationEffect();
+	}
+
+	pendingDebugDisintegrationReload_ = false;
+	pendingDebugDisintegrationPlay_ = false;
+	pendingDebugDisintegrationPath_.clear();
 }
 
 void DebugScene::PlayDebugDisintegrationEffect()

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
@@ -47,6 +47,19 @@ public: /// ---------- メンバ関数 ---------- ///
 	// ImGui描画処理
 	void DrawImGui() override;
 
+private: /// ---------- 型 ---------- ///
+
+	enum class DebugModelBlockSequenceRequest
+	{
+		None,
+		PlaySpawnThenDisintegrate,
+		PlayDisintegrateThenReconstruct,
+		PlayLoop,
+		Stop,
+		Reset,
+		Reload,
+	};
+
 private: /// ---------- メンバ関数 ---------- ///
 
 	// デバッグカメラの更新
@@ -67,6 +80,12 @@ private: /// ---------- メンバ関数 ---------- ///
 	/// モデル崩壊エフェクトをデバッグ位置で再生
 	void PlayDebugDisintegrationEffect();
 
+	/// モデル崩壊テスト用モデルを読み直す
+	void ReloadDebugDisintegrationModel();
+
+	/// 予約されたモデル崩壊テスト操作を描画前に処理
+	void ProcessDebugDisintegrationRequest();
+
 	/// モデル再構築エフェクトの単体検証更新
 	void UpdateDebugReconstructionTest(float deltaTime);
 
@@ -76,11 +95,17 @@ private: /// ---------- メンバ関数 ---------- ///
 	/// モデル再構築テスト用モデルを読み直す
 	void ReloadDebugReconstructionModel();
 
+	/// 予約されたモデル再構築テスト操作を描画前に処理
+	void ProcessDebugReconstructionRequest();
+
 	/// モデルブロック演出シーケンスの更新
 	void UpdateDebugModelBlockSequence(float deltaTime);
 
 	/// モデルブロック演出シーケンス用モデルを読み直す
 	void ReloadDebugModelBlockSequenceModel();
+
+	/// 予約されたモデルブロック演出シーケンス操作を描画前に処理
+	void ProcessDebugModelBlockSequenceRequest();
 
 	/// モデルブロック演出シーケンスのワールド行列を作成
 	K4E::Matrix4x4 MakeDebugModelBlockSequenceWorldMatrix() const;
@@ -121,6 +146,9 @@ private: /// ---------- メンバ変数 ---------- ///
 	std::string debugDisintegrationModelPath_ = "Characters/body.gltf";
 	std::string debugDisintegrationLog_ = "Press F9 or the ImGui button to play.";
 	bool debugDisintegrationModelVisible_ = true;
+	bool pendingDebugDisintegrationPlay_ = false;
+	bool pendingDebugDisintegrationReload_ = false;
+	std::string pendingDebugDisintegrationPath_;
 
 	// --- モデル再構築エフェクト単体テスト用 ---
 	std::unique_ptr<K4E::Object3D> debugReconstructionModel_;
@@ -131,6 +159,9 @@ private: /// ---------- メンバ変数 ---------- ///
 	std::string debugReconstructionModelPath_ = "Characters/body.gltf";
 	std::string debugReconstructionLog_ = "Press F10 or the ImGui button to play.";
 	bool debugReconstructionModelVisible_ = true;
+	bool pendingDebugReconstructionPlay_ = false;
+	bool pendingDebugReconstructionReload_ = false;
+	std::string pendingDebugReconstructionPath_;
 
 	// --- モデルブロック演出シーケンステスト用 ---
 	std::unique_ptr<K4E::Object3D> debugModelBlockSequenceModel_;
@@ -142,5 +173,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	K4E::Vector3 debugModelBlockSequenceScale_{ 1.0f, 1.0f, 1.0f };
 	std::string debugModelBlockSequenceModelPath_ = "Characters/body.gltf";
 	std::string debugModelBlockSequenceLog_ = "Use the ImGui sequence buttons to play.";
+	DebugModelBlockSequenceRequest debugModelBlockSequenceRequest_ = DebugModelBlockSequenceRequest::None;
+	std::string pendingDebugModelBlockSequencePath_;
 };
 


### PR DESCRIPTION
### Motivation
- Prevent GPU resources (instance buffers / SRVs / Object3D) from being destroyed while a command list that references them is still being recorded by deferring ImGui-triggered play/reload/reset operations to a safe Update-time point before rendering.
- Reduce D3D12 execution errors such as `OBJECT_DELETED_WHILE_STILL_IN_USE` when using the DebugScene controls and the Model Block Effect Sequence.

### Description
- Introduced a request/queue approach for Model Block Effect Sequence by adding `DebugModelBlockSequenceRequest`, `debugModelBlockSequenceRequest_`, and `pendingDebugModelBlockSequencePath_`, and implemented `ProcessDebugModelBlockSequenceRequest()` which is executed from `UpdateDebugModelBlockSequence()` before draw-time.
- Changed the ImGui buttons in `DebugScene::DrawImGui()` for sequence / disintegration / reconstruction tests to only set request flags/paths (e.g. `pendingDebugDisintegrationPlay_`, `pendingDebugReconstructionReload_`, `debugModelBlockSequenceRequest_`) instead of calling play/reload/reset directly.
- Added `ProcessDebugDisintegrationRequest()` and `ProcessDebugReconstructionRequest()` to handle queued Disintegration/Reconstruction requests during `Update()` (before command list recording); added `ReloadDebugDisintegrationModel()` helper for deferred reloads.
- Modified `EnsureInstanceCapacity()` in `DisintegrationRenderer` and `ReconstructionRenderer` to retire old `instanceBuffer_` / SRV indices into `retiredInstanceBuffers_` / `retiredSrvIndices_` rather than freeing them immediately during draw-time, and updated `ReleaseSrv()` to free retired SRVs safely; this avoids freeing resources while they might still be referenced by the GPU.
- Kept an explanatory one-line comment documenting that GPU resource updates from ImGui are executed only in Update (before command-list recording) to clarify intent.

### Testing
- Ran `git diff --check` to ensure no whitespace or diff-check issues and it passed.
- Performed an automated scan verifying `DebugScene::DrawImGui()` no longer contains direct calls to sequence/play/reload functions (Python check) and it passed (`DrawImGui request-only check passed`).
- Attempted to run the solution build with `msbuild Project/Ken4lowEngine.sln /p:Configuration=Debug /p:Platform=x64` but `msbuild` is not available in this Linux container, so an actual build was not executed there (noted in the PR metadata).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe12a02e80832daa4914587969bb73)