### PR TITLE
再構築ブロックのフェードイン追加（alpha 時間/距離フェード・ImGui制御）

### DIFF
--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelBlockEffectSequence.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelBlockEffectSequence.cpp
@@ -286,6 +286,14 @@ void ModelBlockEffectSequence::ApplySharedParameters()
 		reconstructionParams.useVoxelInsideTest = parameters_.useVoxelInsideTest;
 		reconstructionParams.useVoxelSurfaceNearTest = parameters_.useVoxelSurfaceNearTest;
 		reconstructionParams.alignVoxelGridToCenter = parameters_.alignVoxelGridToCenter;
+		reconstructionParams.useFadeIn = parameters_.useFadeIn;
+		reconstructionParams.fadeInDuration = parameters_.fadeInDuration;
+		reconstructionParams.fadeInDelayRange = parameters_.fadeInDelayRange;
+		reconstructionParams.initialAlpha = parameters_.initialAlpha;
+		reconstructionParams.targetAlpha = parameters_.targetAlpha;
+		reconstructionParams.fadeInEasePower = parameters_.fadeInEasePower;
+		reconstructionParams.fadeInByDistance = parameters_.fadeInByDistance;
+		reconstructionParams.fadeInNearTarget = parameters_.fadeInNearTarget;
 		reconstructionParams.holdTime = 0.0f;
 		reconstructionParams.showFinalModel = false;
 		reconstructionParams.autoHideBlocksAfterComplete = false;

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelBlockEffectSequence.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelBlockEffectSequence.h
@@ -70,6 +70,14 @@ public:
 		bool useRandomRotation = false;
 		float rotationRandomness = 1.2f;
 		uint32_t placementSeed = 0xD157E6A7u;
