### PR TITLE
StageChunk: use AABB multi-chunk registration and conservative culling

### DIFF
--- a/Project/ApplicationLayer/DebugTools/StageChunk/StageChunkDebugController.cpp
+++ b/Project/ApplicationLayer/DebugTools/StageChunk/StageChunkDebugController.cpp
@@ -2,6 +2,8 @@
 
 #include "Stage.h"
 
+#include <cstddef>
+
 #ifdef USE_IMGUI
 #include <imgui.h>
 #endif
@@ -15,7 +17,10 @@ void StageChunkDebugController::DrawImGui(K4E::Stage* stage)
 	auto stats = chunkManager.GetStatistics();
 	bool enabled = stage->IsStageChunkCullingEnabled();
 	bool showBounds = stage->IsStageChunkBoundsVisible();
+	bool showObjectBounds = stage->IsStageChunkObjectBoundsVisible();
+	bool autoExcludeLargeObjects = stage->IsStageChunkAutoExcludeLargeObjects();
 	float chunkSize = stage->GetStageChunkSize();
+	int selectedMeshIndex = static_cast<int>(chunkManager.GetDebugSelectedMeshIndex());
 
 	ImGui::Begin("StageChunk Culling Debug");
 	if (ImGui::Checkbox("StageChunk Culling 有効", &enabled))
@@ -26,9 +31,26 @@ void StageChunkDebugController::DrawImGui(K4E::Stage* stage)
 	{
 		stage->SetStageChunkSize(chunkSize);
 	}
+	if (ImGui::Checkbox("巨大ObjectをChunk Culling対象外", &autoExcludeLargeObjects))
+	{
+		stage->SetStageChunkAutoExcludeLargeObjects(autoExcludeLargeObjects);
+	}
 	if (ImGui::Checkbox("Chunk Bounds表示", &showBounds))
 	{
 		stage->SetStageChunkBoundsVisible(showBounds);
+	}
+	if (ImGui::Checkbox("Object Bounds表示", &showObjectBounds))
+	{
+		stage->SetStageChunkObjectBoundsVisible(showObjectBounds);
+	}
+	if (ImGui::InputInt("選択中Object(Mesh) Index", &selectedMeshIndex))
+	{
+		if (selectedMeshIndex < 0)
+		{
+			selectedMeshIndex = 0;
+		}
+		chunkManager.SetDebugSelectedMeshIndex(static_cast<size_t>(selectedMeshIndex));
+		stage->RebuildStageChunks();
 	}
 	if (ImGui::Button("Chunk再構築"))
 	{
@@ -40,9 +62,15 @@ void StageChunkDebugController::DrawImGui(K4E::Stage* stage)
 	ImGui::Text("総Chunk数: %d", stats.totalChunkCount);
 	ImGui::Text("描画Chunk数: %d", stats.drawnChunkCount);
 	ImGui::Text("カリングChunk数: %d", stats.culledChunkCount);
-	ImGui::Text("Chunk内Object数: %d", stats.totalObjectCountInChunks);
-	ImGui::Text("Chunk内Mesh数: %d", stats.totalMeshCountInChunks);
-	ImGui::TextWrapped("DebugCameraで外側から見て、カリングカメラをMainCameraにするとMainCameraのFrustum内Chunkだけが描画されます。");
+	ImGui::Text("選択中Objectの所属Chunk数: %d", stats.selectedObjectChunkCount);
+	ImGui::Text("Chunkに登録されたObject数: %d", stats.totalObjectCountInChunks);
+	ImGui::Text("Chunkに登録されたMesh数: %d", stats.totalMeshCountInChunks);
+	ImGui::Text("Bounds未設定で描画したObject数: %d", stats.boundsUnsetDrawObjectCount);
+	ImGui::Text("Chunk外扱いで描画したObject数: %d", stats.chunkOutsideDrawObjectCount);
+	ImGui::Text("Chunk Culling対象外Object数: %d", stats.chunkCullingIgnoredObjectCount);
+	ImGui::Text("大きすぎてChunk Culling除外されたObject数: %d", stats.largeObjectExcludedCount);
+	ImGui::TextWrapped("可視Chunkは緑、カリングChunkは赤、Object Boundsは青、Chunk Culling対象外Boundsは黄で表示します。");
+	ImGui::TextWrapped("床や壁など大きいBoundsは複数Chunk登録または安全側でChunk Culling対象外にし、見えているObjectを消さないようにDraw側だけを制御します。");
 	ImGui::End();
 #else
 	(void)stage;

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3D.h
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3D.h
@@ -86,6 +86,9 @@ namespace Ken4lowEngine
 		bool IsFrustumCullingEnabled() const { return frustumCullingEnabled_; }
 		void SetStageObjectCullingUnit(bool enabled) { isStageObjectCullingUnit_ = enabled; }
 		bool IsStageObjectCullingUnit() const { return isStageObjectCullingUnit_; }
+		void SetIgnoreStageChunkCulling(bool ignore) { ignoreStageChunkCulling_ = ignore; }
+		bool IsIgnoreStageChunkCulling() const { return ignoreStageChunkCulling_; }
+		bool HasWorldBoundsForCulling() const { return HasWorldBounds(); }
 
 	public: /// ---------- ディゾルブの設定 ---------- ///
 
@@ -157,6 +160,7 @@ namespace Ken4lowEngine
 
 		bool frustumCullingEnabled_ = true;
 		bool isStageObjectCullingUnit_ = false;
+		bool ignoreStageChunkCulling_ = false;
 	};
 
 } // namespace Ken4lowEngine

