### PR TITLE
Add Object3D frustum culling (BoundingSphere + Frustum)

### DIFF
--- a/Project/Engine/Core/Application/GameApplication.cpp
+++ b/Project/Engine/Core/Application/GameApplication.cpp
@@ -135,6 +135,7 @@ namespace Ken4lowEngine
 		PostEffectManager::GetInstance()->BeginDraw(); // RTV/DSVの設定・Clear
 
 		// --- 2. 3Dオブジェクトの描画 ---
+		Object3DCommon::GetInstance()->BeginObject3DPass();
 		SceneManager::GetInstance()->Draw3DObjects();
 
 		// --- デバッグ描画（3D用） ---

--- a/Project/Engine/Graphics/Culling/Frustum.cpp
+++ b/Project/Engine/Graphics/Culling/Frustum.cpp
@@ -1,0 +1,50 @@
+#include "Frustum.h"
+
+#include <cmath>
+
+namespace Ken4lowEngine
+{
+	void Frustum::BuildFromViewProjection(const Matrix4x4& viewProjection)
+	{
+		// 行ベクトル前提のクリップ空間条件から、ワールド空間の6平面を抽出する。
+		planes_[0] = { viewProjection.m[0][3] + viewProjection.m[0][0], viewProjection.m[1][3] + viewProjection.m[1][0], viewProjection.m[2][3] + viewProjection.m[2][0], viewProjection.m[3][3] + viewProjection.m[3][0] }; // Left
+		planes_[1] = { viewProjection.m[0][3] - viewProjection.m[0][0], viewProjection.m[1][3] - viewProjection.m[1][0], viewProjection.m[2][3] - viewProjection.m[2][0], viewProjection.m[3][3] - viewProjection.m[3][0] }; // Right
+		planes_[2] = { viewProjection.m[0][3] + viewProjection.m[0][1], viewProjection.m[1][3] + viewProjection.m[1][1], viewProjection.m[2][3] + viewProjection.m[2][1], viewProjection.m[3][3] + viewProjection.m[3][1] }; // Bottom
+		planes_[3] = { viewProjection.m[0][3] - viewProjection.m[0][1], viewProjection.m[1][3] - viewProjection.m[1][1], viewProjection.m[2][3] - viewProjection.m[2][1], viewProjection.m[3][3] - viewProjection.m[3][1] }; // Top
+		planes_[4] = { viewProjection.m[0][2], viewProjection.m[1][2], viewProjection.m[2][2], viewProjection.m[3][2] }; // Near
+		planes_[5] = { viewProjection.m[0][3] - viewProjection.m[0][2], viewProjection.m[1][3] - viewProjection.m[1][2], viewProjection.m[2][3] - viewProjection.m[2][2], viewProjection.m[3][3] - viewProjection.m[3][2] }; // Far
+
+		for (auto& plane : planes_)
+		{
+			NormalizePlane(plane);
+		}
+	}
+
+	bool Frustum::Intersects(const BoundingSphere& sphere) const
+	{
+		for (const auto& plane : planes_)
+		{
+			const float distance = plane.x * sphere.center.x + plane.y * sphere.center.y + plane.z * sphere.center.z + plane.w;
+			if (distance < -sphere.radius)
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
+	void Frustum::NormalizePlane(Vector4& plane) const
+	{
+		const float length = std::sqrt(plane.x * plane.x + plane.y * plane.y + plane.z * plane.z);
+		if (length <= 0.000001f)
+		{
+			return;
+		}
+
+		plane.x /= length;
+		plane.y /= length;
+		plane.z /= length;
+		plane.w /= length;
+	}
+}

--- a/Project/Engine/Graphics/Culling/Frustum.h
+++ b/Project/Engine/Graphics/Culling/Frustum.h
@@ -1,0 +1,33 @@
+#pragma once
+#include "Matrix4x4.h"
+#include "Vector3.h"
+#include "Vector4.h"
+
+#include <array>
+
+namespace Ken4lowEngine
+{
+	/// <summary>
+	/// ローカル/ワールド空間で扱う簡易的な球 Bounds。
+	/// </summary>
+	struct BoundingSphere
+	{
+		Vector3 center{};
+		float radius = 1.0f;
+	};
+
+	/// <summary>
+	/// ViewProjection 行列から生成した 6 平面で可視判定を行う視錐台。
+	/// </summary>
+	class Frustum
+	{
+	public:
+		void BuildFromViewProjection(const Matrix4x4& viewProjection);
+		bool Intersects(const BoundingSphere& sphere) const;
+
+	private:
+		void NormalizePlane(Vector4& plane) const;
+
+		std::array<Vector4, 6> planes_{};
+	};
+}

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3D.cpp
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3D.cpp
@@ -12,6 +12,9 @@
 #include "ParameterManager.h"
 #include "SkyBox.h"
 
+#include <algorithm>
+#include <cmath>
+
 namespace Ken4lowEngine
 {
 
@@ -159,6 +162,7 @@ namespace Ken4lowEngine
 			ImGui::DragFloat3("Position##pos", &worldTransform_.translate_.x, 0.01f);
 			ImGui::DragFloat3("Rotation##rot", &worldTransform_.rotate_.x, 0.01f);
 			ImGui::DragFloat3("Scale##scl", &worldTransform_.scale_.x, 0.01f);
+			ImGui::Checkbox("Object Frustum Culling", &frustumCullingEnabled_);
 
 			// カメラ（必要ならスコープを分ける）
 			if (ImGui::CollapsingHeader("Camera Settings"))
@@ -184,6 +188,11 @@ namespace Ken4lowEngine
 	void Object3D::Draw()
 	{
 		if (!model_) { return; }
+
+		if (!Object3DCommon::GetInstance()->ShouldDrawObject(GetWorldBounds(), frustumCullingEnabled_))
+		{
+			return;
+		}
 
 		ID3D12GraphicsCommandList* commandList = dxCommon_->GetCommandManager()->GetCommandList();
 
@@ -329,6 +338,25 @@ namespace Ken4lowEngine
 		shadowParameterData_->lightViewProjection = Matrix4x4::MakeIdentity();
 		shadowParameterData_->shadowBias = 0.015f;
 		shadowParameterData_->normalBias = 0.02f;
+	}
+
+	BoundingSphere Object3D::GetWorldBounds() const
+	{
+		BoundingSphere worldBounds{};
+		if (!model_)
+		{
+			return worldBounds;
+		}
+
+		const BoundingSphere& localBounds = model_->GetLocalBounds();
+		worldBounds.center = Vector3::Transform(localBounds.center, worldTransform_.matWorld_);
+
+		const float scaleX = std::sqrt(worldTransform_.matWorld_.m[0][0] * worldTransform_.matWorld_.m[0][0] + worldTransform_.matWorld_.m[0][1] * worldTransform_.matWorld_.m[0][1] + worldTransform_.matWorld_.m[0][2] * worldTransform_.matWorld_.m[0][2]);
+		const float scaleY = std::sqrt(worldTransform_.matWorld_.m[1][0] * worldTransform_.matWorld_.m[1][0] + worldTransform_.matWorld_.m[1][1] * worldTransform_.matWorld_.m[1][1] + worldTransform_.matWorld_.m[1][2] * worldTransform_.matWorld_.m[1][2]);
+		const float scaleZ = std::sqrt(worldTransform_.matWorld_.m[2][0] * worldTransform_.matWorld_.m[2][0] + worldTransform_.matWorld_.m[2][1] * worldTransform_.matWorld_.m[2][1] + worldTransform_.matWorld_.m[2][2] * worldTransform_.matWorld_.m[2][2]);
+		const float maxScale = std::max({ scaleX, scaleY, scaleZ, 1.0f });
+		worldBounds.radius = localBounds.radius * maxScale;
+		return worldBounds;
 	}
 
 	void Object3D::AcquireShadowMapHandle()

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3D.h
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3D.h
@@ -6,6 +6,7 @@
 #include "VertexData.h"
 #include "Camera.h"
 #include "TransformationMatrix.h"
+#include "Engine/Graphics/Culling/Frustum.h"
 
 #include <fstream>
 #include <sstream>
@@ -77,6 +78,8 @@ namespace Ken4lowEngine
 		void SetTextureForAll(const std::string& texturePath);
 		void SetTextureForSubmesh(size_t index, const std::string& texturePath);
 		size_t GetSubmeshCount() const;
+		void SetFrustumCullingEnabled(bool enabled) { frustumCullingEnabled_ = enabled; }
+		bool IsFrustumCullingEnabled() const { return frustumCullingEnabled_; }
 
 	public: /// ---------- ディゾルブの設定 ---------- ///
 
@@ -91,6 +94,7 @@ namespace Ken4lowEngine
 		void InitializeShadowResource();
 		void InitializeShadowParameterResource();
 		void AcquireShadowMapHandle();
+		BoundingSphere GetWorldBounds() const;
 
 	private: /// ---------- メンバ変数 ---------- ///
 
@@ -138,6 +142,8 @@ namespace Ken4lowEngine
 
 		// ShadowMap の SRV を引くための GPU ハンドル
 		D3D12_GPU_DESCRIPTOR_HANDLE shadowMapHandle_{};
+
+		bool frustumCullingEnabled_ = true;
 	};
 
 } // namespace Ken4lowEngine

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3DCommon.cpp
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3DCommon.cpp
@@ -1,5 +1,10 @@
 #include "Object3DCommon.h"
 #include "DirectXCommon.h"
+#include "CameraManager.h"
+
+#ifdef USE_IMGUI
+#include "ImGuiManager.h"
+#endif // USE_IMGUI
 
 namespace Ken4lowEngine
 {
@@ -25,9 +30,24 @@ namespace Ken4lowEngine
 		dxCommon_ = nullptr;
 	}
 
+	void Object3DCommon::BeginObject3DPass()
+	{
+		drawnObjectCount_ = 0;
+		culledObjectCount_ = 0;
+		totalObjectCount_ = 0;
+		activeFrustum_.BuildFromViewProjection(CameraManager::GetInstance()->GetActiveViewProjectionMatrix());
+	}
+
 	void Object3DCommon::DrawImGui()
 	{
 #ifdef USE_IMGUI
+		ImGui::Begin("Object3D Frustum Culling");
+		ImGui::Checkbox("Frustum Culling 有効", &frustumCullingEnabled_);
+		ImGui::Separator();
+		ImGui::Text("現在の描画対象数: %d", drawnObjectCount_);
+		ImGui::Text("カリングされた数: %d", culledObjectCount_);
+		ImGui::Text("総オブジェクト数: %d", totalObjectCount_);
+		ImGui::End();
 #endif
 	}
 
@@ -41,6 +61,20 @@ namespace Ken4lowEngine
 		commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
 
 		LightManager::GetInstance()->BindPunctualLights(5, 6);
+	}
+
+	bool Object3DCommon::ShouldDrawObject(const BoundingSphere& worldBounds, bool objectCullingEnabled)
+	{
+		++totalObjectCount_;
+
+		if (!frustumCullingEnabled_ || !objectCullingEnabled || activeFrustum_.Intersects(worldBounds))
+		{
+			++drawnObjectCount_;
+			return true;
+		}
+
+		++culledObjectCount_;
+		return false;
 	}
 
 	void Object3DCommon::SetShadowMapRenderSetting()

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3DCommon.h
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3DCommon.h
@@ -3,6 +3,7 @@
 #include "LightManager.h"
 #include "Camera.h"
 #include "Object3DPipelineSet.h"
