### PR TITLE
Visualize frustum culling bounds in DebugScene (Wireframe frustum + ImGui controls)

### DIFF
--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -6,6 +6,7 @@
 #include <SpriteManager.h>
 #include "CameraManager.h"
 #include "Wireframe.h"
+#include "Object3DCommon.h"
 #include <GameTimer.h>
 #ifdef _DEBUG
 #include <DebugCamera.h>
@@ -22,6 +23,7 @@
 #include <algorithm>
 #include <filesystem>
 #include <cstdio>
+#include <array>
 
 using namespace Ken4lowEngine;
 
@@ -178,6 +180,10 @@ void DebugScene::Draw3DObjects()
 #ifdef _DEBUG
 	// ワイヤーフレームの描画
 	Wireframe::GetInstance()->DrawGrid(100.0f, 50.0f, { 0.25f, 0.25f, 0.25f,1.0f });
+	if (showCullingFrustum_)
+	{
+		Wireframe::GetInstance()->DrawFrustum(BuildCullingFrustumCorners(), cullingFrustumWireColor_);
+	}
 
 	collisionManager_->Draw();
 #endif // _DEBUG
@@ -237,6 +243,8 @@ void DebugScene::DrawImGui()
 	{
 		debugBoss_->DrawImGui();
 	}
+
+	DrawCullingFrustumImGui();
 
 	ImGui::Begin("Debug Boss Hit Test");
 
@@ -487,6 +495,106 @@ void DebugScene::DrawImGui()
 
 #endif // USE_IMGUI
 
+}
+
+std::array<Vector3, 8> DebugScene::BuildCullingFrustumCorners() const
+{
+	const Matrix4x4 inverseViewProjection = Matrix4x4::Inverse(Object3DCommon::GetInstance()->GetCullingViewProjectionMatrix());
+	const std::array<Vector3, 8> ndcCorners = {
+		Vector3{ -1.0f, -1.0f, 0.0f },
+		Vector3{ -1.0f,  1.0f, 0.0f },
+		Vector3{  1.0f,  1.0f, 0.0f },
+		Vector3{  1.0f, -1.0f, 0.0f },
+		Vector3{ -1.0f, -1.0f, 1.0f },
+		Vector3{ -1.0f,  1.0f, 1.0f },
+		Vector3{  1.0f,  1.0f, 1.0f },
+		Vector3{  1.0f, -1.0f, 1.0f },
+	};
+
+	std::array<Vector3, 8> worldCorners{};
+	for (size_t i = 0; i < ndcCorners.size(); ++i)
+	{
+		worldCorners[i] = Vector3::Transform(ndcCorners[i], inverseViewProjection);
+	}
+	return worldCorners;
+}
+
+void DebugScene::DrawCullingFrustumImGui()
+{
+#ifdef USE_IMGUI
+	Object3DCommon* object3DCommon = Object3DCommon::GetInstance();
+	int cullingCameraIndex = static_cast<int>(object3DCommon->GetCullingCameraMode());
+	const char* cullingCameraItems[] = { "ActiveCamera", "MainCamera", "DebugCamera" };
+
+	float nearDistance = 0.0f;
+	float farDistance = 0.0f;
+	GetCullingCameraClipDistances(nearDistance, farDistance);
+
+	ImGui::Begin("DebugScene Frustum Culling");
+	ImGui::Checkbox("カリング視錐台を表示", &showCullingFrustum_);
+	ImGui::ColorEdit4("視錐台ワイヤー色", &cullingFrustumWireColor_.x);
+	ImGui::InputFloat("Near距離", &nearDistance, 0.0f, 0.0f, "%.3f", ImGuiInputTextFlags_ReadOnly);
+	ImGui::InputFloat("Far距離", &farDistance, 0.0f, 0.0f, "%.3f", ImGuiInputTextFlags_ReadOnly);
+	if (ImGui::Combo("カリング基準カメラ", &cullingCameraIndex, cullingCameraItems, IM_ARRAYSIZE(cullingCameraItems)))
+	{
+		object3DCommon->SetCullingCameraMode(static_cast<Object3DCommon::CullingCameraMode>(cullingCameraIndex));
+	}
+	ImGui::TextWrapped("DebugCameraで外側から見る場合は、カリング基準カメラをMainCameraにするとMainCameraの判定範囲を確認できます。");
+	ImGui::End();
+#endif // USE_IMGUI
+}
+
+void DebugScene::GetCullingCameraClipDistances(float& nearDistance, float& farDistance) const
+{
+	nearDistance = 0.0f;
+	farDistance = 0.0f;
+
+	const Object3DCommon::CullingCameraMode mode = Object3DCommon::GetInstance()->GetCullingCameraMode();
+	auto* cameraManager = CameraManager::GetInstance();
+
+	auto setMainCameraClips = [&]() -> bool
+		{
+			if (Camera* mainCamera = cameraManager->GetMainCamera())
+			{
+				nearDistance = mainCamera->GetNearClip();
+				farDistance = mainCamera->GetFarClip();
+				return true;
+			}
+			return false;
+		};
+
+	auto setDebugCameraClips = [&]() -> bool
+		{
+#ifdef _DEBUG
+			if (DebugCamera* debugCamera = cameraManager->GetDebugCamera())
+			{
+				nearDistance = debugCamera->GetNearClip();
+				farDistance = debugCamera->GetFarClip();
+				return true;
+			}
+#endif
+			return false;
+		};
+
+	switch (mode)
+	{
+	case Object3DCommon::CullingCameraMode::Main:
+		if (setMainCameraClips()) { return; }
+		break;
+	case Object3DCommon::CullingCameraMode::Debug:
+		if (setDebugCameraClips()) { return; }
+		break;
+	case Object3DCommon::CullingCameraMode::Active:
+	default:
+		if (cameraManager->IsUsingDebugCamera())
+		{
+			if (setDebugCameraClips()) { return; }
+		}
+		if (setMainCameraClips()) { return; }
+		break;
+	}
+
+	setMainCameraClips();
 }
 
 void DebugScene::UpdateDebug()

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
@@ -6,7 +6,10 @@
 #include "Player.h"
 #include "Derived/GuardianBoss/GuardianBoss.h"
 #include "DisintegrationDebugController.h"
