### PR TITLE
Add sweep-erosion disintegration effect with glow edge and ImGui controls

### DIFF
--- a/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationEmitter.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationEmitter.cpp
@@ -50,6 +50,7 @@ std::vector<DisintegrationParticle> DisintegrationEmitter::EmitFromModel(
 
 		DisintegrationParticle particle{};
 		particle.initialPosition = sample.position;
+		particle.origin = sample.position;
 		particle.position = sample.position;
 		particle.outward = outward;
 		particle.rotation = {
@@ -73,7 +74,12 @@ std::vector<DisintegrationParticle> DisintegrationEmitter::EmitFromModel(
 		particle.startDelay = RandomRange(0.0f, settings.startDelay);
 		particle.size = settings.particleSize * RandomRange(0.80f, 1.15f);
 		particle.color = color;
+		particle.edgeColor = { 0.0f, 0.0f, 0.0f, 0.0f };
 		particle.alpha = 1.0f;
+		particle.edgeFactor = 0.0f;
+		particle.erosionNoise = 0.5f;
+		particle.sweepCoord = 0.0f;
+		particle.active = true;
 		particle.alive = true;
 		particles.push_back(particle);
 	}

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationParticle.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationParticle.h
@@ -10,6 +10,7 @@ namespace K4E = ::Ken4lowEngine;
 struct DisintegrationParticle
 {
 	K4E::Vector3 initialPosition{};
+	K4E::Vector3 origin{};
 	K4E::Vector3 position{};
 	K4E::Vector3 rotation{};
 	K4E::Vector3 rotationVelocity{};
@@ -17,10 +18,15 @@ struct DisintegrationParticle
 	K4E::Vector3 velocity{};
 	K4E::Vector3 outward{};
 	K4E::Vector4 color{ 0.72f, 0.66f, 0.55f, 1.0f };
+	K4E::Vector4 edgeColor{ 0.0f, 0.0f, 0.0f, 0.0f };
 	float age = 0.0f;
 	float life = 1.0f;
 	float startDelay = 0.0f;
 	float size = 0.04f;
 	float alpha = 1.0f;
+	float edgeFactor = 0.0f;
+	float erosionNoise = 0.5f;
+	float sweepCoord = 0.0f;
+	bool active = true;
 	bool alive = false;
 };

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationRenderer.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationRenderer.cpp
@@ -54,6 +54,9 @@ void DisintegrationRenderer::Draw(const std::vector<DisintegrationParticle>& par
 		if (!particle.alive || particle.alpha <= 0.0f) { continue; }
 
 		K4E::Vector4 color = particle.color;
+		color.x = std::clamp(color.x + particle.edgeColor.x, 0.0f, 1.0f);
+		color.y = std::clamp(color.y + particle.edgeColor.y, 0.0f, 1.0f);
+		color.z = std::clamp(color.z + particle.edgeColor.z, 0.0f, 1.0f);
 		color.w *= particle.alpha;
 		instanceData_[writeIndex].world = MakeWorldMatrix(particle);
 		instanceData_[writeIndex].color = color;

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelBlockEffectSequence.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelBlockEffectSequence.cpp
@@ -193,6 +193,17 @@ void ModelBlockEffectSequence::ApplySharedParameters()
 		disintegrationParams.particleSize = parameters_.blockSize;
 		disintegrationParams.blockSize = parameters_.blockSize;
 		disintegrationParams.surfaceSampling = parameters_.surfaceSampling;
+		disintegrationParams.useSweepErosion = parameters_.useSweepErosion;
+		disintegrationParams.sweepDirection = parameters_.sweepDirection;
+		disintegrationParams.sweepDuration = parameters_.sweepDuration;
+		disintegrationParams.erosionNoisePower = parameters_.erosionNoisePower;
+		disintegrationParams.erosionBandWidth = parameters_.erosionBandWidth;
+		disintegrationParams.preGlowWidth = parameters_.preGlowWidth;
+		disintegrationParams.postGlowWidth = parameters_.postGlowWidth;
+		disintegrationParams.glowEdgeWidth = parameters_.glowEdgeWidth;
+		disintegrationParams.glowIntensity = parameters_.glowIntensity;
+		disintegrationParams.glowSharpness = parameters_.glowSharpness;
+		disintegrationParams.glowColor = parameters_.glowColor;
 	}
 }
 

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelBlockEffectSequence.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelBlockEffectSequence.h
@@ -1,5 +1,7 @@
 #pragma once
 #include "Matrix4x4.h"
+#include "Vector3.h"
+#include "Vector4.h"
 
 #include <string>
 
@@ -32,6 +34,17 @@ public:
 		int blockCount = 1200;
 		float blockSize = 0.045f;
 		bool surfaceSampling = true;
+		bool useSweepErosion = true;
+		K4E::Vector3 sweepDirection{ 1.0f, 0.0f, 0.0f };
+		float sweepDuration = 1.6f;
+		float erosionNoisePower = 0.35f;
+		float erosionBandWidth = 0.10f;
+		float preGlowWidth = 0.20f;
+		float postGlowWidth = 0.16f;
+		float glowEdgeWidth = 0.24f;
+		float glowIntensity = 1.8f;
+		float glowSharpness = 1.6f;
+		K4E::Vector4 glowColor{ 1.0f, 0.55f, 0.18f, 1.0f };
 	};
 
 	void Initialize(ModelReconstructionEffect* reconstructionEffect, ModelDisintegrationEffect* disintegrationEffect);

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelDisintegrationEffect.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelDisintegrationEffect.cpp
@@ -6,6 +6,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 #include <random>
 
 #ifdef USE_IMGUI