+#include "Engine/Graphics/Culling/Frustum.h"
 
 namespace Ken4lowEngine
 {
@@ -16,12 +17,14 @@ namespace Ken4lowEngine
 
 		void Initialize(DirectXCommon* dxCommon);
 		void Finalize();
+		void BeginObject3DPass();
 		void DrawImGui();
 
 	public: /// ---------- 描画設定関数 ---------- ///
 
 		void SetRenderSetting();
 		void SetShadowMapRenderSetting();
+		bool ShouldDrawObject(const BoundingSphere& worldBounds, bool objectCullingEnabled);
 
 	public: /// ---------- 拡張予定の関数 ---------- ///
 
@@ -41,5 +44,11 @@ namespace Ken4lowEngine
 		DirectXCommon* dxCommon_ = nullptr;
 
 		Object3DPipelineSet pipelineSet_{};
+
+		Frustum activeFrustum_{};
+		bool frustumCullingEnabled_ = false;
+		int drawnObjectCount_ = 0;
+		int culledObjectCount_ = 0;
+		int totalObjectCount_ = 0;
 	};
 }

--- a/Project/Engine/Graphics/Resource/Model/Model.cpp
+++ b/Project/Engine/Graphics/Resource/Model/Model.cpp
@@ -2,6 +2,9 @@
 #include "AssimpLoader.h"
 #include "TextureManager.h"
 