+#include "Vector3.h"
+#include "Vector4.h"
 
+#include <array>
 #include <memory>
 #include <string>
 
@@ -59,6 +62,15 @@ private: /// ---------- メンバ関数 ---------- ///
 	/// テスト用GPUパーティクル発火
 	void UpdateDebugParticleTest();
 
+	// カリング基準カメラの ViewProjection から視錐台の 8 頂点を作成
+	std::array<K4E::Vector3, 8> BuildCullingFrustumCorners() const;
+
+	// DebugScene 専用のカリング視錐台 ImGui
+	void DrawCullingFrustumImGui();
+
+	// 選択中カリング基準カメラの Near/Far 距離を取得
+	void GetCullingCameraClipDistances(float& nearDistance, float& farDistance) const;
+
 	/// -------------------------------------------------------------
 	/// BossHitPart を文字列へ変換
 	/// ログ確認用
@@ -87,6 +99,10 @@ private: /// ---------- メンバ変数 ---------- ///
 	std::string debugParticleLog_ = "Press 1/2/3 to test GPU particles.";
 
 	std::unique_ptr<DisintegrationDebugController> disintegrationDebug_;
+
+	// カリング視錐台のワイヤー表示設定
+	bool showCullingFrustum_ = true;
+	K4E::Vector4 cullingFrustumWireColor_ = { 0.1f, 1.0f, 0.2f, 1.0f };
 
 };
 

--- a/Project/Engine/Graphics/Camera/Core/Camera.h
+++ b/Project/Engine/Graphics/Camera/Core/Camera.h
@@ -151,6 +151,16 @@ public: /// ---------- ゲッター ---------- ///
 	const Matrix4x4& GetViewProjectionMatrix() const { return viewProjectionMatrix_; }
 
 	/// <summary>
+	/// 現在のニアクリップ距離を取得します。
+	/// </summary>
+	float GetNearClip() const { return nearClip_; }
+
+	/// <summary>
+	/// 現在のファークリップ距離を取得します。
+	/// </summary>
+	float GetFarClip() const { return farClip_; }
+
+	/// <summary>
 	/// カメラの前方ベクトル（ワールド空間）を取得します。<br/>
 	/// ローカル Z+ を前方向とみなし、現在の回転行列を適用して正規化したベクトルを返します。
 	/// </summary>

--- a/Project/Engine/Graphics/Camera/DebugCamera/DebugCamera.h
+++ b/Project/Engine/Graphics/Camera/DebugCamera/DebugCamera.h
@@ -144,6 +144,16 @@ public: /// ---------- 取得 ---------- ///
 	Matrix4x4 GetViewProjectionMatrix() const { return viewProjectionMatrix_; }
 
 	/// <summary>
