### PR TITLE
Add mesh-level frustum culling and debug UI for stage models

### DIFF
--- a/Project/ApplicationLayer/DebugTools/FrustumCulling/FrustumCullingDebugController.cpp
+++ b/Project/ApplicationLayer/DebugTools/FrustumCulling/FrustumCullingDebugController.cpp
@@ -65,16 +65,17 @@ void FrustumCullingDebugController::DrawImGui()
 	const char* cullingCameraItems[] = { "MainCamera", "DebugCamera", "ActiveCamera" };
 
 	bool frustumCullingEnabled = object3DCommon->IsFrustumCullingEnabled();
+	bool boundsDebugVisible = object3DCommon->IsBoundsDebugVisible();
 	float nearDistance = 0.0f;
 	float farDistance = 0.0f;
 	GetCullingCameraClipDistances(nearDistance, farDistance);
 
 	ImGui::Begin("Frustum Culling Debug");
-	if (ImGui::Checkbox("Frustum Culling Enabled", &frustumCullingEnabled))
+	if (ImGui::Checkbox("Frustum Culling 有効", &frustumCullingEnabled))
 	{
 		object3DCommon->SetFrustumCullingEnabled(frustumCullingEnabled);
 	}
-	if (ImGui::Combo("Culling Camera", &cullingCameraIndex, cullingCameraItems, IM_ARRAYSIZE(cullingCameraItems)))
+	if (ImGui::Combo("カリングカメラ", &cullingCameraIndex, cullingCameraItems, IM_ARRAYSIZE(cullingCameraItems)))
 	{
 		object3DCommon->SetCullingCameraMode(static_cast<K4E::Object3DCommon::CullingCameraMode>(cullingCameraIndex));
 	}
@@ -87,18 +88,26 @@ void FrustumCullingDebugController::DrawImGui()
 #else
 	ImGui::Text("DebugCamera: Disabled in release builds");
 #endif
-	ImGui::Checkbox("Show Frustum Wireframe", &showFrustumWireframe_);
+	ImGui::Checkbox("Frustumワイヤー表示", &showFrustumWireframe_);
+	if (ImGui::Checkbox("Bounds表示ON/OFF", &boundsDebugVisible))
+	{
+		object3DCommon->SetBoundsDebugVisible(boundsDebugVisible);
+	}
 	ImGui::ColorEdit4("Frustum Wire Color", &frustumWireColor_.x);
 	ImGui::InputFloat("Near", &nearDistance, 0.0f, 0.0f, "%.3f", ImGuiInputTextFlags_ReadOnly);
 	ImGui::InputFloat("Far", &farDistance, 0.0f, 0.0f, "%.3f", ImGuiInputTextFlags_ReadOnly);
 
 	ImGui::Separator();
-	ImGui::Text("Total Objects: %d", object3DCommon->GetTotalObjectCount());
-	ImGui::Text("Drawn Objects: %d", object3DCommon->GetDrawnObjectCount());
-	ImGui::Text("Culled Objects: %d", object3DCommon->GetCulledObjectCount());
-	ImGui::Text("Drawn (Culling Disabled): %d", object3DCommon->GetCullingDisabledDrawnObjectCount());
-	ImGui::Text("Drawn (Missing Bounds): %d", object3DCommon->GetMissingBoundsDrawnObjectCount());
-	ImGui::TextWrapped("Use DebugCamera outside the view and select MainCamera to inspect gameplay culling results.");
+	ImGui::Text("Object単位カリング数: %d / %d", object3DCommon->GetCulledObjectCount(), object3DCommon->GetTotalObjectCount());
+	ImGui::Text("StageObject単位カリング数: %d / %d", object3DCommon->GetCulledStageObjectCount(), object3DCommon->GetTotalStageObjectCount());
+	ImGui::Text("Mesh単位カリング数: %d / %d", object3DCommon->GetCulledMeshCount(), object3DCommon->GetTotalMeshCount());
+	ImGui::Text("DrawされたMesh数: %d", object3DCommon->GetDrawnMeshCount());
+	ImGui::Text("カリングされたMesh数: %d", object3DCommon->GetCulledMeshCount());
+	ImGui::Text("DrawされたObject数: %d", object3DCommon->GetDrawnObjectCount());
+	ImGui::Text("DrawされたStageObject数: %d", object3DCommon->GetDrawnStageObjectCount());
+	ImGui::Text("Bounds未設定でDrawしたObject数: %d", object3DCommon->GetMissingBoundsDrawnObjectCount());
+	ImGui::TextWrapped("DebugCameraで外側から見て、カリングカメラをMainCameraにするとMainCameraのFrustum内にあるMesh / StageObjectだけ描画されます。");
+	ImGui::TextWrapped("ステージが1つの巨大メッシュの場合はMesh単位では分割できないため、今後StageChunk単位に分割する設計で拡張してください。");
 
 	DrawMainCameraImGui();
 	ImGui::End();

