### PR TITLE
Add center-out disintegration erosion mode

### DIFF
--- a/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationParticle.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationParticle.h
@@ -27,6 +27,7 @@ struct DisintegrationParticle
 	float edgeFactor = 0.0f;
 	float erosionNoise = 0.5f;
 	float sweepCoord = 0.0f;
+	float centerDistance = 0.0f;
 	bool active = true;
 	bool alive = false;
 };

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelDisintegrationEffect.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelDisintegrationEffect.cpp
@@ -36,6 +36,9 @@ void ModelDisintegrationEffect::Initialize()
 	sweepDirectionNormalized_ = GetSafeSweepDirection();
 	sweepMin_ = 0.0f;
 	sweepMax_ = 0.0f;
+	erosionCenterResolved_ = { 0.0f, 0.0f, 0.0f };
+	centerMinDistance_ = 0.0f;
+	centerMaxDistance_ = 0.0f;
 }
 
 void ModelDisintegrationEffect::PlayFromModel(const std::string& modelPath, const K4E::Matrix4x4& worldMatrix)
@@ -66,7 +69,7 @@ void ModelDisintegrationEffect::PlayFromModel(const std::string& modelPath, cons
 	settings.colorVariation = parameters_.colorVariation;
 
 	particles_ = emitter_.EmitFromModel(model->GetModelData(), worldMatrix, settings);
-	InitializeSweepData();
+	InitializeErosionData();
 	isActive_ = !particles_.empty();
 	isStarted_ = isActive_;
 	globalAlpha_ = 1.0f;
@@ -89,7 +92,7 @@ void ModelDisintegrationEffect::StartPrepared()
 {
 	if (particles_.empty()) { return; }
 	// フェード完了までは同じ配置のブロックを静止させ、開始時の配置ジャンプを防ぐ。
-	InitializeSweepData();
+	InitializeErosionData();
 	isActive_ = true;
 	isStarted_ = true;
 	elapsedTime_ = 0.0f;
@@ -120,7 +123,7 @@ void ModelDisintegrationEffect::BuildParticlesFromSamples(const std::vector<Disi
 	settings.colorVariation = parameters_.colorVariation;
 
 	particles_ = emitter_.EmitFromSamples(samples, worldMatrix.GetTranslation(), settings);
-	InitializeSweepData();
+	InitializeErosionData();
 	isActive_ = !particles_.empty();
 	isStarted_ = false;
 	globalAlpha_ = 1.0f;
@@ -134,9 +137,16 @@ void ModelDisintegrationEffect::Update(float deltaTime)
 	elapsedTime_ += deltaTime;
 	bool anyAlive = false;
 
-	if (parameters_.useSweepErosion)
+	if (UsesErosionGate())
 	{
-		UpdateSweepErosion();
+		if (parameters_.erosionMode == ErosionMode::CenterOut)
+		{
+			UpdateCenterErosion();
+		}
+		else
+		{
+			UpdateSweepErosion();
+		}
 	}
 
 	for (auto& particle : particles_)
@@ -249,12 +259,27 @@ void ModelDisintegrationEffect::DrawImGui()
 	ImGui::SliderFloat("形状維持時間", &parameters_.shapePreserveTime, 0.0f, 3.0f);
 	ImGui::ColorEdit4("基本色", &parameters_.baseColor.x);
 	ImGui::SliderFloat("色のばらつき", &parameters_.colorVariation, 0.0f, 0.5f);
+	ImGui::SeparatorText("侵食モード");
+	ImGui::Checkbox("侵食を使う", &parameters_.useSweepErosion);
+	const char* erosionModeLabels[] = { "方向侵食", "中心侵食" };
+	int erosionModeIndex = parameters_.erosionMode == ErosionMode::CenterOut ? 1 : 0;
+	if (ImGui::Combo("侵食モード", &erosionModeIndex, erosionModeLabels, IM_ARRAYSIZE(erosionModeLabels)))
+	{
+		parameters_.erosionMode = erosionModeIndex == 1 ? ErosionMode::CenterOut : ErosionMode::DirectionalSweep;
+		parameters_.useSweepErosion = true;
+	}
 	ImGui::SeparatorText("方向侵食");
-	ImGui::Checkbox("方向侵食を使う", &parameters_.useSweepErosion);
 	ImGui::DragFloat3("侵食方向", &parameters_.sweepDirection.x, 0.01f, -1.0f, 1.0f);
 	ImGui::SliderFloat("侵食時間", &parameters_.sweepDuration, 0.05f, 8.0f);
 	ImGui::SliderFloat("侵食ノイズ強度", &parameters_.erosionNoisePower, 0.0f, 4.0f);
 	ImGui::SliderFloat("侵食境界幅", &parameters_.erosionBandWidth, 0.0f, 2.0f);
+	ImGui::SeparatorText("中心侵食");
+	ImGui::Checkbox("モデル中心を使う", &parameters_.useModelCenterAsErosionCenter);
+	ImGui::DragFloat3("侵食中心", &parameters_.erosionCenter.x, 0.01f);
+	ImGui::SliderFloat("中心侵食時間", &parameters_.centerErosionDuration, 0.05f, 8.0f);
+	ImGui::SliderFloat("中心侵食ノイズ強度", &parameters_.centerErosionNoisePower, 0.0f, 4.0f);
+	ImGui::SliderFloat("中心発光幅", &parameters_.centerGlowWidth, 0.001f, 2.0f);
+	ImGui::SeparatorText("Glow Edge");
 	ImGui::SliderFloat("侵食前の発光幅", &parameters_.preGlowWidth, 0.0f, 2.0f);
 	ImGui::SliderFloat("侵食後の発光幅", &parameters_.postGlowWidth, 0.0f, 2.0f);
 	ImGui::SliderFloat("発光エッジ幅", &parameters_.glowEdgeWidth, 0.001f, 2.0f);
@@ -296,15 +321,41 @@ float ModelDisintegrationEffect::ErosionNoise(const K4E::Vector3& origin) const
 	return static_cast<float>(hash & 0x00FFFFFFu) / static_cast<float>(0x01000000u);
 }
 
-void ModelDisintegrationEffect::InitializeSweepData()
+bool ModelDisintegrationEffect::UsesErosionGate() const
+{
+	return parameters_.useSweepErosion;
+}
+
+void ModelDisintegrationEffect::InitializeErosionData()
 {
 	sweepDirectionNormalized_ = GetSafeSweepDirection();
 	sweepMin_ = 0.0f;
 	sweepMax_ = 0.0f;
+	erosionCenterResolved_ = parameters_.erosionCenter;
+	centerMinDistance_ = 0.0f;
+	centerMaxDistance_ = 0.0f;
 	if (particles_.empty()) { return; }
 
-	sweepMin_ = K4E::Vector3::Dot(particles_.front().origin, sweepDirectionNormalized_);
+	K4E::Vector3 boundsMin = particles_.front().initialPosition;
+	K4E::Vector3 boundsMax = particles_.front().initialPosition;
+	for (const auto& particle : particles_)
+	{
+		boundsMin.x = std::min(boundsMin.x, particle.initialPosition.x);
+		boundsMin.y = std::min(boundsMin.y, particle.initialPosition.y);
+		boundsMin.z = std::min(boundsMin.z, particle.initialPosition.z);
+		boundsMax.x = std::max(boundsMax.x, particle.initialPosition.x);
+		boundsMax.y = std::max(boundsMax.y, particle.initialPosition.y);
+		boundsMax.z = std::max(boundsMax.z, particle.initialPosition.z);
+	}
+	if (parameters_.useModelCenterAsErosionCenter)
+	{
+		erosionCenterResolved_ = (boundsMin + boundsMax) * 0.5f;
+	}
+
+	sweepMin_ = K4E::Vector3::Dot(particles_.front().initialPosition, sweepDirectionNormalized_);
 	sweepMax_ = sweepMin_;
+	centerMinDistance_ = K4E::Vector3::Length(particles_.front().initialPosition - erosionCenterResolved_);
+	centerMaxDistance_ = centerMinDistance_;
 	for (auto& particle : particles_)
 	{
 		particle.origin = particle.initialPosition;
@@ -315,10 +366,13 @@ void ModelDisintegrationEffect::InitializeSweepData()
 		particle.edgeColor = { 0.0f, 0.0f, 0.0f, 0.0f };
 		particle.erosionNoise = ErosionNoise(particle.origin);
 		particle.sweepCoord = K4E::Vector3::Dot(particle.origin, sweepDirectionNormalized_);
-		particle.active = !parameters_.useSweepErosion;
+		particle.centerDistance = K4E::Vector3::Length(particle.origin - erosionCenterResolved_);
+		particle.active = !UsesErosionGate();
 		particle.alive = true;
 		sweepMin_ = std::min(sweepMin_, particle.sweepCoord);
 		sweepMax_ = std::max(sweepMax_, particle.sweepCoord);
+		centerMinDistance_ = std::min(centerMinDistance_, particle.centerDistance);
+		centerMaxDistance_ = std::max(centerMaxDistance_, particle.centerDistance);
 	}
 }
 
@@ -364,12 +418,53 @@ void ModelDisintegrationEffect::UpdateSweepErosion()
 	}
 }
 