+	/// 現在のニアクリップ距離を取得します。
+	/// </summary>
+	float GetNearClip() const { return nearClip_; }
+
+	/// <summary>
+	/// 現在のファークリップ距離を取得します。
+	/// </summary>
+	float GetFarClip() const { return farClip_; }
+
+	/// <summary>
 	/// 現在の回転角（オイラー角）を取得します。
 	/// </summary>
 	Vector3 GetRotate() const { return worldTransform_.rotate_; }

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3DCommon.cpp
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3DCommon.cpp
@@ -1,6 +1,7 @@
 #include "Object3DCommon.h"
 #include "DirectXCommon.h"
 #include "CameraManager.h"
+#include "DebugCamera.h"
 
 #ifdef USE_IMGUI
 #include "ImGuiManager.h"
@@ -17,6 +18,7 @@ namespace Ken4lowEngine
 	void Object3DCommon::Initialize(DirectXCommon* dxCommon)
 	{
 		dxCommon_ = dxCommon;
+		cullingCameraMode_ = CullingCameraMode::Active;
 
 		pipelineSet_.Initialize(dxCommon_->GetPipelineFactory(), dxCommon_->GetDXCCompilerManager(), DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, DXGI_FORMAT_D24_UNORM_S8_UINT);
 
@@ -27,6 +29,7 @@ namespace Ken4lowEngine
 	{
 		LightManager::GetInstance()->Finalize();
 		pipelineSet_.Finalize();
+		cullingCameraMode_ = CullingCameraMode::Active;
 		dxCommon_ = nullptr;
 	}
 
@@ -35,7 +38,7 @@ namespace Ken4lowEngine
 		drawnObjectCount_ = 0;
 		culledObjectCount_ = 0;
 		totalObjectCount_ = 0;
-		activeFrustum_.BuildFromViewProjection(CameraManager::GetInstance()->GetActiveViewProjectionMatrix());
+		activeFrustum_.BuildFromViewProjection(GetCullingViewProjectionMatrix());
 	}
 
 	void Object3DCommon::DrawImGui()
@@ -49,6 +52,33 @@ namespace Ken4lowEngine
 		ImGui::Text("総オブジェクト数: %d", totalObjectCount_);
 		ImGui::End();
 #endif