--- a/Project/Engine/Graphics/Culling/FrustumCullingSystem.cpp
+++ b/Project/Engine/Graphics/Culling/FrustumCullingSystem.cpp
@@ -15,43 +15,106 @@ namespace Ken4lowEngine
 		culledObjectCount_ = 0;
 		cullingDisabledDrawnObjectCount_ = 0;
 		missingBoundsDrawnObjectCount_ = 0;
+		totalMeshCount_ = 0;
+		drawnMeshCount_ = 0;
+		culledMeshCount_ = 0;
+		totalStageObjectCount_ = 0;
+		drawnStageObjectCount_ = 0;
+		culledStageObjectCount_ = 0;
 	}
 
-	bool FrustumCullingSystem::IsVisible(const BoundingSphere& bounds, bool ignoreFrustumCulling, bool hasBounds)
+	bool FrustumCullingSystem::IsVisible(const BoundingSphere& bounds, bool ignoreFrustumCulling, bool hasBounds, CullingUnit unit)
 	{
-		return IsVisibleInternal(hasBounds ? frustum_.Intersects(bounds) : true, ignoreFrustumCulling, hasBounds);
+		return IsVisibleInternal(hasBounds ? frustum_.Intersects(bounds) : true, ignoreFrustumCulling, hasBounds, unit);
 	}
 
-	bool FrustumCullingSystem::IsVisible(const BoundingAABB& bounds, bool ignoreFrustumCulling, bool hasBounds)
+	bool FrustumCullingSystem::IsVisible(const BoundingAABB& bounds, bool ignoreFrustumCulling, bool hasBounds, CullingUnit unit)
 	{
-		return IsVisibleInternal(hasBounds ? frustum_.Intersects(bounds) : true, ignoreFrustumCulling, hasBounds);
+		return IsVisibleInternal(hasBounds ? frustum_.Intersects(bounds) : true, ignoreFrustumCulling, hasBounds, unit);
 	}
 