+		bool useFadeIn = true;
+		float fadeInDuration = 0.4f;
+		float fadeInDelayRange = 0.2f;
+		float initialAlpha = 0.0f;
+		float targetAlpha = 1.0f;
+		float fadeInEasePower = 2.0f;
+		bool fadeInByDistance = false;
+		bool fadeInNearTarget = true;
 		bool useSweepErosion = true;
 		ErosionMode erosionMode = ErosionMode::DirectionalSweep;
 		K4E::Vector3 erosionCenter{ 0.0f, 0.0f, 0.0f };

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelReconstructionEffect.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelReconstructionEffect.cpp
@@ -50,6 +50,7 @@ void ModelReconstructionEffect::PlayFromModel(const std::string& modelPath, cons
 	settings.autoSurfaceInsetFromBlockSize = parameters_.autoSurfaceInsetFromBlockSize;
 	settings.color = parameters_.color;
 	settings.colorVariation = parameters_.colorVariation;
+	ApplyFadeInSettings(settings);
 
 	blocks_ = emitter_.EmitFromModel(model->GetModelData(), worldMatrix, settings);
 	isActive_ = !blocks_.empty();
@@ -86,6 +87,7 @@ void ModelReconstructionEffect::PlayFromSamples(const std::vector<Disintegration
 	settings.autoSurfaceInsetFromBlockSize = parameters_.autoSurfaceInsetFromBlockSize;
 	settings.color = parameters_.color;
 	settings.colorVariation = parameters_.colorVariation;
+	ApplyFadeInSettings(settings);
 
 	blocks_ = emitter_.EmitFromSamples(samples, worldMatrix.GetTranslation(), settings);
 	isActive_ = !blocks_.empty();
@@ -107,9 +109,11 @@ void ModelReconstructionEffect::Update(float deltaTime)
 		if (!block.alive) { continue; }
 
 		block.age += deltaTime;
+		block.appearAge += deltaTime;
 		if (block.age < block.startDelay)
 		{
 			block.position = block.startPosition;
+			UpdateBlockFade(block);
 			allArrived = false;
 			continue;
 		}
@@ -121,10 +125,13 @@ void ModelReconstructionEffect::Update(float deltaTime)
 		block.position = block.startPosition + (block.targetPosition - block.startPosition) * easedT;
 		block.rotation = block.startRotation + block.rotationVelocity * ((1.0f - easedT) * block.age);
 		block.arrived = localT >= 1.0f;
+		UpdateBlockFade(block);
 		if (block.arrived)
 		{
 			block.position = block.targetPosition;
 			block.rotation = { 0.0f, 0.0f, 0.0f };
+			block.alpha = parameters_.useFadeIn ? Clamp01(parameters_.targetAlpha) : block.alpha;
+			block.visibility = block.alpha;
 		}
 		else
 		{
@@ -231,6 +238,15 @@ void ModelReconstructionEffect::DrawImGui()
 	ImGui::SliderFloat("イージング強度", &parameters_.easePower, 1.0f, 8.0f);
 	ImGui::ColorEdit4("色", &parameters_.color.x);
 	ImGui::SliderFloat("色のばらつき", &parameters_.colorVariation, 0.0f, 0.8f);
+	ImGui::SeparatorText("フェードイン");
+	ImGui::Checkbox("フェードインを使う", &parameters_.useFadeIn);
+	ImGui::SliderFloat("初期透明度", &parameters_.initialAlpha, 0.0f, 1.0f);
+	ImGui::SliderFloat("目標透明度", &parameters_.targetAlpha, 0.0f, 1.0f);
+	ImGui::SliderFloat("フェードイン時間", &parameters_.fadeInDuration, 0.01f, 3.0f);
+	ImGui::SliderFloat("フェードイン遅延幅", &parameters_.fadeInDelayRange, 0.0f, 2.0f);
+	ImGui::SliderFloat("フェードインの鋭さ", &parameters_.fadeInEasePower, 0.1f, 8.0f);
+	ImGui::Checkbox("距離でフェードイン", &parameters_.fadeInByDistance);
+	ImGui::Checkbox("到着付近で不透明化", &parameters_.fadeInNearTarget);
 	ImGui::SliderFloat("完了後の保持時間", &parameters_.holdTime, 0.0f, 5.0f);
 	ImGui::Checkbox("完了後にモデル表示", &parameters_.showFinalModel);
 	ImGui::Checkbox("完了後にブロック自動非表示", &parameters_.autoHideBlocksAfterComplete);
@@ -259,4 +275,44 @@ float ModelReconstructionEffect::EaseOut(float value) const
 {
 	const float t = Clamp01(value);
 	return 1.0f - std::pow(1.0f - t, std::max(parameters_.easePower, 1.0f));
+}
+
+void ModelReconstructionEffect::ApplyFadeInSettings(ReconstructionEmitter::Settings& settings) const
+{
+	settings.useFadeIn = parameters_.useFadeIn;
+	settings.fadeInDuration = std::max(parameters_.fadeInDuration, 0.0001f);
+	settings.fadeInDelayRange = std::max(parameters_.fadeInDelayRange, 0.0f);
+	settings.initialAlpha = Clamp01(parameters_.initialAlpha);
+	settings.targetAlpha = Clamp01(parameters_.targetAlpha);
+}
+
+void ModelReconstructionEffect::UpdateBlockFade(ReconstructionBlock& block) const
+{
+	if (!parameters_.useFadeIn)
+	{
+		block.alpha = Clamp01(parameters_.targetAlpha);
+		block.visibility = block.alpha;
+		return;
+	}
+
+	const float fadeDuration = std::max(block.fadeInDuration, 0.0001f);
+	const float fadeT = Clamp01((block.appearAge - block.fadeInDelay) / fadeDuration);
+	const float easedT = 1.0f - std::pow(1.0f - fadeT, std::max(parameters_.fadeInEasePower, 0.0001f));
+	const float initialAlpha = Clamp01(parameters_.initialAlpha);
+	const float targetAlpha = Clamp01(parameters_.targetAlpha);
+	float alpha = initialAlpha + (targetAlpha - initialAlpha) * easedT;
+
+	if (parameters_.fadeInByDistance || parameters_.fadeInNearTarget)
+	{
+		const float startDistance = std::max(block.startDistance, 0.0001f);
+		const float distanceToTarget = K4E::Vector3::Length(block.targetPosition - block.position);
+		const float distanceRate = 1.0f - Clamp01(distanceToTarget / startDistance);
+		const float distanceAlpha = initialAlpha + (targetAlpha - initialAlpha) * distanceRate;
+
+		// 到着に近づくほど透明度を押し上げ、再構築中のブロックを徐々に物質化させる。
+		alpha = parameters_.fadeInNearTarget ? std::max(alpha, distanceAlpha) : distanceAlpha;
+	}
+
+	block.alpha = Clamp01(alpha);
+	block.visibility = block.alpha;
 }

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ModelReconstructionEffect.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ModelReconstructionEffect.h
@@ -39,6 +39,14 @@ public:
 		float easePower = 3.0f;
 		K4E::Vector4 color{ 0.64f, 0.72f, 0.86f, 1.0f };
 		float colorVariation = 0.18f;
+		bool useFadeIn = true;
+		float fadeInDuration = 0.4f;
+		float fadeInDelayRange = 0.2f;
+		float initialAlpha = 0.0f;
+		float targetAlpha = 1.0f;
+		float fadeInEasePower = 2.0f;
+		bool fadeInByDistance = false;
+		bool fadeInNearTarget = true;
 		float holdTime = 0.60f;
 		bool showFinalModel = true;
 		bool autoHideBlocksAfterComplete = true;
@@ -67,6 +75,8 @@ public:
 private:
 	float Clamp01(float value) const;
 	float EaseOut(float value) const;
+	void ApplyFadeInSettings(ReconstructionEmitter::Settings& settings) const;
+	void UpdateBlockFade(ReconstructionBlock& block) const;
 
 	Parameters parameters_{};
 	ReconstructionEmitter emitter_{};

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionBlock.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionBlock.h
@@ -22,6 +22,11 @@ struct ReconstructionBlock
 	float startDelay = 0.0f;
 	float size = 0.04f;
 	float alpha = 1.0f;
+	float fadeInDelay = 0.0f;
+	float fadeInDuration = 0.4f;
+	float appearAge = 0.0f;
+	float visibility = 1.0f;
+	float startDistance = 0.0f;
 	bool alive = false;
 	bool arrived = false;
 };

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionEmitter.cpp
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionEmitter.cpp
@@ -92,7 +92,12 @@ std::vector<ReconstructionBlock> ReconstructionEmitter::EmitFromSamples(
 		block.color = MakeColor(settings);
 		block.startDelay = RandomRange(0.0f, settings.startDelayRange);
 		block.size = settings.blockSize * RandomRange(1.0f - scaleVariation, 1.0f + scaleVariation);
-		block.alpha = 1.0f;
+		block.fadeInDelay = settings.useFadeIn ? RandomRange(0.0f, settings.fadeInDelayRange) : 0.0f;
+		block.fadeInDuration = std::max(settings.fadeInDuration, 0.0001f);
+		block.appearAge = 0.0f;
+		block.startDistance = K4E::Vector3::Length(block.targetPosition - block.startPosition);
+		block.alpha = settings.useFadeIn ? std::clamp(settings.initialAlpha, 0.0f, 1.0f) : std::clamp(settings.targetAlpha, 0.0f, 1.0f);
+		block.visibility = block.alpha;
 		block.alive = true;
 		blocks.push_back(block);
 	}

--- a/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionEmitter.h
+++ b/Project/ApplicationLayer/EffectLayer/Disintegration/ReconstructionEmitter.h
@@ -41,6 +41,11 @@ public:
 		bool autoSurfaceInsetFromBlockSize = true;
 		K4E::Vector4 color{ 0.64f, 0.72f, 0.86f, 1.0f };
 		float colorVariation = 0.18f;
+		bool useFadeIn = true;
+		float fadeInDuration = 0.4f;
+		float fadeInDelayRange = 0.2f;
+		float initialAlpha = 0.0f;
+		float targetAlpha = 1.0f;
 	};
 
 	std::vector<ReconstructionBlock> EmitFromModel(

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -631,6 +631,15 @@ void DebugScene::DrawImGui()
 			ImGui::SliderFloat("サイズばらつき##BlockSequence", &sequenceParams.scaleVariation, 0.0f, 0.75f);
 			ImGui::Checkbox("ランダム回転を使う##BlockSequence", &sequenceParams.useRandomRotation);
 			ImGui::SliderFloat("回転ばらつき##BlockSequence", &sequenceParams.rotationRandomness, 0.0f, 8.0f);
+			ImGui::SeparatorText("フェードイン##BlockSequence");
+			ImGui::Checkbox("フェードインを使う##BlockSequence", &sequenceParams.useFadeIn);
+			ImGui::SliderFloat("初期透明度##BlockSequence", &sequenceParams.initialAlpha, 0.0f, 1.0f);
+			ImGui::SliderFloat("目標透明度##BlockSequence", &sequenceParams.targetAlpha, 0.0f, 1.0f);
+			ImGui::SliderFloat("フェードイン時間##BlockSequence", &sequenceParams.fadeInDuration, 0.01f, 3.0f);
+			ImGui::SliderFloat("フェードイン遅延幅##BlockSequence", &sequenceParams.fadeInDelayRange, 0.0f, 2.0f);
+			ImGui::SliderFloat("フェードインの鋭さ##BlockSequence", &sequenceParams.fadeInEasePower, 0.1f, 8.0f);
+			ImGui::Checkbox("距離でフェードイン##BlockSequence", &sequenceParams.fadeInByDistance);
+			ImGui::Checkbox("到着付近で不透明化##BlockSequence", &sequenceParams.fadeInNearTarget);
 			int sequencePlacementSeed = static_cast<int>(sequenceParams.placementSeed);
 			if (ImGui::InputInt("配置シード##BlockSequence", &sequencePlacementSeed))
 			{


### PR DESCRIPTION
### Motivation
- 再構築開始時に散らばったブロックが瞬間的に不透明で表示されてしまう問題を解消し、ブロックが集まりながら徐々に物質化する見た目にするため。 
- DebugScene とブロックシーケンスから調整できるようにフェードイン制御をパラメータ化するため。 

### Description
- `ReconstructionBlock` にフェードイン用の状態を追加してブロック単位で管理可能にしました（`fadeInDelay` / `fadeInDuration` / `appearAge` / `visibility` / `startDistance`）。
- エミッタ側 (`ReconstructionEmitter`) で配置シードに基づくランダム遅延と初期 alpha を設定し、毎回同じ見た目になるようにしました。 
- `ModelReconstructionEffect::Parameters` と `ReconstructionEmitter::Settings`、および `ModelBlockEffectSequence::Parameters` にフェードイン関連パラメータを追加し、デフォルト値は要望通りに設定しました（`useFadeIn=true` / `initialAlpha=0.0f` / `targetAlpha=1.0f` / `fadeInDuration=0.4f` / `fadeInDelayRange=0.2f` / `fadeInEasePower=2.0f` / `fadeInNearTarget=true`）。
- 指定の計算式に基づくフェードイン処理を `ModelReconstructionEffect::UpdateBlockFade` に実装し、時間フェード + （オプションで）到着近傍による不透明化を組み合わせて適用しています（処理意図が分かる日本語コメントを追加）。
- DebugScene とブロック演出シーケンスの ImGui に日本語ラベルでフェードイン調整 UI を追加しました。 

### Testing
- `git diff --check` を実行して差分チェックを行い問題無く終了しました（成功）。
- 変更はローカルでコミット済み（コミットメッセージ: "Add reconstruction block fade-in"）。
- ビルド検証はこの環境で `msbuild` が利用できなかったため未実行です（CI/ローカル環境でのビルド実行を推奨します）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fed6bd46f4832d9d85dc5d46cab876)