@@ -18,6 +19,11 @@ namespace
 	{
 		return std::clamp(value, 0.0f, 1.0f);
 	}
+
+	float Lerp(float a, float b, float t)
+	{
+		return a + (b - a) * t;
+	}
 }
 
 void ModelDisintegrationEffect::Initialize()
@@ -25,6 +31,9 @@ void ModelDisintegrationEffect::Initialize()
 	particles_.clear();
 	isActive_ = false;
 	elapsedTime_ = 0.0f;
+	sweepDirectionNormalized_ = GetSafeSweepDirection();
+	sweepMin_ = 0.0f;
+	sweepMax_ = 0.0f;
 }
 
 void ModelDisintegrationEffect::PlayFromModel(const std::string& modelPath, const K4E::Matrix4x4& worldMatrix)
@@ -45,6 +54,7 @@ void ModelDisintegrationEffect::PlayFromModel(const std::string& modelPath, cons
 	settings.colorVariation = parameters_.colorVariation;
 
 	particles_ = emitter_.EmitFromModel(model->GetModelData(), worldMatrix, settings);
+	InitializeSweepData();
 	isActive_ = !particles_.empty();
 	elapsedTime_ = 0.0f;
 }
@@ -56,48 +66,29 @@ void ModelDisintegrationEffect::Update(float deltaTime)
 	elapsedTime_ += deltaTime;
 	bool anyAlive = false;
 
+	if (parameters_.useSweepErosion)
+	{
+		UpdateSweepErosion();
+	}
+
 	for (auto& particle : particles_)
 	{
 		if (!particle.alive) { continue; }
 
-		particle.age += deltaTime;
-		if (particle.age < particle.startDelay)
+		if (!particle.active)
 		{
-			anyAlive = true;
-			continue;
-		}
-
-		const float activeAge = particle.age - particle.startDelay;
-		if (parameters_.preserveShape && activeAge < parameters_.shapePreserveTime)
-		{
-			// 崩壊開始までは初期位置へ引き戻し、粒子群のシルエットをモデル表面に固定する。
-			particle.velocity *= std::pow(0.08f, deltaTime);
-			particle.position += (particle.initialPosition - particle.position) * Clamp01(deltaTime * 12.0f);
+			particle.position = particle.origin;
+			particle.age = 0.0f;
 			particle.alpha = 1.0f;
 			anyAlive = true;
 			continue;
 		}
 
-		const float disintegrationAge = activeAge - (parameters_.preserveShape ? parameters_.shapePreserveTime : 0.0f);
-		const float disintegrationRate = Clamp01(disintegrationAge / std::max(particle.life, 0.0001f));
-		const K4E::Vector3 noise = RandomNoiseVector() * parameters_.noisePower;
-		const K4E::Vector3 downward = { 0.0f, parameters_.gravity, 0.0f };
-
-		// ブロック粒子を下方向・外方向・ランダム方向へ崩す力として collapsePower をまとめて掛ける。
-		particle.velocity += (particle.outward * parameters_.spreadPower + noise + downward) * parameters_.collapsePower * deltaTime;
-		particle.velocity.y += parameters_.upwardPower * parameters_.collapsePower * deltaTime;
-		particle.position += particle.velocity * deltaTime;
-		particle.rotation += particle.rotationVelocity * parameters_.blockRotationRandomness * deltaTime;
-		particle.size *= std::pow(0.96f, deltaTime);
-		particle.alpha = Clamp01(1.0f - disintegrationRate * parameters_.fadeSpeed);
-
-		if (disintegrationAge >= particle.life || particle.alpha <= 0.0f)
+		UpdateParticlePhysics(particle, deltaTime);
+		if (particle.alive)
 		{
-			particle.alive = false;
-			continue;
+			anyAlive = true;
 		}
-
-		anyAlive = true;
 	}
 
 	if (!anyAlive)
