### PR TITLE
Add StageChunk frustum culling (grid-based chunking + debug UI)

### DIFF
--- a/Project/ApplicationLayer/DebugTools/FrustumCulling/FrustumCullingDebugController.cpp
+++ b/Project/ApplicationLayer/DebugTools/FrustumCulling/FrustumCullingDebugController.cpp
@@ -107,7 +107,7 @@ void FrustumCullingDebugController::DrawImGui()
 	ImGui::Text("DrawされたStageObject数: %d", object3DCommon->GetDrawnStageObjectCount());
 	ImGui::Text("Bounds未設定でDrawしたObject数: %d", object3DCommon->GetMissingBoundsDrawnObjectCount());
 	ImGui::TextWrapped("DebugCameraで外側から見て、カリングカメラをMainCameraにするとMainCameraのFrustum内にあるMesh / StageObjectだけ描画されます。");
-	ImGui::TextWrapped("ステージが1つの巨大メッシュの場合はMesh単位では分割できないため、今後StageChunk単位に分割する設計で拡張してください。");
+	ImGui::TextWrapped("StageChunk Cullingを有効にすると、静的ステージMeshをXZグリッドChunk単位で先に判定してからMesh単位カリングを行います。");
 
 	DrawMainCameraImGui();
 	ImGui::End();

--- a/Project/ApplicationLayer/DebugTools/StageChunk/StageChunkDebugController.cpp
+++ b/Project/ApplicationLayer/DebugTools/StageChunk/StageChunkDebugController.cpp
@@ -1,0 +1,50 @@
+#include "StageChunkDebugController.h"
+
+#include "Stage.h"
+
+#ifdef USE_IMGUI
+#include <imgui.h>
+#endif
+
+void StageChunkDebugController::DrawImGui(K4E::Stage* stage)
+{
+#ifdef USE_IMGUI
+	if (!stage) { return; }
+
+	auto& chunkManager = stage->GetStageChunkManager();
+	auto stats = chunkManager.GetStatistics();
+	bool enabled = stage->IsStageChunkCullingEnabled();
+	bool showBounds = stage->IsStageChunkBoundsVisible();
+	float chunkSize = stage->GetStageChunkSize();
+
+	ImGui::Begin("StageChunk Culling Debug");
+	if (ImGui::Checkbox("StageChunk Culling 有効", &enabled))
+	{
+		stage->SetStageChunkCullingEnabled(enabled);
+	}
+	if (ImGui::DragFloat("Chunkサイズ", &chunkSize, 1.0f, 1.0f, 200.0f))
+	{
+		stage->SetStageChunkSize(chunkSize);
+	}
+	if (ImGui::Checkbox("Chunk Bounds表示", &showBounds))
+	{
+		stage->SetStageChunkBoundsVisible(showBounds);
+	}
+	if (ImGui::Button("Chunk再構築"))
+	{
+		stage->RebuildStageChunks();
+	}
+
+	stats = chunkManager.GetStatistics();
+	ImGui::Separator();
+	ImGui::Text("総Chunk数: %d", stats.totalChunkCount);
+	ImGui::Text("描画Chunk数: %d", stats.drawnChunkCount);
+	ImGui::Text("カリングChunk数: %d", stats.culledChunkCount);
+	ImGui::Text("Chunk内Object数: %d", stats.totalObjectCountInChunks);
+	ImGui::Text("Chunk内Mesh数: %d", stats.totalMeshCountInChunks);
+	ImGui::TextWrapped("DebugCameraで外側から見て、カリングカメラをMainCameraにするとMainCameraのFrustum内Chunkだけが描画されます。");
+	ImGui::End();
+#else
+	(void)stage;
+#endif
+}

--- a/Project/ApplicationLayer/DebugTools/StageChunk/StageChunkDebugController.h
+++ b/Project/ApplicationLayer/DebugTools/StageChunk/StageChunkDebugController.h
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace Ken4lowEngine { class Stage; }
+namespace K4E = ::Ken4lowEngine;
+
+/// <summary>
+/// StageChunk Culling の ImGui 操作と統計表示を Scene から分離する Controller。
+/// </summary>
+class StageChunkDebugController
+{
+public:
+	void DrawImGui(K4E::Stage* stage);
+};

--- a/Project/ApplicationLayer/Scene/GamePlayScene/DebugTools/GamePlayDebugTools.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/DebugTools/GamePlayDebugTools.cpp
@@ -118,6 +118,7 @@ void GamePlayDebugTools::DrawImGui(GamePlayWorld* world)
 
 	K4E::LightManager::GetInstance()->DrawImGui();
 	characters.DrawImGui();
+	stageChunkDebugController_.DrawImGui(world->GetStage());
 
 	/// ---------- 武器マスターデータエディタ ---------- ///
 	static WeaponMasterDataDatabase weaponDB;

--- a/Project/ApplicationLayer/Scene/GamePlayScene/DebugTools/GamePlayDebugTools.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/DebugTools/GamePlayDebugTools.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <cstdint>
+#include "ApplicationLayer/DebugTools/StageChunk/StageChunkDebugController.h"
 
 /// ---------- 前方宣言 ---------- ///
 namespace Ken4lowEngine { class Input; }
