### PR TITLE
Organize frustum culling debug flow

### DIFF
--- a/Project/ApplicationLayer/DebugTools/FrustumCulling/FrustumCullingDebugController.cpp
+++ b/Project/ApplicationLayer/DebugTools/FrustumCulling/FrustumCullingDebugController.cpp
@@ -1,0 +1,252 @@
+#define NOMINMAX
+#include "FrustumCullingDebugController.h"
+
+#include "Camera.h"
+#include "CameraManager.h"
+#include "Engine/Graphics/Culling/FrustumDebugRenderer.h"
+#include "Object3DCommon.h"
+#include "WinApp.h"
+
+#ifdef _DEBUG
+#include "DebugCamera.h"
+#endif
+
+#ifdef USE_IMGUI
+#include <imgui.h>
+#endif
+
+#include <algorithm>
+#include <numbers>
+
+namespace
+{
+	constexpr float kDegToRad = std::numbers::pi_v<float> / 180.0f;
+	constexpr float kRadToDeg = 180.0f / std::numbers::pi_v<float>;
+
+	K4E::Vector3 GetDefaultMainCameraPosition()
+	{
+		return { 0.0f, 3.0f, -12.0f };
+	}
+
+	K4E::Vector3 GetDefaultMainCameraRotation()
+	{
+		return { 8.0f * kDegToRad, 0.0f, 0.0f };
+	}
+}
+
+void FrustumCullingDebugController::Initialize(bool resetMainCamera)
+{
+	if (resetMainCamera)
+	{
+		ResetMainCamera();
+	}
+}
+
+void FrustumCullingDebugController::Update(float deltaTime)
+{
+	(void)deltaTime;
+}
+
+void FrustumCullingDebugController::DrawDebug()
+{
+#ifdef _DEBUG
+	if (!showFrustumWireframe_) { return; }
+
+	const K4E::Matrix4x4 viewProjection = K4E::Object3DCommon::GetInstance()->GetCullingViewProjectionMatrix();
+	K4E::FrustumDebugRenderer{}.Draw(viewProjection, frustumWireColor_);
+#endif
+}
+
+void FrustumCullingDebugController::DrawImGui()
+{
+#ifdef USE_IMGUI
+	K4E::Object3DCommon* object3DCommon = K4E::Object3DCommon::GetInstance();
+	int cullingCameraIndex = static_cast<int>(object3DCommon->GetCullingCameraMode());
+	const char* cullingCameraItems[] = { "ActiveCamera", "MainCamera", "DebugCamera" };
+
+	bool frustumCullingEnabled = object3DCommon->IsFrustumCullingEnabled();
+	float nearDistance = 0.0f;
+	float farDistance = 0.0f;
+	GetCullingCameraClipDistances(nearDistance, farDistance);
+
+	ImGui::Begin("Frustum Culling Debug");
+	if (ImGui::Checkbox("Frustum Culling Enabled", &frustumCullingEnabled))
+	{
+		object3DCommon->SetFrustumCullingEnabled(frustumCullingEnabled);
+	}
+	if (ImGui::Combo("Culling Camera", &cullingCameraIndex, cullingCameraItems, IM_ARRAYSIZE(cullingCameraItems)))
+	{
+		object3DCommon->SetCullingCameraMode(static_cast<K4E::Object3DCommon::CullingCameraMode>(cullingCameraIndex));
+	}
+
+	ImGui::Separator();
+	ImGui::Text("ActiveCamera: %s", K4E::CameraManager::GetInstance()->IsUsingDebugCamera() ? "DebugCamera" : "MainCamera");
+	ImGui::Text("MainCamera: %s", K4E::CameraManager::GetInstance()->GetMainCamera() ? "Available" : "None");
+#ifdef _DEBUG
+	ImGui::Text("DebugCamera: %s", K4E::CameraManager::GetInstance()->GetDebugCamera() ? "Available" : "None");
+#else
+	ImGui::Text("DebugCamera: Disabled in release builds");
+#endif
+	ImGui::Checkbox("Show Frustum Wireframe", &showFrustumWireframe_);
+	ImGui::ColorEdit4("Frustum Wire Color", &frustumWireColor_.x);
+	ImGui::InputFloat("Near", &nearDistance, 0.0f, 0.0f, "%.3f", ImGuiInputTextFlags_ReadOnly);
+	ImGui::InputFloat("Far", &farDistance, 0.0f, 0.0f, "%.3f", ImGuiInputTextFlags_ReadOnly);
+
+	ImGui::Separator();
+	ImGui::Text("Total Objects: %d", object3DCommon->GetTotalObjectCount());
+	ImGui::Text("Drawn Objects: %d", object3DCommon->GetDrawnObjectCount());
+	ImGui::Text("Culled Objects: %d", object3DCommon->GetCulledObjectCount());
+	ImGui::TextWrapped("Use DebugCamera outside the view and select MainCamera to inspect gameplay culling results.");
+
+	DrawMainCameraImGui();
+	ImGui::End();
+#endif
+}
+
+void FrustumCullingDebugController::DrawMainCameraImGui()
+{
+#ifdef USE_IMGUI
+	K4E::Camera* mainCamera = K4E::CameraManager::GetInstance()->GetMainCamera();
+	if (!mainCamera)
+	{
+		ImGui::Separator();
+		ImGui::Text("MainCamera is not set.");
+		return;
+	}
+
+	if (ImGui::CollapsingHeader("MainCamera Settings", ImGuiTreeNodeFlags_DefaultOpen))
+	{
+		K4E::Vector3 position = mainCamera->GetTranslate();
+		K4E::Vector3 rotation = mainCamera->GetRotate();
+		float fovDeg = mainCamera->GetFovY() * kRadToDeg;
+		float nearClip = mainCamera->GetNearClip();
+		float farClip = mainCamera->GetFarClip();
+		float aspectRatio = mainCamera->GetAspectRatio();
+		bool changed = false;
+
+		changed |= ImGui::DragFloat3("Position", &position.x, 0.05f);
+		changed |= ImGui::DragFloat3("Rotation", &rotation.x, 0.005f);
+		changed |= ImGui::SliderFloat("FOV", &fovDeg, 10.0f, 140.0f, "%.1f deg");
+		changed |= ImGui::DragFloat("Near Clip", &nearClip, 0.001f, 0.001f, 10.0f, "%.3f");
+		changed |= ImGui::DragFloat("Far Clip", &farClip, 0.5f, 1.0f, 1000.0f, "%.1f");
+		changed |= ImGui::DragFloat("Aspect", &aspectRatio, 0.001f, 0.1f, 4.0f, "%.3f");
+
+		if (changed)
+		{
+			farClip = std::max(farClip, 0.011f);
+			nearClip = std::clamp(nearClip, 0.001f, farClip - 0.01f);
+			farClip = std::max(farClip, nearClip + 0.01f);
+			aspectRatio = std::max(aspectRatio, 0.1f);
+			mainCamera->SetTranslate(position);
+			mainCamera->SetRotate(rotation);
+			mainCamera->SetFovY(fovDeg * kDegToRad);
+			mainCamera->SetNearClip(nearClip);
+			mainCamera->SetFarClip(farClip);
+			mainCamera->SetAspectRatio(aspectRatio);
+			mainCamera->Update();
+		}
+
+		if (ImGui::Button("Reset MainCamera"))
+		{
+			ResetMainCamera();
+		}
+#ifdef _DEBUG
+		ImGui::SameLine();
+		if (ImGui::Button("Copy Current DebugCamera to MainCamera"))
+		{
+			CopyDebugCameraToMainCamera();
+		}
+#endif
+	}
+#endif
+}
+
+void FrustumCullingDebugController::CopyDebugCameraToMainCamera()
+{
+#ifdef _DEBUG
+	K4E::Camera* mainCamera = K4E::CameraManager::GetInstance()->GetMainCamera();
+	K4E::DebugCamera* debugCamera = K4E::CameraManager::GetInstance()->GetDebugCamera();
+	if (!mainCamera || !debugCamera) { return; }
+
+	mainCamera->SetTranslate(debugCamera->GetTranslate());
+	mainCamera->SetRotate(debugCamera->GetRotate());
+	mainCamera->SetFovY(debugCamera->GetFovY());
+	mainCamera->SetNearClip(debugCamera->GetNearClip());
+	mainCamera->SetFarClip(debugCamera->GetFarClip());
+	mainCamera->SetAspectRatio(debugCamera->GetAspectRatio());
+	mainCamera->Update();
+#endif
+}
+
+void FrustumCullingDebugController::ResetMainCamera()
+{
+	K4E::Camera* mainCamera = K4E::CameraManager::GetInstance()->GetMainCamera();
+	if (!mainCamera) { return; }
+
+	mainCamera->SetTranslate(GetDefaultMainCameraPosition());
+	mainCamera->SetRotate(GetDefaultMainCameraRotation());
+	mainCamera->SetFovY(60.0f * kDegToRad);
+	mainCamera->SetNearClip(0.1f);
+	mainCamera->SetFarClip(80.0f);
+	mainCamera->SetAspectRatio(GetCurrentWindowAspectRatio());
+	mainCamera->Update();
+}
+
+void FrustumCullingDebugController::GetCullingCameraClipDistances(float& nearDistance, float& farDistance) const
+{
+	nearDistance = 0.0f;
+	farDistance = 0.0f;
+
+	const K4E::Object3DCommon::CullingCameraMode mode = K4E::Object3DCommon::GetInstance()->GetCullingCameraMode();
+	auto* cameraManager = K4E::CameraManager::GetInstance();
+
+	auto setMainCameraClips = [&]() -> bool
+		{
+			if (K4E::Camera* mainCamera = cameraManager->GetMainCamera())
+			{
+				nearDistance = mainCamera->GetNearClip();
+				farDistance = mainCamera->GetFarClip();
+				return true;
+			}
+			return false;
+		};
+
+	auto setDebugCameraClips = [&]() -> bool
+		{
+#ifdef _DEBUG
+			if (K4E::DebugCamera* debugCamera = cameraManager->GetDebugCamera())
+			{
+				nearDistance = debugCamera->GetNearClip();
+				farDistance = debugCamera->GetFarClip();
+				return true;
+			}
+#endif
+			return false;
+		};
+
+	switch (mode)
+	{
+	case K4E::Object3DCommon::CullingCameraMode::MainCamera:
+		if (setMainCameraClips()) { return; }
+		break;
+	case K4E::Object3DCommon::CullingCameraMode::DebugCamera:
+		if (setDebugCameraClips()) { return; }
+		break;
+	case K4E::Object3DCommon::CullingCameraMode::ActiveCamera:
+	default:
+		if (cameraManager->IsUsingDebugCamera())
+		{
+			if (setDebugCameraClips()) { return; }
+		}
+		if (setMainCameraClips()) { return; }
+		break;
+	}
+
+	setMainCameraClips();
+}
+
+float FrustumCullingDebugController::GetCurrentWindowAspectRatio() const
+{
+	const float height = static_cast<float>(std::max(K4E::WinApp::GetInstance()->GetClientHeight(), 1u));
+	return static_cast<float>(K4E::WinApp::GetInstance()->GetClientWidth()) / height;
+}

