### PR TITLE
Add uniform/aligned surface placement and sequence hold/fade options

### DIFF
--- a/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationEmitter.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationEmitter.cpp
@@ -28,16 +28,24 @@ std::vector<DisintegrationParticle> DisintegrationEmitter::EmitFromModel(
 		modelData,
 		worldMatrix,
 		settings.particleCount,
-		settings.placementMode == DisintegrationPlacementMode::UniformSurface ? true : settings.surfaceSampling,
+		settings.placementMode != DisintegrationPlacementMode::RandomSurface ? true : settings.surfaceSampling,
 		settings.particleSize * 1.5f,
 		settings.placementMode,
-		settings.placementSeed);
+		settings.placementSeed,
+		settings.placementSpacing);
+	return EmitFromSamples(samples, worldMatrix.GetTranslation(), settings);
+}
 
+std::vector<DisintegrationParticle> DisintegrationEmitter::EmitFromSamples(
+	const std::vector<DisintegrationSamplePoint>& samples,
+	const K4E::Vector3& center,
+	const Settings& settings)
+{
+	rng_.seed(settings.placementSeed ^ 0xD157E6A7u);
 	std::vector<DisintegrationParticle> particles;
 	particles.reserve(samples.size());
 	if (samples.empty()) { return particles; }
 
-	const K4E::Vector3 center = worldMatrix.GetTranslation();
 	for (const auto& sample : samples)
 	{
 		K4E::Vector3 outward = K4E::Vector3::NormalizeSafe(sample.position - center, sample.normal);

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationEmitter.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationEmitter.h
@@ -26,6 +26,7 @@ public:
 		bool useRandomRotation = true;
 		float rotationRandomness = 1.2f;
 		uint32_t placementSeed = 0xD157E6A7u;
+		float placementSpacing = 0.0f;
 		bool surfaceSampling = true;
 		float lifeTime = 2.0f;
 		float spreadPower = 1.6f;
@@ -38,6 +39,10 @@ public:
 	std::vector<DisintegrationParticle> EmitFromModel(
 		const K4E::ModelData& modelData,
 		const K4E::Matrix4x4& worldMatrix,
+		const Settings& settings);
+	std::vector<DisintegrationParticle> EmitFromSamples(
+		const std::vector<DisintegrationSamplePoint>& samples,
+		const K4E::Vector3& center,
 		const Settings& settings);
 
 private:

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelBlockEffectSequence.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelBlockEffectSequence.cpp
@@ -40,6 +40,7 @@ void ModelBlockEffectSequence::Stop(bool showModelAfterStop)
 	waitingReason_ = WaitingReason::None;
 	sequenceElapsed_ = 0.0f;
 	stateElapsed_ = 0.0f;
+	sharedCompletedSamples_.clear();
 }
 
 void ModelBlockEffectSequence::Reset()
@@ -53,6 +54,7 @@ void ModelBlockEffectSequence::Reset()
 	stateElapsed_ = 0.0f;
 	reconstructionCompleted_ = false;
 	disintegrationCompleted_ = false;
+	sharedCompletedSamples_.clear();
 }
 
 void ModelBlockEffectSequence::Update(float deltaTime)
@@ -80,10 +82,11 @@ void ModelBlockEffectSequence::Update(float deltaTime)
 		if (reconstructionEffect_ && reconstructionEffect_->IsComplete())
 		{
 			reconstructionCompleted_ = true;
-			modelVisible_ = true;
+			sharedCompletedSamples_ = reconstructionEffect_->GetTargetSamples();
+			modelVisible_ = parameters_.showFinalModelAfterComplete && !parameters_.disintegrateAsCompleteBlocks;
 			if (mode_ == SequenceMode::DisintegrateThenReconstruct && !parameters_.loopEnabled)
 			{
-				ResetEffects();
+				if (!parameters_.keepBlocksAfterComplete) { ResetEffects(); }
 				EnterState(SequenceState::Completed);
 			}
 			else
@@ -93,9 +96,20 @@ void ModelBlockEffectSequence::Update(float deltaTime)
 		}
 		break;
 	case SequenceState::ShowingModel:
-		if (stateElapsed_ >= std::max(parameters_.showDuration, 0.0f))
+		if (parameters_.fadeToModelAfterComplete && stateElapsed_ >= parameters_.fullBodyHoldTime)
 		{
-			StartDisintegration();
+			modelVisible_ = parameters_.showFinalModelAfterComplete;
+		}
+		if (stateElapsed_ >= std::max(parameters_.fullBodyHoldTime + parameters_.modelSwitchBlendTime, 0.0f))
+		{
+			if (parameters_.disintegrateAsCompleteBlocks && !sharedCompletedSamples_.empty())
+			{
+				StartDisintegrationFromSharedSamples();
+			}
+			else
+			{
+				StartDisintegration();
+			}
 		}
 		break;
 	case SequenceState::Disintegrating:
