### PR TITLE
Fix voxel surface inset placement

### DIFF
--- a/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationEmitter.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationEmitter.cpp
@@ -15,6 +15,17 @@ namespace
 			std::clamp(color.w, 0.0f, 1.0f),
 		};
 	}
+
+	K4E::Vector3 ResolveSurfaceNormal(const DisintegrationSamplePoint& sample, const K4E::Vector3& center)
+	{
+		const K4E::Vector3 radial = K4E::Vector3::NormalizeSafe(sample.position - center, { 0.0f, 1.0f, 0.0f });
+		K4E::Vector3 normal = K4E::Vector3::NormalizeSafe(sample.normal, radial);
+		if (K4E::Vector3::Dot(normal, radial) < 0.0f)
+		{
+			normal = normal * -1.0f;
+		}
+		return normal;
+	}
 }
 
 std::vector<DisintegrationParticle> DisintegrationEmitter::EmitFromModel(
@@ -46,10 +57,17 @@ std::vector<DisintegrationParticle> DisintegrationEmitter::EmitFromSamples(
 	particles.reserve(samples.size());
 	if (samples.empty()) { return particles; }
 
+	const float effectiveSurfaceInset = settings.useSurfaceInset
+		? std::max(settings.autoSurfaceInsetFromBlockSize ? settings.particleSize * 0.5f : settings.surfaceInset, 0.0f)
+		: 0.0f;
+
 	for (const auto& sample : samples)
 	{
-		K4E::Vector3 outward = K4E::Vector3::NormalizeSafe(sample.position - center, sample.normal);
-		outward = K4E::Vector3::NormalizeSafe(outward * 0.70f + sample.normal * 0.25f + RandomUnitVector() * 0.20f, sample.normal);
+		const K4E::Vector3 surfaceNormal = ResolveSurfaceNormal(sample, center);
+		// 表面上のサンプル点から法線の内側へ中心を入れ、Cubeの外側への半分はみ出しを抑える。
+		const K4E::Vector3 insetPosition = sample.position - surfaceNormal * effectiveSurfaceInset;
+		K4E::Vector3 outward = K4E::Vector3::NormalizeSafe(sample.position - center, surfaceNormal);
+		outward = K4E::Vector3::NormalizeSafe(outward * 0.70f + surfaceNormal * 0.25f + RandomUnitVector() * 0.20f, surfaceNormal);
 
 		const float brightness = RandomRange(1.0f - settings.colorVariation, 1.0f + settings.colorVariation);
 		K4E::Vector4 color = ClampColor({
@@ -60,9 +78,9 @@ std::vector<DisintegrationParticle> DisintegrationEmitter::EmitFromSamples(
 		});
 
 		DisintegrationParticle particle{};
-		particle.initialPosition = sample.position;
-		particle.origin = sample.position;
-		particle.position = sample.position;
+		particle.initialPosition = insetPosition;
+		particle.origin = insetPosition;
+		particle.position = insetPosition;
 		particle.outward = outward;
 		const float rotationRandomness = settings.useRandomRotation ? settings.rotationRandomness : 0.0f;
 		particle.rotation = {

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationEmitter.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationEmitter.h
@@ -28,6 +28,9 @@ public:
 		uint32_t placementSeed = 0xD157E6A7u;
 		float placementSpacing = 0.0f;
 		bool surfaceSampling = true;
+		bool useSurfaceInset = false;
+		float surfaceInset = 0.0225f;
+		bool autoSurfaceInsetFromBlockSize = true;
 		float lifeTime = 2.0f;
 		float spreadPower = 1.6f;
 		float upwardPower = 0.65f;

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelBlockEffectSequence.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelBlockEffectSequence.cpp
@@ -140,6 +140,7 @@ void ModelBlockEffectSequence::Update(float deltaTime)
 				ApplySharedParameters();
 				if (disintegrationEffect_)
 				{
+					disintegrationEffect_->GetParameters().useSurfaceInset = false;
 					disintegrationEffect_->PrepareFromSamples(sharedCompletedSamples_, worldMatrix_);
 				}
 				SetDisintegrationAlpha(0.0f);
@@ -265,6 +266,9 @@ void ModelBlockEffectSequence::ApplySharedParameters()
 		reconstructionParams.blockCount = parameters_.blockCount;
 		reconstructionParams.blockSize = parameters_.blockSize;
 		reconstructionParams.surfaceSampling = parameters_.surfaceSampling;
+		reconstructionParams.useSurfaceInset = parameters_.useSurfaceInset;
+		reconstructionParams.surfaceInset = parameters_.surfaceInset;
+		reconstructionParams.autoSurfaceInsetFromBlockSize = parameters_.autoSurfaceInsetFromBlockSize;
 		reconstructionParams.placementMode = parameters_.placementMode;
 		reconstructionParams.useRandomScale = parameters_.useRandomScale;
 		reconstructionParams.scaleVariation = parameters_.scaleVariation;
@@ -284,6 +288,9 @@ void ModelBlockEffectSequence::ApplySharedParameters()
 		disintegrationParams.particleSize = parameters_.blockSize;
 		disintegrationParams.blockSize = parameters_.blockSize;
 		disintegrationParams.surfaceSampling = parameters_.surfaceSampling;
+		disintegrationParams.useSurfaceInset = parameters_.useSurfaceInset;
+		disintegrationParams.surfaceInset = parameters_.surfaceInset;
+		disintegrationParams.autoSurfaceInsetFromBlockSize = parameters_.autoSurfaceInsetFromBlockSize;
 		disintegrationParams.placementMode = parameters_.placementMode;
 		disintegrationParams.useRandomScale = parameters_.useRandomScale;
 		disintegrationParams.scaleVariation = parameters_.scaleVariation;
@@ -349,6 +356,7 @@ void ModelBlockEffectSequence::StartDisintegrationFromSharedSamples()
 	if (disintegrationEffect_)
 	{
 		// 再構築で到着した表面サンプルを崩壊にも使い、完全体から崩れる瞬間の配置ジャンプを防ぐ。
+		disintegrationEffect_->GetParameters().useSurfaceInset = false;
 		disintegrationEffect_->PlayFromSamples(samples, worldMatrix_);
 	}
 }

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelBlockEffectSequence.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelBlockEffectSequence.h
@@ -54,6 +54,9 @@ public:
 		float blockSize = 0.045f;
 		float placementSpacing = 0.0f;
 		bool surfaceSampling = true;
+		bool useSurfaceInset = true;
+		float surfaceInset = 0.0225f;
+		bool autoSurfaceInsetFromBlockSize = true;
 		DisintegrationPlacementMode placementMode = DisintegrationPlacementMode::UniformSurface;
 		bool useRandomScale = false;
 		float scaleVariation = 0.18f;

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelDisintegrationEffect.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelDisintegrationEffect.cpp
@@ -55,6 +55,9 @@ void ModelDisintegrationEffect::PlayFromModel(const std::string& modelPath, cons
 	settings.placementSeed = parameters_.placementSeed;
 	settings.placementSpacing = parameters_.placementSpacing;
 	settings.surfaceSampling = parameters_.surfaceSampling;
+	settings.useSurfaceInset = parameters_.useSurfaceInset;
+	settings.surfaceInset = parameters_.surfaceInset;
+	settings.autoSurfaceInsetFromBlockSize = parameters_.autoSurfaceInsetFromBlockSize;
 	settings.lifeTime = parameters_.lifeTime;
 	settings.spreadPower = parameters_.spreadPower;
 	settings.upwardPower = parameters_.upwardPower;
@@ -106,6 +109,9 @@ void ModelDisintegrationEffect::BuildParticlesFromSamples(const std::vector<Disi
 	settings.placementSeed = parameters_.placementSeed;
 	settings.placementSpacing = parameters_.placementSpacing;
 	settings.surfaceSampling = parameters_.surfaceSampling;
+	settings.useSurfaceInset = parameters_.useSurfaceInset;
+	settings.surfaceInset = parameters_.surfaceInset;
+	settings.autoSurfaceInsetFromBlockSize = parameters_.autoSurfaceInsetFromBlockSize;
 	settings.lifeTime = parameters_.lifeTime;
 	settings.spreadPower = parameters_.spreadPower;
 	settings.upwardPower = parameters_.upwardPower;
@@ -195,6 +201,7 @@ void ModelDisintegrationEffect::DrawImGui()
 		{
 			parameters_.useRandomScale = false;
 			parameters_.useRandomRotation = false;
+			parameters_.useSurfaceInset = true;
 		}
 	}
 	ImGui::Checkbox("ランダムサイズを使う", &parameters_.useRandomScale);
@@ -219,6 +226,17 @@ void ModelDisintegrationEffect::DrawImGui()
 		ImGui::TextWrapped("整列表面配置はAABBを埋めず、三角形表面上の格子候補からブロックを選びます。");
 	}
 	ImGui::Checkbox("表面サンプリング", &parameters_.surfaceSampling);
+	ImGui::Checkbox("表面内側オフセットを使う", &parameters_.useSurfaceInset);
+	ImGui::Checkbox("ブロックサイズから自動計算", &parameters_.autoSurfaceInsetFromBlockSize);
+	if (!parameters_.autoSurfaceInsetFromBlockSize)
+	{
+		ImGui::SliderFloat("表面内側オフセット量", &parameters_.surfaceInset, 0.0f, 0.30f);
+	}
+	else
+	{
+		const float effectiveSurfaceInset = parameters_.blockSize * 0.5f;
+		ImGui::Text("表面内側オフセット量: %.3f", effectiveSurfaceInset);
+	}
 	ImGui::Checkbox("形状維持", &parameters_.preserveShape);
 	ImGui::SliderFloat("寿命", &parameters_.lifeTime, 0.10f, 8.0f);
 	ImGui::SliderFloat("拡散力", &parameters_.spreadPower, 0.0f, 8.0f);

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelDisintegrationEffect.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelDisintegrationEffect.h
@@ -31,6 +31,9 @@ public:
 		uint32_t placementSeed = 0xD157E6A7u;
 		float placementSpacing = 0.0f;
 		bool surfaceSampling = true;
+		bool useSurfaceInset = false;
+		float surfaceInset = 0.0225f;
+		bool autoSurfaceInsetFromBlockSize = true;
 		bool preserveShape = true;
 		float lifeTime = 2.2f;
 		float spreadPower = 1.6f;

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelReconstructionEffect.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelReconstructionEffect.cpp
@@ -39,6 +39,9 @@ void ModelReconstructionEffect::PlayFromModel(const std::string& modelPath, cons
 	settings.placementSeed = parameters_.placementSeed;
 	settings.placementSpacing = parameters_.placementSpacing;
 	settings.surfaceSampling = parameters_.surfaceSampling;
+	settings.useSurfaceInset = parameters_.useSurfaceInset;
+	settings.surfaceInset = parameters_.surfaceInset;
+	settings.autoSurfaceInsetFromBlockSize = parameters_.autoSurfaceInsetFromBlockSize;
 	settings.color = parameters_.color;
 	settings.colorVariation = parameters_.colorVariation;
 
@@ -154,6 +157,7 @@ void ModelReconstructionEffect::DrawImGui()
 		{
 			parameters_.useRandomScale = false;
 			parameters_.useRandomRotation = false;
+			parameters_.useSurfaceInset = true;
 		}
 	}
 	int placementSeed = static_cast<int>(parameters_.placementSeed);
@@ -169,6 +173,17 @@ void ModelReconstructionEffect::DrawImGui()
 	ImGui::Checkbox("完了後にモデル表示", &parameters_.showFinalModel);
 	ImGui::Checkbox("完了後にブロック自動非表示", &parameters_.autoHideBlocksAfterComplete);
 	ImGui::Checkbox("表面サンプリング", &parameters_.surfaceSampling);
+	ImGui::Checkbox("表面内側オフセットを使う", &parameters_.useSurfaceInset);
+	ImGui::Checkbox("ブロックサイズから自動計算", &parameters_.autoSurfaceInsetFromBlockSize);
+	if (!parameters_.autoSurfaceInsetFromBlockSize)
+	{
+		ImGui::SliderFloat("表面内側オフセット量", &parameters_.surfaceInset, 0.0f, 0.30f);
+	}
+	else
+	{
+		const float effectiveSurfaceInset = parameters_.blockSize * 0.5f;
+		ImGui::Text("表面内側オフセット量: %.3f", effectiveSurfaceInset);
+	}
 	ImGui::End();
 #endif
 }

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelReconstructionEffect.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelReconstructionEffect.h
@@ -37,6 +37,9 @@ public:
 		bool showFinalModel = true;
 		bool autoHideBlocksAfterComplete = true;
 		bool surfaceSampling = true;
+		bool useSurfaceInset = false;
+		float surfaceInset = 0.0225f;
+		bool autoSurfaceInsetFromBlockSize = true;
 	};
 
 	void Initialize();

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionEmitter.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionEmitter.cpp
@@ -4,6 +4,20 @@
 #include <algorithm>
 #include <cmath>
 
+namespace
+{
+	K4E::Vector3 ResolveSurfaceNormal(const DisintegrationSamplePoint& sample, const K4E::Vector3& center)
+	{
+		const K4E::Vector3 radial = K4E::Vector3::NormalizeSafe(sample.position - center, { 0.0f, 1.0f, 0.0f });
+		K4E::Vector3 normal = K4E::Vector3::NormalizeSafe(sample.normal, radial);
+		if (K4E::Vector3::Dot(normal, radial) < 0.0f)
+		{
+			normal = normal * -1.0f;
+		}
+		return normal;
+	}
+}
+
 std::vector<ReconstructionBlock> ReconstructionEmitter::EmitFromModel(
 	const K4E::ModelData& modelData,
 	const K4E::Matrix4x4& worldMatrix,
@@ -26,17 +40,22 @@ std::vector<ReconstructionBlock> ReconstructionEmitter::EmitFromModel(
 	if (targets.empty()) { return blocks; }
 
 	const K4E::Vector3 center = worldMatrix.GetTranslation();
+	const float effectiveSurfaceInset = settings.useSurfaceInset
+		? std::max(settings.autoSurfaceInsetFromBlockSize ? settings.blockSize * 0.5f : settings.surfaceInset, 0.0f)
+		: 0.0f;
 	for (const auto& target : targets)
 	{
+		const K4E::Vector3 surfaceNormal = ResolveSurfaceNormal(target, center);
+		const K4E::Vector3 targetPosition = target.position - surfaceNormal * effectiveSurfaceInset;
 		const K4E::Vector3 radial = K4E::Vector3::NormalizeSafe(target.position - center, RandomUnitVector());
 		K4E::Vector3 scatter = radial * RandomRange(settings.startScatterRadius * 0.35f, settings.startScatterRadius);
 		scatter += RandomUnitVector() * RandomRange(0.0f, settings.startScatterRadius * 0.35f);
 		scatter.y += RandomRange(-0.25f, settings.startHeight);
 
 		ReconstructionBlock block{};
-		block.startPosition = target.position + scatter;
-		block.targetPosition = target.position;
-		block.targetNormal = target.normal;
+		block.startPosition = targetPosition + scatter;
+		block.targetPosition = targetPosition;
+		block.targetNormal = surfaceNormal;
 		block.position = block.startPosition;
 		const float rotationRandomness = settings.useRandomRotation ? settings.rotationRandomness : 0.0f;
 		block.startRotation = {

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionEmitter.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionEmitter.h
@@ -30,6 +30,9 @@ public:
 		uint32_t placementSeed = 0xD157E6A7u;
 		float placementSpacing = 0.0f;
 		bool surfaceSampling = true;
+		bool useSurfaceInset = false;
+		float surfaceInset = 0.0225f;
+		bool autoSurfaceInsetFromBlockSize = true;
 		K4E::Vector4 color{ 0.64f, 0.72f, 0.86f, 1.0f };
 		float colorVariation = 0.18f;
 	};

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -596,6 +596,7 @@ void DebugScene::DrawImGui()
 				{
 					sequenceParams.useRandomScale = false;
 					sequenceParams.useRandomRotation = false;
+					sequenceParams.useSurfaceInset = true;
 				}
 			}
 			ImGui::Checkbox("ランダムサイズを使う##BlockSequence", &sequenceParams.useRandomScale);
@@ -608,6 +609,17 @@ void DebugScene::DrawImGui()
 				sequenceParams.placementSeed = static_cast<uint32_t>(std::max(sequencePlacementSeed, 0));
 			}
 			ImGui::SliderFloat("配置間隔##BlockSequence", &sequenceParams.placementSpacing, 0.0f, 0.5f);
+			ImGui::Checkbox("表面内側オフセットを使う##BlockSequence", &sequenceParams.useSurfaceInset);
+			ImGui::Checkbox("ブロックサイズから自動計算##BlockSequence", &sequenceParams.autoSurfaceInsetFromBlockSize);
+			if (!sequenceParams.autoSurfaceInsetFromBlockSize)
+			{
+				ImGui::SliderFloat("表面内側オフセット量##BlockSequence", &sequenceParams.surfaceInset, 0.0f, 0.30f);
+			}
+			else
+			{
+				const float effectiveSurfaceInset = sequenceParams.blockSize * 0.5f;
+				ImGui::Text("表面内側オフセット量: %.3f", effectiveSurfaceInset);
+			}
 			if (sequenceParams.placementMode == DisintegrationPlacementMode::UniformSurface)
 			{
 				ImGui::TextWrapped("均一表面配置はSweep Erosionで形を保って蝕む表現に推奨です。");


### PR DESCRIPTION
### Motivation
- 均一表面配置や整列表面配置で各Cubeの半分がモデル外側にはみ出して見える問題を修正するための対応です。 
- 原因は各サンプル点をそのままブロック中心に使っているためで、ブロック中心を法線方向へ内側にずらす必要があります。 
- 目的は均一/整列配置でブロック集合がモデル外形から大きくはみ出さないようにしつつ、ランダム表面配置の見た目を壊さないことです。

### Description
- `Parameters` に `useSurfaceInset` / `surfaceInset` / `autoSurfaceInsetFromBlockSize` を追加し、`DisintegrationEmitter::Settings` / `ReconstructionEmitter::Settings` / 各 `Effect::Parameters` に伝搬するようにしました（デフォルトは `false`、均一/整列選択時は推奨で `true`）。
- サンプル点で三角形法線（ない場合はモデル中心からの方向を代替法線）を解決し、`origin = sample.position - normal * effectiveInset` のように中心を内側へオフセットして `initialPosition` / `origin` / `position` に設定する処理を導入しました（`effectiveInset` は `blockSize * 0.5f` または明示 `surfaceInset`）。
- 再構築（`ReconstructionEmitter`）側にも同様のオフセットを適用し、シーケンスで再構築→崩壊へ渡す際に二重オフセットが起きないように、共有サンプルから崩壊へ移るときは崩壊側の追加オフセットを無効化しています。 
- Debug/Inspector の ImGui 表示に日本語で `表面内側オフセットを使う` / `表面内側オフセット量` / `ブロックサイズから自動計算` を追加し、均一/整列配置を選んだ場合は `useSurfaceInset` を推奨で ON にする自動化を入れました。

### Testing
- `git diff --check` を実行して差分の問題は検出されなかったため問題なしとしました（成功）。
- `clang++ -std=c++20 -fsyntax-only` による構文チェックを試行しましたが、実行環境に DirectX ヘッダ（`d3d12.h` 等）が無いため構文チェックは途中で止まり実行できませんでした（環境依存で失敗）。
- 変更はローカルでコミット済み（コミット説明: `Fix voxel surface inset placement`）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feadc924f8832da42a5dc970bce573)