@@ -43,4 +44,5 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	bool weaponEditorInitialized_ = false;
 	int32_t lastAppliedWeaponID_ = 0;
+	StageChunkDebugController stageChunkDebugController_{};
 };

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
@@ -275,6 +275,7 @@ void GamePlayWorld::Draw3D(bool hideCharactersDuringIntro)
 	if (stage_)
 	{
 		stage_->Draw();
+		stage_->DrawChunkDebug();
 	}
 
 	if (bulletManager_)

--- a/Project/Engine/Graphics/Culling/FrustumCullingSystem.cpp
+++ b/Project/Engine/Graphics/Culling/FrustumCullingSystem.cpp
@@ -21,6 +21,9 @@ namespace Ken4lowEngine
 		totalStageObjectCount_ = 0;
 		drawnStageObjectCount_ = 0;
 		culledStageObjectCount_ = 0;
+		totalStageChunkCount_ = 0;
+		drawnStageChunkCount_ = 0;
+		culledStageChunkCount_ = 0;
 	}
 
 	bool FrustumCullingSystem::IsVisible(const BoundingSphere& bounds, bool ignoreFrustumCulling, bool hasBounds, CullingUnit unit)
@@ -74,6 +77,9 @@ namespace Ken4lowEngine
 		case CullingUnit::Mesh:
 			++totalMeshCount_;
 			break;
+		case CullingUnit::StageChunk:
+			++totalStageChunkCount_;
+			break;
 		case CullingUnit::StageObject:
 			++totalStageObjectCount_;
 			[[fallthrough]];
@@ -91,6 +97,9 @@ namespace Ken4lowEngine
 		case CullingUnit::Mesh:
 			++drawnMeshCount_;
 			break;
+		case CullingUnit::StageChunk:
+			++drawnStageChunkCount_;
+			break;
 		case CullingUnit::StageObject:
 			++drawnStageObjectCount_;
 			[[fallthrough]];