+void ModelDisintegrationEffect::UpdateCenterErosion()
+{
+	const float duration = std::max(parameters_.centerErosionDuration, 0.0001f);
+	const float t = Clamp01(elapsedTime_ / duration);
+	const float currentRadius = Lerp(centerMinDistance_, centerMaxDistance_, t);
+	const float glowEdgeWidth = std::max(parameters_.centerGlowWidth, 0.0001f);
+	const float glowSharpness = std::max(parameters_.glowSharpness, 0.0001f);
+
+	for (auto& particle : particles_)
+	{
+		if (!particle.alive) { continue; }
+
+		const float distanceWithNoise = particle.centerDistance + (particle.erosionNoise - 0.5f) * parameters_.centerErosionNoisePower;
+		const float signedDistance = currentRadius - distanceWithNoise;
+		if (!particle.active && (signedDistance >= 0.0f || t >= 1.0f))
+		{
+			// 中心から広がる半径が粒子へ届いた瞬間に、静止ブロックを崩壊物理へ渡す。
+			particle.active = true;
+			particle.age = 0.0f;
+			particle.position = particle.origin;
+		}
+
+		if (signedDistance >= -parameters_.preGlowWidth && signedDistance <= parameters_.postGlowWidth)
+		{
+			particle.edgeFactor = std::pow(1.0f - Clamp01(std::abs(signedDistance) / glowEdgeWidth), glowSharpness);
+		}
+		else
+		{
+			particle.edgeFactor = 0.0f;
+		}
+
+		const float glowAmount = particle.edgeFactor * parameters_.glowIntensity;
+		particle.edgeColor = {
+			parameters_.glowColor.x * glowAmount,
+			parameters_.glowColor.y * glowAmount,
+			parameters_.glowColor.z * glowAmount,
+			0.0f,
+		};
+	}
+}
+
 void ModelDisintegrationEffect::UpdateParticlePhysics(DisintegrationParticle& particle, float deltaTime)
 {
 	particle.age += deltaTime;
 	if (particle.age < particle.startDelay)
 	{
-		particle.position = parameters_.useSweepErosion ? particle.origin : particle.position;
+		particle.position = UsesErosionGate() ? particle.origin : particle.position;
 		return;
 	}
 

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelDisintegrationEffect.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelDisintegrationEffect.h
@@ -13,6 +13,12 @@
 /// -------------------------------------------------------------
 /// モデル形状を小さいブロック粒子として崩して消す完全新規エフェクト
 /// -------------------------------------------------------------
+enum class ErosionMode
+{
+	DirectionalSweep,
+	CenterOut,
+};
+
 class ModelDisintegrationEffect
 {
 public:
@@ -47,6 +53,12 @@ public:
 		K4E::Vector4 baseColor{ 0.64f, 0.61f, 0.56f, 1.0f };
 		float colorVariation = 0.16f;
 		bool useSweepErosion = false;
+		ErosionMode erosionMode = ErosionMode::DirectionalSweep;
+		K4E::Vector3 erosionCenter{ 0.0f, 0.0f, 0.0f };
+		bool useModelCenterAsErosionCenter = true;
+		float centerErosionDuration = 1.6f;
+		float centerErosionNoisePower = 0.35f;
+		float centerGlowWidth = 0.24f;
 		K4E::Vector3 sweepDirection{ 1.0f, 0.0f, 0.0f };
 		float sweepDuration = 1.6f;
 		float erosionNoisePower = 0.35f;
@@ -77,8 +89,10 @@ private:
 	K4E::Vector3 RandomNoiseVector();
 	K4E::Vector3 GetSafeSweepDirection() const;
 	float ErosionNoise(const K4E::Vector3& origin) const;
-	void InitializeSweepData();
+	bool UsesErosionGate() const;
+	void InitializeErosionData();
 	void UpdateSweepErosion();
+	void UpdateCenterErosion();
 	void UpdateParticlePhysics(DisintegrationParticle& particle, float deltaTime);
 	void StopIfFinished();
 	void BuildParticlesFromSamples(const std::vector<DisintegrationSamplePoint>& samples, const K4E::Matrix4x4& worldMatrix);
@@ -94,4 +108,7 @@ private:
 	K4E::Vector3 sweepDirectionNormalized_{ 1.0f, 0.0f, 0.0f };
 	float sweepMin_ = 0.0f;
 	float sweepMax_ = 0.0f;
+	K4E::Vector3 erosionCenterResolved_{ 0.0f, 0.0f, 0.0f };
+	float centerMinDistance_ = 0.0f;
+	float centerMaxDistance_ = 0.0f;
 };

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -509,6 +509,23 @@ void DebugScene::DrawImGui()
 			pendingDebugDisintegrationPlay_ = true;
 			debugDisintegrationLog_ = "再生を予約: " + pendingDebugDisintegrationPath_;
 		}