@@ -138,7 +152,7 @@ const char* ModelBlockEffectSequence::GetStateName() const
 	{
 	case SequenceState::Idle: return "待機中";
 	case SequenceState::Reconstructing: return "再構築中";
-	case SequenceState::ShowingModel: return "通常モデル表示中";
+	case SequenceState::ShowingModel: return parameters_.disintegrateAsCompleteBlocks ? "ブロック完全体保持中" : "通常モデル表示中";
 	case SequenceState::Disintegrating: return "崩壊中";
 	case SequenceState::Waiting: return "待機中";
 	case SequenceState::Completed: return "完了";
@@ -157,6 +171,7 @@ void ModelBlockEffectSequence::Begin(const std::string& modelPath, const K4E::Ma
 	reconstructionCompleted_ = false;
 	disintegrationCompleted_ = false;
 	waitingReason_ = WaitingReason::None;
+	sharedCompletedSamples_.clear();
 	ResetEffects();
 	ApplySharedParameters();
 	modelVisible_ = false;
@@ -182,8 +197,16 @@ void ModelBlockEffectSequence::ApplySharedParameters()
 		reconstructionParams.blockCount = parameters_.blockCount;
 		reconstructionParams.blockSize = parameters_.blockSize;
 		reconstructionParams.surfaceSampling = parameters_.surfaceSampling;
-		reconstructionParams.showFinalModel = false;
-		reconstructionParams.autoHideBlocksAfterComplete = true;
+		reconstructionParams.placementMode = parameters_.placementMode;
+		reconstructionParams.useRandomScale = parameters_.useRandomScale;
+		reconstructionParams.scaleVariation = parameters_.scaleVariation;
+		reconstructionParams.useRandomRotation = parameters_.useRandomRotation;
+		reconstructionParams.rotationRandomness = parameters_.rotationRandomness;
+		reconstructionParams.placementSeed = parameters_.placementSeed;
+		reconstructionParams.placementSpacing = parameters_.placementSpacing;
+		reconstructionParams.holdTime = parameters_.fullBodyHoldTime;
+		reconstructionParams.showFinalModel = parameters_.showFinalModelAfterComplete;
+		reconstructionParams.autoHideBlocksAfterComplete = !parameters_.keepBlocksAfterComplete;
 	}
 
 	if (disintegrationEffect_)
@@ -199,6 +222,7 @@ void ModelBlockEffectSequence::ApplySharedParameters()
 		disintegrationParams.useRandomRotation = parameters_.useRandomRotation;
 		disintegrationParams.rotationRandomness = parameters_.rotationRandomness;
 		disintegrationParams.placementSeed = parameters_.placementSeed;
+		disintegrationParams.placementSpacing = parameters_.placementSpacing;
 		disintegrationParams.useSweepErosion = parameters_.useSweepErosion;
 		disintegrationParams.sweepDirection = parameters_.sweepDirection;
 		disintegrationParams.sweepDuration = parameters_.sweepDuration;
@@ -242,6 +266,22 @@ void ModelBlockEffectSequence::StartDisintegration()
 	}
 }
 
+void ModelBlockEffectSequence::StartDisintegrationFromSharedSamples()
+{
+	const auto samples = sharedCompletedSamples_;
+	ResetEffects();
+	ApplySharedParameters();
+	modelVisible_ = false;
+	disintegrationCompleted_ = false;
+	waitingReason_ = WaitingReason::None;
+	EnterState(SequenceState::Disintegrating);
+	if (disintegrationEffect_)
+	{
+		// 再構築で到着した表面サンプルを崩壊にも使い、完全体から崩れる瞬間の配置ジャンプを防ぐ。
+		disintegrationEffect_->PlayFromSamples(samples, worldMatrix_);
+	}
+}
+
 void ModelBlockEffectSequence::EnterState(SequenceState nextState)
 {
 	state_ = nextState;
@@ -260,5 +300,6 @@ void ModelBlockEffectSequence::CompleteOrLoop()
 	ResetEffects();
 	modelVisible_ = false;
 	waitingReason_ = WaitingReason::None;
+	sharedCompletedSamples_.clear();
 	EnterState(SequenceState::Completed);
 }

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelBlockEffectSequence.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelBlockEffectSequence.h
@@ -6,6 +6,7 @@
 
 #include <cstdint>
 #include <string>
+#include <vector>
 
 namespace K4E = ::Ken4lowEngine;
 
