### PR TITLE
ボクセル敷き詰め配置 (VoxelFill) の追加

### DIFF
--- a/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationEmitter.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationEmitter.cpp
@@ -43,7 +43,13 @@ std::vector<DisintegrationParticle> DisintegrationEmitter::EmitFromModel(
 		settings.particleSize * 1.5f,
 		settings.placementMode,
 		settings.placementSeed,
-		settings.placementSpacing);
+		settings.placementSpacing,
+		settings.voxelSpacing,
+		settings.maxVoxelBlockCount,
+		settings.voxelSurfaceThickness,
+		settings.useVoxelInsideTest,
+		settings.useVoxelSurfaceNearTest,
+		settings.alignVoxelGridToCenter);
 	return EmitFromSamples(samples, worldMatrix.GetTranslation(), settings);
 }
 

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationEmitter.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/DisintegrationEmitter.h
@@ -27,6 +27,12 @@ public:
 		float rotationRandomness = 1.2f;
 		uint32_t placementSeed = 0xD157E6A7u;
 		float placementSpacing = 0.0f;
+		float voxelSpacing = 0.0f;
+		int maxVoxelBlockCount = 10000;
+		float voxelSurfaceThickness = 0.0675f;
+		bool useVoxelInsideTest = true;
+		bool useVoxelSurfaceNearTest = true;
+		bool alignVoxelGridToCenter = true;
 		bool surfaceSampling = true;
 		bool useSurfaceInset = false;
 		float surfaceInset = 0.0225f;

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelBlockEffectSequence.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelBlockEffectSequence.cpp
@@ -178,6 +178,10 @@ void ModelBlockEffectSequence::Update(float deltaTime)
 		if (disintegrationEffect_ && !disintegrationEffect_->IsActive())
 		{
 			disintegrationCompleted_ = true;
+			if (mode_ == SequenceMode::DisintegrateThenReconstruct)
+			{
+				sharedCompletedSamples_ = disintegrationEffect_->GetInitialSamples();
+			}
 			modelVisible_ = false;
 			if (mode_ == SequenceMode::DisintegrateThenReconstruct)
 			{
@@ -276,6 +280,12 @@ void ModelBlockEffectSequence::ApplySharedParameters()
 		reconstructionParams.rotationRandomness = parameters_.rotationRandomness;
 		reconstructionParams.placementSeed = parameters_.placementSeed;
 		reconstructionParams.placementSpacing = parameters_.placementSpacing;
+		reconstructionParams.voxelSpacing = parameters_.voxelSpacing;
+		reconstructionParams.maxVoxelBlockCount = parameters_.maxVoxelBlockCount;
+		reconstructionParams.voxelSurfaceThickness = parameters_.voxelSurfaceThickness;
+		reconstructionParams.useVoxelInsideTest = parameters_.useVoxelInsideTest;
+		reconstructionParams.useVoxelSurfaceNearTest = parameters_.useVoxelSurfaceNearTest;
+		reconstructionParams.alignVoxelGridToCenter = parameters_.alignVoxelGridToCenter;
 		reconstructionParams.holdTime = 0.0f;
 		reconstructionParams.showFinalModel = false;
 		reconstructionParams.autoHideBlocksAfterComplete = false;
@@ -298,7 +308,19 @@ void ModelBlockEffectSequence::ApplySharedParameters()
 		disintegrationParams.rotationRandomness = parameters_.rotationRandomness;
 		disintegrationParams.placementSeed = parameters_.placementSeed;
 		disintegrationParams.placementSpacing = parameters_.placementSpacing;
+		disintegrationParams.voxelSpacing = parameters_.voxelSpacing;
+		disintegrationParams.maxVoxelBlockCount = parameters_.maxVoxelBlockCount;
+		disintegrationParams.voxelSurfaceThickness = parameters_.voxelSurfaceThickness;
+		disintegrationParams.useVoxelInsideTest = parameters_.useVoxelInsideTest;
+		disintegrationParams.useVoxelSurfaceNearTest = parameters_.useVoxelSurfaceNearTest;
+		disintegrationParams.alignVoxelGridToCenter = parameters_.alignVoxelGridToCenter;
 		disintegrationParams.useSweepErosion = parameters_.useSweepErosion;
+		disintegrationParams.erosionMode = parameters_.erosionMode;
+		disintegrationParams.erosionCenter = parameters_.erosionCenter;
+		disintegrationParams.useModelCenterAsErosionCenter = parameters_.useModelCenterAsErosionCenter;
+		disintegrationParams.centerErosionDuration = parameters_.centerErosionDuration;
+		disintegrationParams.centerErosionNoisePower = parameters_.centerErosionNoisePower;
+		disintegrationParams.centerGlowWidth = parameters_.centerGlowWidth;
 		disintegrationParams.sweepDirection = parameters_.sweepDirection;
 		disintegrationParams.sweepDuration = parameters_.sweepDuration;
 		disintegrationParams.erosionNoisePower = parameters_.erosionNoisePower;
@@ -324,7 +346,15 @@ void ModelBlockEffectSequence::StartReconstruction()
 	if (reconstructionEffect_)
 	{
 		// 再構築中は通常モデルを隠し、ブロックだけで登場演出を確認する。
-		reconstructionEffect_->PlayFromModel(modelPath_, worldMatrix_);
+		if (!sharedCompletedSamples_.empty())
+		{
+			reconstructionEffect_->GetParameters().useSurfaceInset = false;
+			reconstructionEffect_->PlayFromSamples(sharedCompletedSamples_, worldMatrix_);
+		}
+		else
+		{
+			reconstructionEffect_->PlayFromModel(modelPath_, worldMatrix_);
+		}
 	}
 }
 

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelBlockEffectSequence.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelBlockEffectSequence.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "ModelSurfaceSampler.h"
+#include "ModelDisintegrationEffect.h"
 #include "Matrix4x4.h"
 #include "Vector3.h"
 #include "Vector4.h"
@@ -53,6 +54,12 @@ public:
 		int blockCount = 1200;
 		float blockSize = 0.045f;
 		float placementSpacing = 0.0f;
+		float voxelSpacing = 0.0f;
+		int maxVoxelBlockCount = 10000;
+		float voxelSurfaceThickness = 0.0675f;
+		bool useVoxelInsideTest = true;
+		bool useVoxelSurfaceNearTest = true;
+		bool alignVoxelGridToCenter = true;
 		bool surfaceSampling = true;
 		bool useSurfaceInset = true;
 		float surfaceInset = 0.0225f;
@@ -64,6 +71,12 @@ public:
 		float rotationRandomness = 1.2f;
 		uint32_t placementSeed = 0xD157E6A7u;
 		bool useSweepErosion = true;
+		ErosionMode erosionMode = ErosionMode::DirectionalSweep;
+		K4E::Vector3 erosionCenter{ 0.0f, 0.0f, 0.0f };
+		bool useModelCenterAsErosionCenter = true;
+		float centerErosionDuration = 1.6f;
+		float centerErosionNoisePower = 0.35f;
+		float centerGlowWidth = 0.24f;
 		K4E::Vector3 sweepDirection{ 1.0f, 0.0f, 0.0f };
 		float sweepDuration = 1.6f;
 		float erosionNoisePower = 0.35f;

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelDisintegrationEffect.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelDisintegrationEffect.cpp
@@ -29,6 +29,7 @@ namespace
 void ModelDisintegrationEffect::Initialize()
 {
 	particles_.clear();
+	initialSamples_.clear();
 	isActive_ = false;
 	isStarted_ = false;
 	globalAlpha_ = 1.0f;
@@ -57,6 +58,12 @@ void ModelDisintegrationEffect::PlayFromModel(const std::string& modelPath, cons
 	settings.rotationRandomness = parameters_.rotationRandomness;
 	settings.placementSeed = parameters_.placementSeed;
 	settings.placementSpacing = parameters_.placementSpacing;
+	settings.voxelSpacing = parameters_.voxelSpacing;
+	settings.maxVoxelBlockCount = parameters_.maxVoxelBlockCount;
+	settings.voxelSurfaceThickness = parameters_.voxelSurfaceThickness;
+	settings.useVoxelInsideTest = parameters_.useVoxelInsideTest;
+	settings.useVoxelSurfaceNearTest = parameters_.useVoxelSurfaceNearTest;
+	settings.alignVoxelGridToCenter = parameters_.alignVoxelGridToCenter;
 	settings.surfaceSampling = parameters_.surfaceSampling;
 	settings.useSurfaceInset = parameters_.useSurfaceInset;
 	settings.surfaceInset = parameters_.surfaceInset;
@@ -69,6 +76,12 @@ void ModelDisintegrationEffect::PlayFromModel(const std::string& modelPath, cons
 	settings.colorVariation = parameters_.colorVariation;
 
 	particles_ = emitter_.EmitFromModel(model->GetModelData(), worldMatrix, settings);
+	initialSamples_.clear();
+	initialSamples_.reserve(particles_.size());
+	for (const auto& particle : particles_)
+	{
+		initialSamples_.push_back({ particle.initialPosition, particle.outward });
+	}
 	InitializeErosionData();
 	isActive_ = !particles_.empty();
 	isStarted_ = isActive_;
@@ -111,6 +124,12 @@ void ModelDisintegrationEffect::BuildParticlesFromSamples(const std::vector<Disi
 	settings.rotationRandomness = parameters_.rotationRandomness;
 	settings.placementSeed = parameters_.placementSeed;
 	settings.placementSpacing = parameters_.placementSpacing;
+	settings.voxelSpacing = parameters_.voxelSpacing;
+	settings.maxVoxelBlockCount = parameters_.maxVoxelBlockCount;
+	settings.voxelSurfaceThickness = parameters_.voxelSurfaceThickness;
+	settings.useVoxelInsideTest = parameters_.useVoxelInsideTest;
+	settings.useVoxelSurfaceNearTest = parameters_.useVoxelSurfaceNearTest;
+	settings.alignVoxelGridToCenter = parameters_.alignVoxelGridToCenter;
 	settings.surfaceSampling = parameters_.surfaceSampling;
 	settings.useSurfaceInset = parameters_.useSurfaceInset;
 	settings.surfaceInset = parameters_.surfaceInset;
@@ -123,6 +142,7 @@ void ModelDisintegrationEffect::BuildParticlesFromSamples(const std::vector<Disi
 	settings.colorVariation = parameters_.colorVariation;
 
 	particles_ = emitter_.EmitFromSamples(samples, worldMatrix.GetTranslation(), settings);
+	initialSamples_ = samples;
 	InitializeErosionData();
 	isActive_ = !particles_.empty();
 	isStarted_ = false;
@@ -186,6 +206,11 @@ void ModelDisintegrationEffect::SetGlobalAlpha(float alpha)
 	globalAlpha_ = Clamp01(alpha);
 }
 
+std::vector<DisintegrationSamplePoint> ModelDisintegrationEffect::GetInitialSamples() const
+{
+	return initialSamples_;
+}
+
 void ModelDisintegrationEffect::DrawImGui()
 {
 #ifdef USE_IMGUI
@@ -202,12 +227,23 @@ void ModelDisintegrationEffect::DrawImGui()
 	{
 		parameters_.particleSize = parameters_.blockSize;
 	}
-	const char* placementModeLabels[] = { "ランダム表面配置", "均一表面配置", "整列表面配置" };
-	int placementModeIndex = parameters_.placementMode == DisintegrationPlacementMode::AlignedSurfaceGrid ? 2 : (parameters_.placementMode == DisintegrationPlacementMode::UniformSurface ? 1 : 0);
+	const char* placementModeLabels[] = { "ランダム表面配置", "均一表面配置", "整列表面配置", "ボクセル敷き詰め配置" };
+	int placementModeIndex = parameters_.placementMode == DisintegrationPlacementMode::VoxelFill ? 3 : (parameters_.placementMode == DisintegrationPlacementMode::AlignedSurfaceGrid ? 2 : (parameters_.placementMode == DisintegrationPlacementMode::UniformSurface ? 1 : 0));
 	if (ImGui::Combo("配置モード", &placementModeIndex, placementModeLabels, IM_ARRAYSIZE(placementModeLabels)))
 	{
-		parameters_.placementMode = placementModeIndex == 2 ? DisintegrationPlacementMode::AlignedSurfaceGrid : (placementModeIndex == 1 ? DisintegrationPlacementMode::UniformSurface : DisintegrationPlacementMode::RandomSurface);
-		if (parameters_.placementMode != DisintegrationPlacementMode::RandomSurface)
+		parameters_.placementMode = placementModeIndex == 3 ? DisintegrationPlacementMode::VoxelFill : (placementModeIndex == 2 ? DisintegrationPlacementMode::AlignedSurfaceGrid : (placementModeIndex == 1 ? DisintegrationPlacementMode::UniformSurface : DisintegrationPlacementMode::RandomSurface));
+		if (parameters_.placementMode == DisintegrationPlacementMode::VoxelFill)
+		{
+			parameters_.useRandomScale = false;
+			parameters_.useRandomRotation = false;
+			parameters_.surfaceSampling = false;
+			parameters_.useSurfaceInset = false;
+			parameters_.voxelSpacing = parameters_.blockSize;
+			parameters_.placementSpacing = parameters_.voxelSpacing;
+			parameters_.voxelSurfaceThickness = parameters_.blockSize * 1.5f;
+			parameters_.maxVoxelBlockCount = std::max(parameters_.maxVoxelBlockCount, 10000);
+		}
+		else if (parameters_.placementMode != DisintegrationPlacementMode::RandomSurface)
 		{
 			parameters_.useRandomScale = false;
 			parameters_.useRandomRotation = false;
@@ -227,6 +263,15 @@ void ModelDisintegrationEffect::DrawImGui()
 		parameters_.placementSeed = static_cast<uint32_t>(std::max(placementSeed, 0));
 	}
 	ImGui::SliderFloat("配置間隔", &parameters_.placementSpacing, 0.0f, 0.5f);
+	if (parameters_.placementMode == DisintegrationPlacementMode::VoxelFill)
+	{
+		ImGui::SliderFloat("ボクセル間隔", &parameters_.voxelSpacing, 0.005f, 0.50f);
+		ImGui::SliderInt("最大ブロック数", &parameters_.maxVoxelBlockCount, 128, 30000);
+		ImGui::SliderFloat("表面厚み", &parameters_.voxelSurfaceThickness, 0.0f, 1.0f);
+		ImGui::Checkbox("内外判定を使う", &parameters_.useVoxelInsideTest);
+		ImGui::Checkbox("表面近傍判定を使う", &parameters_.useVoxelSurfaceNearTest);
+		ImGui::Checkbox("グリッド原点を中央に揃える", &parameters_.alignVoxelGridToCenter);
+	}
 	if (parameters_.placementMode == DisintegrationPlacementMode::UniformSurface)
 	{
 		ImGui::TextWrapped("均一表面配置はモデル表面を面積に応じて規則的にサンプルします。Sweep Erosionで形を保って蝕む表現に推奨です。");
@@ -234,6 +279,10 @@ void ModelDisintegrationEffect::DrawImGui()
 	else if (parameters_.placementMode == DisintegrationPlacementMode::AlignedSurfaceGrid)
 	{
 		ImGui::TextWrapped("整列表面配置はAABBを埋めず、三角形表面上の格子候補からブロックを選びます。");
+	}
+	else if (parameters_.placementMode == DisintegrationPlacementMode::VoxelFill)
+	{
+		ImGui::TextWrapped("ボクセル敷き詰め配置は一定間隔の3Dグリッドをモデル形状で間引き、穴の少ないブロック完全体を作ります。");
 	}
 	ImGui::Checkbox("表面サンプリング", &parameters_.surfaceSampling);
 	ImGui::Checkbox("表面内側オフセットを使う", &parameters_.useSurfaceInset);

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelDisintegrationEffect.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelDisintegrationEffect.h
@@ -36,6 +36,12 @@ public:
 		float rotationRandomness = 1.2f;
 		uint32_t placementSeed = 0xD157E6A7u;
 		float placementSpacing = 0.0f;
+		float voxelSpacing = 0.0f;
+		int maxVoxelBlockCount = 10000;
+		float voxelSurfaceThickness = 0.0675f;
+		bool useVoxelInsideTest = true;
+		bool useVoxelSurfaceNearTest = true;
+		bool alignVoxelGridToCenter = true;
 		bool surfaceSampling = true;
 		bool useSurfaceInset = false;
 		float surfaceInset = 0.0225f;
@@ -81,6 +87,7 @@ public:
 	void DrawImGui();
 	void SetGlobalAlpha(float alpha);
 	bool IsActive() const { return isActive_ && isStarted_; }
+	std::vector<DisintegrationSamplePoint> GetInitialSamples() const;
 
 	Parameters& GetParameters() { return parameters_; }
 	const Parameters& GetParameters() const { return parameters_; }
@@ -101,6 +108,7 @@ private:
 	DisintegrationEmitter emitter_{};
 	DisintegrationRenderer renderer_{};
 	std::vector<DisintegrationParticle> particles_{};
+	std::vector<DisintegrationSamplePoint> initialSamples_{};
 	bool isActive_ = false;
 	bool isStarted_ = false;
 	float globalAlpha_ = 1.0f;

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelReconstructionEffect.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelReconstructionEffect.cpp
@@ -38,6 +38,12 @@ void ModelReconstructionEffect::PlayFromModel(const std::string& modelPath, cons
 	settings.useRandomRotation = parameters_.useRandomRotation;
 	settings.placementSeed = parameters_.placementSeed;
 	settings.placementSpacing = parameters_.placementSpacing;
+	settings.voxelSpacing = parameters_.voxelSpacing;
+	settings.maxVoxelBlockCount = parameters_.maxVoxelBlockCount;
+	settings.voxelSurfaceThickness = parameters_.voxelSurfaceThickness;
+	settings.useVoxelInsideTest = parameters_.useVoxelInsideTest;
+	settings.useVoxelSurfaceNearTest = parameters_.useVoxelSurfaceNearTest;
+	settings.alignVoxelGridToCenter = parameters_.alignVoxelGridToCenter;
 	settings.surfaceSampling = parameters_.surfaceSampling;
 	settings.useSurfaceInset = parameters_.useSurfaceInset;
 	settings.surfaceInset = parameters_.surfaceInset;
@@ -46,6 +52,42 @@ void ModelReconstructionEffect::PlayFromModel(const std::string& modelPath, cons
 	settings.colorVariation = parameters_.colorVariation;
 
 	blocks_ = emitter_.EmitFromModel(model->GetModelData(), worldMatrix, settings);
+	isActive_ = !blocks_.empty();
+	isComplete_ = false;
+	elapsedTime_ = 0.0f;
+	globalAlpha_ = 1.0f;
+}
+
+
+void ModelReconstructionEffect::PlayFromSamples(const std::vector<DisintegrationSamplePoint>& samples, const K4E::Matrix4x4& worldMatrix)
+{
+	ReconstructionEmitter::Settings settings{};
+	settings.blockCount = parameters_.blockCount;
+	settings.blockSize = parameters_.blockSize;
+	settings.startScatterRadius = parameters_.startScatterRadius;
+	settings.startHeight = parameters_.startHeight;
+	settings.startDelayRange = parameters_.startDelayRange;
+	settings.rotationRandomness = parameters_.rotationRandomness;
+	settings.placementMode = parameters_.placementMode;
+	settings.useRandomScale = parameters_.useRandomScale;
+	settings.scaleVariation = parameters_.scaleVariation;
+	settings.useRandomRotation = parameters_.useRandomRotation;
+	settings.placementSeed = parameters_.placementSeed;
+	settings.placementSpacing = parameters_.placementSpacing;
+	settings.voxelSpacing = parameters_.voxelSpacing;
+	settings.maxVoxelBlockCount = parameters_.maxVoxelBlockCount;
+	settings.voxelSurfaceThickness = parameters_.voxelSurfaceThickness;
+	settings.useVoxelInsideTest = parameters_.useVoxelInsideTest;
+	settings.useVoxelSurfaceNearTest = parameters_.useVoxelSurfaceNearTest;
+	settings.alignVoxelGridToCenter = parameters_.alignVoxelGridToCenter;
+	settings.surfaceSampling = parameters_.surfaceSampling;
+	settings.useSurfaceInset = parameters_.useSurfaceInset;
+	settings.surfaceInset = parameters_.surfaceInset;
+	settings.autoSurfaceInsetFromBlockSize = parameters_.autoSurfaceInsetFromBlockSize;
+	settings.color = parameters_.color;
+	settings.colorVariation = parameters_.colorVariation;
+
+	blocks_ = emitter_.EmitFromSamples(samples, worldMatrix.GetTranslation(), settings);
 	isActive_ = !blocks_.empty();
 	isComplete_ = false;
 	elapsedTime_ = 0.0f;
@@ -148,12 +190,23 @@ void ModelReconstructionEffect::DrawImGui()
 	ImGui::SliderFloat("回転ばらつき", &parameters_.rotationRandomness, 0.0f, 12.0f);
 	ImGui::Checkbox("ランダムサイズを使う", &parameters_.useRandomScale);
 	ImGui::SliderFloat("サイズばらつき", &parameters_.scaleVariation, 0.0f, 0.75f);
-	const char* placementModeLabels[] = { "ランダム表面配置", "均一表面配置", "整列表面配置" };
-	int placementModeIndex = parameters_.placementMode == DisintegrationPlacementMode::AlignedSurfaceGrid ? 2 : (parameters_.placementMode == DisintegrationPlacementMode::UniformSurface ? 1 : 0);
+	const char* placementModeLabels[] = { "ランダム表面配置", "均一表面配置", "整列表面配置", "ボクセル敷き詰め配置" };
+	int placementModeIndex = parameters_.placementMode == DisintegrationPlacementMode::VoxelFill ? 3 : (parameters_.placementMode == DisintegrationPlacementMode::AlignedSurfaceGrid ? 2 : (parameters_.placementMode == DisintegrationPlacementMode::UniformSurface ? 1 : 0));
 	if (ImGui::Combo("配置モード", &placementModeIndex, placementModeLabels, IM_ARRAYSIZE(placementModeLabels)))
 	{
-		parameters_.placementMode = placementModeIndex == 2 ? DisintegrationPlacementMode::AlignedSurfaceGrid : (placementModeIndex == 1 ? DisintegrationPlacementMode::UniformSurface : DisintegrationPlacementMode::RandomSurface);
-		if (parameters_.placementMode != DisintegrationPlacementMode::RandomSurface)
+		parameters_.placementMode = placementModeIndex == 3 ? DisintegrationPlacementMode::VoxelFill : (placementModeIndex == 2 ? DisintegrationPlacementMode::AlignedSurfaceGrid : (placementModeIndex == 1 ? DisintegrationPlacementMode::UniformSurface : DisintegrationPlacementMode::RandomSurface));
+		if (parameters_.placementMode == DisintegrationPlacementMode::VoxelFill)
+		{
+			parameters_.useRandomScale = false;
+			parameters_.useRandomRotation = false;
+			parameters_.surfaceSampling = false;
+			parameters_.useSurfaceInset = false;
+			parameters_.voxelSpacing = parameters_.blockSize;
+			parameters_.placementSpacing = parameters_.voxelSpacing;
+			parameters_.voxelSurfaceThickness = parameters_.blockSize * 1.5f;
+			parameters_.maxVoxelBlockCount = std::max(parameters_.maxVoxelBlockCount, 10000);
+		}
+		else if (parameters_.placementMode != DisintegrationPlacementMode::RandomSurface)
 		{
 			parameters_.useRandomScale = false;
 			parameters_.useRandomRotation = false;
@@ -166,6 +219,15 @@ void ModelReconstructionEffect::DrawImGui()
 		parameters_.placementSeed = static_cast<uint32_t>(std::max(placementSeed, 0));
 	}
 	ImGui::SliderFloat("配置間隔", &parameters_.placementSpacing, 0.0f, 0.5f);
+	if (parameters_.placementMode == DisintegrationPlacementMode::VoxelFill)
+	{
+		ImGui::SliderFloat("ボクセル間隔", &parameters_.voxelSpacing, 0.005f, 0.50f);
+		ImGui::SliderInt("最大ブロック数", &parameters_.maxVoxelBlockCount, 128, 30000);
+		ImGui::SliderFloat("表面厚み", &parameters_.voxelSurfaceThickness, 0.0f, 1.0f);
+		ImGui::Checkbox("内外判定を使う", &parameters_.useVoxelInsideTest);
+		ImGui::Checkbox("表面近傍判定を使う", &parameters_.useVoxelSurfaceNearTest);
+		ImGui::Checkbox("グリッド原点を中央に揃える", &parameters_.alignVoxelGridToCenter);
+	}
 	ImGui::SliderFloat("イージング強度", &parameters_.easePower, 1.0f, 8.0f);
 	ImGui::ColorEdit4("色", &parameters_.color.x);
 	ImGui::SliderFloat("色のばらつき", &parameters_.colorVariation, 0.0f, 0.8f);

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelReconstructionEffect.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelReconstructionEffect.h
@@ -30,6 +30,12 @@ public:
 		bool useRandomRotation = true;
 		uint32_t placementSeed = 0xD157E6A7u;
 		float placementSpacing = 0.0f;
+		float voxelSpacing = 0.0f;
+		int maxVoxelBlockCount = 10000;
+		float voxelSurfaceThickness = 0.0675f;
+		bool useVoxelInsideTest = true;
+		bool useVoxelSurfaceNearTest = true;
+		bool alignVoxelGridToCenter = true;
 		float easePower = 3.0f;
 		K4E::Vector4 color{ 0.64f, 0.72f, 0.86f, 1.0f };
 		float colorVariation = 0.18f;
@@ -44,6 +50,7 @@ public:
 
 	void Initialize();
 	void PlayFromModel(const std::string& modelPath, const K4E::Matrix4x4& worldMatrix);
+	void PlayFromSamples(const std::vector<DisintegrationSamplePoint>& samples, const K4E::Matrix4x4& worldMatrix);
 	void Update(float deltaTime);
 	void Draw();
 	void DrawImGui();

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelSurfaceSampler.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelSurfaceSampler.cpp
@@ -4,6 +4,8 @@
 #include <algorithm>
 #include <cmath>
 #include <cstdint>
+#include <initializer_list>
+#include <limits>
 #include <tuple>
 
 namespace
@@ -26,6 +28,82 @@ namespace
 			direction.x * matrix.m[0][2] + direction.y * matrix.m[1][2] + direction.z * matrix.m[2][2],
 		};
 	}
+
+	struct WorldTriangle
+	{
+		K4E::Vector3 a{};
+		K4E::Vector3 b{};
+		K4E::Vector3 c{};
+		K4E::Vector3 normal{ 0.0f, 1.0f, 0.0f };
+	};
+
+	K4E::Vector3 ClosestPointOnTriangle(const K4E::Vector3& point, const WorldTriangle& tri)
+	{
+		const K4E::Vector3 ab = tri.b - tri.a;
+		const K4E::Vector3 ac = tri.c - tri.a;
+		const K4E::Vector3 ap = point - tri.a;
+		const float d1 = K4E::Vector3::Dot(ab, ap);
+		const float d2 = K4E::Vector3::Dot(ac, ap);
+		if (d1 <= 0.0f && d2 <= 0.0f) { return tri.a; }
+
+		const K4E::Vector3 bp = point - tri.b;
+		const float d3 = K4E::Vector3::Dot(ab, bp);
+		const float d4 = K4E::Vector3::Dot(ac, bp);
+		if (d3 >= 0.0f && d4 <= d3) { return tri.b; }
+
+		const float vc = d1 * d4 - d3 * d2;
+		if (vc <= 0.0f && d1 >= 0.0f && d3 <= 0.0f)
+		{
+			const float v = d1 / (d1 - d3);
+			return tri.a + ab * v;
+		}
+
+		const K4E::Vector3 cp = point - tri.c;
+		const float d5 = K4E::Vector3::Dot(ab, cp);
+		const float d6 = K4E::Vector3::Dot(ac, cp);
+		if (d6 >= 0.0f && d5 <= d6) { return tri.c; }
+
+		const float vb = d5 * d2 - d1 * d6;
+		if (vb <= 0.0f && d2 >= 0.0f && d6 <= 0.0f)
+		{
+			const float w = d2 / (d2 - d6);
+			return tri.a + ac * w;
+		}
+
+		const float va = d3 * d6 - d5 * d4;
+		if (va <= 0.0f && (d4 - d3) >= 0.0f && (d5 - d6) >= 0.0f)
+		{
+			const float w = (d4 - d3) / ((d4 - d3) + (d5 - d6));
+			return tri.b + (tri.c - tri.b) * w;
+		}
+
+		const float denom = 1.0f / (va + vb + vc);
+		const float v = vb * denom;
+		const float w = vc * denom;
+		return tri.a + ab * v + ac * w;
+	}
+
+	bool RayIntersectsTriangle(const K4E::Vector3& origin, const K4E::Vector3& direction, const WorldTriangle& tri, float& t)
+	{
+		constexpr float kEpsilon = 0.000001f;
+		const K4E::Vector3 edge1 = tri.b - tri.a;
+		const K4E::Vector3 edge2 = tri.c - tri.a;
+		const K4E::Vector3 h = K4E::Vector3::Cross(direction, edge2);
+		const float det = K4E::Vector3::Dot(edge1, h);
+		if (det > -kEpsilon && det < kEpsilon) { return false; }
+
+		const float invDet = 1.0f / det;
+		const K4E::Vector3 s = origin - tri.a;
+		const float u = invDet * K4E::Vector3::Dot(s, h);
+		if (u < 0.0f || u > 1.0f) { return false; }
+
+		const K4E::Vector3 q = K4E::Vector3::Cross(s, edge1);
+		const float v = invDet * K4E::Vector3::Dot(direction, q);
+		if (v < 0.0f || u + v > 1.0f) { return false; }
+
+		t = invDet * K4E::Vector3::Dot(edge2, q);
+		return t > kEpsilon;
+	}
 }
 
 std::vector<DisintegrationSamplePoint> ModelSurfaceSampler::SampleFromModel(
@@ -36,7 +114,13 @@ std::vector<DisintegrationSamplePoint> ModelSurfaceSampler::SampleFromModel(
 	float vertexJitterRadius,
 	DisintegrationPlacementMode placementMode,
 	uint32_t placementSeed,
-	float placementSpacing)
+	float placementSpacing,
+	float voxelSpacing,
+	int maxVoxelBlockCount,
+	float voxelSurfaceThickness,
+	bool useVoxelInsideTest,
+	bool useVoxelSurfaceNearTest,
+	bool alignVoxelGridToCenter)
 {
 	rng_.seed(placementSeed);
 	std::vector<TriangleSample> triangles;
@@ -91,6 +175,115 @@ std::vector<DisintegrationSamplePoint> ModelSurfaceSampler::SampleFromModel(
 	std::vector<DisintegrationSamplePoint> samples;
 	samples.reserve(static_cast<size_t>(std::max(0, sampleCount)));
 	if ((triangles.empty() && vertices.empty()) || sampleCount <= 0) { return samples; }
+
+	if (placementMode == DisintegrationPlacementMode::VoxelFill && !triangles.empty())
+	{
+		std::vector<WorldTriangle> worldTriangles;
+		worldTriangles.reserve(triangles.size());
+		K4E::Vector3 boundsMin{ std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max() };
+		K4E::Vector3 boundsMax{ -std::numeric_limits<float>::max(), -std::numeric_limits<float>::max(), -std::numeric_limits<float>::max() };
+		for (const auto& tri : triangles)
+		{
+			WorldTriangle worldTri{};
+			worldTri.a = K4E::Vector3::Transform(tri.a, worldMatrix);
+			worldTri.b = K4E::Vector3::Transform(tri.b, worldMatrix);
+			worldTri.c = K4E::Vector3::Transform(tri.c, worldMatrix);
+			worldTri.normal = K4E::Vector3::NormalizeSafe(TransformDirection(tri.normal, worldMatrix), { 0.0f, 1.0f, 0.0f });
+			worldTriangles.push_back(worldTri);
+			for (const auto& p : { worldTri.a, worldTri.b, worldTri.c })
+			{
+				boundsMin.x = std::min(boundsMin.x, p.x);
+				boundsMin.y = std::min(boundsMin.y, p.y);
+				boundsMin.z = std::min(boundsMin.z, p.z);
+				boundsMax.x = std::max(boundsMax.x, p.x);
+				boundsMax.y = std::max(boundsMax.y, p.y);
+				boundsMax.z = std::max(boundsMax.z, p.z);
+			}
+		}
+
+		const int maxBlocks = std::max(maxVoxelBlockCount > 0 ? maxVoxelBlockCount : sampleCount, 1);
+		const float safeSpacing = voxelSpacing > 0.0001f ? voxelSpacing : (placementSpacing > 0.0001f ? placementSpacing : std::max(vertexJitterRadius / 1.5f, 0.01f));
+		const float thickness = voxelSurfaceThickness > 0.0001f ? voxelSurfaceThickness : safeSpacing * 1.5f;
+		const K4E::Vector3 center = (boundsMin + boundsMax) * 0.5f;
+		K4E::Vector3 start = boundsMin;
+		if (alignVoxelGridToCenter)
+		{
+			const auto alignAxis = [safeSpacing](float minValue, float maxValue) {
+				const float centerValue = (minValue + maxValue) * 0.5f;
+				const int halfSteps = static_cast<int>(std::floor((centerValue - minValue) / safeSpacing));
+				return centerValue - static_cast<float>(halfSteps) * safeSpacing;
+			};
+			start = { alignAxis(boundsMin.x, boundsMax.x), alignAxis(boundsMin.y, boundsMax.y), alignAxis(boundsMin.z, boundsMax.z) };
+		}
+
+		std::vector<DisintegrationSamplePoint> voxelCandidates;
+		voxelCandidates.reserve(static_cast<size_t>(maxBlocks));
+		const K4E::Vector3 rayDirection{ 1.0f, 0.173f, 0.097f };
+		for (float z = start.z; z <= boundsMax.z + safeSpacing * 0.25f; z += safeSpacing)
+		{
+			if (z < boundsMin.z - safeSpacing * 0.25f) { continue; }
+			for (float y = start.y; y <= boundsMax.y + safeSpacing * 0.25f; y += safeSpacing)
+			{
+				if (y < boundsMin.y - safeSpacing * 0.25f) { continue; }
+				for (float x = start.x; x <= boundsMax.x + safeSpacing * 0.25f; x += safeSpacing)
+				{
+					if (x < boundsMin.x - safeSpacing * 0.25f) { continue; }
+					const K4E::Vector3 point{ x, y, z };
+					bool inside = false;
+					if (useVoxelInsideTest)
+					{
+						int hitCount = 0;
+						for (const auto& tri : worldTriangles)
+						{
+							float t = 0.0f;
+							if (RayIntersectsTriangle(point, rayDirection, tri, t)) { ++hitCount; }
+						}
+						inside = (hitCount & 1) != 0;
+					}
+
+					float nearestDistanceSq = std::numeric_limits<float>::max();
+					K4E::Vector3 nearestNormal{ 0.0f, 1.0f, 0.0f };
+					if (!inside || useVoxelSurfaceNearTest)
+					{
+						for (const auto& tri : worldTriangles)
+						{
+							const K4E::Vector3 closest = ClosestPointOnTriangle(point, tri);
+							const float distanceSq = K4E::Vector3::LengthSquared(point - closest);
+							if (distanceSq < nearestDistanceSq)
+							{
+								nearestDistanceSq = distanceSq;
+								nearestNormal = tri.normal;
+							}
+						}
+					}
+
+					const bool nearSurface = useVoxelSurfaceNearTest && nearestDistanceSq <= thickness * thickness;
+					if ((useVoxelInsideTest && inside) || nearSurface)
+					{
+						DisintegrationSamplePoint sample{};
+						// VoxelFillはモデルAABB内の格子中心を形状判定で間引き、箱埋めではない塊を作る。
+						sample.position = point;
+						sample.normal = K4E::Vector3::NormalizeSafe(nearestNormal, K4E::Vector3::NormalizeSafe(point - center, { 0.0f, 1.0f, 0.0f }));
+						voxelCandidates.push_back(sample);
+					}
+				}
+			}
+		}
+
+		if (!voxelCandidates.empty())
+		{
+			const int outputCount = std::min(maxBlocks, static_cast<int>(voxelCandidates.size()));
+			samples.reserve(static_cast<size_t>(outputCount));
+			for (int i = 0; i < outputCount; ++i)
+			{
+				const size_t index = outputCount < static_cast<int>(voxelCandidates.size())
+					? (static_cast<size_t>(i) * voxelCandidates.size()) / static_cast<size_t>(outputCount)
+					: static_cast<size_t>(i);
+				samples.push_back(voxelCandidates[std::min(index, voxelCandidates.size() - 1)]);
+			}
+			return samples;
+		}
+	}
 
 	const bool useUniformSurface = placementMode == DisintegrationPlacementMode::UniformSurface && !triangles.empty();
 	const bool useAlignedSurfaceGrid = placementMode == DisintegrationPlacementMode::AlignedSurfaceGrid && !triangles.empty();

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelSurfaceSampler.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelSurfaceSampler.h
@@ -17,6 +17,7 @@ enum class DisintegrationPlacementMode
 	RandomSurface,
 	UniformSurface,
 	AlignedSurfaceGrid,
+	VoxelFill,
 };
 
 /// -------------------------------------------------------------
@@ -42,7 +43,13 @@ public:
 		float vertexJitterRadius = 0.0f,
 		DisintegrationPlacementMode placementMode = DisintegrationPlacementMode::RandomSurface,
 		uint32_t placementSeed = 0x51A7F00Du,
-		float placementSpacing = 0.0f);
+		float placementSpacing = 0.0f,
+		float voxelSpacing = 0.0f,
+		int maxVoxelBlockCount = 10000,
+		float voxelSurfaceThickness = 0.0f,
+		bool useVoxelInsideTest = true,
+		bool useVoxelSurfaceNearTest = true,
+		bool alignVoxelGridToCenter = true);
 
 private:
 	struct TriangleSample

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionEmitter.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionEmitter.cpp
@@ -33,13 +33,27 @@ std::vector<ReconstructionBlock> ReconstructionEmitter::EmitFromModel(
 		settings.blockSize * 1.5f,
 		settings.placementMode,
 		settings.placementSeed,
-		settings.placementSpacing);
+		settings.placementSpacing,
+		settings.voxelSpacing,
+		settings.maxVoxelBlockCount,
+		settings.voxelSurfaceThickness,
+		settings.useVoxelInsideTest,
+		settings.useVoxelSurfaceNearTest,
+		settings.alignVoxelGridToCenter);
 
+	return EmitFromSamples(targets, worldMatrix.GetTranslation(), settings);
+}
+
+std::vector<ReconstructionBlock> ReconstructionEmitter::EmitFromSamples(
+	const std::vector<DisintegrationSamplePoint>& targets,
+	const K4E::Vector3& center,
+	const Settings& settings)
+{
+	rng_.seed(settings.placementSeed ^ 0xC0DE2026u);
 	std::vector<ReconstructionBlock> blocks;
 	blocks.reserve(targets.size());
 	if (targets.empty()) { return blocks; }
 
-	const K4E::Vector3 center = worldMatrix.GetTranslation();
 	const float effectiveSurfaceInset = settings.useSurfaceInset
 		? std::max(settings.autoSurfaceInsetFromBlockSize ? settings.blockSize * 0.5f : settings.surfaceInset, 0.0f)
 		: 0.0f;

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionEmitter.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionEmitter.h
@@ -29,6 +29,12 @@ public:
 		bool useRandomRotation = true;
 		uint32_t placementSeed = 0xD157E6A7u;
 		float placementSpacing = 0.0f;
+		float voxelSpacing = 0.0f;
+		int maxVoxelBlockCount = 10000;
+		float voxelSurfaceThickness = 0.0675f;
+		bool useVoxelInsideTest = true;
+		bool useVoxelSurfaceNearTest = true;
+		bool alignVoxelGridToCenter = true;
 		bool surfaceSampling = true;
 		bool useSurfaceInset = false;
 		float surfaceInset = 0.0225f;
@@ -40,6 +46,10 @@ public:
 	std::vector<ReconstructionBlock> EmitFromModel(
 		const K4E::ModelData& modelData,
 		const K4E::Matrix4x4& worldMatrix,
+		const Settings& settings);
+	std::vector<ReconstructionBlock> EmitFromSamples(
+		const std::vector<DisintegrationSamplePoint>& targets,
+		const K4E::Vector3& center,
 		const Settings& settings);
 
 private:

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -604,12 +604,23 @@ void DebugScene::DrawImGui()
 				sequenceParams.blockSize = std::max(sequenceParams.blockSize, 0.005f);
 			}
 			ImGui::Checkbox("表面サンプリング##BlockSequence", &sequenceParams.surfaceSampling);
-			const char* sequencePlacementModeLabels[] = { "ランダム表面配置", "均一表面配置", "整列表面配置" };
-			int sequencePlacementModeIndex = sequenceParams.placementMode == DisintegrationPlacementMode::AlignedSurfaceGrid ? 2 : (sequenceParams.placementMode == DisintegrationPlacementMode::UniformSurface ? 1 : 0);
+			const char* sequencePlacementModeLabels[] = { "ランダム表面配置", "均一表面配置", "整列表面配置", "ボクセル敷き詰め配置" };
+			int sequencePlacementModeIndex = sequenceParams.placementMode == DisintegrationPlacementMode::VoxelFill ? 3 : (sequenceParams.placementMode == DisintegrationPlacementMode::AlignedSurfaceGrid ? 2 : (sequenceParams.placementMode == DisintegrationPlacementMode::UniformSurface ? 1 : 0));
 			if (ImGui::Combo("配置モード##BlockSequence", &sequencePlacementModeIndex, sequencePlacementModeLabels, IM_ARRAYSIZE(sequencePlacementModeLabels)))
 			{
-				sequenceParams.placementMode = sequencePlacementModeIndex == 2 ? DisintegrationPlacementMode::AlignedSurfaceGrid : (sequencePlacementModeIndex == 1 ? DisintegrationPlacementMode::UniformSurface : DisintegrationPlacementMode::RandomSurface);
-				if (sequenceParams.placementMode != DisintegrationPlacementMode::RandomSurface)
+				sequenceParams.placementMode = sequencePlacementModeIndex == 3 ? DisintegrationPlacementMode::VoxelFill : (sequencePlacementModeIndex == 2 ? DisintegrationPlacementMode::AlignedSurfaceGrid : (sequencePlacementModeIndex == 1 ? DisintegrationPlacementMode::UniformSurface : DisintegrationPlacementMode::RandomSurface));
+				if (sequenceParams.placementMode == DisintegrationPlacementMode::VoxelFill)
+				{
+					sequenceParams.useRandomScale = false;
+					sequenceParams.useRandomRotation = false;
+					sequenceParams.surfaceSampling = false;
+					sequenceParams.useSurfaceInset = false;
+					sequenceParams.voxelSpacing = sequenceParams.blockSize;
+					sequenceParams.placementSpacing = sequenceParams.voxelSpacing;
+					sequenceParams.voxelSurfaceThickness = sequenceParams.blockSize * 1.5f;
+					sequenceParams.maxVoxelBlockCount = std::max(sequenceParams.maxVoxelBlockCount, 10000);
+				}
+				else if (sequenceParams.placementMode != DisintegrationPlacementMode::RandomSurface)
 				{
 					sequenceParams.useRandomScale = false;
 					sequenceParams.useRandomRotation = false;
@@ -626,6 +637,15 @@ void DebugScene::DrawImGui()
 				sequenceParams.placementSeed = static_cast<uint32_t>(std::max(sequencePlacementSeed, 0));
 			}
 			ImGui::SliderFloat("配置間隔##BlockSequence", &sequenceParams.placementSpacing, 0.0f, 0.5f);
+			if (sequenceParams.placementMode == DisintegrationPlacementMode::VoxelFill)
+			{
+				ImGui::SliderFloat("ボクセル間隔##BlockSequence", &sequenceParams.voxelSpacing, 0.005f, 0.50f);
+				ImGui::SliderInt("最大ブロック数##BlockSequence", &sequenceParams.maxVoxelBlockCount, 128, 30000);
+				ImGui::SliderFloat("表面厚み##BlockSequence", &sequenceParams.voxelSurfaceThickness, 0.0f, 1.0f);
+				ImGui::Checkbox("内外判定を使う##BlockSequence", &sequenceParams.useVoxelInsideTest);
+				ImGui::Checkbox("表面近傍判定を使う##BlockSequence", &sequenceParams.useVoxelSurfaceNearTest);
+				ImGui::Checkbox("グリッド原点を中央に揃える##BlockSequence", &sequenceParams.alignVoxelGridToCenter);
+			}
 			ImGui::Checkbox("表面内側オフセットを使う##BlockSequence", &sequenceParams.useSurfaceInset);
 			ImGui::Checkbox("ブロックサイズから自動計算##BlockSequence", &sequenceParams.autoSurfaceInsetFromBlockSize);
 			if (!sequenceParams.autoSurfaceInsetFromBlockSize)
@@ -645,12 +665,30 @@ void DebugScene::DrawImGui()
 			{
 				ImGui::TextWrapped("整列表面配置はAABBではなくモデル表面上の格子候補へ配置します。");
 			}
-			ImGui::SeparatorText("方向侵食崩壊##BlockSequence");
-			ImGui::Checkbox("方向侵食を使う##BlockSequence", &sequenceParams.useSweepErosion);
+			else if (sequenceParams.placementMode == DisintegrationPlacementMode::VoxelFill)
+			{
+				ImGui::TextWrapped("ボクセル敷き詰め配置は同じ3Dグリッド配置を再構築と崩壊で共有します。");
+			}
+			ImGui::SeparatorText("侵食崩壊##BlockSequence");
+			ImGui::Checkbox("侵食を使う##BlockSequence", &sequenceParams.useSweepErosion);
+			const char* sequenceErosionModeLabels[] = { "方向侵食", "中心侵食" };
+			int sequenceErosionModeIndex = sequenceParams.erosionMode == ErosionMode::CenterOut ? 1 : 0;
+			if (ImGui::Combo("侵食モード##BlockSequence", &sequenceErosionModeIndex, sequenceErosionModeLabels, IM_ARRAYSIZE(sequenceErosionModeLabels)))
+			{
+				sequenceParams.erosionMode = sequenceErosionModeIndex == 1 ? ErosionMode::CenterOut : ErosionMode::DirectionalSweep;
+				sequenceParams.useSweepErosion = true;
+			}
+			ImGui::SeparatorText("方向侵食##BlockSequence");
 			ImGui::DragFloat3("侵食方向##BlockSequence", &sequenceParams.sweepDirection.x, 0.01f, -1.0f, 1.0f);
 			ImGui::SliderFloat("侵食時間##BlockSequence", &sequenceParams.sweepDuration, 0.05f, 8.0f);
 			ImGui::SliderFloat("侵食ノイズ強度##BlockSequence", &sequenceParams.erosionNoisePower, 0.0f, 4.0f);
 			ImGui::SliderFloat("侵食境界幅##BlockSequence", &sequenceParams.erosionBandWidth, 0.0f, 2.0f);
+			ImGui::SeparatorText("中心侵食##BlockSequence");
+			ImGui::Checkbox("モデル中心を使う##BlockSequence", &sequenceParams.useModelCenterAsErosionCenter);
+			ImGui::DragFloat3("侵食中心##BlockSequence", &sequenceParams.erosionCenter.x, 0.01f);
+			ImGui::SliderFloat("中心侵食時間##BlockSequence", &sequenceParams.centerErosionDuration, 0.05f, 8.0f);
+			ImGui::SliderFloat("中心侵食ノイズ強度##BlockSequence", &sequenceParams.centerErosionNoisePower, 0.0f, 4.0f);
+			ImGui::SliderFloat("中心発光幅##BlockSequence", &sequenceParams.centerGlowWidth, 0.001f, 2.0f);
 			ImGui::SliderFloat("侵食前の発光幅##BlockSequence", &sequenceParams.preGlowWidth, 0.0f, 2.0f);
 			ImGui::SliderFloat("侵食後の発光幅##BlockSequence", &sequenceParams.postGlowWidth, 0.0f, 2.0f);
 			ImGui::SliderFloat("発光エッジ幅##BlockSequence", &sequenceParams.glowEdgeWidth, 0.001f, 2.0f);
@@ -684,6 +722,19 @@ void DebugScene::DrawImGui()
 				pendingDebugModelBlockSequencePath_ = sequenceModelPathBuffer;
 				debugModelBlockSequenceRequest_ = DebugModelBlockSequenceRequest::PlayLoop;
 				debugModelBlockSequenceLog_ = "ループ再生を予約: " + pendingDebugModelBlockSequencePath_;
+			}
+
+			ImGui::SameLine();
+			if (ImGui::Button(debugModelBlockSequencePaused_ ? "再開##BlockSequence" : "一時停止##BlockSequence"))
+			{
+				debugModelBlockSequencePaused_ = !debugModelBlockSequencePaused_;
+			}
+
+			ImGui::SameLine();
+			if (ImGui::Button("1フレーム送り##BlockSequence"))
+			{
+				debugModelBlockSequenceStepFrame_ = true;
+				debugModelBlockSequencePaused_ = true;
 			}
 
 			ImGui::SameLine();
@@ -906,7 +957,9 @@ void DebugScene::UpdateDebugModelBlockSequence(float deltaTime)
 
 	if (debugModelBlockSequence_)
 	{
-		debugModelBlockSequence_->Update(deltaTime);
+		const bool shouldAdvanceSequence = !debugModelBlockSequencePaused_ || debugModelBlockSequenceStepFrame_;
+		debugModelBlockSequence_->Update(shouldAdvanceSequence ? deltaTime : 0.0f);
+		debugModelBlockSequenceStepFrame_ = false;
 	}
 }
 
@@ -949,29 +1002,39 @@ void DebugScene::ProcessDebugModelBlockSequenceRequest()
 		ReloadDebugModelBlockSequenceModel();
 		break;
 	case DebugModelBlockSequenceRequest::PlaySpawnThenDisintegrate:
+		debugModelBlockSequencePaused_ = false;
+		debugModelBlockSequenceStepFrame_ = false;
 		ReloadDebugModelBlockSequenceModel();
 		debugModelBlockSequence_->PlaySpawnThenDisintegrate(debugModelBlockSequenceModelPath_, MakeDebugModelBlockSequenceWorldMatrix());
 		debugModelBlockSequenceLog_ = "再構築 → 崩壊 を再生: " + debugModelBlockSequenceModelPath_;
 		DebugLog(debugModelBlockSequenceLog_);
 		break;
 	case DebugModelBlockSequenceRequest::PlayDisintegrateThenReconstruct:
+		debugModelBlockSequencePaused_ = false;
+		debugModelBlockSequenceStepFrame_ = false;
 		ReloadDebugModelBlockSequenceModel();
 		debugModelBlockSequence_->PlayDisintegrateThenReconstruct(debugModelBlockSequenceModelPath_, MakeDebugModelBlockSequenceWorldMatrix());
 		debugModelBlockSequenceLog_ = "崩壊 → 再構築 を再生: " + debugModelBlockSequenceModelPath_;
 		DebugLog(debugModelBlockSequenceLog_);
 		break;
 	case DebugModelBlockSequenceRequest::PlayLoop:
+		debugModelBlockSequencePaused_ = false;
+		debugModelBlockSequenceStepFrame_ = false;
 		ReloadDebugModelBlockSequenceModel();
 		debugModelBlockSequence_->PlayLoop(debugModelBlockSequenceModelPath_, MakeDebugModelBlockSequenceWorldMatrix());
 		debugModelBlockSequenceLog_ = "ループ再生: " + debugModelBlockSequenceModelPath_;
 		DebugLog(debugModelBlockSequenceLog_);
 		break;
 	case DebugModelBlockSequenceRequest::Stop:
+		debugModelBlockSequencePaused_ = false;
+		debugModelBlockSequenceStepFrame_ = false;
 		debugModelBlockSequence_->Stop(false);
 		debugModelBlockSequenceLog_ = "シーケンスを停止しました。";
 		DebugLog(debugModelBlockSequenceLog_);
 		break;
 	case DebugModelBlockSequenceRequest::Reset:
+		debugModelBlockSequencePaused_ = false;
+		debugModelBlockSequenceStepFrame_ = false;
 		debugModelBlockSequence_->Reset();
 		debugModelBlockSequenceLog_ = "シーケンスをリセットしました。";
 		DebugLog(debugModelBlockSequenceLog_);

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
@@ -177,6 +177,8 @@ private: /// ---------- メンバ変数 ---------- ///
 	std::string debugModelBlockSequenceModelPath_ = "Characters/body.gltf";
 	std::string debugModelBlockSequenceLog_ = "Use the ImGui sequence buttons to play.";
 	DebugModelBlockSequenceRequest debugModelBlockSequenceRequest_ = DebugModelBlockSequenceRequest::None;
+	bool debugModelBlockSequencePaused_ = false;
+	bool debugModelBlockSequenceStepFrame_ = false;
 	std::string pendingDebugModelBlockSequencePath_;
 };
 


### PR DESCRIPTION
### Motivation
- 既存の表面サンプリング（ランダム / 均一 / 整列）はオブジェクトを小立方体で密に詰めた“完全体”に見せる要件を満たしておらず、空きや穴・パーティクル数依存の見た目揺らぎが発生しているため改善が必要です。
- 再構築と崩壊で同じブロック配置を共有し、開始時点で配置ジャンプが起きないようにしたいという要件があります。
- デバッグ操作で一時停止・1フレーム送り等を行いながら検証できるようにしたいという要求があります。

### Description
- 新しい配置モード `DisintegrationPlacementMode::VoxelFill` を追加し、`ModelSurfaceSampler::SampleFromModel` に voxel グリッド生成／フィルタ（レイによる内外判定、三角形最近接距離による表面近傍判定）を実装して候補点を生成する処理を追加しました（AABB を単純に埋めるのではなく形状判定で間引きます）。
- ボクセル関連パラメータ（`voxelSpacing` / `maxVoxelBlockCount` / `voxelSurfaceThickness` / `useVoxelInsideTest` / `useVoxelSurfaceNearTest` / `alignVoxelGridToCenter`）をサンプラー → エミッタ（`ReconstructionEmitter` / `DisintegrationEmitter`）→ 効果（`ModelReconstructionEffect` / `ModelDisintegrationEffect`）→ シーケンス（`ModelBlockEffectSequence`）へ伝搬するように追加しました。
- 再構築と崩壊で同一配置を共有するために、崩壊側で生成した初期サンプルを `initialSamples_` に保持して `GetInitialSamples()` を提供し、シーケンス側で共有して `PlayFromSamples` / `EmitFromSamples` を介して同一のサンプル配置を再利用する仕組みを導入しました。
- ImGui を更新して「ボクセル敷き詰め配置」選択時の UI（ボクセル間隔／最大ブロック数／表面厚み／内外判定／表面近傍判定／グリッド原点中央揃え等）を追加し、同時にシーケンス用の侵食（方向／中心）設定、DebugScene に一時停止・1フレーム送りの制御を追加しました。

### Testing
- 自動チェックとして `git diff --check` を実行し問題は検出されませんでした（成功）。
- ソース構文チェックを `g++ -std=c++20 -fsyntax-only` で試行しましたが、実行環境に DirectX ヘッダ（例: `d3d12.h`）が無いためフル構文チェックは環境依存で中断されました（失敗／環境制約）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fecd6b1fa4832dabbad713302c4f8d)