@@ -142,6 +133,18 @@ void ModelDisintegrationEffect::DrawImGui()
 	ImGui::SliderFloat("形状維持時間", &parameters_.shapePreserveTime, 0.0f, 3.0f);
 	ImGui::ColorEdit4("基本色", &parameters_.baseColor.x);
 	ImGui::SliderFloat("色のばらつき", &parameters_.colorVariation, 0.0f, 0.5f);
+	ImGui::SeparatorText("方向侵食");
+	ImGui::Checkbox("方向侵食を使う", &parameters_.useSweepErosion);
+	ImGui::DragFloat3("侵食方向", &parameters_.sweepDirection.x, 0.01f, -1.0f, 1.0f);
+	ImGui::SliderFloat("侵食時間", &parameters_.sweepDuration, 0.05f, 8.0f);
+	ImGui::SliderFloat("侵食ノイズ強度", &parameters_.erosionNoisePower, 0.0f, 4.0f);
+	ImGui::SliderFloat("侵食境界幅", &parameters_.erosionBandWidth, 0.0f, 2.0f);
+	ImGui::SliderFloat("侵食前の発光幅", &parameters_.preGlowWidth, 0.0f, 2.0f);
+	ImGui::SliderFloat("侵食後の発光幅", &parameters_.postGlowWidth, 0.0f, 2.0f);
+	ImGui::SliderFloat("発光エッジ幅", &parameters_.glowEdgeWidth, 0.001f, 2.0f);
+	ImGui::SliderFloat("発光強度", &parameters_.glowIntensity, 0.0f, 8.0f);
+	ImGui::SliderFloat("発光の鋭さ", &parameters_.glowSharpness, 0.1f, 8.0f);
+	ImGui::ColorEdit4("発光色", &parameters_.glowColor.x);
 	ImGui::Text("デバッグキー: F9でCharacters/body.gltfをプレイヤー位置で再生します。");
 	ImGui::End();
 #endif
@@ -152,6 +155,135 @@ K4E::Vector3 ModelDisintegrationEffect::RandomNoiseVector()
 	static std::mt19937 rng{ 0xA5A5D157u };
 	static std::uniform_real_distribution<float> dist{ -1.0f, 1.0f };
 	return K4E::Vector3::NormalizeSafe({ dist(rng), dist(rng), dist(rng) }, { 0.0f, 1.0f, 0.0f });