+#include <algorithm>
+#include <limits>
+
 namespace Ken4lowEngine
 {
 
@@ -17,6 +20,8 @@ namespace Ken4lowEngine
 
 		static const std::string kDefaultTexturePath = "Effects/white.dds";
 
+		BuildLocalBounds();
+
 		for (const auto& sub : modelData_.subMeshes)
 		{
 			std::string texturePath = sub.material.textureFilePath;
@@ -31,6 +36,49 @@ namespace Ken4lowEngine
 			Mesh mesh{};
 			mesh.Initialize(sub.vertices, sub.indices);
 			meshes_.push_back(std::move(mesh));
+		}
+	}
+
+	void Model::BuildLocalBounds()
+	{
+		Vector3 minPos{
+			std::numeric_limits<float>::max(),
+			std::numeric_limits<float>::max(),
+			std::numeric_limits<float>::max()
+		};
+		Vector3 maxPos{
+			std::numeric_limits<float>::lowest(),
+			std::numeric_limits<float>::lowest(),
+			std::numeric_limits<float>::lowest()
+		};
+		bool hasVertex = false;
+
+		for (const auto& sub : modelData_.subMeshes)
+		{
+			for (const auto& vertex : sub.vertices)
+			{
+				const Vector3 position{ vertex.position.x, vertex.position.y, vertex.position.z };
+				minPos.x = std::min(minPos.x, position.x);
+				minPos.y = std::min(minPos.y, position.y);
+				minPos.z = std::min(minPos.z, position.z);
+				maxPos.x = std::max(maxPos.x, position.x);
+				maxPos.y = std::max(maxPos.y, position.y);
+				maxPos.z = std::max(maxPos.z, position.z);
+				hasVertex = true;
+			}
+		}
+
+		if (!hasVertex)
+		{
+			localBounds_ = { {}, 1.0f };
+			return;
+		}
+
+		localBounds_.center = (minPos + maxPos) * 0.5f;
+		localBounds_.radius = Vector3::Length(maxPos - localBounds_.center) * 1.1f;
+		if (localBounds_.radius <= 0.001f)
+		{
+			localBounds_.radius = 1.0f;
 		}
 	}
 