@@ -107,6 +116,9 @@ namespace Ken4lowEngine
 		{
 		case CullingUnit::Mesh:
 			++culledMeshCount_;
+			break;
+		case CullingUnit::StageChunk:
+			++culledStageChunkCount_;
 			break;
 		case CullingUnit::StageObject:
 			++culledStageObjectCount_;

--- a/Project/Engine/Graphics/Culling/FrustumCullingSystem.h
+++ b/Project/Engine/Graphics/Culling/FrustumCullingSystem.h
@@ -21,7 +21,8 @@ namespace Ken4lowEngine
 		{
 			Object,
 			Mesh,
-			StageObject
+			StageObject,
+			StageChunk
 		};
 
 		bool IsVisible(const BoundingSphere& bounds, bool ignoreFrustumCulling = false, bool hasBounds = true, CullingUnit unit = CullingUnit::Object);
@@ -38,6 +39,9 @@ namespace Ken4lowEngine
 		int GetTotalStageObjectCount() const { return totalStageObjectCount_; }
 		int GetDrawnStageObjectCount() const { return drawnStageObjectCount_; }
 		int GetCulledStageObjectCount() const { return culledStageObjectCount_; }
+		int GetTotalStageChunkCount() const { return totalStageChunkCount_; }
+		int GetDrawnStageChunkCount() const { return drawnStageChunkCount_; }
+		int GetCulledStageChunkCount() const { return culledStageChunkCount_; }
 
 		const Matrix4x4& GetViewProjectionMatrix() const { return viewProjection_; }
 		const Frustum& GetFrustum() const { return frustum_; }
@@ -62,5 +66,8 @@ namespace Ken4lowEngine
 		int totalStageObjectCount_ = 0;
 		int drawnStageObjectCount_ = 0;
 		int culledStageObjectCount_ = 0;
+		int totalStageChunkCount_ = 0;
+		int drawnStageChunkCount_ = 0;
+		int culledStageChunkCount_ = 0;
 	};
 }

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3D.cpp
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3D.cpp
@@ -189,18 +189,32 @@ namespace Ken4lowEngine
 	/// -------------------------------------------------------------
 	void Object3D::Draw()
 	{
+		DrawInternal(nullptr);
+	}
+
+	void Object3D::DrawMeshes(const std::vector<size_t>& meshIndices)
+	{
+		DrawInternal(&meshIndices);
+	}
+
+	void Object3D::DrawInternal(const std::vector<size_t>* meshIndices)
+	{
 		if (!model_) { return; }
 
 		Object3DCommon* object3DCommon = Object3DCommon::GetInstance();
-		const BoundingSphere objectBounds = GetWorldBounds();
 
-		// Object3D 全体が完全に視錐台外なら、更新系は止めず Draw だけをスキップする。
-		if (!object3DCommon->ShouldDrawObject(objectBounds, frustumCullingEnabled_, HasWorldBounds(), isStageObjectCullingUnit_))
+		if (!meshIndices)
 		{
-			DrawBoundsDebug(objectBounds, false);
-			return;
+			const BoundingSphere objectBounds = GetWorldBounds();
+
+			// Object3D 全体が完全に視錐台外なら、更新系は止めず Draw だけをスキップする。
+			if (!object3DCommon->ShouldDrawObject(objectBounds, frustumCullingEnabled_, HasWorldBounds(), isStageObjectCullingUnit_))
+			{
+				DrawBoundsDebug(objectBounds, false);
+				return;
+			}
+			DrawBoundsDebug(objectBounds, true);
 		}
-		DrawBoundsDebug(objectBounds, true);
 
 		ID3D12GraphicsCommandList* commandList = dxCommon_->GetCommandManager()->GetCommandList();
 
@@ -218,10 +232,17 @@ namespace Ken4lowEngine
 		commandList->SetGraphicsRootConstantBufferView(9, shadowParameterResource_->GetGPUVirtualAddress()); // シャドウマップ用行列
 		commandList->SetGraphicsRootDescriptorTable(10, shadowMapHandle_); // シャドウマップのSRV
 
-		// 大きなステージモデルでも一部メッシュだけ Draw できるよう、サブメッシュ単位で Frustum 判定する。
+		// StageChunk 経由でも Mesh 単位の既存カリングを残し、Chunk 内の不可視 Mesh はさらに Draw を抑制する。
 		auto& meshes = model_->GetMeshes();
-		for (size_t i = 0; i < meshes.size(); i++)
+		const size_t drawCount = meshIndices ? meshIndices->size() : meshes.size();
+		for (size_t drawIndex = 0; drawIndex < drawCount; ++drawIndex)
 		{
+			const size_t i = meshIndices ? (*meshIndices)[drawIndex] : drawIndex;
+			if (i >= meshes.size())
+			{
+				continue;
+			}
+
 			const BoundingSphere meshBounds = GetMeshWorldBounds(i);
 			const bool hasMeshBounds = HasMeshWorldBounds(i);
 			const bool meshVisible = object3DCommon->ShouldDrawMesh(meshBounds, frustumCullingEnabled_, hasMeshBounds);

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3D.h
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3D.h
@@ -61,6 +61,7 @@ namespace Ken4lowEngine
 		void UpdateShadowMatrix(const Matrix4x4& lightViewProjection);
 		void DrawImGui();
 		void Draw();
+		void DrawMeshes(const std::vector<size_t>& meshIndices);
 		void DrawShadow();
 
 	public: /// ---------- 設定処理 ---------- ///
@@ -78,6 +79,9 @@ namespace Ken4lowEngine
 		void SetTextureForAll(const std::string& texturePath);
 		void SetTextureForSubmesh(size_t index, const std::string& texturePath);
 		size_t GetSubmeshCount() const;
+		BoundingSphere GetWorldBoundsForCulling() const { return GetWorldBounds(); }
+		BoundingSphere GetMeshWorldBoundsForCulling(size_t meshIndex) const { return GetMeshWorldBounds(meshIndex); }
+		bool HasMeshWorldBoundsForCulling(size_t meshIndex) const { return HasMeshWorldBounds(meshIndex); }
 		void SetFrustumCullingEnabled(bool enabled) { frustumCullingEnabled_ = enabled; }
 		bool IsFrustumCullingEnabled() const { return frustumCullingEnabled_; }
 		void SetStageObjectCullingUnit(bool enabled) { isStageObjectCullingUnit_ = enabled; }
@@ -101,6 +105,7 @@ namespace Ken4lowEngine
 		BoundingSphere TransformLocalBounds(const BoundingSphere& localBounds) const;
 		bool HasWorldBounds() const;
 		bool HasMeshWorldBounds(size_t meshIndex) const;
+		void DrawInternal(const std::vector<size_t>* meshIndices);
 		void DrawBoundsDebug(const BoundingSphere& bounds, bool visible) const;
 
 	private: /// ---------- メンバ変数 ---------- ///

--- a/Project/Engine/Scene/Level/Stage.cpp
+++ b/Project/Engine/Scene/Level/Stage.cpp
@@ -18,6 +18,8 @@ namespace Ken4lowEngine
 		}
 
 		stageModel_ = StageAssetLoader::BuildStageModel(*levelData_, defaultModelName, offset_);
+		stageModel_->Update();
+		RebuildStageChunks();
 
 		StageCollisionBuildResult collisionResult =
 			StageCollisionBuilder::Build(*levelData_, offset_);
@@ -30,6 +32,7 @@ namespace Ken4lowEngine
 	{
 		levelData_.reset();
 		stageModel_.reset();
+		stageChunkManager_.Clear();
 		worldAABBs_.clear();
 		worldColliders_.clear();
 	}
@@ -44,10 +47,30 @@ namespace Ken4lowEngine
 
 	void Stage::Draw()
 	{
-		if (stageModel_)
+		if (!stageModel_)
 		{
-			stageModel_->Draw();
+			return;
 		}
+
+		if (stageChunkManager_.NeedsRebuild())
+		{
+			RebuildStageChunks();
+		}
+
+		if (stageChunkManager_.IsEnabled() && !stageChunkManager_.GetChunks().empty())
+		{
+			stageChunkManager_.UpdateVisibility(true);
+			stageChunkManager_.DrawVisibleChunks();
+			return;
+		}
+
+		stageChunkManager_.UpdateVisibility(false);
+		stageModel_->Draw();
+	}
+
+	void Stage::DrawChunkDebug()
+	{
+		stageChunkManager_.DrawDebugBounds();
 	}
 
 	void Stage::DrawShadow()
@@ -73,6 +96,42 @@ namespace Ken4lowEngine
 			// まずはステージの静的 Object3D だけを Draw スキップ対象にする。
 			stageModel_->SetFrustumCullingEnabled(enabled);
 		}