-	bool FrustumCullingSystem::IsVisibleInternal(bool intersects, bool ignoreFrustumCulling, bool hasBounds)
+	bool FrustumCullingSystem::IsVisibleInternal(bool intersects, bool ignoreFrustumCulling, bool hasBounds, CullingUnit unit)
 	{
-		++totalObjectCount_;
+		CountTotal(unit);
 
 		if (!enabled_ || ignoreFrustumCulling)
 		{
-			++drawnObjectCount_;
-			++cullingDisabledDrawnObjectCount_;
+			CountDrawn(unit);
+			if (unit == CullingUnit::Object || unit == CullingUnit::StageObject)
+			{
+				++cullingDisabledDrawnObjectCount_;
+			}
 			return true;
 		}
 
 		if (!hasBounds)
 		{
-			++drawnObjectCount_;
-			++missingBoundsDrawnObjectCount_;
+			CountDrawn(unit);
+			if (unit == CullingUnit::Object || unit == CullingUnit::StageObject)
+			{
+				++missingBoundsDrawnObjectCount_;
+			}
 			return true;
 		}
 
 		if (intersects)
 		{
-			++drawnObjectCount_;
+			CountDrawn(unit);
 			return true;
 		}
 
-		++culledObjectCount_;
+		CountCulled(unit);
 		return false;
+	}
+
+	void FrustumCullingSystem::CountTotal(CullingUnit unit)
+	{
+		switch (unit)
+		{
+		case CullingUnit::Mesh:
+			++totalMeshCount_;
+			break;
+		case CullingUnit::StageObject:
+			++totalStageObjectCount_;
+			[[fallthrough]];
+		case CullingUnit::Object:
+		default:
+			++totalObjectCount_;
+			break;
+		}
+	}
+
+	void FrustumCullingSystem::CountDrawn(CullingUnit unit)
+	{
+		switch (unit)
+		{
+		case CullingUnit::Mesh:
+			++drawnMeshCount_;
+			break;
+		case CullingUnit::StageObject:
+			++drawnStageObjectCount_;
+			[[fallthrough]];
+		case CullingUnit::Object:
+		default:
+			++drawnObjectCount_;
+			break;
+		}
+	}
+
+	void FrustumCullingSystem::CountCulled(CullingUnit unit)
+	{
+		switch (unit)
+		{
+		case CullingUnit::Mesh:
+			++culledMeshCount_;
+			break;
+		case CullingUnit::StageObject:
+			++culledStageObjectCount_;
+			[[fallthrough]];
+		case CullingUnit::Object:
+		default:
+			++culledObjectCount_;
+			break;
+		}
 	}
 }

--- a/Project/Engine/Graphics/Culling/FrustumCullingSystem.h
+++ b/Project/Engine/Graphics/Culling/FrustumCullingSystem.h
@@ -17,20 +17,36 @@ namespace Ken4lowEngine
 		void BuildFrustum(const Matrix4x4& viewProjection);
 		void ResetStatistics();
 
-		bool IsVisible(const BoundingSphere& bounds, bool ignoreFrustumCulling = false, bool hasBounds = true);
-		bool IsVisible(const BoundingAABB& bounds, bool ignoreFrustumCulling = false, bool hasBounds = true);
+		enum class CullingUnit
+		{
+			Object,
+			Mesh,
+			StageObject
+		};
+
+		bool IsVisible(const BoundingSphere& bounds, bool ignoreFrustumCulling = false, bool hasBounds = true, CullingUnit unit = CullingUnit::Object);
+		bool IsVisible(const BoundingAABB& bounds, bool ignoreFrustumCulling = false, bool hasBounds = true, CullingUnit unit = CullingUnit::Object);
 
 		int GetTotalObjectCount() const { return totalObjectCount_; }
 		int GetDrawnObjectCount() const { return drawnObjectCount_; }
 		int GetCulledObjectCount() const { return culledObjectCount_; }
 		int GetCullingDisabledDrawnObjectCount() const { return cullingDisabledDrawnObjectCount_; }
 		int GetMissingBoundsDrawnObjectCount() const { return missingBoundsDrawnObjectCount_; }
+		int GetTotalMeshCount() const { return totalMeshCount_; }
+		int GetDrawnMeshCount() const { return drawnMeshCount_; }
+		int GetCulledMeshCount() const { return culledMeshCount_; }
+		int GetTotalStageObjectCount() const { return totalStageObjectCount_; }
+		int GetDrawnStageObjectCount() const { return drawnStageObjectCount_; }
+		int GetCulledStageObjectCount() const { return culledStageObjectCount_; }
 
 		const Matrix4x4& GetViewProjectionMatrix() const { return viewProjection_; }
 		const Frustum& GetFrustum() const { return frustum_; }
 
 	private:
