### PR TITLE
Integrate frustum culling into Object3D draw path

### DIFF
--- a/Project/ApplicationLayer/DebugTools/FrustumCulling/FrustumCullingDebugController.cpp
+++ b/Project/ApplicationLayer/DebugTools/FrustumCulling/FrustumCullingDebugController.cpp
@@ -62,7 +62,7 @@ void FrustumCullingDebugController::DrawImGui()
 #ifdef USE_IMGUI
 	K4E::Object3DCommon* object3DCommon = K4E::Object3DCommon::GetInstance();
 	int cullingCameraIndex = static_cast<int>(object3DCommon->GetCullingCameraMode());
-	const char* cullingCameraItems[] = { "ActiveCamera", "MainCamera", "DebugCamera" };
+	const char* cullingCameraItems[] = { "MainCamera", "DebugCamera", "ActiveCamera" };
 
 	bool frustumCullingEnabled = object3DCommon->IsFrustumCullingEnabled();
 	float nearDistance = 0.0f;
@@ -96,6 +96,8 @@ void FrustumCullingDebugController::DrawImGui()
 	ImGui::Text("Total Objects: %d", object3DCommon->GetTotalObjectCount());
 	ImGui::Text("Drawn Objects: %d", object3DCommon->GetDrawnObjectCount());
 	ImGui::Text("Culled Objects: %d", object3DCommon->GetCulledObjectCount());
+	ImGui::Text("Drawn (Culling Disabled): %d", object3DCommon->GetCullingDisabledDrawnObjectCount());
+	ImGui::Text("Drawn (Missing Bounds): %d", object3DCommon->GetMissingBoundsDrawnObjectCount());
 	ImGui::TextWrapped("Use DebugCamera outside the view and select MainCamera to inspect gameplay culling results.");
 
 	DrawMainCameraImGui();

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -7,7 +7,6 @@
 #include <SpriteManager.h>
 #include "CameraManager.h"
 #include "Wireframe.h"
-#include "Object3DCommon.h"
 #include "Object3D.h"
 #include "Camera.h"
 #include "WinApp.h"
@@ -138,8 +137,6 @@ void DebugScene::Initialize()
 
 	frustumCullingDebug_ = std::make_unique<FrustumCullingDebugController>();
 	frustumCullingDebug_->Initialize(true);
-	Object3DCommon::GetInstance()->SetFrustumCullingEnabled(true);
-	Object3DCommon::GetInstance()->SetCullingCameraMode(Object3DCommon::CullingCameraMode::MainCamera);
 	InitializeCullingTestObjects();
 }
 
@@ -557,8 +554,7 @@ void DebugScene::InitializeCullingTestObjects()
 		object->SetTranslate(desc.position);
 		object->SetScale(desc.scale);
 		object->SetColor(desc.color);
-		// Object3D のみをカリング対象にし、Wireframe や UI は確認結果から除外する。
-		object->SetFrustumCullingEnabled(true);
+		// Object3D のデフォルト設定で共通カリング経路を確認する。
 		object->Update();
 		cullingTestObjects_.push_back(std::move(object));
 	}

--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
@@ -4,7 +4,6 @@
 #include <SpriteManager.h>
 #include <SceneManager.h>
 #include <GameTimer.h>
-#include <Object3DCommon.h>
 
 #ifdef _DEBUG
 #include <DebugCamera.h>
@@ -79,8 +78,6 @@ void GamePlayScene::InitializeGameplayObjects()
 
 	frustumCullingDebug_ = std::make_unique<FrustumCullingDebugController>();
 	frustumCullingDebug_->Initialize();
-	K4E::Object3DCommon::GetInstance()->SetFrustumCullingEnabled(false);
-	K4E::Object3DCommon::GetInstance()->SetCullingCameraMode(K4E::Object3DCommon::CullingCameraMode::ActiveCamera);
 
 	if (!fadeManager_)
 	{
@@ -589,8 +586,6 @@ void GamePlayScene::UpdateLoad()
 		debugTools_->Initialize();
 		frustumCullingDebug_ = std::make_unique<FrustumCullingDebugController>();
 		frustumCullingDebug_->Initialize();
-		K4E::Object3DCommon::GetInstance()->SetFrustumCullingEnabled(false);
-		K4E::Object3DCommon::GetInstance()->SetCullingCameraMode(K4E::Object3DCommon::CullingCameraMode::ActiveCamera);
 		++loadStep_;
 		break;
 

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
@@ -92,7 +92,6 @@ void GamePlayWorld::Initialize(GamePlayStageContext& stageContext)
 
 	if (stage_)
 	{
-		stage_->SetFrustumCullingEnabled(true);
 		stage_->Update();
 	}
 

--- a/Project/Engine/Graphics/Culling/FrustumCullingSystem.cpp
+++ b/Project/Engine/Graphics/Culling/FrustumCullingSystem.cpp
@@ -13,23 +13,39 @@ namespace Ken4lowEngine
 		totalObjectCount_ = 0;
 		drawnObjectCount_ = 0;
 		culledObjectCount_ = 0;
+		cullingDisabledDrawnObjectCount_ = 0;
+		missingBoundsDrawnObjectCount_ = 0;
 	}
 