+}
+
+K4E::Vector3 ModelDisintegrationEffect::GetSafeSweepDirection() const
+{
+	if (K4E::Vector3::LengthSquared(parameters_.sweepDirection) <= 0.000001f)
+	{
+		return { 1.0f, 0.0f, 0.0f };
+	}
+	return K4E::Vector3::Normalize(parameters_.sweepDirection);
+}
+
+float ModelDisintegrationEffect::ErosionNoise(const K4E::Vector3& origin) const
+{
+	const int32_t ix = static_cast<int32_t>(std::floor(origin.x * 73.0f));
+	const int32_t iy = static_cast<int32_t>(std::floor(origin.y * 73.0f));
+	const int32_t iz = static_cast<int32_t>(std::floor(origin.z * 73.0f));
+	uint32_t hash = static_cast<uint32_t>(ix) * 73856093u ^ static_cast<uint32_t>(iy) * 19349663u ^ static_cast<uint32_t>(iz) * 83492791u;
+	hash ^= hash >> 16;
+	hash *= 0x7feb352du;
+	hash ^= hash >> 15;
+	hash *= 0x846ca68bu;
+	hash ^= hash >> 16;
+	return static_cast<float>(hash & 0x00FFFFFFu) / static_cast<float>(0x01000000u);
+}
+
+void ModelDisintegrationEffect::InitializeSweepData()
+{
+	sweepDirectionNormalized_ = GetSafeSweepDirection();
+	sweepMin_ = 0.0f;
+	sweepMax_ = 0.0f;
+	if (particles_.empty()) { return; }
+
+	sweepMin_ = K4E::Vector3::Dot(particles_.front().origin, sweepDirectionNormalized_);
+	sweepMax_ = sweepMin_;
+	for (auto& particle : particles_)
+	{
+		particle.origin = particle.initialPosition;
+		particle.position = particle.origin;
+		particle.age = 0.0f;
+		particle.alpha = 1.0f;
+		particle.edgeFactor = 0.0f;
+		particle.edgeColor = { 0.0f, 0.0f, 0.0f, 0.0f };
+		particle.erosionNoise = ErosionNoise(particle.origin);
+		particle.sweepCoord = K4E::Vector3::Dot(particle.origin, sweepDirectionNormalized_);
+		particle.active = !parameters_.useSweepErosion;
+		particle.alive = true;
+		sweepMin_ = std::min(sweepMin_, particle.sweepCoord);
+		sweepMax_ = std::max(sweepMax_, particle.sweepCoord);
+	}
+}
+
+void ModelDisintegrationEffect::UpdateSweepErosion()
+{
+	const float duration = std::max(parameters_.sweepDuration, 0.0001f);
+	const float t = Clamp01(elapsedTime_ / duration);
+	const float planeCoord = Lerp(sweepMin_, sweepMax_, t);
+	const float glowEdgeWidth = std::max(parameters_.glowEdgeWidth, 0.0001f);
+	const float glowSharpness = std::max(parameters_.glowSharpness, 0.0001f);
+	const float bandPadding = std::max(parameters_.erosionBandWidth, 0.0f) * 0.5f;
+
+	for (auto& particle : particles_)
+	{
+		if (!particle.alive) { continue; }
+
+		const float coordWithNoise = particle.sweepCoord + (particle.erosionNoise - 0.5f) * parameters_.erosionNoisePower;
+		const float signedDistance = planeCoord - coordWithNoise;
+		if (!particle.active && (signedDistance >= 0.0f || t >= 1.0f))
+		{
+			// Sweep Planeを越えた瞬間から、そのブロックだけ物理崩壊へ切り替える。
+			particle.active = true;
+			particle.age = 0.0f;
+			particle.position = particle.origin;
+		}
+
+		if (signedDistance >= -parameters_.preGlowWidth - bandPadding && signedDistance <= parameters_.postGlowWidth + bandPadding)
+		{
+			particle.edgeFactor = std::pow(1.0f - Clamp01(std::abs(signedDistance) / glowEdgeWidth), glowSharpness);
+		}
+		else
+		{
+			particle.edgeFactor = 0.0f;
+		}
+
+		const float glowAmount = particle.edgeFactor * parameters_.glowIntensity;
+		particle.edgeColor = {
+			parameters_.glowColor.x * glowAmount,
+			parameters_.glowColor.y * glowAmount,
+			parameters_.glowColor.z * glowAmount,
+			0.0f,
+		};
+	}
+}
+
+void ModelDisintegrationEffect::UpdateParticlePhysics(DisintegrationParticle& particle, float deltaTime)
+{
+	particle.age += deltaTime;
+	if (particle.age < particle.startDelay)
+	{
+		particle.position = parameters_.useSweepErosion ? particle.origin : particle.position;
+		return;
+	}
+
+	const float activeAge = particle.age - particle.startDelay;
+	if (parameters_.preserveShape && activeAge < parameters_.shapePreserveTime)
+	{
+		// 崩壊開始までは初期位置へ引き戻し、粒子群のシルエットをモデル表面に固定する。
+		particle.velocity *= std::pow(0.08f, deltaTime);
+		particle.position += (particle.origin - particle.position) * Clamp01(deltaTime * 12.0f);
+		particle.alpha = 1.0f;
+		return;
+	}
+
+	const float disintegrationAge = activeAge - (parameters_.preserveShape ? parameters_.shapePreserveTime : 0.0f);
+	const float disintegrationRate = Clamp01(disintegrationAge / std::max(particle.life, 0.0001f));
+	const K4E::Vector3 noise = RandomNoiseVector() * parameters_.noisePower;
+	const K4E::Vector3 downward = { 0.0f, parameters_.gravity, 0.0f };
+
+	// ブロック粒子を下方向・外方向・ランダム方向へ崩す力として collapsePower をまとめて掛ける。
+	particle.velocity += (particle.outward * parameters_.spreadPower + noise + downward) * parameters_.collapsePower * deltaTime;
+	particle.velocity.y += parameters_.upwardPower * parameters_.collapsePower * deltaTime;
+	particle.position += particle.velocity * deltaTime;
+	particle.rotation += particle.rotationVelocity * parameters_.blockRotationRandomness * deltaTime;
+	particle.size *= std::pow(0.96f, deltaTime);
+	particle.alpha = Clamp01(1.0f - disintegrationRate * parameters_.fadeSpeed);
+
+	if (disintegrationAge >= particle.life || particle.alpha <= 0.0f)
+	{
+		particle.alive = false;
+	}
 }
 
 void ModelDisintegrationEffect::StopIfFinished()

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelDisintegrationEffect.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelDisintegrationEffect.h
@@ -3,6 +3,7 @@
 #include "DisintegrationRenderer.h"
 #include "Matrix4x4.h"
 #include "Vector4.h"