-		bool IsVisibleInternal(bool intersects, bool ignoreFrustumCulling, bool hasBounds);
+		bool IsVisibleInternal(bool intersects, bool ignoreFrustumCulling, bool hasBounds, CullingUnit unit);
+		void CountTotal(CullingUnit unit);
+		void CountDrawn(CullingUnit unit);
+		void CountCulled(CullingUnit unit);
 
 		Frustum frustum_{};
 		Matrix4x4 viewProjection_{};
@@ -40,5 +56,11 @@ namespace Ken4lowEngine
 		int culledObjectCount_ = 0;
 		int cullingDisabledDrawnObjectCount_ = 0;
 		int missingBoundsDrawnObjectCount_ = 0;
+		int totalMeshCount_ = 0;
+		int drawnMeshCount_ = 0;
+		int culledMeshCount_ = 0;
+		int totalStageObjectCount_ = 0;
+		int drawnStageObjectCount_ = 0;
+		int culledStageObjectCount_ = 0;
 	};
 }

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3D.cpp
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3D.cpp
@@ -12,6 +12,7 @@
 #include "AssimpLoader.h"
 #include "ParameterManager.h"
 #include "SkyBox.h"
+#include "Wireframe.h"
 
 #include <algorithm>
 #include <cmath>
@@ -190,15 +191,20 @@ namespace Ken4lowEngine
 	{
 		if (!model_) { return; }
 
-		// Object3D の共通描画直前で Frustum 判定し、Scene 側には Draw 呼び出しだけを残す。
-		if (!Object3DCommon::GetInstance()->ShouldDrawObject(GetWorldBounds(), frustumCullingEnabled_, HasWorldBounds()))
+		Object3DCommon* object3DCommon = Object3DCommon::GetInstance();
+		const BoundingSphere objectBounds = GetWorldBounds();
+
+		// Object3D 全体が完全に視錐台外なら、更新系は止めず Draw だけをスキップする。
+		if (!object3DCommon->ShouldDrawObject(objectBounds, frustumCullingEnabled_, HasWorldBounds(), isStageObjectCullingUnit_))
 		{
+			DrawBoundsDebug(objectBounds, false);
 			return;
 		}
+		DrawBoundsDebug(objectBounds, true);
 
 		ID3D12GraphicsCommandList* commandList = dxCommon_->GetCommandManager()->GetCommandList();
 
-		Object3DCommon::GetInstance()->SetRenderSetting();
+		object3DCommon->SetRenderSetting();
 
 		material_.SetPipeline();
 		worldTransform_.SetPipeline();
@@ -212,10 +218,19 @@ namespace Ken4lowEngine
 		commandList->SetGraphicsRootConstantBufferView(9, shadowParameterResource_->GetGPUVirtualAddress()); // シャドウマップ用行列
 		commandList->SetGraphicsRootDescriptorTable(10, shadowMapHandle_); // シャドウマップのSRV
 
-		// サブメッシュ事にテクスチャを差し替えて描画
+		// 大きなステージモデルでも一部メッシュだけ Draw できるよう、サブメッシュ単位で Frustum 判定する。
 		auto& meshes = model_->GetMeshes();
 		for (size_t i = 0; i < meshes.size(); i++)
 		{
+			const BoundingSphere meshBounds = GetMeshWorldBounds(i);
+			const bool hasMeshBounds = HasMeshWorldBounds(i);
+			const bool meshVisible = object3DCommon->ShouldDrawMesh(meshBounds, frustumCullingEnabled_, hasMeshBounds);
+			DrawBoundsDebug(meshBounds, meshVisible);
+			if (!meshVisible)
+			{
+				continue;
+			}
+
 			if (i < materialSRVs_.size())
 			{
 				TextureManager::GetInstance()->SetGraphicsRootDescriptorTable(commandList, 2, materialSRVs_[i]);
@@ -344,13 +359,27 @@ namespace Ken4lowEngine
 
 	BoundingSphere Object3D::GetWorldBounds() const
 	{
-		BoundingSphere worldBounds{};
 		if (!HasWorldBounds())
 		{
-			return worldBounds;
+			return {};
 		}
 
-		const BoundingSphere& localBounds = model_->GetLocalBounds();
+		return TransformLocalBounds(model_->GetLocalBounds());
+	}
+
+	BoundingSphere Object3D::GetMeshWorldBounds(size_t meshIndex) const
+	{
+		if (!HasMeshWorldBounds(meshIndex))
+		{
+			return {};
+		}
+
+		return TransformLocalBounds(model_->GetMeshLocalBounds(meshIndex));
+	}
+
+	BoundingSphere Object3D::TransformLocalBounds(const BoundingSphere& localBounds) const
+	{
+		BoundingSphere worldBounds{};
 		worldBounds.center = Vector3::Transform(localBounds.center, worldTransform_.matWorld_);
 
 		const float scaleX = std::sqrt(worldTransform_.matWorld_.m[0][0] * worldTransform_.matWorld_.m[0][0] + worldTransform_.matWorld_.m[0][1] * worldTransform_.matWorld_.m[0][1] + worldTransform_.matWorld_.m[0][2] * worldTransform_.matWorld_.m[0][2]);
@@ -364,6 +393,22 @@ namespace Ken4lowEngine
 	bool Object3D::HasWorldBounds() const
 	{
 		return model_ && model_->HasLocalBounds();
+	}
+
+	bool Object3D::HasMeshWorldBounds(size_t meshIndex) const
+	{
+		return model_ && model_->HasMeshLocalBounds(meshIndex);
+	}
+
+	void Object3D::DrawBoundsDebug(const BoundingSphere& bounds, bool visible) const
+	{
+		if (!Object3DCommon::GetInstance()->IsBoundsDebugVisible() || bounds.radius <= 0.0f)
+		{
+			return;
+		}
+
+		const Vector4 color = visible ? Vector4{ 0.1f, 1.0f, 0.2f, 1.0f } : Vector4{ 1.0f, 0.15f, 0.1f, 1.0f };
+		Wireframe::GetInstance()->DrawSphere(bounds.center, bounds.radius, color);
 	}
 
 	void Object3D::AcquireShadowMapHandle()

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3D.h
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3D.h
@@ -80,6 +80,8 @@ namespace Ken4lowEngine
 		size_t GetSubmeshCount() const;
 		void SetFrustumCullingEnabled(bool enabled) { frustumCullingEnabled_ = enabled; }
 		bool IsFrustumCullingEnabled() const { return frustumCullingEnabled_; }
+		void SetStageObjectCullingUnit(bool enabled) { isStageObjectCullingUnit_ = enabled; }
+		bool IsStageObjectCullingUnit() const { return isStageObjectCullingUnit_; }
 
 	public: /// ---------- ディゾルブの設定 ---------- ///
 
@@ -95,7 +97,11 @@ namespace Ken4lowEngine
 		void InitializeShadowParameterResource();
 		void AcquireShadowMapHandle();
 		BoundingSphere GetWorldBounds() const;
+		BoundingSphere GetMeshWorldBounds(size_t meshIndex) const;
+		BoundingSphere TransformLocalBounds(const BoundingSphere& localBounds) const;
 		bool HasWorldBounds() const;
+		bool HasMeshWorldBounds(size_t meshIndex) const;
+		void DrawBoundsDebug(const BoundingSphere& bounds, bool visible) const;
 
 	private: /// ---------- メンバ変数 ---------- ///
 
@@ -145,6 +151,7 @@ namespace Ken4lowEngine
 		D3D12_GPU_DESCRIPTOR_HANDLE shadowMapHandle_{};
 
 		bool frustumCullingEnabled_ = true;
+		bool isStageObjectCullingUnit_ = false;
 	};
 
 } // namespace Ken4lowEngine

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3DCommon.cpp
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3DCommon.cpp
@@ -83,9 +83,15 @@ namespace Ken4lowEngine
 		LightManager::GetInstance()->BindPunctualLights(5, 6);
 	}
 
-	bool Object3DCommon::ShouldDrawObject(const BoundingSphere& worldBounds, bool objectCullingEnabled, bool hasBounds)
+	bool Object3DCommon::ShouldDrawObject(const BoundingSphere& worldBounds, bool objectCullingEnabled, bool hasBounds, bool isStageObject)
 	{
-		return frustumCullingSystem_.IsVisible(worldBounds, !objectCullingEnabled, hasBounds);
+		const auto unit = isStageObject ? FrustumCullingSystem::CullingUnit::StageObject : FrustumCullingSystem::CullingUnit::Object;
+		return frustumCullingSystem_.IsVisible(worldBounds, !objectCullingEnabled, hasBounds, unit);
+	}
+
+	bool Object3DCommon::ShouldDrawMesh(const BoundingSphere& worldBounds, bool objectCullingEnabled, bool hasBounds)
+	{
+		return frustumCullingSystem_.IsVisible(worldBounds, !objectCullingEnabled, hasBounds, FrustumCullingSystem::CullingUnit::Mesh);
 	}
 
 	void Object3DCommon::SetShadowMapRenderSetting()

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3DCommon.h
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3DCommon.h
@@ -32,7 +32,8 @@ namespace Ken4lowEngine
 
 		void SetRenderSetting();
 		void SetShadowMapRenderSetting();
-		bool ShouldDrawObject(const BoundingSphere& worldBounds, bool objectCullingEnabled, bool hasBounds);
+		bool ShouldDrawObject(const BoundingSphere& worldBounds, bool objectCullingEnabled, bool hasBounds, bool isStageObject = false);
+		bool ShouldDrawMesh(const BoundingSphere& worldBounds, bool objectCullingEnabled, bool hasBounds);
 		FrustumCullingSystem& GetFrustumCullingSystem() { return frustumCullingSystem_; }
 		const FrustumCullingSystem& GetFrustumCullingSystem() const { return frustumCullingSystem_; }
 		void SetCullingCameraMode(CullingCameraMode mode) { cullingCameraMode_ = mode; }
@@ -44,6 +45,14 @@ namespace Ken4lowEngine
 		int GetTotalObjectCount() const { return frustumCullingSystem_.GetTotalObjectCount(); }
 		int GetCullingDisabledDrawnObjectCount() const { return frustumCullingSystem_.GetCullingDisabledDrawnObjectCount(); }
 		int GetMissingBoundsDrawnObjectCount() const { return frustumCullingSystem_.GetMissingBoundsDrawnObjectCount(); }
+		int GetDrawnMeshCount() const { return frustumCullingSystem_.GetDrawnMeshCount(); }
+		int GetCulledMeshCount() const { return frustumCullingSystem_.GetCulledMeshCount(); }
+		int GetTotalMeshCount() const { return frustumCullingSystem_.GetTotalMeshCount(); }
+		int GetTotalStageObjectCount() const { return frustumCullingSystem_.GetTotalStageObjectCount(); }
+		int GetDrawnStageObjectCount() const { return frustumCullingSystem_.GetDrawnStageObjectCount(); }
+		int GetCulledStageObjectCount() const { return frustumCullingSystem_.GetCulledStageObjectCount(); }
+		void SetBoundsDebugVisible(bool visible) { showBoundsDebug_ = visible; }
+		bool IsBoundsDebugVisible() const { return showBoundsDebug_; }
 		Matrix4x4 GetCullingViewProjectionMatrix() const;
 
 	public: /// ---------- 拡張予定の関数 ---------- ///
@@ -67,5 +76,6 @@ namespace Ken4lowEngine
 
 		FrustumCullingSystem frustumCullingSystem_{};
 		CullingCameraMode cullingCameraMode_ = CullingCameraMode::MainCamera;
+		bool showBoundsDebug_ = false;
 	};
 }