--- a/Project/Engine/Scene/Level/Stage.cpp
+++ b/Project/Engine/Scene/Level/Stage.cpp
@@ -118,6 +118,26 @@ namespace Ken4lowEngine
 		return stageChunkManager_.IsShowBounds();
 	}
 
+	void Stage::SetStageChunkObjectBoundsVisible(bool visible)
+	{
+		stageChunkManager_.SetShowObjectBounds(visible);
+	}
+
+	bool Stage::IsStageChunkObjectBoundsVisible() const
+	{
+		return stageChunkManager_.IsShowObjectBounds();
+	}
+
+	void Stage::SetStageChunkAutoExcludeLargeObjects(bool enabled)
+	{
+		stageChunkManager_.SetAutoExcludeLargeObjects(enabled);
+	}
+
+	bool Stage::IsStageChunkAutoExcludeLargeObjects() const
+	{
+		return stageChunkManager_.IsAutoExcludeLargeObjects();
+	}
+
 	void Stage::SetStageChunkSize(float chunkSize)
 	{
 		stageChunkManager_.SetChunkSize(chunkSize);

--- a/Project/Engine/Scene/Level/Stage.h
+++ b/Project/Engine/Scene/Level/Stage.h
@@ -71,6 +71,10 @@ namespace Ken4lowEngine
 		bool IsStageChunkCullingEnabled() const;
 		void SetStageChunkBoundsVisible(bool visible);
 		bool IsStageChunkBoundsVisible() const;
+		void SetStageChunkObjectBoundsVisible(bool visible);
+		bool IsStageChunkObjectBoundsVisible() const;
+		void SetStageChunkAutoExcludeLargeObjects(bool enabled);
+		bool IsStageChunkAutoExcludeLargeObjects() const;
 		void SetStageChunkSize(float chunkSize);
 		float GetStageChunkSize() const;
 		void RebuildStageChunks();

--- a/Project/Engine/Scene/Level/StageChunkManager.cpp
+++ b/Project/Engine/Scene/Level/StageChunkManager.cpp
@@ -2,11 +2,14 @@
 #include "StageChunkManager.h"
 
 #include "Object3DCommon.h"
+#include "Wireframe.h"
 
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <map>
 #include <unordered_map>
+#include <vector>
 
 namespace Ken4lowEngine
 {
@@ -19,11 +22,32 @@ namespace Ken4lowEngine
 		{
 			return std::max(chunkSize, kMinChunkSize);
 		}
+
+		BoundingAABB MakeAABBFromSphere(const BoundingSphere& sphere)
+		{
+			const Vector3 radius{ sphere.radius, sphere.radius, sphere.radius };
+			return { sphere.center - radius, sphere.center + radius };
+		}
+
+		Vector3 GetAABBSize(const BoundingAABB& bounds)
+		{
+			return bounds.max - bounds.min;
+		}
+
+		AABB ToDebugAABB(const BoundingAABB& bounds)
+		{
+			AABB aabb{};
+			aabb.min = bounds.min;
+			aabb.max = bounds.max;
+			return aabb;
+		}
 	}
 
 	void StageChunkManager::Clear()
 	{
 		chunks_.clear();
+		chunkCullingExcludedMeshes_.clear();
+		meshChunkAssignments_.clear();
 		statistics_ = {};
 		needsRebuild_ = false;
 	}
@@ -31,6 +55,8 @@ namespace Ken4lowEngine
 	void StageChunkManager::Rebuild(Object3D* stageObject, float chunkSize)
 	{
 		chunks_.clear();
+		chunkCullingExcludedMeshes_.clear();
+		meshChunkAssignments_.clear();
 		chunkSize_ = ClampChunkSize(chunkSize);
 		needsRebuild_ = false;
 
@@ -45,25 +71,51 @@ namespace Ken4lowEngine
 		struct PendingMesh
 		{
 			size_t meshIndex = 0;
-			int xIndex = 0;
-			int zIndex = 0;
+			BoundingAABB bounds{};
+			int minXIndex = 0;
+			int maxXIndex = 0;
+			int minZIndex = 0;
+			int maxZIndex = 0;
 		};
 		std::vector<PendingMesh> pendingMeshes;
 		pendingMeshes.reserve(stageObject->GetSubmeshCount());
+		meshChunkAssignments_.reserve(stageObject->GetSubmeshCount());
 
 		for (size_t meshIndex = 0; meshIndex < stageObject->GetSubmeshCount(); ++meshIndex)
 		{
-			const BoundingSphere meshBounds = stageObject->GetMeshWorldBoundsForCulling(meshIndex);
-			if (!stageObject->HasMeshWorldBoundsForCulling(meshIndex))
+			if (stageObject->IsIgnoreStageChunkCulling())
 			{
+				chunkCullingExcludedMeshes_.push_back({ stageObject, meshIndex });
+				++statistics_.chunkCullingIgnoredObjectCount;
 				continue;
 			}
 
-			const int xIndex = static_cast<int>(std::floor(meshBounds.center.x / chunkSize_));
-			const int zIndex = static_cast<int>(std::floor(meshBounds.center.z / chunkSize_));
-			pendingMeshes.push_back({ meshIndex, xIndex, zIndex });
-			minY = std::min(minY, meshBounds.center.y - meshBounds.radius);
-			maxY = std::max(maxY, meshBounds.center.y + meshBounds.radius);
+			if (!stageObject->HasMeshWorldBoundsForCulling(meshIndex))
+			{
+				chunkCullingExcludedMeshes_.push_back({ stageObject, meshIndex });
+				++statistics_.boundsUnsetDrawObjectCount;
+				continue;
+			}
+
+			const BoundingAABB meshAABB = MakeAABBFromSphere(stageObject->GetMeshWorldBoundsForCulling(meshIndex));
+			minY = std::min(minY, meshAABB.min.y);
+			maxY = std::max(maxY, meshAABB.max.y);
+
+			const Vector3 meshSize = GetAABBSize(meshAABB);
+			if (autoExcludeLargeObjects_ && (meshSize.x > chunkSize_ || meshSize.z > chunkSize_))
+			{
+				chunkCullingExcludedMeshes_.push_back({ stageObject, meshIndex });
+				++statistics_.chunkCullingIgnoredObjectCount;
+				++statistics_.largeObjectExcludedCount;
+				continue;
+			}
+
+			const int minXIndex = static_cast<int>(std::floor(meshAABB.min.x / chunkSize_));
+			const int maxXIndex = static_cast<int>(std::floor(meshAABB.max.x / chunkSize_));
+			const int minZIndex = static_cast<int>(std::floor(meshAABB.min.z / chunkSize_));
+			const int maxZIndex = static_cast<int>(std::floor(meshAABB.max.z / chunkSize_));
+			pendingMeshes.push_back({ meshIndex, meshAABB, minXIndex, maxXIndex, minZIndex, maxZIndex });
+
 		}
 
 		if (pendingMeshes.empty())
@@ -80,22 +132,38 @@ namespace Ken4lowEngine
 		std::unordered_map<unsigned long long, size_t> keyToChunkIndex;
 		for (const PendingMesh& pending : pendingMeshes)
 		{
-			const unsigned long long key = CalculateChunkKey(pending.xIndex, pending.zIndex);
-			auto it = keyToChunkIndex.find(key);
-			if (it == keyToChunkIndex.end())
+			int assignedChunkCount = 0;
+			for (int xIndex = pending.minXIndex; xIndex <= pending.maxXIndex; ++xIndex)
 			{
-				const int chunkId = static_cast<int>(chunks_.size());
-				const Vector3 center = {
-					(static_cast<float>(pending.xIndex) + 0.5f) * chunkSize_,
-					centerY,
-					(static_cast<float>(pending.zIndex) + 0.5f) * chunkSize_
-				};
-				const Vector3 size = { chunkSize_, height, chunkSize_ };
-				it = keyToChunkIndex.emplace(key, chunks_.size()).first;
-				chunks_.emplace_back(chunkId, center, size);
+				for (int zIndex = pending.minZIndex; zIndex <= pending.maxZIndex; ++zIndex)
+				{
+					const unsigned long long key = CalculateChunkKey(xIndex, zIndex);
+					auto it = keyToChunkIndex.find(key);
+					if (it == keyToChunkIndex.end())
+					{
+						const int chunkId = static_cast<int>(chunks_.size());
+						const Vector3 center = {
+							(static_cast<float>(xIndex) + 0.5f) * chunkSize_,
+							centerY,
+							(static_cast<float>(zIndex) + 0.5f) * chunkSize_
+						};
+						const Vector3 size = { chunkSize_, height, chunkSize_ };
+						it = keyToChunkIndex.emplace(key, chunks_.size()).first;
+						chunks_.emplace_back(chunkId, center, size);
+					}
+
+					// Mesh の AABB が重なる全 Chunk に登録し、どれかが可視なら Draw する安全側の判定にする。
+					chunks_[it->second].AddMesh(stageObject, pending.meshIndex);
+					++assignedChunkCount;
+				}
 			}
 
-			chunks_[it->second].AddMesh(stageObject, pending.meshIndex);
+			if (assignedChunkCount <= 0)
+			{
+				chunkCullingExcludedMeshes_.push_back({ stageObject, pending.meshIndex });
+				++statistics_.chunkOutsideDrawObjectCount;
+			}
+			meshChunkAssignments_.push_back({ pending.meshIndex, assignedChunkCount });
 		}
 
 		BuildStatistics();
@@ -109,7 +177,6 @@ namespace Ken4lowEngine
 		auto& cullingSystem = Object3DCommon::GetInstance()->GetFrustumCullingSystem();
 		for (StageChunk& chunk : chunks_)
 		{
-			// 既存 FrustumCullingSystem に Chunk AABB を渡し、Chunk 外の静的 Mesh Draw だけを止める。
 			const bool visible = cullingSystem.IsVisible(
 				chunk.GetBounds(),
 				!enabled,
@@ -129,9 +196,38 @@ namespace Ken4lowEngine
 
 	void StageChunkManager::DrawVisibleChunks() const
 	{
+		std::map<Object3D*, std::vector<size_t>> visibleMeshesByObject;
+
+		for (const StageChunkMeshRef& ref : chunkCullingExcludedMeshes_)
+		{
+			if (ref.object)
+			{
+				visibleMeshesByObject[ref.object].push_back(ref.meshIndex);
+			}
+		}
+
 		for (const StageChunk& chunk : chunks_)
 		{
-			chunk.Draw();
+			if (!chunk.IsVisible()) { continue; }
+
+			for (const StageChunkMeshRef& ref : chunk.GetMeshes())
+			{
+				if (!ref.object) { continue; }
+
+				auto& indices = visibleMeshesByObject[ref.object];
+				if (std::find(indices.begin(), indices.end(), ref.meshIndex) == indices.end())
+				{
+					indices.push_back(ref.meshIndex);
+				}
+			}
+		}
+
+		for (const auto& [object, meshIndices] : visibleMeshesByObject)
+		{
+			if (object && !meshIndices.empty())
+			{
+				object->DrawMeshes(meshIndices);
+			}
 		}
 	}
 
@@ -141,16 +237,52 @@ namespace Ken4lowEngine
 		{
 			chunk.DrawBoundsDebug(showBounds_);
 		}
+
+		if (!showObjectBounds_) { return; }
+
+		const Vector4 registeredColor{ 0.2f, 0.6f, 1.0f, 1.0f };
+		const Vector4 excludedColor{ 1.0f, 0.85f, 0.1f, 1.0f };
+		for (const StageChunk& chunk : chunks_)
+		{
+			for (const StageChunkMeshRef& ref : chunk.GetMeshes())
+			{
+				if (!ref.object || !ref.object->HasMeshWorldBoundsForCulling(ref.meshIndex)) { continue; }
+				Wireframe::GetInstance()->DrawAABB(ToDebugAABB(MakeAABBFromSphere(ref.object->GetMeshWorldBoundsForCulling(ref.meshIndex))), registeredColor);
+			}
+		}
+		for (const StageChunkMeshRef& ref : chunkCullingExcludedMeshes_)
+		{
+			if (!ref.object || !ref.object->HasMeshWorldBoundsForCulling(ref.meshIndex)) { continue; }
+			Wireframe::GetInstance()->DrawAABB(ToDebugAABB(MakeAABBFromSphere(ref.object->GetMeshWorldBoundsForCulling(ref.meshIndex))), excludedColor);
+		}
 	}
 
 	void StageChunkManager::BuildStatistics()
 	{
+		const int boundsUnsetDrawObjectCount = statistics_.boundsUnsetDrawObjectCount;
+		const int chunkOutsideDrawObjectCount = statistics_.chunkOutsideDrawObjectCount;
+		const int chunkCullingIgnoredObjectCount = statistics_.chunkCullingIgnoredObjectCount;
+		const int largeObjectExcludedCount = statistics_.largeObjectExcludedCount;
+
 		statistics_ = {};
+		statistics_.boundsUnsetDrawObjectCount = boundsUnsetDrawObjectCount;
+		statistics_.chunkOutsideDrawObjectCount = chunkOutsideDrawObjectCount;
+		statistics_.chunkCullingIgnoredObjectCount = chunkCullingIgnoredObjectCount;
+		statistics_.largeObjectExcludedCount = largeObjectExcludedCount;
 		statistics_.totalChunkCount = static_cast<int>(chunks_.size());
 		for (const StageChunk& chunk : chunks_)
 		{
 			statistics_.totalObjectCountInChunks += chunk.GetObjectCount();
 			statistics_.totalMeshCountInChunks += static_cast<int>(chunk.GetMeshes().size());
+		}
+
+		for (const MeshChunkAssignment& assignment : meshChunkAssignments_)
+		{
+			if (assignment.meshIndex == debugSelectedMeshIndex_)
+			{
+				statistics_.selectedObjectChunkCount = assignment.chunkCount;
+				break;
+			}
 		}
 	}
 

--- a/Project/Engine/Scene/Level/StageChunkManager.h
+++ b/Project/Engine/Scene/Level/StageChunkManager.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "StageChunk.h"
 
+#include <cstddef>
 #include <vector>
 
 namespace Ken4lowEngine
@@ -15,6 +16,11 @@ namespace Ken4lowEngine
 			int culledChunkCount = 0;
 			int totalObjectCountInChunks = 0;
 			int totalMeshCountInChunks = 0;
+			int boundsUnsetDrawObjectCount = 0;
+			int chunkOutsideDrawObjectCount = 0;
+			int chunkCullingIgnoredObjectCount = 0;
+			int largeObjectExcludedCount = 0;
+			int selectedObjectChunkCount = 0;
 		};
 
 		void Clear();
@@ -27,23 +33,40 @@ namespace Ken4lowEngine
 		bool IsEnabled() const { return enabled_; }
 		void SetShowBounds(bool showBounds) { showBounds_ = showBounds; }
 		bool IsShowBounds() const { return showBounds_; }
+		void SetShowObjectBounds(bool showObjectBounds) { showObjectBounds_ = showObjectBounds; }
+		bool IsShowObjectBounds() const { return showObjectBounds_; }
+		void SetAutoExcludeLargeObjects(bool enabled) { autoExcludeLargeObjects_ = enabled; MarkRebuildRequested(); }
+		bool IsAutoExcludeLargeObjects() const { return autoExcludeLargeObjects_; }
 		void SetChunkSize(float chunkSize) { chunkSize_ = chunkSize; }
 		float GetChunkSize() const { return chunkSize_; }
 		bool NeedsRebuild() const { return needsRebuild_; }
 		void MarkRebuildRequested() { needsRebuild_ = true; }
+		void SetDebugSelectedMeshIndex(size_t meshIndex) { debugSelectedMeshIndex_ = meshIndex; }
+		size_t GetDebugSelectedMeshIndex() const { return debugSelectedMeshIndex_; }
 
 		const Statistics& GetStatistics() const { return statistics_; }
 		const std::vector<StageChunk>& GetChunks() const { return chunks_; }
 
 	private:
+		struct MeshChunkAssignment
+		{
+			size_t meshIndex = 0;
+			int chunkCount = 0;
+		};
+
 		void BuildStatistics();
 		unsigned long long CalculateChunkKey(int xIndex, int zIndex) const;
 
 		std::vector<StageChunk> chunks_{};
+		std::vector<StageChunkMeshRef> chunkCullingExcludedMeshes_{};
+		std::vector<MeshChunkAssignment> meshChunkAssignments_{};
 		Statistics statistics_{};
 		float chunkSize_ = 20.0f;
 		bool enabled_ = true;
 		bool showBounds_ = false;
+		bool showObjectBounds_ = false;
+		bool autoExcludeLargeObjects_ = true;
 		bool needsRebuild_ = false;
+		size_t debugSelectedMeshIndex_ = 0;
 	};
 }