--- a/Project/ApplicationLayer/DebugTools/FrustumCulling/FrustumCullingDebugController.h
+++ b/Project/ApplicationLayer/DebugTools/FrustumCulling/FrustumCullingDebugController.h
@@ -1,0 +1,30 @@
+#pragma once
+#include "Vector4.h"
+
+namespace Ken4lowEngine { class Camera; }
+namespace K4E = ::Ken4lowEngine;
+
+/// <summary>
+/// Scene から Frustum Culling 確認用 UI / Wireframe 表示を分離する Controller。
+/// </summary>
+class FrustumCullingDebugController
+{
+public:
+	void Initialize(bool resetMainCamera = false);
+	void Update(float deltaTime);
+	void DrawDebug();
+	void DrawImGui();
+
+	void SetWireframeVisible(bool visible) { showFrustumWireframe_ = visible; }
+	bool IsWireframeVisible() const { return showFrustumWireframe_; }
+
+private:
+	void DrawMainCameraImGui();
+	void CopyDebugCameraToMainCamera();
+	void ResetMainCamera();
+	void GetCullingCameraClipDistances(float& nearDistance, float& farDistance) const;
+	float GetCurrentWindowAspectRatio() const;
+
+	K4E::Vector4 frustumWireColor_ = { 0.1f, 1.0f, 0.2f, 1.0f };
+	bool showFrustumWireframe_ = true;
+};

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -1,6 +1,7 @@
 #define NOMINMAX
 #include "DebugScene.h"
 #include "DisintegrationDebugController.h"
+#include "ApplicationLayer/DebugTools/FrustumCulling/FrustumCullingDebugController.h"
 #include <DirectXCommon.h>
 #include <Input.h>
 #include <SpriteManager.h>
@@ -43,25 +44,6 @@ namespace
 		OutputDebugStringA(line.c_str());
 	}
 