+	}
+
+	Matrix4x4 Object3DCommon::GetCullingViewProjectionMatrix() const
+	{
+		auto* cameraManager = CameraManager::GetInstance();
+		switch (cullingCameraMode_)
+		{
+		case CullingCameraMode::Main:
+			if (Camera* mainCamera = cameraManager->GetMainCamera())
+			{
+				return mainCamera->GetViewProjectionMatrix();
+			}
+			break;
+		case CullingCameraMode::Debug:
+#ifdef _DEBUG
+			if (DebugCamera* debugCamera = cameraManager->GetDebugCamera())
+			{
+				return debugCamera->GetViewProjectionMatrix();
+			}
+#endif
+			break;
+		case CullingCameraMode::Active:
+		default:
+			return cameraManager->GetActiveViewProjectionMatrix();
+		}
+
+		return cameraManager->GetActiveViewProjectionMatrix();
 	}
 
 	void Object3DCommon::SetRenderSetting()

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3DCommon.h
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3DCommon.h
@@ -13,6 +13,14 @@ namespace Ken4lowEngine
 	class Object3DCommon
 	{
 	public:
+		enum class CullingCameraMode
+		{
+			Active,
+			Main,
+			Debug
+		};
+
+	public:
 		static Object3DCommon* GetInstance();
 
 		void Initialize(DirectXCommon* dxCommon);
@@ -25,6 +33,9 @@ namespace Ken4lowEngine
 		void SetRenderSetting();
 		void SetShadowMapRenderSetting();
 		bool ShouldDrawObject(const BoundingSphere& worldBounds, bool objectCullingEnabled);
+		void SetCullingCameraMode(CullingCameraMode mode) { cullingCameraMode_ = mode; }
+		CullingCameraMode GetCullingCameraMode() const { return cullingCameraMode_; }
+		Matrix4x4 GetCullingViewProjectionMatrix() const;
 
 	public: /// ---------- 拡張予定の関数 ---------- ///
 
@@ -46,6 +57,7 @@ namespace Ken4lowEngine
 		Object3DPipelineSet pipelineSet_{};
 
 		Frustum activeFrustum_{};
+		CullingCameraMode cullingCameraMode_ = CullingCameraMode::Active;
 		bool frustumCullingEnabled_ = false;
 		int drawnObjectCount_ = 0;
 		int culledObjectCount_ = 0;

--- a/Project/Engine/Graphics/Renderer/Wireframe/Wireframe.cpp
+++ b/Project/Engine/Graphics/Renderer/Wireframe/Wireframe.cpp
@@ -200,6 +200,11 @@ namespace Ken4lowEngine
 	/// -------------------------------------------------------------
 	void Wireframe::DrawLine(const Vector3& start, const Vector3& end, const Vector4& color)
 	{
+		if (!lineData_ || !lineData_->vertexData || lineIndex_ + 1 >= kLineMaxCount_ * kLineVertexCount)
+		{
+			return;
+		}
+
 		// 頂点データの設定
 		lineData_->vertexData[lineIndex_].position = start;
 		lineData_->vertexData[lineIndex_ + 1].position = end;
@@ -209,6 +214,18 @@ namespace Ken4lowEngine
 		lineData_->vertexData[lineIndex_ + 1].color = color;
 
 		lineIndex_ += kLineVertexCount;
+	}
+
+	void Wireframe::DrawFrustum(const std::array<Vector3, 8>& corners, const Vector4& color)
+	{
+		// Near/Far の四角形と対応頂点を結び、視錐台を 12 本の線で可視化する。
+		for (uint32_t i = 0; i < 4; ++i)
+		{
+			const uint32_t next = (i + 1) % 4;
+			DrawLine(corners[i], corners[next], color);
+			DrawLine(corners[i + 4], corners[next + 4], color);
+			DrawLine(corners[i], corners[i + 4], color);
+		}
 	}
 
 	void Wireframe::DrawSegment(const Segment& segment, const Vector4& color)

--- a/Project/Engine/Graphics/Renderer/Wireframe/Wireframe.h
+++ b/Project/Engine/Graphics/Renderer/Wireframe/Wireframe.h
@@ -9,6 +9,7 @@
 #include "OBB.h"
 #include "Capsule.h"
 
+#include <array>
 #include <vector>
 #include <list>
 #include <map>
@@ -129,6 +130,13 @@ public: /// ---------- 2D用の線の描画 ---------- ///
 	/// <param name="end">線分の終点のワールド座標。</param>
 	/// <param name="color">RGBA 形式の色。</param>
 	void DrawLine(const Vector3& start, const Vector3& end, const Vector4& color);
+
+	/// <summary>
+	/// Near/Far それぞれ 4 点の合計 8 点から視錐台を 12 本の線で描画します。
+	/// </summary>
+	/// <param name="corners">near 左下/左上/右上/右下、far 左下/左上/右上/右下の順の頂点。</param>
+	/// <param name="color">視錐台ワイヤーの色（RGBA）。</param>
+	void DrawFrustum(const std::array<Vector3, 8>& corners, const Vector4& color);
 
 	/// <summary>
 	/// Segment 構造体で指定された線分を描画します。


### PR DESCRIPTION
### Motivation

- Make it easy to verify Frustum Culling in `DebugScene` by visualizing the culling camera's frustum as a wireframe from the outside. 
- Allow switching the culling reference camera (Active/Main/Debug) so `DebugCamera` can view the actual `MainCamera` frustum and confirm that only in-frustum `Object3D` instances are drawn. 

### Description

- Added `Wireframe::DrawFrustum(const std::array<Vector3,8>&, const Vector4&)` and a safety guard in `Wireframe::DrawLine` to avoid buffer overruns and to draw the frustum as 12 lines (near 4, far 4, and 4 connecting edges). 
- Added a `CullingCameraMode` enum and methods to `Object3DCommon` to select which camera's ViewProjection is used for culling and exposed `GetCullingViewProjectionMatrix()` to build the frustum without changing culling logic. 
- Implemented DebugScene functions `BuildCullingFrustumCorners()`, `DrawCullingFrustumImGui()`, and `GetCullingCameraClipDistances()` to compute the 8 frustum corners by inverting the chosen ViewProjection and transforming NDC corners (DirectX NDC z in [0,1]) to world space, and to expose ImGui controls (Japanese labels): `カリング視錐台を表示`, `視錐台ワイヤー色`, `Near距離`, `Far距離`, and `カリング基準カメラ`. 
- Added `GetNearClip()`/`GetFarClip()` accessors to `Camera` and `DebugCamera` used for the ImGui readouts, and kept the actual culling behavior unchanged (visualization only). 

### Testing

- Ran `git diff --check` to ensure no whitespace/patch issues and it succeeded. 
- Attempted to build with `msbuild Project/Ken4lowEngine.sln` but the environment lacked `msbuild` so a full build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fee747e270832d968deae7ca5a1fbf)