--- a/Project/Engine/Graphics/Resource/Model/Model.cpp
+++ b/Project/Engine/Graphics/Resource/Model/Model.cpp
@@ -42,6 +42,11 @@ namespace Ken4lowEngine
 
 	void Model::BuildLocalBounds()
 	{
+		meshLocalBounds_.clear();
+		meshHasLocalBounds_.clear();
+		meshLocalBounds_.reserve(modelData_.subMeshes.size());
+		meshHasLocalBounds_.reserve(modelData_.subMeshes.size());
+
 		Vector3 minPos{
 			std::numeric_limits<float>::max(),
 			std::numeric_limits<float>::max(),
@@ -56,6 +61,18 @@ namespace Ken4lowEngine
 
 		for (const auto& sub : modelData_.subMeshes)
 		{
+			Vector3 meshMin{
+				std::numeric_limits<float>::max(),
+				std::numeric_limits<float>::max(),
+				std::numeric_limits<float>::max()
+			};
+			Vector3 meshMax{
+				std::numeric_limits<float>::lowest(),
+				std::numeric_limits<float>::lowest(),
+				std::numeric_limits<float>::lowest()
+			};
+			bool hasMeshVertex = false;
+
 			for (const auto& vertex : sub.vertices)
 			{
 				const Vector3 position{ vertex.position.x, vertex.position.y, vertex.position.z };
@@ -65,8 +82,28 @@ namespace Ken4lowEngine
 				maxPos.x = std::max(maxPos.x, position.x);
 				maxPos.y = std::max(maxPos.y, position.y);
 				maxPos.z = std::max(maxPos.z, position.z);
+				meshMin.x = std::min(meshMin.x, position.x);
+				meshMin.y = std::min(meshMin.y, position.y);
+				meshMin.z = std::min(meshMin.z, position.z);
+				meshMax.x = std::max(meshMax.x, position.x);
+				meshMax.y = std::max(meshMax.y, position.y);
+				meshMax.z = std::max(meshMax.z, position.z);
 				hasVertex = true;
+				hasMeshVertex = true;
 			}
+
+			BoundingSphere meshBounds{};
+			if (hasMeshVertex)
+			{
+				meshBounds.center = (meshMin + meshMax) * 0.5f;
+				meshBounds.radius = Vector3::Length(meshMax - meshBounds.center) * 1.1f;
+				if (meshBounds.radius <= 0.001f)
+				{
+					meshBounds.radius = 1.0f;
+				}
+			}
+			meshLocalBounds_.push_back(meshBounds);
+			meshHasLocalBounds_.push_back(hasMeshVertex);
 		}
 
 		if (!hasVertex)

--- a/Project/Engine/Graphics/Resource/Model/Model.h
+++ b/Project/Engine/Graphics/Resource/Model/Model.h
@@ -4,6 +4,7 @@
 #include <Mesh.h>
 #include "Engine/Graphics/Culling/Frustum.h"
 
+#include <cstddef>
 #include <vector>
 #include <string>
 
@@ -25,6 +26,8 @@ namespace Ken4lowEngine
 		std::vector<Mesh>& GetMeshes() { return meshes_; }
 		const BoundingSphere& GetLocalBounds() const { return localBounds_; }
 		bool HasLocalBounds() const { return hasLocalBounds_; }
+		const BoundingSphere& GetMeshLocalBounds(size_t index) const { return meshLocalBounds_.at(index); }
+		bool HasMeshLocalBounds(size_t index) const { return index < meshHasLocalBounds_.size() && meshHasLocalBounds_[index]; }
 		
 		const std::vector<D3D12_GPU_DESCRIPTOR_HANDLE>& GetMaterialSRVs() const { return materialSRVs_; }
 		std::vector<D3D12_GPU_DESCRIPTOR_HANDLE>& GetMaterialSRVs() { return materialSRVs_; }
@@ -36,6 +39,8 @@ namespace Ken4lowEngine
 		std::vector<D3D12_GPU_DESCRIPTOR_HANDLE> materialSRVs_;
 		BoundingSphere localBounds_{};
 		bool hasLocalBounds_ = false;
+		std::vector<BoundingSphere> meshLocalBounds_{};
+		std::vector<bool> meshHasLocalBounds_{};
 	};
 
 

--- a/Project/Engine/Scene/Level/StageAssetLoader.cpp
+++ b/Project/Engine/Scene/Level/StageAssetLoader.cpp
@@ -40,6 +40,7 @@ namespace Ken4lowEngine
 		stageModel->SetTranslate(offset);
 		stageModel->SetRotate({ 0.0f, 0.0f, 0.0f });
 		stageModel->SetScale({ 1.0f, 1.0f, 1.0f });
+		stageModel->SetStageObjectCullingUnit(true);
 
 		return stageModel;
 	}