-
-	constexpr float kDegToRad = std::numbers::pi_v<float> / 180.0f;
-	constexpr float kRadToDeg = 180.0f / std::numbers::pi_v<float>;
-
-	Vector3 GetDefaultMainCameraPosition()
-	{
-		return { 0.0f, 3.0f, -12.0f };
-	}
-
-	Vector3 GetDefaultMainCameraRotation()
-	{
-		return { 8.0f * kDegToRad, 0.0f, 0.0f };
-	}
-
-	float GetCurrentWindowAspectRatio()
-	{
-		const float height = static_cast<float>(std::max(WinApp::GetInstance()->GetClientHeight(), 1u));
-		return static_cast<float>(WinApp::GetInstance()->GetClientWidth()) / height;
-	}
 
 	GpuParticleType ToDebugParticleType(int index)
 	{
@@ -154,18 +136,10 @@ void DebugScene::Initialize()
 	// Disintegration系の確認処理は専用コントローラへ委譲し、DebugScene本体の責務を絞る。
 	disintegrationDebug_->Initialize();
 
-	if (Camera* mainCamera = CameraManager::GetInstance()->GetMainCamera())
-	{
-		mainCamera->SetTranslate(GetDefaultMainCameraPosition());
-		mainCamera->SetRotate(GetDefaultMainCameraRotation());
-		mainCamera->SetFovY(60.0f * kDegToRad);
-		mainCamera->SetNearClip(0.1f);
-		mainCamera->SetFarClip(80.0f);
-		mainCamera->SetAspectRatio(GetCurrentWindowAspectRatio());
-		mainCamera->Update();
-	}
-
+	frustumCullingDebug_ = std::make_unique<FrustumCullingDebugController>();
+	frustumCullingDebug_->Initialize(true);
 	Object3DCommon::GetInstance()->SetFrustumCullingEnabled(true);
+	Object3DCommon::GetInstance()->SetCullingCameraMode(Object3DCommon::CullingCameraMode::MainCamera);
 	InitializeCullingTestObjects();
 }
 
@@ -195,6 +169,11 @@ void DebugScene::Update()
 	if (disintegrationDebug_)
 	{
 		disintegrationDebug_->Update(deltaTime);
+	}
+
+	if (frustumCullingDebug_)
+	{
+		frustumCullingDebug_->Update(deltaTime);
 	}
 
 	for (auto& object : cullingTestObjects_)
@@ -228,9 +207,9 @@ void DebugScene::Draw3DObjects()
 #ifdef _DEBUG
 	// ワイヤーフレームの描画
 	Wireframe::GetInstance()->DrawGrid(100.0f, 50.0f, { 0.25f, 0.25f, 0.25f,1.0f });
-	if (showCullingFrustum_)
+	if (frustumCullingDebug_)
 	{
-		Wireframe::GetInstance()->DrawFrustum(BuildCullingFrustumCorners(), cullingFrustumWireColor_);
+		frustumCullingDebug_->DrawDebug();
 	}
 
 	collisionManager_->Draw();
@@ -276,6 +255,7 @@ void DebugScene::Finalize()
 	input_->SetCursorVisible(true);
 
 	cullingTestObjects_.clear();
+	frustumCullingDebug_.reset();
 	disintegrationDebug_.reset();
 	debugBoss_.reset();
 	collisionManager_.reset();
@@ -293,7 +273,10 @@ void DebugScene::DrawImGui()
 		debugBoss_->DrawImGui();
 	}
 
-	DrawCullingFrustumImGui();
+	if (frustumCullingDebug_)
+	{
+		frustumCullingDebug_->DrawImGui();
+	}
 
 	ImGui::Begin("Debug Boss Hit Test");
 
@@ -579,200 +562,6 @@ void DebugScene::InitializeCullingTestObjects()
 		object->Update();
 		cullingTestObjects_.push_back(std::move(object));
 	}