+	}
+
+	void Stage::SetStageChunkCullingEnabled(bool enabled)
+	{
+		stageChunkManager_.SetEnabled(enabled);
+	}
+
+	bool Stage::IsStageChunkCullingEnabled() const
+	{
+		return stageChunkManager_.IsEnabled();
+	}
+
+	void Stage::SetStageChunkBoundsVisible(bool visible)
+	{
+		stageChunkManager_.SetShowBounds(visible);
+	}
+
+	bool Stage::IsStageChunkBoundsVisible() const
+	{
+		return stageChunkManager_.IsShowBounds();
+	}
+
+	void Stage::SetStageChunkSize(float chunkSize)
+	{
+		stageChunkManager_.SetChunkSize(chunkSize);
+		stageChunkManager_.MarkRebuildRequested();
+	}
+
+	float Stage::GetStageChunkSize() const
+	{
+		return stageChunkManager_.GetChunkSize();
+	}
+
+	void Stage::RebuildStageChunks()
+	{
+		stageChunkManager_.Rebuild(stageModel_.get(), stageChunkManager_.GetChunkSize());
 	}
 
 	void Stage::RegisterColliders(CollisionManager* collisionManager)

--- a/Project/Engine/Scene/Level/Stage.h
+++ b/Project/Engine/Scene/Level/Stage.h
@@ -3,6 +3,7 @@
 #include "Collider.h"
 #include "Object3D.h"
 #include "LevelData.h"
+#include "StageChunkManager.h"
 
 #include <memory>
 #include <string>
@@ -47,6 +48,11 @@ namespace Ken4lowEngine
 		void Draw();
 
 		/// <summary>
+		/// StageChunk Bounds のデバッグワイヤーを描画する。
+		/// </summary>
+		void DrawChunkDebug();
+
+		/// <summary>
 		/// シャドウ描画
 		/// </summary>
 		void DrawShadow();
@@ -60,6 +66,16 @@ namespace Ken4lowEngine
 		/// ステージ描画モデルを Frustum Culling 対象にするか設定する。
 		/// </summary>
 		void SetFrustumCullingEnabled(bool enabled);
+
+		void SetStageChunkCullingEnabled(bool enabled);
+		bool IsStageChunkCullingEnabled() const;
+		void SetStageChunkBoundsVisible(bool visible);
+		bool IsStageChunkBoundsVisible() const;
+		void SetStageChunkSize(float chunkSize);
+		float GetStageChunkSize() const;
+		void RebuildStageChunks();
+		StageChunkManager& GetStageChunkManager() { return stageChunkManager_; }
+		const StageChunkManager& GetStageChunkManager() const { return stageChunkManager_; }
 
 	public: /// ---------- アクセサ ---------- ///
 
@@ -77,6 +93,7 @@ namespace Ken4lowEngine
 
 		std::unique_ptr<LevelData> levelData_;
 		std::unique_ptr<Object3D> stageModel_;                 // ステージ描画モデル
+		StageChunkManager stageChunkManager_;                 // 静的ステージを Chunk 単位で Draw スキップする管理クラス
 		std::vector<AABB> worldAABBs_;                         // ワールド衝突AABB
 		std::vector<std::unique_ptr<Collider>> worldColliders_; // ワールド衝突Collider
 		Vector3 offset_ = { 0.0f, 0.0f, 0.0f };               // ステージ全体オフセット