+#include "Vector3.h"
 
 #include <string>
 #include <vector>
@@ -33,6 +34,17 @@ public:
 		float shapePreserveTime = 0.60f;
 		K4E::Vector4 baseColor{ 0.64f, 0.61f, 0.56f, 1.0f };
 		float colorVariation = 0.16f;
+		bool useSweepErosion = false;
+		K4E::Vector3 sweepDirection{ 1.0f, 0.0f, 0.0f };
+		float sweepDuration = 1.6f;
+		float erosionNoisePower = 0.35f;
+		float erosionBandWidth = 0.10f;
+		float preGlowWidth = 0.20f;
+		float postGlowWidth = 0.16f;
+		float glowEdgeWidth = 0.24f;
+		float glowIntensity = 1.8f;
+		float glowSharpness = 1.6f;
+		K4E::Vector4 glowColor{ 1.0f, 0.55f, 0.18f, 1.0f };
 	};
 
 	void Initialize();
@@ -47,6 +59,11 @@ public:
 
 private:
 	K4E::Vector3 RandomNoiseVector();
+	K4E::Vector3 GetSafeSweepDirection() const;
+	float ErosionNoise(const K4E::Vector3& origin) const;
+	void InitializeSweepData();
+	void UpdateSweepErosion();
+	void UpdateParticlePhysics(DisintegrationParticle& particle, float deltaTime);
 	void StopIfFinished();
 
 	Parameters parameters_{};
@@ -55,4 +72,7 @@ private:
 	std::vector<DisintegrationParticle> particles_{};
 	bool isActive_ = false;
 	float elapsedTime_ = 0.0f;
+	K4E::Vector3 sweepDirectionNormalized_{ 1.0f, 0.0f, 0.0f };
+	float sweepMin_ = 0.0f;
+	float sweepMax_ = 0.0f;
 };

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -580,6 +580,18 @@ void DebugScene::DrawImGui()
 				sequenceParams.blockSize = std::max(sequenceParams.blockSize, 0.005f);
 			}
 			ImGui::Checkbox("表面サンプリング##BlockSequence", &sequenceParams.surfaceSampling);