-	bool FrustumCullingSystem::IsVisible(const BoundingSphere& bounds, bool ignoreFrustumCulling)
+	bool FrustumCullingSystem::IsVisible(const BoundingSphere& bounds, bool ignoreFrustumCulling, bool hasBounds)
 	{
-		return IsVisibleInternal(frustum_.Intersects(bounds), ignoreFrustumCulling);
+		return IsVisibleInternal(hasBounds ? frustum_.Intersects(bounds) : true, ignoreFrustumCulling, hasBounds);
 	}
 
-	bool FrustumCullingSystem::IsVisible(const BoundingAABB& bounds, bool ignoreFrustumCulling)
+	bool FrustumCullingSystem::IsVisible(const BoundingAABB& bounds, bool ignoreFrustumCulling, bool hasBounds)
 	{
-		return IsVisibleInternal(frustum_.Intersects(bounds), ignoreFrustumCulling);
+		return IsVisibleInternal(hasBounds ? frustum_.Intersects(bounds) : true, ignoreFrustumCulling, hasBounds);
 	}
 
-	bool FrustumCullingSystem::IsVisibleInternal(bool intersects, bool ignoreFrustumCulling)
+	bool FrustumCullingSystem::IsVisibleInternal(bool intersects, bool ignoreFrustumCulling, bool hasBounds)
 	{
 		++totalObjectCount_;
 
-		if (!enabled_ || ignoreFrustumCulling || intersects)
+		if (!enabled_ || ignoreFrustumCulling)
+		{
+			++drawnObjectCount_;
+			++cullingDisabledDrawnObjectCount_;
+			return true;
+		}
+
+		if (!hasBounds)
+		{
+			++drawnObjectCount_;
+			++missingBoundsDrawnObjectCount_;
+			return true;
+		}
+
+		if (intersects)
 		{
 			++drawnObjectCount_;
 			return true;

--- a/Project/Engine/Graphics/Culling/FrustumCullingSystem.h
+++ b/Project/Engine/Graphics/Culling/FrustumCullingSystem.h
@@ -17,24 +17,28 @@ namespace Ken4lowEngine
 		void BuildFrustum(const Matrix4x4& viewProjection);
 		void ResetStatistics();
 
-		bool IsVisible(const BoundingSphere& bounds, bool ignoreFrustumCulling = false);
-		bool IsVisible(const BoundingAABB& bounds, bool ignoreFrustumCulling = false);
+		bool IsVisible(const BoundingSphere& bounds, bool ignoreFrustumCulling = false, bool hasBounds = true);
+		bool IsVisible(const BoundingAABB& bounds, bool ignoreFrustumCulling = false, bool hasBounds = true);
 
 		int GetTotalObjectCount() const { return totalObjectCount_; }
 		int GetDrawnObjectCount() const { return drawnObjectCount_; }
 		int GetCulledObjectCount() const { return culledObjectCount_; }
+		int GetCullingDisabledDrawnObjectCount() const { return cullingDisabledDrawnObjectCount_; }
+		int GetMissingBoundsDrawnObjectCount() const { return missingBoundsDrawnObjectCount_; }
 
 		const Matrix4x4& GetViewProjectionMatrix() const { return viewProjection_; }
 		const Frustum& GetFrustum() const { return frustum_; }
 
 	private:
-		bool IsVisibleInternal(bool intersects, bool ignoreFrustumCulling);
+		bool IsVisibleInternal(bool intersects, bool ignoreFrustumCulling, bool hasBounds);
 
 		Frustum frustum_{};
 		Matrix4x4 viewProjection_{};
-		bool enabled_ = false;
+		bool enabled_ = true;
 		int totalObjectCount_ = 0;
 		int drawnObjectCount_ = 0;
 		int culledObjectCount_ = 0;
+		int cullingDisabledDrawnObjectCount_ = 0;
+		int missingBoundsDrawnObjectCount_ = 0;
 	};
 }

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3D.cpp
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3D.cpp
@@ -190,7 +190,8 @@ namespace Ken4lowEngine
 	{
 		if (!model_) { return; }
 
-		if (!Object3DCommon::GetInstance()->ShouldDrawObject(GetWorldBounds(), frustumCullingEnabled_))
+		// Object3D の共通描画直前で Frustum 判定し、Scene 側には Draw 呼び出しだけを残す。
+		if (!Object3DCommon::GetInstance()->ShouldDrawObject(GetWorldBounds(), frustumCullingEnabled_, HasWorldBounds()))
 		{
 			return;
 		}
@@ -344,7 +345,7 @@ namespace Ken4lowEngine
 	BoundingSphere Object3D::GetWorldBounds() const
 	{
 		BoundingSphere worldBounds{};
-		if (!model_)
+		if (!HasWorldBounds())
 		{
 			return worldBounds;
 		}
@@ -358,6 +359,11 @@ namespace Ken4lowEngine
 		const float maxScale = std::max({ scaleX, scaleY, scaleZ, 1.0f });
 		worldBounds.radius = localBounds.radius * maxScale;
 		return worldBounds;
+	}
+
+	bool Object3D::HasWorldBounds() const
+	{
+		return model_ && model_->HasLocalBounds();
 	}
 
 	void Object3D::AcquireShadowMapHandle()

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3D.h
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3D.h
@@ -95,6 +95,7 @@ namespace Ken4lowEngine
 		void InitializeShadowParameterResource();
 		void AcquireShadowMapHandle();
 		BoundingSphere GetWorldBounds() const;
+		bool HasWorldBounds() const;
 
 	private: /// ---------- メンバ変数 ---------- ///
 
@@ -143,7 +144,7 @@ namespace Ken4lowEngine
 		// ShadowMap の SRV を引くための GPU ハンドル
 		D3D12_GPU_DESCRIPTOR_HANDLE shadowMapHandle_{};
 
-		bool frustumCullingEnabled_ = false;
+		bool frustumCullingEnabled_ = true;
 	};
 
 } // namespace Ken4lowEngine

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3DCommon.cpp
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3DCommon.cpp
@@ -18,7 +18,7 @@ namespace Ken4lowEngine
 	void Object3DCommon::Initialize(DirectXCommon* dxCommon)
 	{
 		dxCommon_ = dxCommon;
-		cullingCameraMode_ = CullingCameraMode::ActiveCamera;
+		cullingCameraMode_ = CullingCameraMode::MainCamera;
 
 		pipelineSet_.Initialize(dxCommon_->GetPipelineFactory(), dxCommon_->GetDXCCompilerManager(), DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, DXGI_FORMAT_D24_UNORM_S8_UINT);
 
@@ -29,7 +29,7 @@ namespace Ken4lowEngine
 	{
 		LightManager::GetInstance()->Finalize();
 		pipelineSet_.Finalize();
-		cullingCameraMode_ = CullingCameraMode::ActiveCamera;
+		cullingCameraMode_ = CullingCameraMode::MainCamera;
 		dxCommon_ = nullptr;
 	}
 
@@ -83,9 +83,9 @@ namespace Ken4lowEngine
 		LightManager::GetInstance()->BindPunctualLights(5, 6);
 	}
 