--- a/Project/Engine/Scene/Level/StageChunk.cpp
+++ b/Project/Engine/Scene/Level/StageChunk.cpp
@@ -1,0 +1,80 @@
+#include "StageChunk.h"
+
+#include "Wireframe.h"
+
+#include <algorithm>
+
+namespace Ken4lowEngine
+{
+	StageChunk::StageChunk(int chunkId, const Vector3& center, const Vector3& size)
+		: chunkId_(chunkId), center_(center), size_(size)
+	{
+		const Vector3 half = size_ * 0.5f;
+		bounds_.min = center_ - half;
+		bounds_.max = center_ + half;
+	}
+
+	void StageChunk::AddMesh(Object3D* object, size_t meshIndex)
+	{
+		if (!object) { return; }
+
+		if (std::none_of(meshes_.begin(), meshes_.end(), [object](const StageChunkMeshRef& ref) { return ref.object == object; }))
+		{
+			++objectCount_;
+		}
+
+		meshes_.push_back({ object, meshIndex });
+	}
+
+	void StageChunk::ClearMeshes()
+	{
+		meshes_.clear();
+		objectCount_ = 0;
+	}
+
+	void StageChunk::Draw() const
+	{
+		if (!visible_) { return; }
+
+		Object3D* currentObject = nullptr;
+		std::vector<size_t> meshIndices;
+
+		const auto flush = [&]()
+			{
+				if (currentObject && !meshIndices.empty())
+				{
+					currentObject->DrawMeshes(meshIndices);
+				}
+			};
+
+		for (const StageChunkMeshRef& ref : meshes_)
+		{
+			if (ref.object != currentObject)
+			{
+				flush();
+				currentObject = ref.object;
+				meshIndices.clear();
+			}
+
+			meshIndices.push_back(ref.meshIndex);
+		}
+
+		flush();
+	}
+
+	void StageChunk::DrawBoundsDebug(bool showBounds) const
+	{
+		if (!showBounds) { return; }
+
+		const Vector4 color = visible_ ? Vector4{ 0.1f, 0.9f, 0.2f, 1.0f } : Vector4{ 1.0f, 0.2f, 0.1f, 1.0f };
+		Wireframe::GetInstance()->DrawAABB(GetDebugAABB(), color);
+	}
+
+	AABB StageChunk::GetDebugAABB() const
+	{
+		AABB aabb{};
+		aabb.min = bounds_.min;
+		aabb.max = bounds_.max;
+		return aabb;
+	}
+}

--- a/Project/Engine/Scene/Level/StageChunk.h
+++ b/Project/Engine/Scene/Level/StageChunk.h
@@ -1,0 +1,51 @@
+#pragma once
+#include "AABB.h"
+#include "Engine/Graphics/Culling/BoundingVolume.h"
+#include "Object3D.h"
+#include "Vector3.h"
+
+#include <cstddef>
+#include <vector>
+
+namespace Ken4lowEngine
+{
+	struct StageChunkMeshRef
+	{
+		Object3D* object = nullptr;
+		size_t meshIndex = 0;
+	};
+
+	/// <summary>
+	/// 静的ステージをグリッド単位でまとめ、Chunk Bounds の可視状態で Draw を制御する単位。
+	/// </summary>
+	class StageChunk
+	{
+	public:
+		StageChunk() = default;
+		StageChunk(int chunkId, const Vector3& center, const Vector3& size);
+
+		void AddMesh(Object3D* object, size_t meshIndex);
+		void ClearMeshes();
+		void Draw() const;
+		void DrawBoundsDebug(bool showBounds) const;
+
+		int GetChunkId() const { return chunkId_; }
+		const Vector3& GetCenter() const { return center_; }
+		const Vector3& GetSize() const { return size_; }
+		const BoundingAABB& GetBounds() const { return bounds_; }
+		AABB GetDebugAABB() const;
+		const std::vector<StageChunkMeshRef>& GetMeshes() const { return meshes_; }
+		int GetObjectCount() const { return objectCount_; }
+		bool IsVisible() const { return visible_; }
+		void SetVisible(bool visible) { visible_ = visible; }
+
+	private:
+		int chunkId_ = 0;
+		Vector3 center_{};
+		Vector3 size_{ 1.0f, 1.0f, 1.0f };
+		BoundingAABB bounds_{};
+		std::vector<StageChunkMeshRef> meshes_{};
+		int objectCount_ = 0;
+		bool visible_ = true;
+	};
+}