-}
-
-std::array<Vector3, 8> DebugScene::BuildCullingFrustumCorners() const
-{
-	const Matrix4x4 inverseViewProjection = Matrix4x4::Inverse(Object3DCommon::GetInstance()->GetCullingViewProjectionMatrix());
-	const std::array<Vector3, 8> ndcCorners = {
-		Vector3{ -1.0f, -1.0f, 0.0f },
-		Vector3{ -1.0f,  1.0f, 0.0f },
-		Vector3{  1.0f,  1.0f, 0.0f },
-		Vector3{  1.0f, -1.0f, 0.0f },
-		Vector3{ -1.0f, -1.0f, 1.0f },
-		Vector3{ -1.0f,  1.0f, 1.0f },
-		Vector3{  1.0f,  1.0f, 1.0f },
-		Vector3{  1.0f, -1.0f, 1.0f },
-	};
-
-	std::array<Vector3, 8> worldCorners{};
-	for (size_t i = 0; i < ndcCorners.size(); ++i)
-	{
-		worldCorners[i] = Vector3::Transform(ndcCorners[i], inverseViewProjection);
-	}
-	return worldCorners;
-}
-
-void DebugScene::DrawCullingFrustumImGui()
-{
-#ifdef USE_IMGUI
-	Object3DCommon* object3DCommon = Object3DCommon::GetInstance();
-	int cullingCameraIndex = static_cast<int>(object3DCommon->GetCullingCameraMode());
-	const char* cullingCameraItems[] = { "アクティブカメラ", "メインカメラ", "デバッグカメラ" };
-
-	bool frustumCullingEnabled = object3DCommon->IsFrustumCullingEnabled();
-	float nearDistance = 0.0f;
-	float farDistance = 0.0f;
-	GetCullingCameraClipDistances(nearDistance, farDistance);
-
-	ImGui::Begin("DebugScene Frustum Culling");
-	if (ImGui::Checkbox("Frustum Culling 有効", &frustumCullingEnabled))
-	{
-		object3DCommon->SetFrustumCullingEnabled(frustumCullingEnabled);
-	}
-	if (ImGui::Combo("カリング基準カメラ", &cullingCameraIndex, cullingCameraItems, IM_ARRAYSIZE(cullingCameraItems)))
-	{
-		object3DCommon->SetCullingCameraMode(static_cast<Object3DCommon::CullingCameraMode>(cullingCameraIndex));
-	}
-
-	ImGui::Separator();
-	ImGui::Text("アクティブカメラ: %s", CameraManager::GetInstance()->IsUsingDebugCamera() ? "デバッグカメラ" : "メインカメラ");
-	ImGui::Text("メインカメラ: %s", CameraManager::GetInstance()->GetMainCamera() ? "利用可能" : "未設定");
-#ifdef _DEBUG
-	ImGui::Text("デバッグカメラ: %s", CameraManager::GetInstance()->GetDebugCamera() ? "利用可能" : "未設定");
-#else
-	ImGui::Text("デバッグカメラ: リリースビルドでは無効");
-#endif
-	ImGui::Checkbox("カリング視錐台を表示", &showCullingFrustum_);
-	ImGui::ColorEdit4("視錐台ワイヤー色", &cullingFrustumWireColor_.x);
-	ImGui::InputFloat("Near", &nearDistance, 0.0f, 0.0f, "%.3f", ImGuiInputTextFlags_ReadOnly);
-	ImGui::InputFloat("Far", &farDistance, 0.0f, 0.0f, "%.3f", ImGuiInputTextFlags_ReadOnly);
-
-	ImGui::Separator();
-	ImGui::Text("総オブジェクト数: %d", object3DCommon->GetTotalObjectCount());
-	ImGui::Text("描画された数: %d", object3DCommon->GetDrawnObjectCount());
-	ImGui::Text("カリングされた数: %d", object3DCommon->GetCulledObjectCount());
-	ImGui::TextWrapped("DebugCameraで外側から見る場合は、カリング基準カメラをメインカメラにするとMainCameraの判定範囲を確認できます。");
-
-	DrawMainCameraCullingImGui();
-	ImGui::End();
-#endif // USE_IMGUI
-}
-
-void DebugScene::DrawMainCameraCullingImGui()
-{
-#ifdef USE_IMGUI
-	Camera* mainCamera = CameraManager::GetInstance()->GetMainCamera();
-	if (!mainCamera)
-	{
-		ImGui::Separator();
-		ImGui::Text("MainCameraが未設定です。");
-		return;
-	}
-
-	if (ImGui::CollapsingHeader("MainCamera 調整", ImGuiTreeNodeFlags_DefaultOpen))
-	{
-		Vector3 position = mainCamera->GetTranslate();
-		Vector3 rotation = mainCamera->GetRotate();
-		float fovDeg = mainCamera->GetFovY() * kRadToDeg;
-		float nearClip = mainCamera->GetNearClip();
-		float farClip = mainCamera->GetFarClip();
-		float aspectRatio = mainCamera->GetAspectRatio();
-		bool changed = false;
-
-		changed |= ImGui::DragFloat3("位置", &position.x, 0.05f);
-		changed |= ImGui::DragFloat3("回転", &rotation.x, 0.005f);
-		changed |= ImGui::SliderFloat("FOV", &fovDeg, 10.0f, 140.0f, "%.1f deg");
-		changed |= ImGui::DragFloat("Near", &nearClip, 0.001f, 0.001f, 10.0f, "%.3f");
-		changed |= ImGui::DragFloat("Far", &farClip, 0.5f, 1.0f, 1000.0f, "%.1f");
-		changed |= ImGui::DragFloat("アスペクト比", &aspectRatio, 0.001f, 0.1f, 4.0f, "%.3f");
-
-		if (changed)
-		{
-			farClip = std::max(farClip, 0.011f);
-			nearClip = std::clamp(nearClip, 0.001f, farClip - 0.01f);
-			farClip = std::max(farClip, nearClip + 0.01f);
-			aspectRatio = std::max(aspectRatio, 0.1f);
-			mainCamera->SetTranslate(position);
-			mainCamera->SetRotate(rotation);
-			mainCamera->SetFovY(fovDeg * kDegToRad);
-			mainCamera->SetNearClip(nearClip);
-			mainCamera->SetFarClip(farClip);
-			mainCamera->SetAspectRatio(aspectRatio);
-			mainCamera->Update();
-		}
-
-		if (ImGui::Button("MainCameraをリセット"))
-		{
-			mainCamera->SetTranslate(GetDefaultMainCameraPosition());
-			mainCamera->SetRotate(GetDefaultMainCameraRotation());
-			mainCamera->SetFovY(60.0f * kDegToRad);
-			mainCamera->SetNearClip(0.1f);
-			mainCamera->SetFarClip(80.0f);
-			mainCamera->SetAspectRatio(GetCurrentWindowAspectRatio());
-			mainCamera->Update();
-		}
-#ifdef _DEBUG
-		ImGui::SameLine();
-		if (ImGui::Button("MainCameraを現在のDebugCamera位置に合わせる"))
-		{
-			if (DebugCamera* debugCamera = CameraManager::GetInstance()->GetDebugCamera())
-			{
-				mainCamera->SetTranslate(debugCamera->GetTranslate());
-				mainCamera->SetRotate(debugCamera->GetRotate());
-				mainCamera->SetFovY(debugCamera->GetFovY());
-				mainCamera->SetNearClip(debugCamera->GetNearClip());
-				mainCamera->SetFarClip(debugCamera->GetFarClip());
-				mainCamera->SetAspectRatio(debugCamera->GetAspectRatio());
-				mainCamera->Update();
-			}
-		}
-#endif
-	}
-#endif // USE_IMGUI
-}
-
-void DebugScene::GetCullingCameraClipDistances(float& nearDistance, float& farDistance) const
-{
-	nearDistance = 0.0f;
-	farDistance = 0.0f;
-
-	const Object3DCommon::CullingCameraMode mode = Object3DCommon::GetInstance()->GetCullingCameraMode();
-	auto* cameraManager = CameraManager::GetInstance();
-
-	auto setMainCameraClips = [&]() -> bool
-		{
-			if (Camera* mainCamera = cameraManager->GetMainCamera())
-			{
-				nearDistance = mainCamera->GetNearClip();
-				farDistance = mainCamera->GetFarClip();
-				return true;
-			}
-			return false;
-		};
-
-	auto setDebugCameraClips = [&]() -> bool
-		{
-#ifdef _DEBUG
-			if (DebugCamera* debugCamera = cameraManager->GetDebugCamera())
-			{
-				nearDistance = debugCamera->GetNearClip();
-				farDistance = debugCamera->GetFarClip();
-				return true;
-			}
-#endif
-			return false;
-		};
-
-	switch (mode)
-	{
-	case Object3DCommon::CullingCameraMode::MainCamera:
-		if (setMainCameraClips()) { return; }
-		break;
-	case Object3DCommon::CullingCameraMode::DebugCamera:
-		if (setDebugCameraClips()) { return; }
-		break;
-	case Object3DCommon::CullingCameraMode::ActiveCamera:
-	default:
-		if (cameraManager->IsUsingDebugCamera())
-		{
-			if (setDebugCameraClips()) { return; }
-		}
-		if (setMainCameraClips()) { return; }
-		break;
-	}
-
-	setMainCameraClips();
 }
 
 void DebugScene::UpdateDebug()

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
@@ -6,10 +6,10 @@
 #include "Player.h"
 #include "Derived/GuardianBoss/GuardianBoss.h"
 #include "DisintegrationDebugController.h"
+#include "ApplicationLayer/DebugTools/FrustumCulling/FrustumCullingDebugController.h"
 #include "Vector3.h"
 #include "Vector4.h"
 
-#include <array>
 #include <memory>
 #include <string>
 #include <vector>
@@ -64,20 +64,8 @@ private: /// ---------- メンバ関数 ---------- ///
 	/// テスト用GPUパーティクル発火
 	void UpdateDebugParticleTest();
 
-	// カリング基準カメラの ViewProjection から視錐台の 8 頂点を作成
-	std::array<K4E::Vector3, 8> BuildCullingFrustumCorners() const;
-
-	// DebugScene 専用のカリング視錐台 ImGui
-	void DrawCullingFrustumImGui();
-
-	// MainCamera のカリング確認用 ImGui
-	void DrawMainCameraCullingImGui();
-
 	// カリング確認用 Object3D を初期化
 	void InitializeCullingTestObjects();
-
-	// 選択中カリング基準カメラの Near/Far 距離を取得
-	void GetCullingCameraClipDistances(float& nearDistance, float& farDistance) const;
 
 	/// -------------------------------------------------------------
 	/// BossHitPart を文字列へ変換