+		ImGui::SameLine();
+		if (ImGui::Button("リセット"))
+		{
+			pendingDebugDisintegrationReset_ = true;
+			debugDisintegrationLog_ = "崩壊リセットを予約しました。";
+		}
+
+		if (ImGui::Button(debugDisintegrationPaused_ ? "再開" : "一時停止"))
+		{
+			debugDisintegrationPaused_ = !debugDisintegrationPaused_;
+		}
+		ImGui::SameLine();
+		if (ImGui::Button("1フレーム送り"))
+		{
+			debugDisintegrationStepFrame_ = true;
+			debugDisintegrationPaused_ = true;
+		}
 
 		ImGui::Text("モデル表示: %s", debugDisintegrationModelVisible_ ? "はい" : "いいえ");
 		ImGui::TextWrapped("%s", debugDisintegrationLog_.c_str());
@@ -1149,7 +1166,9 @@ void DebugScene::UpdateDebugDisintegrationTest(float deltaTime)
 
 	if (debugDisintegrationEffect_)
 	{
-		debugDisintegrationEffect_->Update(deltaTime);
+		const bool shouldAdvanceEffect = !debugDisintegrationPaused_ || debugDisintegrationStepFrame_;
+		debugDisintegrationEffect_->Update(shouldAdvanceEffect ? deltaTime : 0.0f);
+		debugDisintegrationStepFrame_ = false;
 		debugDisintegrationModelVisible_ = !debugDisintegrationEffect_->IsActive();
 	}
 }