--- a/Project/Engine/Scene/Level/StageChunkManager.cpp
+++ b/Project/Engine/Scene/Level/StageChunkManager.cpp
@@ -1,0 +1,161 @@
+#define NOMINMAX
+#include "StageChunkManager.h"
+
+#include "Object3DCommon.h"
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+#include <unordered_map>
+
+namespace Ken4lowEngine
+{
+	namespace
+	{
+		constexpr float kMinChunkSize = 1.0f;
+		constexpr float kBoundsPaddingY = 1.0f;
+
+		float ClampChunkSize(float chunkSize)
+		{
+			return std::max(chunkSize, kMinChunkSize);
+		}
+	}
+
+	void StageChunkManager::Clear()
+	{
+		chunks_.clear();
+		statistics_ = {};
+		needsRebuild_ = false;
+	}
+
+	void StageChunkManager::Rebuild(Object3D* stageObject, float chunkSize)
+	{
+		chunks_.clear();
+		chunkSize_ = ClampChunkSize(chunkSize);
+		needsRebuild_ = false;
+
+		if (!stageObject || stageObject->GetSubmeshCount() == 0)
+		{
+			BuildStatistics();
+			return;
+		}
+
+		float minY = std::numeric_limits<float>::max();
+		float maxY = std::numeric_limits<float>::lowest();
+		struct PendingMesh
+		{
+			size_t meshIndex = 0;
+			int xIndex = 0;
+			int zIndex = 0;
+		};
+		std::vector<PendingMesh> pendingMeshes;
+		pendingMeshes.reserve(stageObject->GetSubmeshCount());
+
+		for (size_t meshIndex = 0; meshIndex < stageObject->GetSubmeshCount(); ++meshIndex)
+		{
+			const BoundingSphere meshBounds = stageObject->GetMeshWorldBoundsForCulling(meshIndex);
+			if (!stageObject->HasMeshWorldBoundsForCulling(meshIndex))
+			{
+				continue;
+			}
+
+			const int xIndex = static_cast<int>(std::floor(meshBounds.center.x / chunkSize_));
+			const int zIndex = static_cast<int>(std::floor(meshBounds.center.z / chunkSize_));
+			pendingMeshes.push_back({ meshIndex, xIndex, zIndex });
+			minY = std::min(minY, meshBounds.center.y - meshBounds.radius);
+			maxY = std::max(maxY, meshBounds.center.y + meshBounds.radius);
+		}
+
+		if (pendingMeshes.empty())
+		{
+			BuildStatistics();
+			return;
+		}
+
+		minY -= kBoundsPaddingY;
+		maxY += kBoundsPaddingY;
+		const float height = std::max(maxY - minY, kMinChunkSize);
+		const float centerY = (minY + maxY) * 0.5f;
+
+		std::unordered_map<unsigned long long, size_t> keyToChunkIndex;
+		for (const PendingMesh& pending : pendingMeshes)
+		{
+			const unsigned long long key = CalculateChunkKey(pending.xIndex, pending.zIndex);
+			auto it = keyToChunkIndex.find(key);
+			if (it == keyToChunkIndex.end())
+			{
+				const int chunkId = static_cast<int>(chunks_.size());
+				const Vector3 center = {
+					(static_cast<float>(pending.xIndex) + 0.5f) * chunkSize_,
+					centerY,
+					(static_cast<float>(pending.zIndex) + 0.5f) * chunkSize_
+				};
+				const Vector3 size = { chunkSize_, height, chunkSize_ };
+				it = keyToChunkIndex.emplace(key, chunks_.size()).first;
+				chunks_.emplace_back(chunkId, center, size);
+			}
+
+			chunks_[it->second].AddMesh(stageObject, pending.meshIndex);
+		}
+
+		BuildStatistics();
+	}
+
+	void StageChunkManager::UpdateVisibility(bool enabled)
+	{
+		statistics_.drawnChunkCount = 0;
+		statistics_.culledChunkCount = 0;
+
+		auto& cullingSystem = Object3DCommon::GetInstance()->GetFrustumCullingSystem();
+		for (StageChunk& chunk : chunks_)
+		{
+			// 既存 FrustumCullingSystem に Chunk AABB を渡し、Chunk 外の静的 Mesh Draw だけを止める。
+			const bool visible = cullingSystem.IsVisible(
+				chunk.GetBounds(),
+				!enabled,
+				true,
+				FrustumCullingSystem::CullingUnit::StageChunk);
+			chunk.SetVisible(visible);
+			if (visible)
+			{
+				++statistics_.drawnChunkCount;
+			}
+			else
+			{
+				++statistics_.culledChunkCount;
+			}
+		}
+	}
+
+	void StageChunkManager::DrawVisibleChunks() const
+	{
+		for (const StageChunk& chunk : chunks_)
+		{
+			chunk.Draw();
+		}
+	}
+
+	void StageChunkManager::DrawDebugBounds() const
+	{
+		for (const StageChunk& chunk : chunks_)
+		{
+			chunk.DrawBoundsDebug(showBounds_);
+		}
+	}
+
+	void StageChunkManager::BuildStatistics()
+	{
+		statistics_ = {};
+		statistics_.totalChunkCount = static_cast<int>(chunks_.size());
+		for (const StageChunk& chunk : chunks_)
+		{
+			statistics_.totalObjectCountInChunks += chunk.GetObjectCount();
+			statistics_.totalMeshCountInChunks += static_cast<int>(chunk.GetMeshes().size());
+		}
+	}
+
+	unsigned long long StageChunkManager::CalculateChunkKey(int xIndex, int zIndex) const
+	{
+		return (static_cast<unsigned long long>(static_cast<unsigned int>(xIndex)) << 32) | static_cast<unsigned int>(zIndex);
+	}
+}