@@ -108,9 +96,7 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	std::unique_ptr<DisintegrationDebugController> disintegrationDebug_;
 
-	// カリング視錐台のワイヤー表示設定
-	bool showCullingFrustum_ = true;
-	K4E::Vector4 cullingFrustumWireColor_ = { 0.1f, 1.0f, 0.2f, 1.0f };
+	std::unique_ptr<FrustumCullingDebugController> frustumCullingDebug_;
 
 	// Frustum Culling の挙動確認用 Object3D 群
 	std::vector<std::unique_ptr<K4E::Object3D>> cullingTestObjects_;

--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
@@ -4,6 +4,7 @@
 #include <SpriteManager.h>
 #include <SceneManager.h>
 #include <GameTimer.h>
+#include <Object3DCommon.h>
 
 #ifdef _DEBUG
 #include <DebugCamera.h>
@@ -26,6 +27,7 @@ void GamePlayScene::Initialize()
 	world_.reset();
 	introDirector_.reset();
 	debugTools_.reset();
+	frustumCullingDebug_.reset();
 
 	if (!fadeManager_)
 	{
@@ -74,6 +76,11 @@ void GamePlayScene::InitializeGameplayObjects()
 
 	debugTools_ = std::make_unique<GamePlayDebugTools>();
 	debugTools_->Initialize();
+
+	frustumCullingDebug_ = std::make_unique<FrustumCullingDebugController>();
+	frustumCullingDebug_->Initialize();
+	K4E::Object3DCommon::GetInstance()->SetFrustumCullingEnabled(false);
+	K4E::Object3DCommon::GetInstance()->SetCullingCameraMode(K4E::Object3DCommon::CullingCameraMode::ActiveCamera);
 
 	if (!fadeManager_)
 	{
@@ -350,6 +357,11 @@ void GamePlayScene::UpdateWorld(float deltaTime)
 	{
 		world_->Update(deltaTime);
 	}
+
+	if (frustumCullingDebug_)
+	{
+		frustumCullingDebug_->Update(deltaTime);
+	}
 }
 
 /// -------------------------------------------------------------
@@ -395,6 +407,11 @@ void GamePlayScene::Draw3DObjects()
 	if (world_)
 	{
 		world_->Draw3D(ShouldHideCharactersDuringIntro());
+	}
+
+	if (frustumCullingDebug_)
+	{
+		frustumCullingDebug_->DrawDebug();
 	}
 }
 
@@ -497,6 +514,7 @@ void GamePlayScene::ReleaseGameplayObjects()
 		debugTools_->Finalize();
 		debugTools_.reset();
 	}
+	frustumCullingDebug_.reset();
 
 	introDirector_.reset();
 
@@ -524,6 +542,11 @@ void GamePlayScene::DrawImGui()
 	if (debugTools_)
 	{
 		debugTools_->DrawImGui(world_.get());
+	}
+
+	if (frustumCullingDebug_)
+	{
+		frustumCullingDebug_->DrawImGui();
 	}
 #endif // USE_IMGUI
 }
@@ -564,6 +587,10 @@ void GamePlayScene::UpdateLoad()
 	case 4:
 		debugTools_ = std::make_unique<GamePlayDebugTools>();
 		debugTools_->Initialize();
+		frustumCullingDebug_ = std::make_unique<FrustumCullingDebugController>();
+		frustumCullingDebug_->Initialize();
+		K4E::Object3DCommon::GetInstance()->SetFrustumCullingEnabled(false);
+		K4E::Object3DCommon::GetInstance()->SetCullingCameraMode(K4E::Object3DCommon::CullingCameraMode::ActiveCamera);
 		++loadStep_;
 		break;
 
@@ -601,6 +628,7 @@ void GamePlayScene::UpdateUnload()
 			debugTools_->Finalize();
 			debugTools_.reset();
 		}
+		frustumCullingDebug_.reset();
 		++unloadStep_;
 		break;
 

--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.h
@@ -7,6 +7,7 @@
 #include "GamePlayIntroDirector.h"
 #include "GamePlayDebugTools.h"
 #include "FadeManager.h"
+#include "ApplicationLayer/DebugTools/FrustumCulling/FrustumCullingDebugController.h"
 
 #include <memory>
 
@@ -145,6 +146,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	std::unique_ptr<GamePlayWorld> world_;
 	std::unique_ptr<GamePlayIntroDirector> introDirector_;
 	std::unique_ptr<GamePlayDebugTools> debugTools_;
+	std::unique_ptr<FrustumCullingDebugController> frustumCullingDebug_;
 	std::unique_ptr<FadeManager> fadeManager_;
 
 	// リトライ遷移制御

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
@@ -92,6 +92,7 @@ void GamePlayWorld::Initialize(GamePlayStageContext& stageContext)
 
 	if (stage_)
 	{
+		stage_->SetFrustumCullingEnabled(true);
 		stage_->Update();
 	}
 

--- a/Project/Engine/Graphics/Culling/BoundingVolume.h
+++ b/Project/Engine/Graphics/Culling/BoundingVolume.h
@@ -1,0 +1,23 @@
+#pragma once
+#include "Vector3.h"
+
+namespace Ken4lowEngine
+{
+	/// <summary>
+	/// Frustum Culling で使う簡易的な球 Bounds。
+	/// </summary>
+	struct BoundingSphere
+	{
+		Vector3 center{};
+		float radius = 1.0f;
+	};
+
+	/// <summary>
+	/// Frustum Culling で使う軸平行 AABB Bounds。
+	/// </summary>
+	struct BoundingAABB
+	{
+		Vector3 min{};
+		Vector3 max{};
+	};
+}

--- a/Project/Engine/Graphics/Culling/Frustum.cpp
+++ b/Project/Engine/Graphics/Culling/Frustum.cpp
@@ -34,6 +34,26 @@ namespace Ken4lowEngine
 		return true;
 	}
 
