### PR TITLE
Add Disintegration placement modes and ImGui controls

### DIFF
--- a/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationEmitter.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationEmitter.cpp
@@ -22,13 +22,16 @@ std::vector<DisintegrationParticle> DisintegrationEmitter::EmitFromModel(
 	const K4E::Matrix4x4& worldMatrix,
 	const Settings& settings)
 {
+	rng_.seed(settings.placementSeed ^ 0xD157E6A7u);
 	ModelSurfaceSampler sampler;
 	const std::vector<DisintegrationSamplePoint> samples = sampler.SampleFromModel(
 		modelData,
 		worldMatrix,
 		settings.particleCount,
-		settings.surfaceSampling,
-		settings.particleSize * 1.5f);
+		settings.placementMode == DisintegrationPlacementMode::UniformSurface ? true : settings.surfaceSampling,
+		settings.particleSize * 1.5f,
+		settings.placementMode,
+		settings.placementSeed);
 
 	std::vector<DisintegrationParticle> particles;
 	particles.reserve(samples.size());
@@ -53,26 +56,28 @@ std::vector<DisintegrationParticle> DisintegrationEmitter::EmitFromModel(
 		particle.origin = sample.position;
 		particle.position = sample.position;
 		particle.outward = outward;
+		const float rotationRandomness = settings.useRandomRotation ? settings.rotationRandomness : 0.0f;
 		particle.rotation = {
-			RandomRange(-settings.blockRotationRandomness, settings.blockRotationRandomness),
-			RandomRange(-settings.blockRotationRandomness, settings.blockRotationRandomness),
-			RandomRange(-settings.blockRotationRandomness, settings.blockRotationRandomness),
+			RandomRange(-rotationRandomness, rotationRandomness),
+			RandomRange(-rotationRandomness, rotationRandomness),
+			RandomRange(-rotationRandomness, rotationRandomness),
 		};
 		particle.rotationVelocity = {
-			RandomRange(-settings.blockRotationRandomness, settings.blockRotationRandomness),
-			RandomRange(-settings.blockRotationRandomness, settings.blockRotationRandomness),
-			RandomRange(-settings.blockRotationRandomness, settings.blockRotationRandomness),
+			RandomRange(-rotationRandomness, rotationRandomness),
+			RandomRange(-rotationRandomness, rotationRandomness),
+			RandomRange(-rotationRandomness, rotationRandomness),
 		};
+		const float scaleVariation = settings.useRandomScale ? std::max(settings.scaleVariation, 0.0f) : 0.0f;
 		particle.scale = {
-			RandomRange(0.82f, 1.18f),
-			RandomRange(0.82f, 1.18f),
-			RandomRange(0.82f, 1.18f),
+			RandomRange(1.0f - scaleVariation, 1.0f + scaleVariation),
+			RandomRange(1.0f - scaleVariation, 1.0f + scaleVariation),
+			RandomRange(1.0f - scaleVariation, 1.0f + scaleVariation),
 		};
 		particle.velocity = outward * RandomRange(settings.spreadPower * 0.15f, settings.spreadPower * 0.55f);
 		particle.velocity.y += RandomRange(-settings.upwardPower * 0.25f, settings.upwardPower);
 		particle.life = RandomRange(settings.lifeTime * 0.85f, settings.lifeTime * 1.20f);
 		particle.startDelay = RandomRange(0.0f, settings.startDelay);
-		particle.size = settings.particleSize * RandomRange(0.80f, 1.15f);
+		particle.size = settings.particleSize * RandomRange(1.0f - scaleVariation, 1.0f + scaleVariation);
 		particle.color = color;
 		particle.edgeColor = { 0.0f, 0.0f, 0.0f, 0.0f };
 		particle.alpha = 1.0f;

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationEmitter.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationEmitter.h
@@ -5,6 +5,7 @@
 #include "ModelData.h"
 #include "Vector4.h"
 
+#include <cstdint>
 #include <random>
 #include <vector>
 
@@ -19,6 +20,12 @@ public:
 		int particleCount = 1200;
 		float particleSize = 0.045f;
 		float blockRotationRandomness = 1.2f;
+		DisintegrationPlacementMode placementMode = DisintegrationPlacementMode::RandomSurface;
+		bool useRandomScale = true;
+		float scaleVariation = 0.18f;
+		bool useRandomRotation = true;
+		float rotationRandomness = 1.2f;
+		uint32_t placementSeed = 0xD157E6A7u;
 		bool surfaceSampling = true;
 		float lifeTime = 2.0f;
 		float spreadPower = 1.6f;

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelBlockEffectSequence.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelBlockEffectSequence.cpp
@@ -193,6 +193,12 @@ void ModelBlockEffectSequence::ApplySharedParameters()
 		disintegrationParams.particleSize = parameters_.blockSize;
 		disintegrationParams.blockSize = parameters_.blockSize;
 		disintegrationParams.surfaceSampling = parameters_.surfaceSampling;
+		disintegrationParams.placementMode = parameters_.placementMode;
+		disintegrationParams.useRandomScale = parameters_.useRandomScale;
+		disintegrationParams.scaleVariation = parameters_.scaleVariation;
+		disintegrationParams.useRandomRotation = parameters_.useRandomRotation;
+		disintegrationParams.rotationRandomness = parameters_.rotationRandomness;
+		disintegrationParams.placementSeed = parameters_.placementSeed;
 		disintegrationParams.useSweepErosion = parameters_.useSweepErosion;
 		disintegrationParams.sweepDirection = parameters_.sweepDirection;
 		disintegrationParams.sweepDuration = parameters_.sweepDuration;

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelBlockEffectSequence.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelBlockEffectSequence.h
@@ -1,8 +1,10 @@
 #pragma once
+#include "ModelSurfaceSampler.h"
 #include "Matrix4x4.h"
 #include "Vector3.h"
 #include "Vector4.h"
 
+#include <cstdint>
 #include <string>
 
 namespace K4E = ::Ken4lowEngine;
@@ -34,6 +36,12 @@ public:
 		int blockCount = 1200;
 		float blockSize = 0.045f;
 		bool surfaceSampling = true;
+		DisintegrationPlacementMode placementMode = DisintegrationPlacementMode::UniformSurface;
+		bool useRandomScale = false;
+		float scaleVariation = 0.18f;
+		bool useRandomRotation = false;
+		float rotationRandomness = 1.2f;
+		uint32_t placementSeed = 0xD157E6A7u;
 		bool useSweepErosion = true;
 		K4E::Vector3 sweepDirection{ 1.0f, 0.0f, 0.0f };
 		float sweepDuration = 1.6f;

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelDisintegrationEffect.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelDisintegrationEffect.cpp
@@ -44,7 +44,13 @@ void ModelDisintegrationEffect::PlayFromModel(const std::string& modelPath, cons
 	DisintegrationEmitter::Settings settings{};
 	settings.particleCount = parameters_.particleCount;
 	settings.particleSize = parameters_.particleSize;
-	settings.blockRotationRandomness = parameters_.blockRotationRandomness;
+	settings.blockRotationRandomness = parameters_.rotationRandomness;
+	settings.placementMode = parameters_.placementMode;
+	settings.useRandomScale = parameters_.useRandomScale;
+	settings.scaleVariation = parameters_.scaleVariation;
+	settings.useRandomRotation = parameters_.useRandomRotation;
+	settings.rotationRandomness = parameters_.rotationRandomness;
+	settings.placementSeed = parameters_.placementSeed;
 	settings.surfaceSampling = parameters_.surfaceSampling;
 	settings.lifeTime = parameters_.lifeTime;
 	settings.spreadPower = parameters_.spreadPower;
@@ -119,7 +125,28 @@ void ModelDisintegrationEffect::DrawImGui()
 	{
 		parameters_.particleSize = parameters_.blockSize;
 	}
-	ImGui::SliderFloat("ブロック回転ランダム", &parameters_.blockRotationRandomness, 0.0f, 8.0f);
+	const char* placementModeLabels[] = { "ランダム表面配置", "均一表面配置" };
+	int placementModeIndex = parameters_.placementMode == DisintegrationPlacementMode::UniformSurface ? 1 : 0;
+	if (ImGui::Combo("配置モード", &placementModeIndex, placementModeLabels, IM_ARRAYSIZE(placementModeLabels)))
+	{
+		parameters_.placementMode = placementModeIndex == 1 ? DisintegrationPlacementMode::UniformSurface : DisintegrationPlacementMode::RandomSurface;
+	}
+	ImGui::Checkbox("ランダムサイズを使う", &parameters_.useRandomScale);
+	ImGui::SliderFloat("サイズばらつき", &parameters_.scaleVariation, 0.0f, 0.75f);
+	ImGui::Checkbox("ランダム回転を使う", &parameters_.useRandomRotation);
+	if (ImGui::SliderFloat("回転ばらつき", &parameters_.rotationRandomness, 0.0f, 8.0f))
+	{
+		parameters_.blockRotationRandomness = parameters_.rotationRandomness;
+	}
+	int placementSeed = static_cast<int>(parameters_.placementSeed);
+	if (ImGui::InputInt("配置シード", &placementSeed))
+	{
+		parameters_.placementSeed = static_cast<uint32_t>(std::max(placementSeed, 0));
+	}
+	if (parameters_.placementMode == DisintegrationPlacementMode::UniformSurface)
+	{
+		ImGui::TextWrapped("均一表面配置はモデル表面を面積に応じて規則的にサンプルします。Sweep Erosionで形を保って蝕む表現に推奨です。");
+	}
 	ImGui::Checkbox("表面サンプリング", &parameters_.surfaceSampling);
 	ImGui::Checkbox("形状維持", &parameters_.preserveShape);
 	ImGui::SliderFloat("寿命", &parameters_.lifeTime, 0.10f, 8.0f);
@@ -276,7 +303,7 @@ void ModelDisintegrationEffect::UpdateParticlePhysics(DisintegrationParticle& pa
 	particle.velocity += (particle.outward * parameters_.spreadPower + noise + downward) * parameters_.collapsePower * deltaTime;
 	particle.velocity.y += parameters_.upwardPower * parameters_.collapsePower * deltaTime;
 	particle.position += particle.velocity * deltaTime;
-	particle.rotation += particle.rotationVelocity * parameters_.blockRotationRandomness * deltaTime;
+	particle.rotation += particle.rotationVelocity * parameters_.rotationRandomness * deltaTime;
 	particle.size *= std::pow(0.96f, deltaTime);
 	particle.alpha = Clamp01(1.0f - disintegrationRate * parameters_.fadeSpeed);
 

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelDisintegrationEffect.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelDisintegrationEffect.h
@@ -5,6 +5,7 @@
 #include "Vector4.h"
 #include "Vector3.h"
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -21,6 +22,12 @@ public:
 		float particleSize = 0.045f;
 		float blockSize = 0.045f;
 		float blockRotationRandomness = 1.2f;
+		DisintegrationPlacementMode placementMode = DisintegrationPlacementMode::RandomSurface;
+		bool useRandomScale = true;
+		float scaleVariation = 0.18f;
+		bool useRandomRotation = true;
+		float rotationRandomness = 1.2f;
+		uint32_t placementSeed = 0xD157E6A7u;
 		bool surfaceSampling = true;
 		bool preserveShape = true;
 		float lifeTime = 2.2f;

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelSurfaceSampler.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelSurfaceSampler.cpp
@@ -3,6 +3,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <cstdint>
 
 namespace
 {
@@ -31,8 +32,11 @@ std::vector<DisintegrationSamplePoint> ModelSurfaceSampler::SampleFromModel(
 	const K4E::Matrix4x4& worldMatrix,
 	int sampleCount,
 	bool surfaceSampling,
-	float vertexJitterRadius)
+	float vertexJitterRadius,
+	DisintegrationPlacementMode placementMode,
+	uint32_t placementSeed)
 {
+	rng_.seed(placementSeed);
 	std::vector<TriangleSample> triangles;
 	std::vector<VertexSample> vertices;
 	triangles.reserve(1024);
@@ -86,14 +90,18 @@ std::vector<DisintegrationSamplePoint> ModelSurfaceSampler::SampleFromModel(
 	samples.reserve(static_cast<size_t>(std::max(0, sampleCount)));
 	if ((triangles.empty() && vertices.empty()) || sampleCount <= 0) { return samples; }
 
+	const bool useUniformSurface = placementMode == DisintegrationPlacementMode::UniformSurface && !triangles.empty();
+	const bool useTriangleSurface = (surfaceSampling || useUniformSurface) && !triangles.empty();
 	for (int i = 0; i < sampleCount; ++i)
 	{
 		K4E::Vector3 local{};
 		K4E::Vector3 localNormal{ 0.0f, 1.0f, 0.0f };
 
-		if (surfaceSampling && !triangles.empty())
+		if (useTriangleSurface)
 		{
-			const float areaPick = RandomRange(0.0f, totalArea);
+			const float areaPick = useUniformSurface
+				? totalArea * (static_cast<float>(i) + 0.5f) / static_cast<float>(sampleCount)
+				: RandomRange(0.0f, totalArea);
 			auto it = std::lower_bound(
 				triangles.begin(), triangles.end(), areaPick,
 				[](const TriangleSample& tri, float value) { return tri.cumulativeArea < value; });
@@ -101,20 +109,37 @@ std::vector<DisintegrationSamplePoint> ModelSurfaceSampler::SampleFromModel(
 
 			float u = Random01();
 			float v = Random01();
-			if (u + v > 1.0f)
+			if (useUniformSurface)
 			{
-				u = 1.0f - u;
-				v = 1.0f - v;
+				// 面積で層化した三角形上に低差異点を置き、毎回同じ均一表面配置にする。
+				u = (static_cast<float>((static_cast<uint32_t>(i) * 2654435761u + placementSeed) & 0x00FFFFFFu) + 0.5f) / static_cast<float>(0x01000000u);
+				v = VanDerCorput(static_cast<uint32_t>(i) + (placementSeed | 1u));
+				const float sqrtU = std::sqrt(u);
+				const float baryB = sqrtU * (1.0f - v);
+				const float baryC = sqrtU * v;
+				local = it->a + (it->b - it->a) * baryB + (it->c - it->a) * baryC;
 			}
-
-			local = it->a + (it->b - it->a) * u + (it->c - it->a) * v;
+			else
+			{
+				if (u + v > 1.0f)
+				{
+					u = 1.0f - u;
+					v = 1.0f - v;
+				}
+				local = it->a + (it->b - it->a) * u + (it->c - it->a) * v;
+			}
 			localNormal = it->normal;
 		}
 		else
 		{
-			const size_t sampleIndex = std::min(static_cast<size_t>(Random01() * static_cast<float>(vertices.size())), vertices.size() - 1);
-			const VertexSample& sample = vertices[sampleIndex];
-			local = sample.position + RandomUnitVector() * RandomRange(0.0f, vertexJitterRadius);
+			const bool useUniformVertexFallback = placementMode == DisintegrationPlacementMode::UniformSurface;
+			const size_t sampleIndex = useUniformVertexFallback
+				? (static_cast<size_t>(i) * vertices.size()) / static_cast<size_t>(sampleCount)
+				: std::min(static_cast<size_t>(Random01() * static_cast<float>(vertices.size())), vertices.size() - 1);
+			const VertexSample& sample = vertices[std::min(sampleIndex, vertices.size() - 1)];
+			local = useUniformVertexFallback
+				? sample.position
+				: sample.position + RandomUnitVector() * RandomRange(0.0f, vertexJitterRadius);
 			localNormal = sample.normal;
 		}
 
@@ -146,4 +171,15 @@ K4E::Vector3 ModelSurfaceSampler::RandomUnitVector()
 	} while (K4E::Vector3::LengthSquared(v) <= 0.000001f);
 
 	return K4E::Vector3::Normalize(v);
+}
+
+
+float ModelSurfaceSampler::VanDerCorput(uint32_t value) const
+{
+	value = (value << 16u) | (value >> 16u);
+	value = ((value & 0x55555555u) << 1u) | ((value & 0xAAAAAAAAu) >> 1u);
+	value = ((value & 0x33333333u) << 2u) | ((value & 0xCCCCCCCCu) >> 2u);
+	value = ((value & 0x0F0F0F0Fu) << 4u) | ((value & 0xF0F0F0F0u) >> 4u);
+	value = ((value & 0x00FF00FFu) << 8u) | ((value & 0xFF00FF00u) >> 8u);
+	return static_cast<float>(value) * 2.3283064365386963e-10f;
 }

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelSurfaceSampler.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelSurfaceSampler.h
@@ -3,10 +3,20 @@
 #include "ModelData.h"
 #include "Vector3.h"
 
+#include <cstdint>
 #include <random>
 #include <vector>
 
 namespace K4E = ::Ken4lowEngine;
+
+/// -------------------------------------------------------------
+/// 崩壊ブロックの初期配置モード
+/// -------------------------------------------------------------
+enum class DisintegrationPlacementMode
+{
+	RandomSurface,
+	UniformSurface,
+};
 
 /// -------------------------------------------------------------
 /// 崩壊・再構築エフェクトで共有するモデル表面サンプル点
@@ -28,7 +38,9 @@ public:
 		const K4E::Matrix4x4& worldMatrix,
 		int sampleCount,
 		bool surfaceSampling,
-		float vertexJitterRadius = 0.0f);
+		float vertexJitterRadius = 0.0f,
+		DisintegrationPlacementMode placementMode = DisintegrationPlacementMode::RandomSurface,
+		uint32_t placementSeed = 0x51A7F00Du);
 
 private:
 	struct TriangleSample
@@ -49,6 +61,7 @@ private:
 	float Random01();
 	float RandomRange(float minValue, float maxValue);
 	K4E::Vector3 RandomUnitVector();
+	float VanDerCorput(uint32_t value) const;
 
 	std::mt19937 rng_{ 0x51A7F00Du };
 	std::uniform_real_distribution<float> unitDist_{ 0.0f, 1.0f };

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -580,6 +580,25 @@ void DebugScene::DrawImGui()
 				sequenceParams.blockSize = std::max(sequenceParams.blockSize, 0.005f);
 			}
 			ImGui::Checkbox("表面サンプリング##BlockSequence", &sequenceParams.surfaceSampling);
+			const char* sequencePlacementModeLabels[] = { "ランダム表面配置", "均一表面配置" };
+			int sequencePlacementModeIndex = sequenceParams.placementMode == DisintegrationPlacementMode::UniformSurface ? 1 : 0;
+			if (ImGui::Combo("配置モード##BlockSequence", &sequencePlacementModeIndex, sequencePlacementModeLabels, IM_ARRAYSIZE(sequencePlacementModeLabels)))
+			{
+				sequenceParams.placementMode = sequencePlacementModeIndex == 1 ? DisintegrationPlacementMode::UniformSurface : DisintegrationPlacementMode::RandomSurface;
+			}
+			ImGui::Checkbox("ランダムサイズを使う##BlockSequence", &sequenceParams.useRandomScale);
+			ImGui::SliderFloat("サイズばらつき##BlockSequence", &sequenceParams.scaleVariation, 0.0f, 0.75f);
+			ImGui::Checkbox("ランダム回転を使う##BlockSequence", &sequenceParams.useRandomRotation);
+			ImGui::SliderFloat("回転ばらつき##BlockSequence", &sequenceParams.rotationRandomness, 0.0f, 8.0f);
+			int sequencePlacementSeed = static_cast<int>(sequenceParams.placementSeed);
+			if (ImGui::InputInt("配置シード##BlockSequence", &sequencePlacementSeed))
+			{
+				sequenceParams.placementSeed = static_cast<uint32_t>(std::max(sequencePlacementSeed, 0));
+			}
+			if (sequenceParams.placementMode == DisintegrationPlacementMode::UniformSurface)
+			{
+				ImGui::TextWrapped("均一表面配置はSweep Erosionで形を保って蝕む表現に推奨です。");
+			}
 			ImGui::SeparatorText("方向侵食崩壊##BlockSequence");
 			ImGui::Checkbox("方向侵食を使う##BlockSequence", &sequenceParams.useSweepErosion);
 			ImGui::DragFloat3("侵食方向##BlockSequence", &sequenceParams.sweepDirection.x, 0.01f, -1.0f, 1.0f);


### PR DESCRIPTION
### Motivation
- 現在のランダム表面サンプリングに加え、モデル表面に沿ってできるだけ均一に配置するモードを追加して、Sweep Erosionなど形を保った侵食表現を作りやすくするため。 
- ランダム配置は演出で有用なため削除せず、切り替え可能にして調整性を向上させるため。 
- 均一配置は決定的（シード固定）にして毎回同じ配置になるようにして調整しやすくするため。

### Description
- 追加で `DisintegrationPlacementMode` を導入し `RandomSurface` / `UniformSurface` を提供した。 (`ModelSurfaceSampler.h`) 
- パラメータを拡張して `ModelDisintegrationEffect::Parameters` に `placementMode` / `useRandomScale` / `scaleVariation` / `useRandomRotation` / `rotationRandomness` / `placementSeed` を追加し、これらをエミッターへ伝搬するようにした。 (`ModelDisintegrationEffect.*`, `DisintegrationEmitter.*`) 
- `ModelSurfaceSampler::SampleFromModel` を拡張して配置モードとシードを受け取り、`UniformSurface` の場合は三角形面積に応じた層化（deterministic）サンプリングと頂点フォールバックを行う実装を追加した（低差異点生成に `VanDerCorput` を使用、コード内に説明コメントあり）。 (`ModelSurfaceSampler.*`) 
- `DisintegrationEmitter` 側で `placementSeed` による RNG シード固定と、`useRandomScale` / `scaleVariation` / `useRandomRotation` / `rotationRandomness` の設定を粒子初期化に反映するようにした。 (`DisintegrationEmitter.*`) 
- Debug 用 ImGui を更新し、日本語の表示名で `配置モード` / `ランダムサイズを使う` / `サイズばらつき` / `ランダム回転を使う` / `回転ばらつき` / `配置シード` を追加し、`均一表面配置` 時の説明テキストを表示するようにした（`DrawImGui` はパラメータ更新に留め、GPU リソース破棄や再生成は行わない方針を維持）。 (`ModelDisintegrationEffect.cpp`, `DebugScene.cpp`, `ModelBlockEffectSequence.*`) 

### Testing
- `git diff --check` を実行して差分に問題がないことを確認した（成功）。
- ソースの簡易構文チェックとして `g++ -std=c++20 -fsyntax-only` を用いて `ModelSurfaceSampler.cpp` と `DisintegrationEmitter.cpp` を検査したが、Linux 環境に Windows DirectX ヘッダ（`d3d12.h`）が存在しないためコンパイルは途中で停止した（環境依存ヘッダ不足により構文チェックは限定的に失敗）。
- 変更ファイル全体についてワード検索で新しいパラメータ名と `DisintegrationPlacementMode` の導入箇所を確認し、ImGui の項目とパラメータ伝搬が正しく接続されていることを静的に検査した（成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fe9f5dad74832da3ca3dcbac4dda54)