--- a/Project/Engine/Scene/Level/StageChunkManager.h
+++ b/Project/Engine/Scene/Level/StageChunkManager.h
@@ -1,0 +1,49 @@
+#pragma once
+#include "StageChunk.h"
+
+#include <vector>
+
+namespace Ken4lowEngine
+{
+	class StageChunkManager
+	{
+	public:
+		struct Statistics
+		{
+			int totalChunkCount = 0;
+			int drawnChunkCount = 0;
+			int culledChunkCount = 0;
+			int totalObjectCountInChunks = 0;
+			int totalMeshCountInChunks = 0;
+		};
+
+		void Clear();
+		void Rebuild(Object3D* stageObject, float chunkSize);
+		void UpdateVisibility(bool enabled);
+		void DrawVisibleChunks() const;
+		void DrawDebugBounds() const;
+
+		void SetEnabled(bool enabled) { enabled_ = enabled; }
+		bool IsEnabled() const { return enabled_; }
+		void SetShowBounds(bool showBounds) { showBounds_ = showBounds; }
+		bool IsShowBounds() const { return showBounds_; }
+		void SetChunkSize(float chunkSize) { chunkSize_ = chunkSize; }
+		float GetChunkSize() const { return chunkSize_; }
+		bool NeedsRebuild() const { return needsRebuild_; }
+		void MarkRebuildRequested() { needsRebuild_ = true; }
+
+		const Statistics& GetStatistics() const { return statistics_; }
+		const std::vector<StageChunk>& GetChunks() const { return chunks_; }
+
+	private:
+		void BuildStatistics();
+		unsigned long long CalculateChunkKey(int xIndex, int zIndex) const;
+
+		std::vector<StageChunk> chunks_{};
+		Statistics statistics_{};
+		float chunkSize_ = 20.0f;
+		bool enabled_ = true;
+		bool showBounds_ = false;
+		bool needsRebuild_ = false;
+	};
+}

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <ItemGroup Label="ProjectConfigurations">
     <ProjectConfiguration Include="Debug|x64">
@@ -319,6 +319,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="Engine\Graphics\Camera\FPS\FpsCamera.cpp" />
     <ClCompile Include="Engine\Graphics\Culling\Frustum.cpp" />
     <ClCompile Include="ApplicationLayer\DebugTools\FrustumCulling\FrustumCullingDebugController.cpp" />
+    <ClCompile Include="ApplicationLayer\DebugTools\StageChunk\StageChunkDebugController.cpp" />
     <ClCompile Include="Engine\Graphics\Culling\FrustumDebugRenderer.cpp" />
     <ClCompile Include="Engine\Graphics\Culling\FrustumCullingSystem.cpp" />
     <ClCompile Include="Engine\Graphics\Descriptor\DSV\DSVManager.cpp" />
@@ -409,6 +410,8 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="Engine\Scene\Level\LevelLoader.cpp" />
     <ClCompile Include="Engine\Scene\Level\LevelObjectManager.cpp" />
     <ClCompile Include="Engine\Scene\Level\Stage.cpp" />
+    <ClCompile Include="Engine\Scene\Level\StageChunk.cpp" />
+    <ClCompile Include="Engine\Scene\Level\StageChunkManager.cpp" />
     <ClCompile Include="Engine\Scene\Level\StageAssetLoader.cpp" />
     <ClCompile Include="Engine\Scene\Level\StageCollisionBuilder.cpp" />
     <ClCompile Include="Engine\System\Audio\Manager\AudioManager.cpp" />
@@ -924,6 +927,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="Engine\Graphics\Camera\FPS\FpsCamera.h" />
     <ClInclude Include="Engine\Graphics\Culling\Frustum.h" />
     <ClInclude Include="ApplicationLayer\DebugTools\FrustumCulling\FrustumCullingDebugController.h" />
+    <ClInclude Include="ApplicationLayer\DebugTools\StageChunk\StageChunkDebugController.h" />
     <ClInclude Include="Engine\Graphics\Culling\FrustumDebugRenderer.h" />
     <ClInclude Include="Engine\Graphics\Culling\FrustumCullingSystem.h" />
     <ClInclude Include="Engine\Graphics\Culling\BoundingVolume.h" />
@@ -1055,6 +1059,8 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="Engine\Scene\Level\Stage.h" />
     <ClInclude Include="Engine\Scene\Level\StageAssetLoader.h" />
     <ClInclude Include="Engine\Scene\Level\StageCollisionBuilder.h" />
+    <ClInclude Include="Engine\Scene\Level\StageChunk.h" />
+    <ClInclude Include="Engine\Scene\Level\StageChunkManager.h" />
     <ClInclude Include="Engine\System\Audio\Data\AudioCategory.h" />
     <ClInclude Include="Engine\System\Audio\Data\AudioStructs.h" />
     <ClInclude Include="Engine\System\Audio\Manager\AudioManager.h" />

--- a/Project/Ken4lowEngine.vcxproj.filters
+++ b/Project/Ken4lowEngine.vcxproj.filters
@@ -118,6 +118,9 @@
       <Filter Include="ApplicationLayer\DebugTools\FrustumCulling">
       <UniqueIdentifier>{4f4cae23-3c32-4724-9ab8-fc7cf0d39a43}</UniqueIdentifier>
     </Filter>
+    <Filter Include="ApplicationLayer\DebugTools\StageChunk">
+      <UniqueIdentifier>{ea618bf4-bd85-414f-85f7-7c6d7022f237}</UniqueIdentifier>
+    </Filter>
 </ItemGroup>
   <ItemGroup>
     <ClCompile Include="WinMain.cpp" />
@@ -496,6 +499,12 @@
     <ClCompile Include="Engine\Scene\Level\Stage.cpp">
       <Filter>Engine\Scene\Level</Filter>
     </ClCompile>