+	bool Frustum::Intersects(const BoundingAABB& aabb) const
+	{
+		for (const auto& plane : planes_)
+		{
+			const Vector3 positiveVertex = {
+				plane.x >= 0.0f ? aabb.max.x : aabb.min.x,
+				plane.y >= 0.0f ? aabb.max.y : aabb.min.y,
+				plane.z >= 0.0f ? aabb.max.z : aabb.min.z,
+			};
+
+			const float distance = plane.x * positiveVertex.x + plane.y * positiveVertex.y + plane.z * positiveVertex.z + plane.w;
+			if (distance < 0.0f)
+			{
+				return false;
+			}
+		}
+
+		return true;
+	}
+
 	void Frustum::NormalizePlane(Vector4& plane) const
 	{
 		const float length = std::sqrt(plane.x * plane.x + plane.y * plane.y + plane.z * plane.z);

--- a/Project/Engine/Graphics/Culling/Frustum.h
+++ b/Project/Engine/Graphics/Culling/Frustum.h
@@ -1,21 +1,12 @@
 #pragma once
+#include "BoundingVolume.h"
 #include "Matrix4x4.h"
-#include "Vector3.h"
 #include "Vector4.h"
 
 #include <array>
 
 namespace Ken4lowEngine
 {
-	/// <summary>
-	/// ローカル/ワールド空間で扱う簡易的な球 Bounds。
-	/// </summary>
-	struct BoundingSphere
-	{
-		Vector3 center{};
-		float radius = 1.0f;
-	};
-
 	/// <summary>
 	/// ViewProjection 行列から生成した 6 平面で可視判定を行う視錐台。
 	/// </summary>
@@ -24,6 +15,7 @@ namespace Ken4lowEngine
 	public:
 		void BuildFromViewProjection(const Matrix4x4& viewProjection);
 		bool Intersects(const BoundingSphere& sphere) const;
+		bool Intersects(const BoundingAABB& aabb) const;
 
 	private:
 		void NormalizePlane(Vector4& plane) const;

--- a/Project/Engine/Graphics/Culling/FrustumCullingSystem.cpp
+++ b/Project/Engine/Graphics/Culling/FrustumCullingSystem.cpp
@@ -1,0 +1,41 @@
+#include "FrustumCullingSystem.h"
+
+namespace Ken4lowEngine
+{
+	void FrustumCullingSystem::BuildFrustum(const Matrix4x4& viewProjection)
+	{
+		viewProjection_ = viewProjection;
+		frustum_.BuildFromViewProjection(viewProjection_);
+	}
+
+	void FrustumCullingSystem::ResetStatistics()
+	{
+		totalObjectCount_ = 0;
+		drawnObjectCount_ = 0;
+		culledObjectCount_ = 0;
+	}
+
+	bool FrustumCullingSystem::IsVisible(const BoundingSphere& bounds, bool ignoreFrustumCulling)
+	{
+		return IsVisibleInternal(frustum_.Intersects(bounds), ignoreFrustumCulling);
+	}
+
+	bool FrustumCullingSystem::IsVisible(const BoundingAABB& bounds, bool ignoreFrustumCulling)
+	{
+		return IsVisibleInternal(frustum_.Intersects(bounds), ignoreFrustumCulling);
+	}
+
+	bool FrustumCullingSystem::IsVisibleInternal(bool intersects, bool ignoreFrustumCulling)
+	{
+		++totalObjectCount_;
+
+		if (!enabled_ || ignoreFrustumCulling || intersects)
+		{
+			++drawnObjectCount_;
+			return true;
+		}
+
+		++culledObjectCount_;
+		return false;
+	}
+}

--- a/Project/Engine/Graphics/Culling/FrustumCullingSystem.h
+++ b/Project/Engine/Graphics/Culling/FrustumCullingSystem.h
@@ -1,0 +1,40 @@
+#pragma once
+#include "BoundingVolume.h"
+#include "Frustum.h"
+#include "Matrix4x4.h"
+
+namespace Ken4lowEngine
+{
+	/// <summary>
+	/// Scene や ImGui に依存しない Frustum Culling の実行状態と統計。
+	/// </summary>
+	class FrustumCullingSystem
+	{
+	public:
+		void SetEnabled(bool enabled) { enabled_ = enabled; }
+		bool IsEnabled() const { return enabled_; }
+
+		void BuildFrustum(const Matrix4x4& viewProjection);
+		void ResetStatistics();
+
+		bool IsVisible(const BoundingSphere& bounds, bool ignoreFrustumCulling = false);
+		bool IsVisible(const BoundingAABB& bounds, bool ignoreFrustumCulling = false);
+
+		int GetTotalObjectCount() const { return totalObjectCount_; }
+		int GetDrawnObjectCount() const { return drawnObjectCount_; }
+		int GetCulledObjectCount() const { return culledObjectCount_; }
+
+		const Matrix4x4& GetViewProjectionMatrix() const { return viewProjection_; }
+		const Frustum& GetFrustum() const { return frustum_; }
+
+	private:
+		bool IsVisibleInternal(bool intersects, bool ignoreFrustumCulling);
+
+		Frustum frustum_{};
+		Matrix4x4 viewProjection_{};
+		bool enabled_ = false;
+		int totalObjectCount_ = 0;
+		int drawnObjectCount_ = 0;
+		int culledObjectCount_ = 0;
+	};
+}

--- a/Project/Engine/Graphics/Culling/FrustumDebugRenderer.cpp
+++ b/Project/Engine/Graphics/Culling/FrustumDebugRenderer.cpp
@@ -1,0 +1,33 @@
+#include "FrustumDebugRenderer.h"
+
+#include "Wireframe.h"
+
+namespace Ken4lowEngine
+{
+	std::array<Vector3, 8> FrustumDebugRenderer::BuildCorners(const Matrix4x4& viewProjection) const
+	{
+		const Matrix4x4 inverseViewProjection = Matrix4x4::Inverse(viewProjection);
+		const std::array<Vector3, 8> ndcCorners = {
+			Vector3{ -1.0f, -1.0f, 0.0f },
+			Vector3{ -1.0f,  1.0f, 0.0f },
+			Vector3{  1.0f,  1.0f, 0.0f },
+			Vector3{  1.0f, -1.0f, 0.0f },
+			Vector3{ -1.0f, -1.0f, 1.0f },
+			Vector3{ -1.0f,  1.0f, 1.0f },
+			Vector3{  1.0f,  1.0f, 1.0f },
+			Vector3{  1.0f, -1.0f, 1.0f },
+		};
+
+		std::array<Vector3, 8> worldCorners{};
+		for (std::size_t i = 0; i < ndcCorners.size(); ++i)
+		{
+			worldCorners[i] = Vector3::Transform(ndcCorners[i], inverseViewProjection);
+		}
+		return worldCorners;
+	}
+
+	void FrustumDebugRenderer::Draw(const Matrix4x4& viewProjection, const Vector4& color) const
+	{
+		Wireframe::GetInstance()->DrawFrustum(BuildCorners(viewProjection), color);
+	}
+}

--- a/Project/Engine/Graphics/Culling/FrustumDebugRenderer.h
+++ b/Project/Engine/Graphics/Culling/FrustumDebugRenderer.h
@@ -1,0 +1,19 @@
+#pragma once
+#include "Matrix4x4.h"
+#include "Vector3.h"
+#include "Vector4.h"
+
+#include <array>
+
+namespace Ken4lowEngine
+{
+	/// <summary>
+	/// ViewProjection 逆行列から視錐台 8 頂点を復元し、Wireframe で描画するデバッグ補助。
+	/// </summary>
+	class FrustumDebugRenderer
+	{
+	public:
+		std::array<Vector3, 8> BuildCorners(const Matrix4x4& viewProjection) const;
+		void Draw(const Matrix4x4& viewProjection, const Vector4& color) const;
+	};
+}

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3D.h
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3D.h
@@ -6,7 +6,7 @@
 #include "VertexData.h"
 #include "Camera.h"
 #include "TransformationMatrix.h"
-#include "Engine/Graphics/Culling/Frustum.h"
+#include "Engine/Graphics/Culling/BoundingVolume.h"
 
 #include <fstream>
 #include <sstream>
@@ -143,7 +143,7 @@ namespace Ken4lowEngine
 		// ShadowMap の SRV を引くための GPU ハンドル
 		D3D12_GPU_DESCRIPTOR_HANDLE shadowMapHandle_{};
 
-		bool frustumCullingEnabled_ = true;
+		bool frustumCullingEnabled_ = false;
 	};
 
 } // namespace Ken4lowEngine

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3DCommon.cpp
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3DCommon.cpp
@@ -35,23 +35,13 @@ namespace Ken4lowEngine
 
 	void Object3DCommon::BeginObject3DPass()
 	{
-		drawnObjectCount_ = 0;
-		culledObjectCount_ = 0;
-		totalObjectCount_ = 0;
-		activeFrustum_.BuildFromViewProjection(GetCullingViewProjectionMatrix());
+		frustumCullingSystem_.ResetStatistics();
+		frustumCullingSystem_.BuildFrustum(GetCullingViewProjectionMatrix());
 	}
 
 	void Object3DCommon::DrawImGui()
 	{
-#ifdef USE_IMGUI
-		ImGui::Begin("Object3D Frustum Culling");
-		ImGui::Checkbox("Frustum Culling 有効", &frustumCullingEnabled_);
-		ImGui::Separator();
-		ImGui::Text("現在の描画対象数: %d", drawnObjectCount_);
-		ImGui::Text("カリングされた数: %d", culledObjectCount_);
-		ImGui::Text("総オブジェクト数: %d", totalObjectCount_);
-		ImGui::End();
-#endif
+		// Frustum Culling の確認 UI は ApplicationLayer の Controller に集約する。
 	}
 
 	Matrix4x4 Object3DCommon::GetCullingViewProjectionMatrix() const