--- a/Project/Engine/Graphics/Resource/Model/Model.h
+++ b/Project/Engine/Graphics/Resource/Model/Model.h
@@ -2,6 +2,7 @@
 #include "DX12Include.h"
 #include <ModelData.h>
 #include <Mesh.h>
+#include "Engine/Graphics/Culling/Frustum.h"
 
 #include <vector>
 #include <string>
@@ -15,11 +16,14 @@ namespace Ken4lowEngine
 
 		void Initialize(const std::string& filePath);
 
+		void BuildLocalBounds();
+
 	public: /// ---------- アクセッサ ---------- ///
 
 		const ModelData& GetModelData() const { return modelData_; }
 		const std::vector<Mesh>& GetMeshes() const { return meshes_; }
 		std::vector<Mesh>& GetMeshes() { return meshes_; }
+		const BoundingSphere& GetLocalBounds() const { return localBounds_; }
 		
 		const std::vector<D3D12_GPU_DESCRIPTOR_HANDLE>& GetMaterialSRVs() const { return materialSRVs_; }
 		std::vector<D3D12_GPU_DESCRIPTOR_HANDLE>& GetMaterialSRVs() { return materialSRVs_; }
@@ -29,6 +33,7 @@ namespace Ken4lowEngine
 		ModelData modelData_;
 		std::vector<Mesh> meshes_;
 		std::vector<D3D12_GPU_DESCRIPTOR_HANDLE> materialSRVs_;
+		BoundingSphere localBounds_{};
 	};
 
 

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -317,6 +317,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="Engine\Graphics\Camera\Core\Camera.cpp" />
     <ClCompile Include="Engine\Graphics\Camera\DebugCamera\DebugCamera.cpp" />
     <ClCompile Include="Engine\Graphics\Camera\FPS\FpsCamera.cpp" />
+    <ClCompile Include="Engine\Graphics\Culling\Frustum.cpp" />
     <ClCompile Include="Engine\Graphics\Descriptor\DSV\DSVManager.cpp" />
     <ClCompile Include="Engine\Graphics\Descriptor\RTV\RTVManager.cpp" />
     <ClCompile Include="Engine\Graphics\Descriptor\SRV\SRVManager.cpp" />
@@ -918,6 +919,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="Engine\Graphics\Camera\Core\Camera.h" />
     <ClInclude Include="Engine\Graphics\Camera\DebugCamera\DebugCamera.h" />
     <ClInclude Include="Engine\Graphics\Camera\FPS\FpsCamera.h" />
+    <ClInclude Include="Engine\Graphics\Culling\Frustum.h" />
     <ClInclude Include="Engine\Graphics\Common\BlendModeType.h" />
     <ClInclude Include="Engine\Graphics\Common\DX12Include.h" />
     <ClInclude Include="Engine\Graphics\Common\ModelData.h" />