+    <ClCompile Include="Engine\Scene\Level\StageChunk.cpp">
+      <Filter>Engine\Scene\Level</Filter>
+    </ClCompile>
+    <ClCompile Include="Engine\Scene\Level\StageChunkManager.cpp">
+      <Filter>Engine\Scene\Level</Filter>
+    </ClCompile>
     <ClCompile Include="Engine\Math\Vector\Vector3.cpp">
       <Filter>Engine\Math\Vector</Filter>
     </ClCompile>
@@ -537,6 +546,9 @@
     </ClCompile>
     <ClCompile Include="ApplicationLayer\DebugTools\FrustumCulling\FrustumCullingDebugController.cpp">
       <Filter>ApplicationLayer\DebugTools\FrustumCulling</Filter>
+    </ClCompile>
+    <ClCompile Include="ApplicationLayer\DebugTools\StageChunk\StageChunkDebugController.cpp">
+      <Filter>ApplicationLayer\DebugTools\StageChunk</Filter>
     </ClCompile>
     <ClCompile Include="Engine\Graphics\Culling\FrustumDebugRenderer.cpp">
       <Filter>Engine\Graphics\Culling</Filter>
@@ -1284,6 +1296,12 @@
     <ClInclude Include="Engine\Scene\Level\StageCollisionBuilder.h">
       <Filter>Engine\Scene\Level</Filter>
     </ClInclude>
+    <ClInclude Include="Engine\Scene\Level\StageChunk.h">
+      <Filter>Engine\Scene\Level</Filter>
+    </ClInclude>
+    <ClInclude Include="Engine\Scene\Level\StageChunkManager.h">
+      <Filter>Engine\Scene\Level</Filter>
+    </ClInclude>
     <ClInclude Include="Engine\Scene\Level\Stage.h">
       <Filter>Engine\Scene\Level</Filter>
     </ClInclude>
@@ -1364,6 +1382,9 @@
     </ClInclude>
     <ClInclude Include="ApplicationLayer\DebugTools\FrustumCulling\FrustumCullingDebugController.h">
       <Filter>ApplicationLayer\DebugTools\FrustumCulling</Filter>
+    </ClInclude>
+    <ClInclude Include="ApplicationLayer\DebugTools\StageChunk\StageChunkDebugController.h">
+      <Filter>ApplicationLayer\DebugTools\StageChunk</Filter>
     </ClInclude>
     <ClInclude Include="Engine\Graphics\Culling\FrustumDebugRenderer.h">
       <Filter>Engine\Graphics\Culling</Filter>


### PR DESCRIPTION
### Motivation
- Prevent large static stage meshes from being entirely drawn when only a small part intersects the camera frustum by introducing a coarser chunk-level culling layer.
- Reuse the existing `FrustumCullingSystem` as the single source of truth for visibility tests and keep mesh/object-level culling unchanged.

### Description
- Introduced `StageChunk` and `StageChunkManager` to partition static stage meshes into an XZ grid, build per-chunk AABB, collect mesh references, compute chunk statistics and control per-chunk visibility and drawing via chunk `Draw()`; these live in `Project/Engine/Scene/Level/StageChunk*.{h,cpp}` and `StageChunkManager*.{h,cpp}`.
- Added `Object3D::DrawMeshes` / `DrawInternal` helpers so chunk-managed draws can issue per-object-per-mesh draws while retaining the existing mesh-level frustum checks in `Object3D` (`Object3D` header and cpp updated). 
- Integrated chunk manager into `Stage` so the stage will `RebuildStageChunks()` after model load, call `UpdateVisibility()` and `DrawVisibleChunks()` when enabled, and fall back to the original `stageModel_->Draw()` when chunks are disabled or empty (`Project/Engine/Scene/Level/Stage.*`).
- Extended `FrustumCullingSystem` with a new `CullingUnit::StageChunk` and per-unit statistics so chunk AABBs can be submitted to the existing frustum implementation instead of adding a separate frustum path (`Project/Engine/Graphics/Culling/FrustumCullingSystem.*`).
- Added a debug controller `StageChunkDebugController` and ImGui controls to toggle chunk culling, change `chunkSize`, rebuild chunks and view statistics and wireframe chunk bounds from gameplay debug UI; chunk AABB wireframe rendering uses the existing `Wireframe` helper (`Project/ApplicationLayer/DebugTools/StageChunk/*` and integration into gameplay debug tools).
- Registered new source and header files into the Visual Studio project files (`Project/Ken4lowEngine.vcxproj` and `.filters`).

### Testing
- Ran `git diff --cached --check` to validate staged changes and it completed without reported issues.
- Validated updated project files by parsing `Project/Ken4lowEngine.vcxproj` and `Project/Ken4lowEngine.vcxproj.filters` with Python `xml.etree.ElementTree` and parsing succeeded.
- Attempted a full build via `msbuild`/`dotnet msbuild` but the Linux container does not provide `msbuild`/`dotnet` so a native Windows/MSVC build was not executed in this environment; source and project changes are ready for a platform build and smoke test on Windows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff263f40f4832d8d4ebc4a91dba4a9)