-	bool Object3DCommon::ShouldDrawObject(const BoundingSphere& worldBounds, bool objectCullingEnabled)
+	bool Object3DCommon::ShouldDrawObject(const BoundingSphere& worldBounds, bool objectCullingEnabled, bool hasBounds)
 	{
-		return frustumCullingSystem_.IsVisible(worldBounds, !objectCullingEnabled);
+		return frustumCullingSystem_.IsVisible(worldBounds, !objectCullingEnabled, hasBounds);
 	}
 
 	void Object3DCommon::SetShadowMapRenderSetting()

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3DCommon.h
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3DCommon.h
@@ -15,9 +15,9 @@ namespace Ken4lowEngine
 	public:
 		enum class CullingCameraMode
 		{
-			ActiveCamera,
 			MainCamera,
-			DebugCamera
+			DebugCamera,
+			ActiveCamera
 		};
 
 	public:
@@ -32,7 +32,7 @@ namespace Ken4lowEngine
 
 		void SetRenderSetting();
 		void SetShadowMapRenderSetting();
-		bool ShouldDrawObject(const BoundingSphere& worldBounds, bool objectCullingEnabled);
+		bool ShouldDrawObject(const BoundingSphere& worldBounds, bool objectCullingEnabled, bool hasBounds);
 		FrustumCullingSystem& GetFrustumCullingSystem() { return frustumCullingSystem_; }
 		const FrustumCullingSystem& GetFrustumCullingSystem() const { return frustumCullingSystem_; }
 		void SetCullingCameraMode(CullingCameraMode mode) { cullingCameraMode_ = mode; }
@@ -42,6 +42,8 @@ namespace Ken4lowEngine
 		int GetDrawnObjectCount() const { return frustumCullingSystem_.GetDrawnObjectCount(); }
 		int GetCulledObjectCount() const { return frustumCullingSystem_.GetCulledObjectCount(); }
 		int GetTotalObjectCount() const { return frustumCullingSystem_.GetTotalObjectCount(); }