--- a/Project/Ken4lowEngine.vcxproj.filters
+++ b/Project/Ken4lowEngine.vcxproj.filters
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup>
+    <Filter Include="Engine\Graphics\Culling">
+      <UniqueIdentifier>{3f7d873e-5b71-4bc1-a491-b26704b48611}</UniqueIdentifier>
+    </Filter>
     <FxCompile Include="Resources\Shaders\Disintegration\DisintegrationBlock.PS.hlsl">
       <Filter>Shader\PixelShader</Filter>
     </FxCompile>
@@ -525,6 +528,9 @@
     </ClCompile>
     <ClCompile Include="Engine\Graphics\Camera\FPS\FpsCamera.cpp">
       <Filter>Engine\Graphics\Camera\FPS</Filter>
+    </ClCompile>
+    <ClCompile Include="Engine\Graphics\Culling\Frustum.cpp">
+      <Filter>Engine\Graphics\Culling</Filter>
     </ClCompile>
     <ClCompile Include="Engine\Graphics\Descriptor\DSV\DSVManager.cpp">
       <Filter>Engine\Graphics\Descriptor\DSV</Filter>
@@ -1340,6 +1346,9 @@
     </ClInclude>
     <ClInclude Include="Engine\Graphics\Camera\FPS\FpsCamera.h">
       <Filter>Engine\Graphics\Camera\FPS</Filter>
+    </ClInclude>
+    <ClInclude Include="Engine\Graphics\Culling\Frustum.h">
+      <Filter>Engine\Graphics\Culling</Filter>
     </ClInclude>
     <ClInclude Include="Engine\Graphics\Descriptor\DSV\DSVManager.h">
       <Filter>Engine\Graphics\Descriptor\DSV</Filter>


### PR DESCRIPTION
### Motivation
- Reduce GPU work and DrawCalls by skipping Object3D draws when they are outside the camera frustum while preserving existing rendering behavior for shadows/UI/particles/skybox/debug.
- Provide an easy way to compare ON/OFF behavior from debug UI and allow per-object opt-out to avoid sudden disappearance.
- Start with a simple, robust approach using a `BoundingSphere` (slightly inflated) to prioritize correctness over tight fitting.

### Description
- Added a `Frustum` utility and `BoundingSphere` type under `Engine/Graphics/Culling` that extracts six planes from the active viewProjection matrix and performs sphere/plane intersection (`Frustum.h/.cpp`).
- Extended `Model` to compute a local `BoundingSphere` at load time via `BuildLocalBounds()` and expose it with `GetLocalBounds()` (`Model.h/.cpp`).
- Added `Object3D::GetWorldBounds()` which converts the model local sphere into world space (applies world matrix and conservative max-scale to radius) and added per-object API `SetFrustumCullingEnabled(bool)` / `IsFrustumCullingEnabled()` (`Object3D.h/.cpp`).
- Integrated culling into the render flow by calling `Object3DCommon::BeginObject3DPass()` before scene draw (added to `GameApplication.cpp`) and checking `Object3DCommon::ShouldDrawObject(worldBounds, objectEnabled)` at the start of `Object3D::Draw()` to skip invisible objects (`Object3DCommon.h/.cpp`, `Object3D.cpp`).
- Added ImGui controls and counters in `Object3DCommon::DrawImGui()` for global ON/OFF (`Frustum Culling 有効`) and display of `現在の描画対象数`, `カリングされた数`, and `総オブジェクト数` (enabled under `USE_IMGUI`).
- Registered new files in Visual Studio project (`Frustum.h/.cpp` added to `Project/Ken4lowEngine.vcxproj` and filters).
- Implementation notes: planes are normalized; model bounds are inflated by ~1.1 to avoid popping; shadow generation, particles, UI, skybox and debug/wireframe rendering remain unaffected.

### Testing
- Parsed project files with Python XML parsing to validate `Project/Ken4lowEngine.vcxproj` and `Project/Ken4lowEngine.vcxproj.filters` and the check succeeded: `ET.parse(...)` reported OK. (succeeded)
- Performed a compile-time syntax check of the new culling unit with `g++ -std=c++20 -fsyntax-only Project/Engine/Graphics/Culling/Frustum.cpp -I...` to ensure the new files are syntactically valid. (succeeded)
- Verified integration points with ripgrep queries such as `rg "BeginObject3DPass|ShouldDrawObject|Frustum Culling 有効|SetFrustumCullingEnabled|BuildFromViewProjection|BuildLocalBounds" Project -n` to ensure changes are wired into the draw path. (succeeded)
- Attempted to run a full Windows/MSBuild build but the build tooling (`msbuild`/`dotnet`) is not available in this environment, so a full solution build was not executed here. (not run)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fede1c8808832db2c9cc756d99a336)