@@ -95,16 +85,7 @@ namespace Ken4lowEngine
 
 	bool Object3DCommon::ShouldDrawObject(const BoundingSphere& worldBounds, bool objectCullingEnabled)
 	{
-		++totalObjectCount_;
-
-		if (!frustumCullingEnabled_ || !objectCullingEnabled || activeFrustum_.Intersects(worldBounds))
-		{
-			++drawnObjectCount_;
-			return true;
-		}
-
-		++culledObjectCount_;
-		return false;
+		return frustumCullingSystem_.IsVisible(worldBounds, !objectCullingEnabled);
 	}
 
 	void Object3DCommon::SetShadowMapRenderSetting()

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3DCommon.h
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3DCommon.h
@@ -3,7 +3,7 @@
 #include "LightManager.h"
 #include "Camera.h"
 #include "Object3DPipelineSet.h"
-#include "Engine/Graphics/Culling/Frustum.h"
+#include "Engine/Graphics/Culling/FrustumCullingSystem.h"
 
 namespace Ken4lowEngine
 {
@@ -33,13 +33,15 @@ namespace Ken4lowEngine
 		void SetRenderSetting();
 		void SetShadowMapRenderSetting();
 		bool ShouldDrawObject(const BoundingSphere& worldBounds, bool objectCullingEnabled);
+		FrustumCullingSystem& GetFrustumCullingSystem() { return frustumCullingSystem_; }
+		const FrustumCullingSystem& GetFrustumCullingSystem() const { return frustumCullingSystem_; }
 		void SetCullingCameraMode(CullingCameraMode mode) { cullingCameraMode_ = mode; }
 		CullingCameraMode GetCullingCameraMode() const { return cullingCameraMode_; }
-		void SetFrustumCullingEnabled(bool enabled) { frustumCullingEnabled_ = enabled; }
-		bool IsFrustumCullingEnabled() const { return frustumCullingEnabled_; }
-		int GetDrawnObjectCount() const { return drawnObjectCount_; }
-		int GetCulledObjectCount() const { return culledObjectCount_; }
-		int GetTotalObjectCount() const { return totalObjectCount_; }
+		void SetFrustumCullingEnabled(bool enabled) { frustumCullingSystem_.SetEnabled(enabled); }
+		bool IsFrustumCullingEnabled() const { return frustumCullingSystem_.IsEnabled(); }
+		int GetDrawnObjectCount() const { return frustumCullingSystem_.GetDrawnObjectCount(); }
+		int GetCulledObjectCount() const { return frustumCullingSystem_.GetCulledObjectCount(); }
+		int GetTotalObjectCount() const { return frustumCullingSystem_.GetTotalObjectCount(); }
 		Matrix4x4 GetCullingViewProjectionMatrix() const;
 
 	public: /// ---------- 拡張予定の関数 ---------- ///
@@ -61,11 +63,7 @@ namespace Ken4lowEngine
 
 		Object3DPipelineSet pipelineSet_{};
 
-		Frustum activeFrustum_{};
+		FrustumCullingSystem frustumCullingSystem_{};
 		CullingCameraMode cullingCameraMode_ = CullingCameraMode::ActiveCamera;
-		bool frustumCullingEnabled_ = false;
-		int drawnObjectCount_ = 0;
-		int culledObjectCount_ = 0;
-		int totalObjectCount_ = 0;
 	};
 }

--- a/Project/Engine/Scene/Level/Stage.cpp
+++ b/Project/Engine/Scene/Level/Stage.cpp
@@ -66,6 +66,15 @@ namespace Ken4lowEngine
 		}
 	}
 