@@ -32,9 +33,16 @@ public:
 	{
 		float showDuration = 1.2f;
 		float waitDuration = 0.8f;
+		bool showFinalModelAfterComplete = false;
+		bool keepBlocksAfterComplete = true;
+		bool fadeToModelAfterComplete = false;
+		bool disintegrateAsCompleteBlocks = true;
+		float fullBodyHoldTime = 0.8f;
+		float modelSwitchBlendTime = 0.25f;
 		bool loopEnabled = false;
 		int blockCount = 1200;
 		float blockSize = 0.045f;
+		float placementSpacing = 0.0f;
 		bool surfaceSampling = true;
 		DisintegrationPlacementMode placementMode = DisintegrationPlacementMode::UniformSurface;
 		bool useRandomScale = false;
@@ -93,6 +101,7 @@ private:
 	void ApplySharedParameters();
 	void StartReconstruction();
 	void StartDisintegration();
+	void StartDisintegrationFromSharedSamples();
 	void EnterState(SequenceState nextState);
 	void CompleteOrLoop();
 
@@ -109,4 +118,5 @@ private:
 	bool modelVisible_ = true;
 	bool reconstructionCompleted_ = false;
 	bool disintegrationCompleted_ = false;
+	std::vector<DisintegrationSamplePoint> sharedCompletedSamples_;
 };

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelDisintegrationEffect.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelDisintegrationEffect.cpp
@@ -51,6 +51,7 @@ void ModelDisintegrationEffect::PlayFromModel(const std::string& modelPath, cons
 	settings.useRandomRotation = parameters_.useRandomRotation;
 	settings.rotationRandomness = parameters_.rotationRandomness;
 	settings.placementSeed = parameters_.placementSeed;
+	settings.placementSpacing = parameters_.placementSpacing;
 	settings.surfaceSampling = parameters_.surfaceSampling;
 	settings.lifeTime = parameters_.lifeTime;
 	settings.spreadPower = parameters_.spreadPower;
@@ -60,6 +61,33 @@ void ModelDisintegrationEffect::PlayFromModel(const std::string& modelPath, cons
 	settings.colorVariation = parameters_.colorVariation;
 
 	particles_ = emitter_.EmitFromModel(model->GetModelData(), worldMatrix, settings);
+	InitializeSweepData();
+	isActive_ = !particles_.empty();
+	elapsedTime_ = 0.0f;
+}
+
+void ModelDisintegrationEffect::PlayFromSamples(const std::vector<DisintegrationSamplePoint>& samples, const K4E::Matrix4x4& worldMatrix)
+{
+	DisintegrationEmitter::Settings settings{};
+	settings.particleCount = parameters_.particleCount;
+	settings.particleSize = parameters_.particleSize;
+	settings.blockRotationRandomness = parameters_.rotationRandomness;
+	settings.placementMode = parameters_.placementMode;
+	settings.useRandomScale = parameters_.useRandomScale;
+	settings.scaleVariation = parameters_.scaleVariation;
+	settings.useRandomRotation = parameters_.useRandomRotation;
+	settings.rotationRandomness = parameters_.rotationRandomness;
+	settings.placementSeed = parameters_.placementSeed;
+	settings.placementSpacing = parameters_.placementSpacing;
+	settings.surfaceSampling = parameters_.surfaceSampling;
+	settings.lifeTime = parameters_.lifeTime;
+	settings.spreadPower = parameters_.spreadPower;
+	settings.upwardPower = parameters_.upwardPower;
+	settings.startDelay = parameters_.startDelay;
+	settings.baseColor = parameters_.baseColor;
+	settings.colorVariation = parameters_.colorVariation;
+
+	particles_ = emitter_.EmitFromSamples(samples, worldMatrix.GetTranslation(), settings);
 	InitializeSweepData();
 	isActive_ = !particles_.empty();
 	elapsedTime_ = 0.0f;
@@ -125,11 +153,16 @@ void ModelDisintegrationEffect::DrawImGui()
 	{
 		parameters_.particleSize = parameters_.blockSize;
 	}
-	const char* placementModeLabels[] = { "ランダム表面配置", "均一表面配置" };
-	int placementModeIndex = parameters_.placementMode == DisintegrationPlacementMode::UniformSurface ? 1 : 0;
+	const char* placementModeLabels[] = { "ランダム表面配置", "均一表面配置", "整列表面配置" };
+	int placementModeIndex = parameters_.placementMode == DisintegrationPlacementMode::AlignedSurfaceGrid ? 2 : (parameters_.placementMode == DisintegrationPlacementMode::UniformSurface ? 1 : 0);
 	if (ImGui::Combo("配置モード", &placementModeIndex, placementModeLabels, IM_ARRAYSIZE(placementModeLabels)))
 	{
-		parameters_.placementMode = placementModeIndex == 1 ? DisintegrationPlacementMode::UniformSurface : DisintegrationPlacementMode::RandomSurface;
+		parameters_.placementMode = placementModeIndex == 2 ? DisintegrationPlacementMode::AlignedSurfaceGrid : (placementModeIndex == 1 ? DisintegrationPlacementMode::UniformSurface : DisintegrationPlacementMode::RandomSurface);
+		if (parameters_.placementMode != DisintegrationPlacementMode::RandomSurface)
+		{
+			parameters_.useRandomScale = false;
+			parameters_.useRandomRotation = false;
+		}
 	}
 	ImGui::Checkbox("ランダムサイズを使う", &parameters_.useRandomScale);
 	ImGui::SliderFloat("サイズばらつき", &parameters_.scaleVariation, 0.0f, 0.75f);
@@ -143,9 +176,14 @@ void ModelDisintegrationEffect::DrawImGui()
 	{
 		parameters_.placementSeed = static_cast<uint32_t>(std::max(placementSeed, 0));
 	}
+	ImGui::SliderFloat("配置間隔", &parameters_.placementSpacing, 0.0f, 0.5f);
 	if (parameters_.placementMode == DisintegrationPlacementMode::UniformSurface)
 	{
 		ImGui::TextWrapped("均一表面配置はモデル表面を面積に応じて規則的にサンプルします。Sweep Erosionで形を保って蝕む表現に推奨です。");
+	}
+	else if (parameters_.placementMode == DisintegrationPlacementMode::AlignedSurfaceGrid)
+	{
+		ImGui::TextWrapped("整列表面配置はAABBを埋めず、三角形表面上の格子候補からブロックを選びます。");
 	}
 	ImGui::Checkbox("表面サンプリング", &parameters_.surfaceSampling);
 	ImGui::Checkbox("形状維持", &parameters_.preserveShape);

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelDisintegrationEffect.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelDisintegrationEffect.h
@@ -4,6 +4,7 @@
 #include "Matrix4x4.h"
 #include "Vector4.h"
 #include "Vector3.h"
+#include "ModelSurfaceSampler.h"
 
 #include <cstdint>
 #include <string>
@@ -28,6 +29,7 @@ public:
 		bool useRandomRotation = true;
 		float rotationRandomness = 1.2f;
 		uint32_t placementSeed = 0xD157E6A7u;
+		float placementSpacing = 0.0f;
 		bool surfaceSampling = true;
 		bool preserveShape = true;
 		float lifeTime = 2.2f;
@@ -56,6 +58,7 @@ public:
 
 	void Initialize();
 	void PlayFromModel(const std::string& modelPath, const K4E::Matrix4x4& worldMatrix);
+	void PlayFromSamples(const std::vector<DisintegrationSamplePoint>& samples, const K4E::Matrix4x4& worldMatrix);
 	void Update(float deltaTime);
 	void Draw();
 	void DrawImGui();

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelReconstructionEffect.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelReconstructionEffect.cpp
@@ -31,6 +31,12 @@ void ModelReconstructionEffect::PlayFromModel(const std::string& modelPath, cons
 	settings.startHeight = parameters_.startHeight;
 	settings.startDelayRange = parameters_.startDelayRange;
 	settings.rotationRandomness = parameters_.rotationRandomness;
+	settings.placementMode = parameters_.placementMode;
+	settings.useRandomScale = parameters_.useRandomScale;
+	settings.scaleVariation = parameters_.scaleVariation;
+	settings.useRandomRotation = parameters_.useRandomRotation;
+	settings.placementSeed = parameters_.placementSeed;
+	settings.placementSpacing = parameters_.placementSpacing;
 	settings.surfaceSampling = parameters_.surfaceSampling;
 	settings.color = parameters_.color;
 	settings.colorVariation = parameters_.colorVariation;
@@ -101,6 +107,19 @@ void ModelReconstructionEffect::Draw()
 	renderer_.Draw(blocks_);
 }
 
+std::vector<DisintegrationSamplePoint> ModelReconstructionEffect::GetTargetSamples() const
+{
+	std::vector<DisintegrationSamplePoint> samples;
+	samples.reserve(blocks_.size());
+	for (const auto& block : blocks_)
+	{
+		DisintegrationSamplePoint sample{};
+		sample.position = block.targetPosition;
+		samples.push_back(sample);
+	}
+	return samples;
+}
+
 void ModelReconstructionEffect::DrawImGui()
 {
 #ifdef USE_IMGUI
@@ -114,7 +133,27 @@ void ModelReconstructionEffect::DrawImGui()
 	ImGui::SliderFloat("開始時の散らばり半径", &parameters_.startScatterRadius, 0.0f, 12.0f);
 	ImGui::SliderFloat("開始高さ", &parameters_.startHeight, -2.0f, 10.0f);
 	ImGui::SliderFloat("開始遅延幅", &parameters_.startDelayRange, 0.0f, 3.0f);
-	ImGui::SliderFloat("回転ランダム", &parameters_.rotationRandomness, 0.0f, 12.0f);
+	ImGui::Checkbox("ランダム回転を使う", &parameters_.useRandomRotation);
+	ImGui::SliderFloat("回転ばらつき", &parameters_.rotationRandomness, 0.0f, 12.0f);
+	ImGui::Checkbox("ランダムサイズを使う", &parameters_.useRandomScale);
+	ImGui::SliderFloat("サイズばらつき", &parameters_.scaleVariation, 0.0f, 0.75f);
+	const char* placementModeLabels[] = { "ランダム表面配置", "均一表面配置", "整列表面配置" };
+	int placementModeIndex = parameters_.placementMode == DisintegrationPlacementMode::AlignedSurfaceGrid ? 2 : (parameters_.placementMode == DisintegrationPlacementMode::UniformSurface ? 1 : 0);
+	if (ImGui::Combo("配置モード", &placementModeIndex, placementModeLabels, IM_ARRAYSIZE(placementModeLabels)))
+	{
+		parameters_.placementMode = placementModeIndex == 2 ? DisintegrationPlacementMode::AlignedSurfaceGrid : (placementModeIndex == 1 ? DisintegrationPlacementMode::UniformSurface : DisintegrationPlacementMode::RandomSurface);
+		if (parameters_.placementMode != DisintegrationPlacementMode::RandomSurface)
+		{
+			parameters_.useRandomScale = false;
+			parameters_.useRandomRotation = false;
+		}
+	}
+	int placementSeed = static_cast<int>(parameters_.placementSeed);
+	if (ImGui::InputInt("配置シード", &placementSeed))
+	{
+		parameters_.placementSeed = static_cast<uint32_t>(std::max(placementSeed, 0));
+	}
+	ImGui::SliderFloat("配置間隔", &parameters_.placementSpacing, 0.0f, 0.5f);
 	ImGui::SliderFloat("イージング強度", &parameters_.easePower, 1.0f, 8.0f);
 	ImGui::ColorEdit4("色", &parameters_.color.x);
 	ImGui::SliderFloat("色のばらつき", &parameters_.colorVariation, 0.0f, 0.8f);

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelReconstructionEffect.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelReconstructionEffect.h
@@ -3,7 +3,9 @@
 #include "ReconstructionRenderer.h"
 #include "Matrix4x4.h"
 #include "Vector4.h"
+#include "ModelSurfaceSampler.h"
 
+#include <cstdint>
 #include <string>
 #include <vector>
 
@@ -22,6 +24,12 @@ public:
 		float startHeight = 2.5f;
 		float startDelayRange = 0.45f;
 		float rotationRandomness = 4.0f;
+		DisintegrationPlacementMode placementMode = DisintegrationPlacementMode::RandomSurface;
+		bool useRandomScale = true;
+		float scaleVariation = 0.12f;
+		bool useRandomRotation = true;
+		uint32_t placementSeed = 0xD157E6A7u;
+		float placementSpacing = 0.0f;
 		float easePower = 3.0f;
 		K4E::Vector4 color{ 0.64f, 0.72f, 0.86f, 1.0f };
 		float colorVariation = 0.18f;
@@ -40,6 +48,7 @@ public:
 	bool IsComplete() const { return isComplete_; }
 	bool ShouldShowFinalModel() const { return isComplete_ && parameters_.showFinalModel; }
 	bool ShouldDrawBlocks() const { return isActive_ || (!parameters_.autoHideBlocksAfterComplete && !blocks_.empty()); }
+	std::vector<DisintegrationSamplePoint> GetTargetSamples() const;
 
 	Parameters& GetParameters() { return parameters_; }
 	const Parameters& GetParameters() const { return parameters_; }

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelSurfaceSampler.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelSurfaceSampler.cpp
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <tuple>
 
 namespace
 {
@@ -34,7 +35,8 @@ std::vector<DisintegrationSamplePoint> ModelSurfaceSampler::SampleFromModel(
 	bool surfaceSampling,
 	float vertexJitterRadius,
 	DisintegrationPlacementMode placementMode,
-	uint32_t placementSeed)
+	uint32_t placementSeed,
+	float placementSpacing)
 {
 	rng_.seed(placementSeed);
 	std::vector<TriangleSample> triangles;
@@ -91,7 +93,50 @@ std::vector<DisintegrationSamplePoint> ModelSurfaceSampler::SampleFromModel(
 	if ((triangles.empty() && vertices.empty()) || sampleCount <= 0) { return samples; }
 
 	const bool useUniformSurface = placementMode == DisintegrationPlacementMode::UniformSurface && !triangles.empty();
-	const bool useTriangleSurface = (surfaceSampling || useUniformSurface) && !triangles.empty();
+	const bool useAlignedSurfaceGrid = placementMode == DisintegrationPlacementMode::AlignedSurfaceGrid && !triangles.empty();
+	const bool useTriangleSurface = (surfaceSampling || useUniformSurface || useAlignedSurfaceGrid) && !triangles.empty();
+	if (useAlignedSurfaceGrid)
+	{
+		std::vector<DisintegrationSamplePoint> gridCandidates;
+		const float safeSpacing = placementSpacing > 0.0001f ? placementSpacing : std::sqrt(totalArea / static_cast<float>(sampleCount));
+		for (size_t triIndex = 0; triIndex < triangles.size(); ++triIndex)
+		{
+			const auto& tri = triangles[triIndex];
+			const float previousArea = triIndex == 0 ? 0.0f : triangles[triIndex - 1].cumulativeArea;
+			const float triangleArea = std::max(tri.cumulativeArea - previousArea, 0.0f);
+			const int subdivision = std::clamp(static_cast<int>(std::ceil(std::sqrt(triangleArea) / safeSpacing * 2.0f)), 1, 128);
+			for (int y = 0; y <= subdivision; ++y)
+			{
+				for (int x = 0; x + y <= subdivision; ++x)
+				{
+					const float baryB = (static_cast<float>(x) + 0.5f) / (static_cast<float>(subdivision) + 1.0f);
+					const float baryC = (static_cast<float>(y) + 0.5f) / (static_cast<float>(subdivision) + 1.0f);
+					if (baryB + baryC >= 1.0f) { continue; }
+					const K4E::Vector3 local = tri.a + (tri.b - tri.a) * baryB + (tri.c - tri.a) * baryC;
+					DisintegrationSamplePoint sample{};
+					sample.position = K4E::Vector3::Transform(local, worldMatrix);
+					sample.normal = K4E::Vector3::NormalizeSafe(TransformDirection(tri.normal, worldMatrix), { 0.0f, 1.0f, 0.0f });
+					gridCandidates.push_back(sample);
+				}
+			}
+		}
+
+		std::sort(gridCandidates.begin(), gridCandidates.end(), [](const DisintegrationSamplePoint& a, const DisintegrationSamplePoint& b) {
+			return std::tie(a.position.x, a.position.y, a.position.z) < std::tie(b.position.x, b.position.y, b.position.z);
+		});
+		if (!gridCandidates.empty())
+		{
+			for (int i = 0; i < sampleCount; ++i)
+			{
+				const size_t index = sampleCount <= static_cast<int>(gridCandidates.size())
+					? (static_cast<size_t>(i) * gridCandidates.size()) / static_cast<size_t>(sampleCount)
+					: static_cast<size_t>(i) % gridCandidates.size();
+				samples.push_back(gridCandidates[std::min(index, gridCandidates.size() - 1)]);
+			}
+			return samples;
+		}
+	}
+
 	for (int i = 0; i < sampleCount; ++i)
 	{
 		K4E::Vector3 local{};
@@ -132,7 +177,7 @@ std::vector<DisintegrationSamplePoint> ModelSurfaceSampler::SampleFromModel(
 		}
 		else
 		{
-			const bool useUniformVertexFallback = placementMode == DisintegrationPlacementMode::UniformSurface;
+			const bool useUniformVertexFallback = placementMode == DisintegrationPlacementMode::UniformSurface || placementMode == DisintegrationPlacementMode::AlignedSurfaceGrid;
 			const size_t sampleIndex = useUniformVertexFallback
 				? (static_cast<size_t>(i) * vertices.size()) / static_cast<size_t>(sampleCount)
 				: std::min(static_cast<size_t>(Random01() * static_cast<float>(vertices.size())), vertices.size() - 1);

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelSurfaceSampler.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelSurfaceSampler.h
@@ -16,6 +16,7 @@ enum class DisintegrationPlacementMode
 {
 	RandomSurface,
 	UniformSurface,
+	AlignedSurfaceGrid,
 };
 
 /// -------------------------------------------------------------
@@ -40,7 +41,8 @@ public:
 		bool surfaceSampling,
 		float vertexJitterRadius = 0.0f,
 		DisintegrationPlacementMode placementMode = DisintegrationPlacementMode::RandomSurface,
-		uint32_t placementSeed = 0x51A7F00Du);
+		uint32_t placementSeed = 0x51A7F00Du,
+		float placementSpacing = 0.0f);
 
 private:
 	struct TriangleSample

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionEmitter.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionEmitter.cpp
@@ -9,13 +9,17 @@ std::vector<ReconstructionBlock> ReconstructionEmitter::EmitFromModel(
 	const K4E::Matrix4x4& worldMatrix,
 	const Settings& settings)
 {
+	rng_.seed(settings.placementSeed ^ 0xC0DE2026u);
 	ModelSurfaceSampler sampler;
 	const std::vector<DisintegrationSamplePoint> targets = sampler.SampleFromModel(
 		modelData,
 		worldMatrix,
 		settings.blockCount,
-		settings.surfaceSampling,
-		settings.blockSize * 1.5f);
+		settings.placementMode != DisintegrationPlacementMode::RandomSurface ? true : settings.surfaceSampling,
+		settings.blockSize * 1.5f,
+		settings.placementMode,
+		settings.placementSeed,
+		settings.placementSpacing);
 
 	std::vector<ReconstructionBlock> blocks;
 	blocks.reserve(targets.size());
@@ -33,25 +37,27 @@ std::vector<ReconstructionBlock> ReconstructionEmitter::EmitFromModel(
 		block.startPosition = target.position + scatter;
 		block.targetPosition = target.position;
 		block.position = block.startPosition;
+		const float rotationRandomness = settings.useRandomRotation ? settings.rotationRandomness : 0.0f;
 		block.startRotation = {
-			RandomRange(-settings.rotationRandomness, settings.rotationRandomness),
-			RandomRange(-settings.rotationRandomness, settings.rotationRandomness),
-			RandomRange(-settings.rotationRandomness, settings.rotationRandomness),
+			RandomRange(-rotationRandomness, rotationRandomness),
+			RandomRange(-rotationRandomness, rotationRandomness),
+			RandomRange(-rotationRandomness, rotationRandomness),
 		};
 		block.rotation = block.startRotation;
 		block.rotationVelocity = {
-			RandomRange(-settings.rotationRandomness, settings.rotationRandomness),
-			RandomRange(-settings.rotationRandomness, settings.rotationRandomness),
-			RandomRange(-settings.rotationRandomness, settings.rotationRandomness),
+			RandomRange(-rotationRandomness, rotationRandomness),
+			RandomRange(-rotationRandomness, rotationRandomness),
+			RandomRange(-rotationRandomness, rotationRandomness),
 		};
+		const float scaleVariation = settings.useRandomScale ? std::max(settings.scaleVariation, 0.0f) : 0.0f;
 		block.scale = {
-			RandomRange(0.86f, 1.12f),
-			RandomRange(0.86f, 1.12f),
-			RandomRange(0.86f, 1.12f),
+			RandomRange(1.0f - scaleVariation, 1.0f + scaleVariation),
+			RandomRange(1.0f - scaleVariation, 1.0f + scaleVariation),
+			RandomRange(1.0f - scaleVariation, 1.0f + scaleVariation),
 		};
 		block.color = MakeColor(settings);
 		block.startDelay = RandomRange(0.0f, settings.startDelayRange);
-		block.size = settings.blockSize * RandomRange(0.86f, 1.12f);
+		block.size = settings.blockSize * RandomRange(1.0f - scaleVariation, 1.0f + scaleVariation);
 		block.alpha = 1.0f;
 		block.alive = true;
 		blocks.push_back(block);

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionEmitter.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionEmitter.h
@@ -5,6 +5,7 @@
 #include "ModelData.h"
 #include "Vector4.h"
 
+#include <cstdint>
 #include <random>
 #include <vector>
 
@@ -22,6 +23,12 @@ public:
 		float startHeight = 2.5f;
 		float startDelayRange = 0.45f;
 		float rotationRandomness = 4.0f;
+		DisintegrationPlacementMode placementMode = DisintegrationPlacementMode::RandomSurface;
+		bool useRandomScale = true;
+		float scaleVariation = 0.12f;
+		bool useRandomRotation = true;
+		uint32_t placementSeed = 0xD157E6A7u;
+		float placementSpacing = 0.0f;
 		bool surfaceSampling = true;
 		K4E::Vector4 color{ 0.64f, 0.72f, 0.86f, 1.0f };
 		float colorVariation = 0.18f;

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -572,7 +572,13 @@ void DebugScene::DrawImGui()
 		{
 			auto& sequenceParams = debugModelBlockSequence_->GetParameters();
 			ImGui::DragFloat("通常モデル表示時間", &sequenceParams.showDuration, 0.05f, 0.0f, 10.0f);
+			ImGui::DragFloat("完全体保持時間", &sequenceParams.fullBodyHoldTime, 0.05f, 0.0f, 10.0f);
+			ImGui::DragFloat("モデル切り替えブレンド時間", &sequenceParams.modelSwitchBlendTime, 0.01f, 0.0f, 3.0f);
 			ImGui::DragFloat("待機時間", &sequenceParams.waitDuration, 0.05f, 0.0f, 10.0f);
+			ImGui::Checkbox("完了後に通常モデルを表示", &sequenceParams.showFinalModelAfterComplete);
+			ImGui::Checkbox("完了後もブロックを保持", &sequenceParams.keepBlocksAfterComplete);
+			ImGui::Checkbox("通常モデルへフェードする", &sequenceParams.fadeToModelAfterComplete);
+			ImGui::Checkbox("ブロック完全体のまま崩壊する", &sequenceParams.disintegrateAsCompleteBlocks);
 			ImGui::Checkbox("ループ有効", &sequenceParams.loopEnabled);
 			ImGui::SliderInt("ブロック数##BlockSequence", &sequenceParams.blockCount, 32, 8000);
 			if (ImGui::SliderFloat("ブロックサイズ##BlockSequence", &sequenceParams.blockSize, 0.005f, 0.30f))
@@ -580,11 +586,16 @@ void DebugScene::DrawImGui()
 				sequenceParams.blockSize = std::max(sequenceParams.blockSize, 0.005f);
 			}
 			ImGui::Checkbox("表面サンプリング##BlockSequence", &sequenceParams.surfaceSampling);
-			const char* sequencePlacementModeLabels[] = { "ランダム表面配置", "均一表面配置" };
-			int sequencePlacementModeIndex = sequenceParams.placementMode == DisintegrationPlacementMode::UniformSurface ? 1 : 0;
+			const char* sequencePlacementModeLabels[] = { "ランダム表面配置", "均一表面配置", "整列表面配置" };
+			int sequencePlacementModeIndex = sequenceParams.placementMode == DisintegrationPlacementMode::AlignedSurfaceGrid ? 2 : (sequenceParams.placementMode == DisintegrationPlacementMode::UniformSurface ? 1 : 0);
 			if (ImGui::Combo("配置モード##BlockSequence", &sequencePlacementModeIndex, sequencePlacementModeLabels, IM_ARRAYSIZE(sequencePlacementModeLabels)))
 			{
-				sequenceParams.placementMode = sequencePlacementModeIndex == 1 ? DisintegrationPlacementMode::UniformSurface : DisintegrationPlacementMode::RandomSurface;
+				sequenceParams.placementMode = sequencePlacementModeIndex == 2 ? DisintegrationPlacementMode::AlignedSurfaceGrid : (sequencePlacementModeIndex == 1 ? DisintegrationPlacementMode::UniformSurface : DisintegrationPlacementMode::RandomSurface);
+				if (sequenceParams.placementMode != DisintegrationPlacementMode::RandomSurface)
+				{
+					sequenceParams.useRandomScale = false;
+					sequenceParams.useRandomRotation = false;
+				}
 			}
 			ImGui::Checkbox("ランダムサイズを使う##BlockSequence", &sequenceParams.useRandomScale);
 			ImGui::SliderFloat("サイズばらつき##BlockSequence", &sequenceParams.scaleVariation, 0.0f, 0.75f);
@@ -595,9 +606,14 @@ void DebugScene::DrawImGui()
 			{
 				sequenceParams.placementSeed = static_cast<uint32_t>(std::max(sequencePlacementSeed, 0));
 			}
+			ImGui::SliderFloat("配置間隔##BlockSequence", &sequenceParams.placementSpacing, 0.0f, 0.5f);
 			if (sequenceParams.placementMode == DisintegrationPlacementMode::UniformSurface)
 			{
 				ImGui::TextWrapped("均一表面配置はSweep Erosionで形を保って蝕む表現に推奨です。");
+			}
+			else if (sequenceParams.placementMode == DisintegrationPlacementMode::AlignedSurfaceGrid)
+			{
+				ImGui::TextWrapped("整列表面配置はAABBではなくモデル表面上の格子候補へ配置します。");
 			}
 			ImGui::SeparatorText("方向侵食崩壊##BlockSequence");
 			ImGui::Checkbox("方向侵食を使う##BlockSequence", &sequenceParams.useSweepErosion);


### PR DESCRIPTION
### Motivation
- Provide a new deterministic, visually-uniform block placement mode to address the visual mismatch when the model is shown as a complete object while preserving the existing random surface look for dramatic effect. 
- Allow the reconstruction → hold → disintegration flow so the exact block layout used for reconstruction can be held and then used again during disintegration to avoid abrupt placement jumps. 
- Expose placement/spacing/seed and post-completion display options in the Debug ImGui so artists can tune the new behaviors interactively. 

### Description
- Added new placement enum `DisintegrationPlacementMode::AlignedSurfaceGrid` and extended `ModelSurfaceSampler::SampleFromModel(...)` with `placementSpacing` to support a grid-like sampling over triangle surfaces while avoiding filling the AABB. 
- Propagated placement options (`placementMode`, `placementSeed`, `placementSpacing`) and randomization toggles through `ReconstructionEmitter`/`DisintegrationEmitter` and their `Settings`, and added `EmitFromSamples(...)`/`PlayFromSamples(...)` to generate particles/blocks from a shared sample list. 
- Implemented sequence improvements in `ModelBlockEffectSequence`: store reconstruction target samples via `ModelReconstructionEffect::GetTargetSamples()`, added `StartDisintegrationFromSharedSamples()` to reuse the same sample list for disintegration, and added parameters for hold/fade/behavior (`showFinalModelAfterComplete`, `keepBlocksAfterComplete`, `fadeToModelAfterComplete`, `disintegrateAsCompleteBlocks`, `fullBodyHoldTime`, `modelSwitchBlendTime`). 
- Updated ImGui UIs (Japanese labels) in `ModelDisintegrationEffect`, `ModelReconstructionEffect`, and `DebugScene` to select placement mode (`ランダム表面配置`, `均一表面配置`, `整列表面配置`), placement spacing, seed, and the new sequence settings; also disable random size/rotation by default when using uniform/aligned modes. 

### Testing
- Ran `git diff --check` to validate whitespace/conflict markers and it passed. 
- Performed a `-fsyntax-only` compile check with `g++` for the modified unit files, which could not complete in this Linux environment due to missing DirectX header `d3d12.h` (environmental limitation), so full compilation was blocked. 
- Committed the changes (13 files modified) after local checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fea42f7d60832da75ccc3d3c32010b)