+		int GetCullingDisabledDrawnObjectCount() const { return frustumCullingSystem_.GetCullingDisabledDrawnObjectCount(); }
+		int GetMissingBoundsDrawnObjectCount() const { return frustumCullingSystem_.GetMissingBoundsDrawnObjectCount(); }
 		Matrix4x4 GetCullingViewProjectionMatrix() const;
 
 	public: /// ---------- 拡張予定の関数 ---------- ///
@@ -64,6 +66,6 @@ namespace Ken4lowEngine
 		Object3DPipelineSet pipelineSet_{};
 
 		FrustumCullingSystem frustumCullingSystem_{};
-		CullingCameraMode cullingCameraMode_ = CullingCameraMode::ActiveCamera;
+		CullingCameraMode cullingCameraMode_ = CullingCameraMode::MainCamera;
 	};
 }

--- a/Project/Engine/Graphics/Resource/Model/Model.cpp
+++ b/Project/Engine/Graphics/Resource/Model/Model.cpp
@@ -72,9 +72,11 @@ namespace Ken4lowEngine
 		if (!hasVertex)
 		{
 			localBounds_ = { {}, 1.0f };
+			hasLocalBounds_ = false;
 			return;
 		}
 
+		hasLocalBounds_ = true;
 		localBounds_.center = (minPos + maxPos) * 0.5f;
 		localBounds_.radius = Vector3::Length(maxPos - localBounds_.center) * 1.1f;
 		if (localBounds_.radius <= 0.001f)

--- a/Project/Engine/Graphics/Resource/Model/Model.h
+++ b/Project/Engine/Graphics/Resource/Model/Model.h
@@ -24,6 +24,7 @@ namespace Ken4lowEngine
 		const std::vector<Mesh>& GetMeshes() const { return meshes_; }
 		std::vector<Mesh>& GetMeshes() { return meshes_; }
 		const BoundingSphere& GetLocalBounds() const { return localBounds_; }
+		bool HasLocalBounds() const { return hasLocalBounds_; }
 		
 		const std::vector<D3D12_GPU_DESCRIPTOR_HANDLE>& GetMaterialSRVs() const { return materialSRVs_; }
 		std::vector<D3D12_GPU_DESCRIPTOR_HANDLE>& GetMaterialSRVs() { return materialSRVs_; }
@@ -34,6 +35,7 @@ namespace Ken4lowEngine
 		std::vector<Mesh> meshes_;
 		std::vector<D3D12_GPU_DESCRIPTOR_HANDLE> materialSRVs_;
 		BoundingSphere localBounds_{};
+		bool hasLocalBounds_ = false;
 	};
 
 


### PR DESCRIPTION
### Motivation

- Eliminate per-scene Frustum Culling duplication so culling is applied from a single common draw path instead of scattered scene-specific logic.
- Ensure `Object3D` instances are culled by default through a shared system while allowing objects to opt out, and avoid disappearing objects when bounds are missing.

### Description

- Move Frustum Culling decision into `Object3D::Draw()` so scenes only call `object->Draw()` and the per-object `SetFrustumCullingEnabled()` opt-out remains available (`Object3D` default is enabled).  A clarifying comment was added at the cull check site.
- Add `HasLocalBounds()` to `Model` and `HasWorldBounds()` to `Object3D`, and pass a `hasBounds` flag to the culling path so objects without bounds are safely drawn.
- Extend `FrustumCullingSystem` API to accept `hasBounds`, and add statistics counters for `cullingDisabledDrawnObjectCount` and `missingBoundsDrawnObjectCount`, updating totals per decision path.
- Make `Object3DCommon` the global culling helper: it resets statistics and `BuildFrustum()` once per Object3D pass using the selected camera; default culling camera is now `MainCamera` while `DebugCamera`/`ActiveCamera` remain selectable.
- Remove scene-level culling setup calls (DebugScene/GamePlayScene/GamePlayWorld) and remove most per-scene culling toggles so Scenes remain responsible only for debug UI/visualization and `Draw()` ordering.
- Update Frustum debug UI (`FrustumCullingDebugController`) to reorder camera combo to `MainCamera / DebugCamera / ActiveCamera` and display the new statistics fields.

### Testing

- Ran `git diff --check` to validate there are no whitespace/error diffs (passed).
- Searched the codebase with `rg` for old per-scene culling calls and patterns (e.g. `SetFrustumCullingEnabled`, `SetCullingCameraMode`, `stage_->SetFrustumCullingEnabled`) to confirm scene-level toggles were removed (no remaining use for scene initialization); search results matched the intended changes.
- Attempted a solution build in the container but no MSBuild-compatible tool is available here, so a full Visual Studio solution build was not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fef1f61468832d842d408a7e51aa55)