@@ -1169,7 +1188,7 @@ void DebugScene::ReloadDebugDisintegrationModel()
 
 void DebugScene::ProcessDebugDisintegrationRequest()
 {
-	if (!pendingDebugDisintegrationReload_ && !pendingDebugDisintegrationPlay_)
+	if (!pendingDebugDisintegrationReload_ && !pendingDebugDisintegrationPlay_ && !pendingDebugDisintegrationReset_)
 	{
 		return;
 	}
@@ -1184,6 +1203,14 @@ void DebugScene::ProcessDebugDisintegrationRequest()
 		ReloadDebugDisintegrationModel();
 	}
 
+	if (pendingDebugDisintegrationReset_ && debugDisintegrationEffect_)
+	{
+		debugDisintegrationEffect_->Initialize();
+		debugDisintegrationModelVisible_ = true;
+		debugDisintegrationPaused_ = false;
+		debugDisintegrationStepFrame_ = false;
+	}
+
 	if (pendingDebugDisintegrationPlay_)
 	{
 		PlayDebugDisintegrationEffect();
@@ -1191,6 +1218,7 @@ void DebugScene::ProcessDebugDisintegrationRequest()
 
 	pendingDebugDisintegrationReload_ = false;
 	pendingDebugDisintegrationPlay_ = false;
+	pendingDebugDisintegrationReset_ = false;
 	pendingDebugDisintegrationPath_.clear();
 }
 