### PR DESCRIPTION
### Motivation
- Large stage models were being fully drawn when any part intersected the view because culling was only at the `Object3D` level. 
- Reduce wasted draw work by allowing finer-grained culling (mesh or stage-object unit) while keeping existing object-level culling intact. 
- Provide visual debug info and per-unit statistics so behavior can be validated from the `Frustum Culling Debug` ImGui panel.

### Description
- Generate and store per-submesh local bounds in `Model::BuildLocalBounds` and expose them via `Model::GetMeshLocalBounds` so each mesh can be tested individually. (files: `Model.h/cpp`)
- Add mesh-level culling to the shared draw path by extending `Object3D::Draw` to compute mesh world bounds (`Object3D::GetMeshWorldBounds` / `TransformLocalBounds`) and skip `Mesh::Draw()` when a mesh is outside the frustum, while preserving the original object-level culling and only skipping draw (not update/collision/AI). (file: `Object3D.cpp/h`)
- Extend `FrustumCullingSystem` with a `CullingUnit` enum (`Object`, `Mesh`, `StageObject`) and per-unit counters (`total/drawn/culled`) and routing (`IsVisible(..., CullingUnit)`), plus helper count methods to keep statistics per unit. (files: `FrustumCullingSystem.h/cpp`)
- Add `Object3DCommon` helpers: `ShouldDrawMesh(...)`, stage-object mode flag support for `ShouldDrawObject(...)`, and a `Bounds` debug visibility flag; these centralize the new culling behavior in the common rendering path. (files: `Object3DCommon.h/cpp`)
- Mark stage models as stage-object culling units in `StageAssetLoader::BuildStageModel` (`stageModel->SetStageObjectCullingUnit(true)`) so stage models count toward the new StageObject statistics. (file: `StageAssetLoader.cpp`)
- Improve debug UI in `FrustumCullingDebugController::DrawImGui` (Japanese labels) to show object/mesh/stage statistics, drawn/culled mesh counts, and a `Bounds` ON/OFF toggle; add bounded wireframe visualization using `Wireframe::DrawSphere` (green for visible, red for culled) to verify behavior. (file: `FrustumCullingDebugController.cpp`) 
- Safety: meshes or objects without bounds are always drawn (safe fallback), and all changes only affect draw-time logic; at least one inline comment explaining intent was added near the draw-path change.

### Testing
- Ran automated `git diff --check` to validate workspace diffs and whitespace issues which passed. 
- Attempted to run build tooling (`msbuild` / `dotnet`) but the Linux runner environment did not provide MSBuild or dotnet CLI, so a full compile/run was not executed in this environment. 
- No additional automated unit tests were present or executed as part of this change; behavior can be validated interactively using the updated `Frustum Culling Debug` ImGui panel (enable DebugCamera and toggle `Bounds表示ON/OFF`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff20950c5c832d9913dbfe2adecb8a)