+			ImGui::SeparatorText("方向侵食崩壊##BlockSequence");
+			ImGui::Checkbox("方向侵食を使う##BlockSequence", &sequenceParams.useSweepErosion);
+			ImGui::DragFloat3("侵食方向##BlockSequence", &sequenceParams.sweepDirection.x, 0.01f, -1.0f, 1.0f);
+			ImGui::SliderFloat("侵食時間##BlockSequence", &sequenceParams.sweepDuration, 0.05f, 8.0f);
+			ImGui::SliderFloat("侵食ノイズ強度##BlockSequence", &sequenceParams.erosionNoisePower, 0.0f, 4.0f);
+			ImGui::SliderFloat("侵食境界幅##BlockSequence", &sequenceParams.erosionBandWidth, 0.0f, 2.0f);
+			ImGui::SliderFloat("侵食前の発光幅##BlockSequence", &sequenceParams.preGlowWidth, 0.0f, 2.0f);
+			ImGui::SliderFloat("侵食後の発光幅##BlockSequence", &sequenceParams.postGlowWidth, 0.0f, 2.0f);
+			ImGui::SliderFloat("発光エッジ幅##BlockSequence", &sequenceParams.glowEdgeWidth, 0.001f, 2.0f);
+			ImGui::SliderFloat("発光強度##BlockSequence", &sequenceParams.glowIntensity, 0.0f, 8.0f);
+			ImGui::SliderFloat("発光の鋭さ##BlockSequence", &sequenceParams.glowSharpness, 0.1f, 8.0f);
+			ImGui::ColorEdit4("発光色##BlockSequence", &sequenceParams.glowColor.x);
 
 			if (ImGui::Button("モデル再読み込み##BlockSequence"))
 			{


### PR DESCRIPTION
### Motivation
- Provide a directional "sweep erosion" mode for ModelDisintegrationEffect so models erode progressively from an arbitrary direction rather than all at once.
- Keep existing immediate-disintegration behavior unchanged when the feature is disabled.
- Allow tuning and visual verification via DebugScene ImGui panels and support using the sequence test (reconstruct → show → sweep erosion).

### Description
- Added per-particle fields to `DisintegrationParticle`: `origin`, `active`, `edgeFactor`, `erosionNoise`, `sweepCoord`, and `edgeColor`, and initialized them in `DisintegrationEmitter::EmitFromModel` so inactive particles can remain statically rendered at their origin.
- Extended `ModelDisintegrationEffect::Parameters` with sweep/erosion and glow settings: `useSweepErosion`, `sweepDirection`, `sweepDuration`, `erosionNoisePower`, `erosionBandWidth`, `preGlowWidth`, `postGlowWidth`, `glowEdgeWidth`, `glowIntensity`, `glowSharpness`, and `glowColor`.
- Implemented sweep logic in `ModelDisintegrationEffect`: compute `sweepMin_`/`sweepMax_` from particle `origin` dot `sweepDirection`, advance a sweep plane over time (`planeCoord`), use a deterministic CPU hash noise per particle (`ErosionNoise`) to make the boundary jagged, mark particles crossing the plane as `active=true`, and cache per-particle erosion noise and sweep coordinate to avoid per-frame rehashing.
- Separated static vs active behavior so `active=false` particles stay fixed at `origin` and only `active=true` particles are updated by the existing physics (velocity, gravity, fade); implemented glow edge calculation (`edgeFactor` → `edgeColor`) for particles near the boundary.
- Updated `DisintegrationRenderer` to add each particle's `edgeColor` into the rendered color so near-boundary particles appear to glow temporarily.
- Propagated sweep parameters from `ModelBlockEffectSequence` to `ModelDisintegrationEffect` and added Japanese ImGui controls for both the single-effect panel and the block-sequence panel to allow tuning and debugging in DebugScene; `useSweepErosion=false` preserves original behavior.

### Testing
- Ran `git diff --check` to validate no whitespace/errors reported by the diff check, which completed successfully.
- Attempted to build the Visual Studio solution but `msbuild` was not available in the Linux container, so a full build was skipped in this environment.
- No automated unit tests were executed as part of this change in the current environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe99b4185c832daf37bcda5bec6b32)