@@ -1208,6 +1236,8 @@ void DebugScene::PlayDebugDisintegrationEffect()
 
 	// 表示中のテストモデルと同じ行列から生成し、形状サンプリングのずれを確認しやすくする。
 	debugDisintegrationEffect_->PlayFromModel(debugDisintegrationModelPath_, worldMatrix);
+	debugDisintegrationPaused_ = false;
+	debugDisintegrationStepFrame_ = false;
 	debugDisintegrationModelVisible_ = !debugDisintegrationEffect_->IsActive();
 	debugDisintegrationLog_ = "崩壊再生: " + debugDisintegrationModelPath_;
 	DebugLog(debugDisintegrationLog_);

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
@@ -148,6 +148,9 @@ private: /// ---------- メンバ変数 ---------- ///
 	bool debugDisintegrationModelVisible_ = true;
 	bool pendingDebugDisintegrationPlay_ = false;
 	bool pendingDebugDisintegrationReload_ = false;
+	bool pendingDebugDisintegrationReset_ = false;
+	bool debugDisintegrationPaused_ = false;
+	bool debugDisintegrationStepFrame_ = false;
 	std::string pendingDebugDisintegrationPath_;
 
 	// --- モデル再構築エフェクト単体テスト用 ---


### PR DESCRIPTION
### Motivation
- Provide a new "center-out" erosion mode so disintegration can expand outward from a specified center (or model center) in addition to the existing directional sweep behavior.
- Allow artists/debuggers to exercise and tune the new mode from DebugScene ImGui without touching gameplay or enemy death logic.

### Description
- Add `enum class ErosionMode { DirectionalSweep, CenterOut };` and new parameters to `ModelDisintegrationEffect::Parameters`: `erosionMode`, `erosionCenter`, `useModelCenterAsErosionCenter`, `centerErosionDuration`, `centerErosionNoisePower`, and `centerGlowWidth`.
- Add `float centerDistance` to `DisintegrationParticle` and per-effect fields `erosionCenterResolved_`, `centerMinDistance_`, and `centerMaxDistance_` to cache distances; implement `InitializeErosionData()` to compute these values.
- Implement `UpdateCenterErosion()` that advances a radius from `centerMinDistance_` to `centerMaxDistance_`, uses per-particle noise to compute `signedDistance`, flips `particle.active` when reached, and computes `edgeFactor`/`edgeColor` for glow; preserve existing `UpdateSweepErosion()` and switch between them in `Update()` based on `erosionMode`.
- Expose controls in `ModelDisintegrationEffect::DrawImGui()` (Japanese labels) for: erosion mode, directional settings, center erosion center, `useModelCenterAsErosionCenter`, center erosion duration, center noise power, and center glow width; also ensure selecting a mode enables the erosion gate.
- Add DebugScene ImGui buttons and queued Update-side handling for `Reset`, `Pause/Resume`, and `Single-frame step` for the disintegration test so the new mode can be inspected frame-by-frame without breaking the existing update/reservation policy.

### Testing
- Ran `git diff --check` to validate workspace diffs and whitespace; it passed.
- Attempted a syntax-only check with `clang++ -std=c++20 -fsyntax-only ... ModelDisintegrationEffect.cpp` with `-DUSE_IMGUI`, but it could not complete in this Linux CI environment due to missing Windows DirectX headers (`d3d12.h`), so a full compiler check was not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feb29ac260832daf3f69be6ba6233b)