+	void Stage::SetFrustumCullingEnabled(bool enabled)
+	{
+		if (stageModel_)
+		{
+			// まずはステージの静的 Object3D だけを Draw スキップ対象にする。
+			stageModel_->SetFrustumCullingEnabled(enabled);
+		}
+	}
+
 	void Stage::RegisterColliders(CollisionManager* collisionManager)
 	{
 		if (!collisionManager)

--- a/Project/Engine/Scene/Level/Stage.h
+++ b/Project/Engine/Scene/Level/Stage.h
@@ -56,6 +56,11 @@ namespace Ken4lowEngine
 		/// </summary>
 		void UpdateShadowMatrix(const Matrix4x4& lightViewProjection);
 
+		/// <summary>
+		/// ステージ描画モデルを Frustum Culling 対象にするか設定する。
+		/// </summary>
+		void SetFrustumCullingEnabled(bool enabled);
+
 	public: /// ---------- アクセサ ---------- ///
 
 		const std::vector<AABB>& GetWorldAABBs() const { return worldAABBs_; }

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -318,6 +318,9 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="Engine\Graphics\Camera\DebugCamera\DebugCamera.cpp" />
     <ClCompile Include="Engine\Graphics\Camera\FPS\FpsCamera.cpp" />
     <ClCompile Include="Engine\Graphics\Culling\Frustum.cpp" />
+    <ClCompile Include="ApplicationLayer\DebugTools\FrustumCulling\FrustumCullingDebugController.cpp" />
+    <ClCompile Include="Engine\Graphics\Culling\FrustumDebugRenderer.cpp" />
+    <ClCompile Include="Engine\Graphics\Culling\FrustumCullingSystem.cpp" />
     <ClCompile Include="Engine\Graphics\Descriptor\DSV\DSVManager.cpp" />
     <ClCompile Include="Engine\Graphics\Descriptor\RTV\RTVManager.cpp" />
     <ClCompile Include="Engine\Graphics\Descriptor\SRV\SRVManager.cpp" />
@@ -920,6 +923,10 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="Engine\Graphics\Camera\DebugCamera\DebugCamera.h" />
     <ClInclude Include="Engine\Graphics\Camera\FPS\FpsCamera.h" />
     <ClInclude Include="Engine\Graphics\Culling\Frustum.h" />
+    <ClInclude Include="ApplicationLayer\DebugTools\FrustumCulling\FrustumCullingDebugController.h" />
+    <ClInclude Include="Engine\Graphics\Culling\FrustumDebugRenderer.h" />
+    <ClInclude Include="Engine\Graphics\Culling\FrustumCullingSystem.h" />
+    <ClInclude Include="Engine\Graphics\Culling\BoundingVolume.h" />
     <ClInclude Include="Engine\Graphics\Common\BlendModeType.h" />
     <ClInclude Include="Engine\Graphics\Common\DX12Include.h" />
     <ClInclude Include="Engine\Graphics\Common\ModelData.h" />

--- a/Project/Ken4lowEngine.vcxproj.filters
+++ b/Project/Ken4lowEngine.vcxproj.filters
@@ -115,7 +115,10 @@
     <FxCompile Include="Resources\Shaders\Object3D\ShadowMap.VS.hlsl">
       <Filter>Shader\VertexShader</Filter>
     </FxCompile>
-  </ItemGroup>
+      <Filter Include="ApplicationLayer\DebugTools\FrustumCulling">
+      <UniqueIdentifier>{4f4cae23-3c32-4724-9ab8-fc7cf0d39a43}</UniqueIdentifier>
+    </Filter>
+</ItemGroup>
   <ItemGroup>
     <ClCompile Include="WinMain.cpp" />
     <ClCompile Include="ApplicationLayer\UISystem\Crosshair\Crosshair.cpp">
@@ -530,6 +533,15 @@
       <Filter>Engine\Graphics\Camera\FPS</Filter>
     </ClCompile>
     <ClCompile Include="Engine\Graphics\Culling\Frustum.cpp">
+      <Filter>Engine\Graphics\Culling</Filter>
+    </ClCompile>
+    <ClCompile Include="ApplicationLayer\DebugTools\FrustumCulling\FrustumCullingDebugController.cpp">
+      <Filter>ApplicationLayer\DebugTools\FrustumCulling</Filter>
+    </ClCompile>
+    <ClCompile Include="Engine\Graphics\Culling\FrustumDebugRenderer.cpp">
+      <Filter>Engine\Graphics\Culling</Filter>
+    </ClCompile>
+    <ClCompile Include="Engine\Graphics\Culling\FrustumCullingSystem.cpp">
       <Filter>Engine\Graphics\Culling</Filter>
     </ClCompile>
     <ClCompile Include="Engine\Graphics\Descriptor\DSV\DSVManager.cpp">
@@ -1348,6 +1360,18 @@
       <Filter>Engine\Graphics\Camera\FPS</Filter>
     </ClInclude>
     <ClInclude Include="Engine\Graphics\Culling\Frustum.h">
+      <Filter>Engine\Graphics\Culling</Filter>
+    </ClInclude>
+    <ClInclude Include="ApplicationLayer\DebugTools\FrustumCulling\FrustumCullingDebugController.h">
+      <Filter>ApplicationLayer\DebugTools\FrustumCulling</Filter>
+    </ClInclude>
+    <ClInclude Include="Engine\Graphics\Culling\FrustumDebugRenderer.h">
+      <Filter>Engine\Graphics\Culling</Filter>
+    </ClInclude>
+    <ClInclude Include="Engine\Graphics\Culling\FrustumCullingSystem.h">
+      <Filter>Engine\Graphics\Culling</Filter>
+    </ClInclude>
+    <ClInclude Include="Engine\Graphics\Culling\BoundingVolume.h">
       <Filter>Engine\Graphics\Culling</Filter>
     </ClInclude>
     <ClInclude Include="Engine\Graphics\Descriptor\DSV\DSVManager.h">


### PR DESCRIPTION
### Motivation
- Prevent `DebugScene` / `GamePlayScene` from becoming cluttered with Frustum Culling UI, camera selection and wireframe code. 
- Provide a reusable, engine-side culling implementation separate from debug visualization so the core game logic can use it without ImGui/scene dependencies. 
- Keep existing drawing behavior stable by making the change additive and opt-in for gameplay objects (stage/static objects) initially. 

### Description
- Added lightweight bounding types and frustum logic: `Engine/Graphics/Culling/BoundingVolume.h` with `BoundingSphere`/`BoundingAABB`, extended `Frustum` to support AABB intersection. 
- Implemented `FrustumCullingSystem` in `Engine/Graphics/Culling` that holds a `Frustum`, `SetEnabled` state, statistics (`total/drawn/culled`) and `IsVisible(...)` APIs for both sphere and AABB. 
- Added debug visualization/ImGui controller in ApplicationLayer: `FrustumDebugRenderer` to rebuild corners from inverse ViewProjection and `FrustumCullingDebugController` (App layer) to host ImGui, camera selection, wireframe toggle/color, main-camera controls and stats display. 
- Integrated with engine rendering: `Object3DCommon` now owns a `FrustumCullingSystem` and uses `BeginObject3DPass()` to build/reset the frustum and `ShouldDrawObject()` to query visibility; `Object3D` exposes `SetFrustumCullingEnabled` per-object; `Stage::SetFrustumCullingEnabled` and `GamePlayWorld` enable culling for static stage model by default but gameplay draw/AI/update remain untouched. 
- Scene-side changes are minimal: `DebugScene` and `GamePlayScene` now create/update/draw the `FrustumCullingDebugController` instead of embedding the UI/wireframe logic directly; new files are added to the project file. 

### Testing
- Ran `git diff --check` to ensure no whitespace/merge markers and the check passed. 
- Parsed the updated project files with Python `xml.etree.ElementTree.parse` for `Project/Ken4lowEngine.vcxproj` and `Project/Ken4lowEngine.vcxproj.filters` and both parsed successfully. 
- Performed a C++ syntax-only check with `g++ -std=c++20 -fsyntax-only` on the modified culling units (`Frustum.cpp` + `FrustumCullingSystem.cpp`) and the check completed without syntax errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69feed4e2998832d8059e8bd776c7987)