### PR DESCRIPTION
### Motivation
- Prevent visible large static geometry (floors/walls) from being incorrectly culled when StageChunk Culling is enabled by making chunk registration and bounds conservative and safe.
- Make StageChunk Culling a draw-only, coarse pass that never affects Update/Collision/AI logic and prefers drawing when in doubt.
- Provide richer debug/ImGui feedback so chunk/mesh overlap and excluded cases can be diagnosed quickly.

### Description
- Replace center-point chunk assignment with AABB-derived assignment so each mesh is registered into every XZ chunk its world AABB overlaps, and chunk Y-range is built from stage-wide minY/maxY with padding. A one-line comment documents the safety intent when registering meshes across all overlapping chunks.
- Make StageChunkManager conservative: meshes with no bounds, meshes explicitly marked to ignore chunk culling, and meshes that are larger than a chunk (configurable auto-exclude) are excluded from chunk culling and always considered for draw.
- Ensure meshes spanning multiple chunks are drawn if any of their chunks is visible by aggregating a unique per-object mesh list and calling `DrawMeshes` once per object with unique indices (avoids duplicate draws and ensures visibility if any chunk is visible).
- Add ImGui controls and diagnostics in Japanese: chunk size, toggle for enabling/disabling chunk culling, toggle to auto-exclude huge objects, show chunk bounds, show object bounds, input for selecting a mesh to inspect; plus stats: total/drawn/culled chunks, selected-object chunk count, registered object/mesh counts, counts for bounds-unset, chunk-outside, chunk-culling-ignored, and large-object-excluded.
- Add debug wireframe visualization for Object Bounds (registered vs excluded) and keep chunk bounds colored by visible/culled state.
- Expose Stage API accessors to control object-bounds debug display and the auto-exclude-large-objects behavior; add `ignoreStageChunkCulling` flag to `Object3D` to opt-out specific objects.

### Testing
- Ran `git diff --check` to validate no whitespace/index errors and it passed successfully. 
- Build/test was not executed because Visual Studio/MSBuild was not available in this environment (`msbuild`/`xbuild`/`dotnet` not found), so no full compile/run was performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff364e6564832d8d4a45c7d9425f82)