### PR TITLE
Lv4: StageChunk向けCPU簡易Occlusion Cullingを追加

### DIFF
--- a/Project/ApplicationLayer/DebugTools/Occlusion/OcclusionDebugController.cpp
+++ b/Project/ApplicationLayer/DebugTools/Occlusion/OcclusionDebugController.cpp
@@ -1,0 +1,60 @@
+#include "OcclusionDebugController.h"
+
+#include "Stage.h"
+
+#ifdef USE_IMGUI
+#include <imgui.h>
+#endif
+
+void OcclusionDebugController::DrawImGui(K4E::Stage* stage)
+{
+#ifdef USE_IMGUI
+	if (!stage) { return; }
+
+	auto& occlusionSystem = stage->GetOcclusionCullingSystem();
+	bool enabled = occlusionSystem.IsEnabled();
+	bool showOccluderBounds = occlusionSystem.IsShowOccluderBounds();
+	bool showOccludedBounds = occlusionSystem.IsShowOccludedBounds();
+	float coverageThreshold = occlusionSystem.GetCoverageThreshold();
+	float depthBias = occlusionSystem.GetDepthBias();
+	float occlusionMargin = occlusionSystem.GetOcclusionMargin();
+
+	ImGui::Begin("Occlusion Culling Debug");
+	if (ImGui::Checkbox("Occlusion Culling 有効", &enabled))
+	{
+		occlusionSystem.SetEnabled(enabled);
+	}
+	if (ImGui::Checkbox("Occluder Bounds表示", &showOccluderBounds))
+	{
+		occlusionSystem.SetShowOccluderBounds(showOccluderBounds);
+	}
+	if (ImGui::Checkbox("Occluded Bounds表示", &showOccludedBounds))
+	{
+		occlusionSystem.SetShowOccludedBounds(showOccludedBounds);
+	}
+
+	if (ImGui::SliderFloat("coverageThreshold", &coverageThreshold, 0.0f, 1.0f))
+	{
+		occlusionSystem.SetCoverageThreshold(coverageThreshold);
+	}
+	if (ImGui::DragFloat("depthBias", &depthBias, 0.001f, 0.0f, 1.0f))
+	{
+		occlusionSystem.SetDepthBias(depthBias);
+	}
+	if (ImGui::DragFloat("occlusionMargin", &occlusionMargin, 0.001f, 0.0f, 0.25f))
+	{
+		occlusionSystem.SetOcclusionMargin(occlusionMargin);
+	}
+
+	const auto& stats = occlusionSystem.GetStatistics();
+	ImGui::Separator();
+	ImGui::Text("Occluder数: %d", stats.occluderCount);
+	ImGui::Text("Occlusion判定対象Chunk数: %d", stats.testedChunkCount);
+	ImGui::Text("OcclusionでカリングされたChunk数: %d", stats.occludedChunkCount);
+	ImGui::TextWrapped("StageChunk Culling 後の Chunk Bounds をスクリーン矩形に投影し、Occluder に十分覆われ、かつ奥にある場合だけ Draw をスキップします。");
+	ImGui::TextWrapped("Frustum Culling のカリング Chunk は赤、Occlusion Culling のカリング Chunk は紫、Occluder は黄で表示します。");
+	ImGui::End();
+#else
+	(void)stage;
+#endif
+}

--- a/Project/ApplicationLayer/DebugTools/Occlusion/OcclusionDebugController.h
+++ b/Project/ApplicationLayer/DebugTools/Occlusion/OcclusionDebugController.h
@@ -1,0 +1,13 @@
+#pragma once
+
+namespace Ken4lowEngine { class Stage; }
+namespace K4E = ::Ken4lowEngine;
+
+/// <summary>
+/// Lv4 簡易 Occlusion Culling の ImGui 操作と統計表示を担当する Controller。
+/// </summary>
+class OcclusionDebugController
+{
+public:
+	void DrawImGui(K4E::Stage* stage);
+};

--- a/Project/ApplicationLayer/Scene/GamePlayScene/DebugTools/GamePlayDebugTools.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/DebugTools/GamePlayDebugTools.cpp
@@ -119,6 +119,7 @@ void GamePlayDebugTools::DrawImGui(GamePlayWorld* world)
 	K4E::LightManager::GetInstance()->DrawImGui();
 	characters.DrawImGui();
 	stageChunkDebugController_.DrawImGui(world->GetStage());
+	occlusionDebugController_.DrawImGui(world->GetStage());
 
 	/// ---------- 武器マスターデータエディタ ---------- ///
 	static WeaponMasterDataDatabase weaponDB;

--- a/Project/ApplicationLayer/Scene/GamePlayScene/DebugTools/GamePlayDebugTools.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/DebugTools/GamePlayDebugTools.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <cstdint>
 #include "ApplicationLayer/DebugTools/StageChunk/StageChunkDebugController.h"
+#include "ApplicationLayer/DebugTools/Occlusion/OcclusionDebugController.h"
 
 /// ---------- 前方宣言 ---------- ///
 namespace Ken4lowEngine { class Input; }
@@ -45,4 +46,5 @@ private: /// ---------- メンバ変数 ---------- ///
 	bool weaponEditorInitialized_ = false;
 	int32_t lastAppliedWeaponID_ = 0;
 	StageChunkDebugController stageChunkDebugController_{};
+	OcclusionDebugController occlusionDebugController_{};
 };

--- a/Project/Engine/Graphics/Culling/Occluder.cpp
+++ b/Project/Engine/Graphics/Culling/Occluder.cpp
@@ -1,0 +1,17 @@
+#include "Occluder.h"
+
+namespace Ken4lowEngine
+{
+	Occluder::Occluder(const BoundingAABB& worldBounds, const std::string& debugName)
+		: worldBounds_(worldBounds), debugName_(debugName)
+	{
+	}
+
+	AABB Occluder::GetDebugAABB() const
+	{
+		AABB aabb{};
+		aabb.min = worldBounds_.min;
+		aabb.max = worldBounds_.max;
+		return aabb;
+	}
+}

--- a/Project/Engine/Graphics/Culling/Occluder.h
+++ b/Project/Engine/Graphics/Culling/Occluder.h
@@ -1,0 +1,30 @@
+#pragma once
+#include "AABB.h"
+#include "BoundingVolume.h"
+#include "Vector4.h"
+
+#include <string>
+
+namespace Ken4lowEngine
+{
+	/// <summary>
+	/// CPU Occlusion Culling で遮蔽物として扱う簡易 AABB。
+	/// </summary>
+	class Occluder
+	{
+	public:
+		Occluder() = default;
+		Occluder(const BoundingAABB& worldBounds, const std::string& debugName = "");
+
+		const BoundingAABB& GetWorldBounds() const { return worldBounds_; }
+		AABB GetDebugAABB() const;
+		const std::string& GetDebugName() const { return debugName_; }
+		bool IsEnabled() const { return enabled_; }
+		void SetEnabled(bool enabled) { enabled_ = enabled; }
+
+	private:
+		BoundingAABB worldBounds_{};
+		std::string debugName_{};
+		bool enabled_ = true;
+	};
+}

--- a/Project/Engine/Graphics/Culling/OcclusionCullingSystem.cpp
+++ b/Project/Engine/Graphics/Culling/OcclusionCullingSystem.cpp
@@ -1,0 +1,228 @@
+#define NOMINMAX
+#include "OcclusionCullingSystem.h"
+
+#include "StageChunk.h"
+#include "Wireframe.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <limits>
+
+namespace Ken4lowEngine
+{
+	namespace
+	{
+		constexpr float kClipEpsilon = 1.0e-4f;
+		constexpr float kMinOccluderHeight = 2.0f;
+		constexpr float kMinOccluderLongSide = 4.0f;
+		constexpr float kMaxWallThickness = 3.0f;
+		constexpr float kMinOccluderBoxSide = 4.0f;
+
+		BoundingAABB ToBoundingAABB(const AABB& aabb)
+		{
+			return { aabb.min, aabb.max };
+		}
+
+		Vector3 GetSize(const BoundingAABB& bounds)
+		{
+			return bounds.max - bounds.min;
+		}
+	}
+
+	void OcclusionCullingSystem::ClearOccluders()
+	{
+		occluders_.clear();
+		statistics_ = {};
+	}
+
+	void OcclusionCullingSystem::AddOccluder(const Occluder& occluder)
+	{
+		occluders_.push_back(occluder);
+	}
+
+	void OcclusionCullingSystem::BuildAutoOccludersFromWorldAABBs(const std::vector<AABB>& worldAABBs)
+	{
+		ClearOccluders();
+		for (const AABB& aabb : worldAABBs)
+		{
+			const BoundingAABB bounds = ToBoundingAABB(aabb);
+			const Vector3 size = GetSize(bounds);
+			const float longSide = std::max(size.x, size.z);
+			const float shortSide = std::min(size.x, size.z);
+			const bool wallLike = longSide >= kMinOccluderLongSide && shortSide <= kMaxWallThickness;
+			const bool boxLike = size.x >= kMinOccluderBoxSide && size.y >= kMinOccluderHeight && size.z >= kMinOccluderBoxSide;
+			if (size.y < kMinOccluderHeight || (!wallLike && !boxLike))
+			{
+				continue;
+			}
+
+			AddOccluder(Occluder(bounds, "AutoWallOccluder"));
+		}
+		statistics_.occluderCount = static_cast<int>(occluders_.size());
+	}
+
+	void OcclusionCullingSystem::ApplyToStageChunks(std::vector<StageChunk>& chunks, const Matrix4x4& viewProjection)
+	{
+		statistics_ = {};
+		statistics_.occluderCount = static_cast<int>(occluders_.size());
+
+		for (StageChunk& chunk : chunks)
+		{
+			chunk.SetOccludedByOcclusion(false);
+			if (!chunk.IsVisible()) { continue; }
+			++statistics_.testedChunkCount;
+
+			// Frustum/StageChunk 後に、完全に遮蔽物へ隠れた Chunk の Draw だけを安全側で止める。
+			if (enabled_ && IsOccluded(chunk.GetBounds(), viewProjection))
+			{
+				chunk.SetOccludedByOcclusion(true);
+				chunk.SetVisible(false);
+				++statistics_.occludedChunkCount;
+			}
+		}
+	}
+
+	void OcclusionCullingSystem::DrawDebugBounds() const
+	{
+		if (!showOccluderBounds_) { return; }
+
+		const Vector4 occluderColor{ 1.0f, 0.7f, 0.05f, 1.0f };
+		for (const Occluder& occluder : occluders_)
+		{
+			if (!occluder.IsEnabled()) { continue; }
+			Wireframe::GetInstance()->DrawAABB(occluder.GetDebugAABB(), occluderColor);
+		}
+	}
+
+	void OcclusionCullingSystem::SetCoverageThreshold(float threshold)
+	{
+		coverageThreshold_ = std::clamp(threshold, 0.0f, 1.0f);
+	}
+
+	void OcclusionCullingSystem::SetDepthBias(float depthBias)
+	{
+		depthBias_ = std::max(0.0f, depthBias);
+	}
+
+	void OcclusionCullingSystem::SetOcclusionMargin(float margin)
+	{
+		occlusionMargin_ = std::max(0.0f, margin);
+	}
+
+	bool OcclusionCullingSystem::IsOccluded(const BoundingAABB& bounds, const Matrix4x4& viewProjection) const
+	{
+		ScreenRect targetRect{};
+		if (!ProjectAABB(bounds, viewProjection, targetRect))
+		{
+			return false;
+		}
+
+		for (const Occluder& occluder : occluders_)
+		{
+			if (!occluder.IsEnabled()) { continue; }
+
+			ScreenRect occluderRect{};
+			if (!ProjectAABB(occluder.GetWorldBounds(), viewProjection, occluderRect))
+			{
+				continue;
+			}
+
+			if (targetRect.minDepth <= occluderRect.minDepth + depthBias_)
+			{
+				continue;
+			}
+
+			ScreenRect safeOccluderRect = occluderRect;
+			safeOccluderRect.minX += occlusionMargin_;
+			safeOccluderRect.maxX -= occlusionMargin_;
+			safeOccluderRect.minY += occlusionMargin_;
+			safeOccluderRect.maxY -= occlusionMargin_;
+			if (safeOccluderRect.minX >= safeOccluderRect.maxX || safeOccluderRect.minY >= safeOccluderRect.maxY)
+			{
+				continue;
+			}
+
+			if (CalculateCoverage(safeOccluderRect, targetRect) >= coverageThreshold_)
+			{
+				return true;
+			}
+		}
+
+		return false;
+	}
+
+	bool OcclusionCullingSystem::ProjectAABB(const BoundingAABB& bounds, const Matrix4x4& viewProjection, ScreenRect& outRect) const
+	{
+		const std::array<Vector3, 8> corners = {
+			Vector3{ bounds.min.x, bounds.min.y, bounds.min.z },
+			Vector3{ bounds.max.x, bounds.min.y, bounds.min.z },
+			Vector3{ bounds.min.x, bounds.max.y, bounds.min.z },
+			Vector3{ bounds.max.x, bounds.max.y, bounds.min.z },
+			Vector3{ bounds.min.x, bounds.min.y, bounds.max.z },
+			Vector3{ bounds.max.x, bounds.min.y, bounds.max.z },
+			Vector3{ bounds.min.x, bounds.max.y, bounds.max.z },
+			Vector3{ bounds.max.x, bounds.max.y, bounds.max.z },
+		};
+
+		outRect.minX = std::numeric_limits<float>::max();
+		outRect.minY = std::numeric_limits<float>::max();
+		outRect.maxX = std::numeric_limits<float>::lowest();
+		outRect.maxY = std::numeric_limits<float>::lowest();
+		outRect.minDepth = std::numeric_limits<float>::max();
+
+		for (const Vector3& corner : corners)
+		{
+			const float clipX = corner.x * viewProjection.m[0][0] + corner.y * viewProjection.m[1][0] + corner.z * viewProjection.m[2][0] + viewProjection.m[3][0];
+			const float clipY = corner.x * viewProjection.m[0][1] + corner.y * viewProjection.m[1][1] + corner.z * viewProjection.m[2][1] + viewProjection.m[3][1];
+			const float clipZ = corner.x * viewProjection.m[0][2] + corner.y * viewProjection.m[1][2] + corner.z * viewProjection.m[2][2] + viewProjection.m[3][2];
+			const float clipW = corner.x * viewProjection.m[0][3] + corner.y * viewProjection.m[1][3] + corner.z * viewProjection.m[2][3] + viewProjection.m[3][3];
+			if (clipW <= kClipEpsilon)
+			{
+				return false;
+			}
+
+			const float invW = 1.0f / clipW;
+			const float ndcX = clipX * invW;
+			const float ndcY = clipY * invW;
+			const float ndcZ = clipZ * invW;
+			if (ndcZ < 0.0f || ndcZ > 1.0f)
+			{
+				return false;
+			}
+
+			const float screenX = ndcX * 0.5f + 0.5f;
+			const float screenY = -ndcY * 0.5f + 0.5f;
+			outRect.minX = std::min(outRect.minX, screenX);
+			outRect.maxX = std::max(outRect.maxX, screenX);
+			outRect.minY = std::min(outRect.minY, screenY);
+			outRect.maxY = std::max(outRect.maxY, screenY);
+			outRect.minDepth = std::min(outRect.minDepth, ndcZ);
+		}
+
+		outRect.minX = std::clamp(outRect.minX, 0.0f, 1.0f);
+		outRect.maxX = std::clamp(outRect.maxX, 0.0f, 1.0f);
+		outRect.minY = std::clamp(outRect.minY, 0.0f, 1.0f);
+		outRect.maxY = std::clamp(outRect.maxY, 0.0f, 1.0f);
+		return outRect.minX < outRect.maxX && outRect.minY < outRect.maxY;
+	}
+
+	float OcclusionCullingSystem::CalculateCoverage(const ScreenRect& occluderRect, const ScreenRect& targetRect)
+	{
+		const float targetWidth = targetRect.maxX - targetRect.minX;
+		const float targetHeight = targetRect.maxY - targetRect.minY;
+		const float targetArea = targetWidth * targetHeight;
+		if (targetArea <= 0.0f)
+		{
+			return 0.0f;
+		}
+
+		const float overlapMinX = std::max(occluderRect.minX, targetRect.minX);
+		const float overlapMaxX = std::min(occluderRect.maxX, targetRect.maxX);
+		const float overlapMinY = std::max(occluderRect.minY, targetRect.minY);
+		const float overlapMaxY = std::min(occluderRect.maxY, targetRect.maxY);
+		const float overlapWidth = std::max(0.0f, overlapMaxX - overlapMinX);
+		const float overlapHeight = std::max(0.0f, overlapMaxY - overlapMinY);
+		return (overlapWidth * overlapHeight) / targetArea;
+	}
+}

--- a/Project/Engine/Graphics/Culling/OcclusionCullingSystem.h
+++ b/Project/Engine/Graphics/Culling/OcclusionCullingSystem.h
@@ -1,0 +1,69 @@
+#pragma once
+#include "BoundingVolume.h"
+#include "Matrix4x4.h"
+#include "Occluder.h"
+
+#include <vector>
+
+namespace Ken4lowEngine
+{
+	class StageChunk;
+
+	/// <summary>
+	/// Occluder と StageChunk Bounds をスクリーン矩形に投影して判定する CPU 側の簡易 Occlusion Culling。
+	/// </summary>
+	class OcclusionCullingSystem
+	{
+	public:
+		struct Statistics
+		{
+			int occluderCount = 0;
+			int testedChunkCount = 0;
+			int occludedChunkCount = 0;
+		};
+
+		void ClearOccluders();
+		void AddOccluder(const Occluder& occluder);
+		void BuildAutoOccludersFromWorldAABBs(const std::vector<AABB>& worldAABBs);
+		void ApplyToStageChunks(std::vector<StageChunk>& chunks, const Matrix4x4& viewProjection);
+		void DrawDebugBounds() const;
+
+		void SetEnabled(bool enabled) { enabled_ = enabled; }
+		bool IsEnabled() const { return enabled_; }
+		void SetShowOccluderBounds(bool visible) { showOccluderBounds_ = visible; }
+		bool IsShowOccluderBounds() const { return showOccluderBounds_; }
+		void SetShowOccludedBounds(bool visible) { showOccludedBounds_ = visible; }
+		bool IsShowOccludedBounds() const { return showOccludedBounds_; }
+		void SetCoverageThreshold(float threshold);
+		float GetCoverageThreshold() const { return coverageThreshold_; }
+		void SetDepthBias(float depthBias);
+		float GetDepthBias() const { return depthBias_; }
+		void SetOcclusionMargin(float margin);
+		float GetOcclusionMargin() const { return occlusionMargin_; }
+		const Statistics& GetStatistics() const { return statistics_; }
+		const std::vector<Occluder>& GetOccluders() const { return occluders_; }
+
+	private:
+		struct ScreenRect
+		{
+			float minX = 0.0f;
+			float maxX = 0.0f;
+			float minY = 0.0f;
+			float maxY = 0.0f;
+			float minDepth = 1.0f;
+		};
+
+		bool IsOccluded(const BoundingAABB& bounds, const Matrix4x4& viewProjection) const;
+		bool ProjectAABB(const BoundingAABB& bounds, const Matrix4x4& viewProjection, ScreenRect& outRect) const;
+		static float CalculateCoverage(const ScreenRect& occluderRect, const ScreenRect& targetRect);
+
+		std::vector<Occluder> occluders_{};
+		Statistics statistics_{};
+		bool enabled_ = false;
+		bool showOccluderBounds_ = false;
+		bool showOccludedBounds_ = false;
+		float coverageThreshold_ = 0.98f;
+		float depthBias_ = 0.02f;
+		float occlusionMargin_ = 0.02f;
+	};
+}

--- a/Project/Engine/Scene/Level/Stage.cpp
+++ b/Project/Engine/Scene/Level/Stage.cpp
@@ -4,6 +4,7 @@
 #include "LevelLoader.h"
 #include "StageAssetLoader.h"
 #include "StageCollisionBuilder.h"
+#include "Object3DCommon.h"
 
 namespace Ken4lowEngine
 {
@@ -26,6 +27,7 @@ namespace Ken4lowEngine
 
 		worldAABBs_ = std::move(collisionResult.worldAABBs);
 		worldColliders_ = std::move(collisionResult.worldColliders);
+		occlusionCullingSystem_.BuildAutoOccludersFromWorldAABBs(worldAABBs_);
 	}
 
 	void Stage::Clear()
@@ -33,6 +35,7 @@ namespace Ken4lowEngine
 		levelData_.reset();
 		stageModel_.reset();
 		stageChunkManager_.Clear();
+		occlusionCullingSystem_.ClearOccluders();
 		worldAABBs_.clear();
 		worldColliders_.clear();
 	}
@@ -60,6 +63,9 @@ namespace Ken4lowEngine
 		if (stageChunkManager_.IsEnabled() && !stageChunkManager_.GetChunks().empty())
 		{
 			stageChunkManager_.UpdateVisibility(true);
+			stageChunkManager_.ApplyOcclusionCulling(
+				occlusionCullingSystem_,
+				Object3DCommon::GetInstance()->GetFrustumCullingSystem().GetViewProjectionMatrix());
 			stageChunkManager_.DrawVisibleChunks();
 			return;
 		}
@@ -70,7 +76,9 @@ namespace Ken4lowEngine
 
 	void Stage::DrawChunkDebug()
 	{
+		stageChunkManager_.SetShowOccludedBounds(occlusionCullingSystem_.IsShowOccludedBounds());
 		stageChunkManager_.DrawDebugBounds();
+		occlusionCullingSystem_.DrawDebugBounds();
 	}
 
 	void Stage::DrawShadow()

--- a/Project/Engine/Scene/Level/Stage.h
+++ b/Project/Engine/Scene/Level/Stage.h
@@ -3,6 +3,7 @@
 #include "Collider.h"
 #include "Object3D.h"
 #include "LevelData.h"
+#include "OcclusionCullingSystem.h"
 #include "StageChunkManager.h"
 
 #include <memory>
@@ -80,6 +81,8 @@ namespace Ken4lowEngine
 		void RebuildStageChunks();
 		StageChunkManager& GetStageChunkManager() { return stageChunkManager_; }
 		const StageChunkManager& GetStageChunkManager() const { return stageChunkManager_; }
+		OcclusionCullingSystem& GetOcclusionCullingSystem() { return occlusionCullingSystem_; }
+		const OcclusionCullingSystem& GetOcclusionCullingSystem() const { return occlusionCullingSystem_; }
 
 	public: /// ---------- アクセサ ---------- ///
 
@@ -98,6 +101,7 @@ namespace Ken4lowEngine
 		std::unique_ptr<LevelData> levelData_;
 		std::unique_ptr<Object3D> stageModel_;                 // ステージ描画モデル
 		StageChunkManager stageChunkManager_;                 // 静的ステージを Chunk 単位で Draw スキップする管理クラス
+		OcclusionCullingSystem occlusionCullingSystem_;          // Lv4: 遮蔽物裏の StageChunk Draw を安全側で止める管理クラス
 		std::vector<AABB> worldAABBs_;                         // ワールド衝突AABB
 		std::vector<std::unique_ptr<Collider>> worldColliders_; // ワールド衝突Collider
 		Vector3 offset_ = { 0.0f, 0.0f, 0.0f };               // ステージ全体オフセット

--- a/Project/Engine/Scene/Level/StageChunk.cpp
+++ b/Project/Engine/Scene/Level/StageChunk.cpp
@@ -62,11 +62,15 @@ namespace Ken4lowEngine
 		flush();
 	}
 
-	void StageChunk::DrawBoundsDebug(bool showBounds) const
+	void StageChunk::DrawBoundsDebug(bool showBounds, bool showOccludedBounds) const
 	{
-		if (!showBounds) { return; }
+		if (!showBounds && !(showOccludedBounds && occludedByOcclusion_)) { return; }
 
-		const Vector4 color = visible_ ? Vector4{ 0.1f, 0.9f, 0.2f, 1.0f } : Vector4{ 1.0f, 0.2f, 0.1f, 1.0f };
+		Vector4 color = visible_ ? Vector4{ 0.1f, 0.9f, 0.2f, 1.0f } : Vector4{ 1.0f, 0.2f, 0.1f, 1.0f };
+		if (occludedByOcclusion_)
+		{
+			color = Vector4{ 0.75f, 0.15f, 1.0f, 1.0f };
+		}
 		Wireframe::GetInstance()->DrawAABB(GetDebugAABB(), color);
 	}
 

--- a/Project/Engine/Scene/Level/StageChunk.h
+++ b/Project/Engine/Scene/Level/StageChunk.h
@@ -27,7 +27,7 @@ namespace Ken4lowEngine
 		void AddMesh(Object3D* object, size_t meshIndex);
 		void ClearMeshes();
 		void Draw() const;
-		void DrawBoundsDebug(bool showBounds) const;
+		void DrawBoundsDebug(bool showBounds, bool showOccludedBounds) const;
 
 		int GetChunkId() const { return chunkId_; }
 		const Vector3& GetCenter() const { return center_; }
@@ -38,6 +38,8 @@ namespace Ken4lowEngine
 		int GetObjectCount() const { return objectCount_; }
 		bool IsVisible() const { return visible_; }
 		void SetVisible(bool visible) { visible_ = visible; }
+		bool IsOccludedByOcclusion() const { return occludedByOcclusion_; }
+		void SetOccludedByOcclusion(bool occluded) { occludedByOcclusion_ = occluded; }
 
 	private:
 		int chunkId_ = 0;
@@ -47,5 +49,6 @@ namespace Ken4lowEngine
 		std::vector<StageChunkMeshRef> meshes_{};
 		int objectCount_ = 0;
 		bool visible_ = true;
+		bool occludedByOcclusion_ = false;
 	};
 }

--- a/Project/Engine/Scene/Level/StageChunkManager.cpp
+++ b/Project/Engine/Scene/Level/StageChunkManager.cpp
@@ -2,6 +2,7 @@
 #include "StageChunkManager.h"
 
 #include "Object3DCommon.h"
+#include "OcclusionCullingSystem.h"
 #include "Wireframe.h"
 
 #include <algorithm>
@@ -177,6 +178,7 @@ namespace Ken4lowEngine
 		auto& cullingSystem = Object3DCommon::GetInstance()->GetFrustumCullingSystem();
 		for (StageChunk& chunk : chunks_)
 		{
+			chunk.SetOccludedByOcclusion(false);
 			const bool visible = cullingSystem.IsVisible(
 				chunk.GetBounds(),
 				!enabled,
@@ -192,6 +194,15 @@ namespace Ken4lowEngine
 				++statistics_.culledChunkCount;
 			}
 		}
+	}
+
+	void StageChunkManager::ApplyOcclusionCulling(OcclusionCullingSystem& occlusionCullingSystem, const Matrix4x4& viewProjection)
+	{
+		const int beforeDrawnCount = statistics_.drawnChunkCount;
+		occlusionCullingSystem.ApplyToStageChunks(chunks_, viewProjection);
+		const int occludedChunkCount = occlusionCullingSystem.GetStatistics().occludedChunkCount;
+		statistics_.drawnChunkCount = std::max(0, beforeDrawnCount - occludedChunkCount);
+		statistics_.culledChunkCount += occludedChunkCount;
 	}
 
 	void StageChunkManager::DrawVisibleChunks() const
@@ -235,7 +246,7 @@ namespace Ken4lowEngine
 	{
 		for (const StageChunk& chunk : chunks_)
 		{
-			chunk.DrawBoundsDebug(showBounds_);
+			chunk.DrawBoundsDebug(showBounds_, showOccludedBounds_);
 		}
 
 		if (!showObjectBounds_) { return; }

--- a/Project/Engine/Scene/Level/StageChunkManager.h
+++ b/Project/Engine/Scene/Level/StageChunkManager.h
@@ -1,11 +1,13 @@
 #pragma once
 #include "StageChunk.h"
+#include "Matrix4x4.h"
 
 #include <cstddef>
 #include <vector>
 
 namespace Ken4lowEngine
 {
+	class OcclusionCullingSystem;
 	class StageChunkManager
 	{
 	public:
@@ -26,6 +28,7 @@ namespace Ken4lowEngine
 		void Clear();
 		void Rebuild(Object3D* stageObject, float chunkSize);
 		void UpdateVisibility(bool enabled);
+		void ApplyOcclusionCulling(OcclusionCullingSystem& occlusionCullingSystem, const Matrix4x4& viewProjection);
 		void DrawVisibleChunks() const;
 		void DrawDebugBounds() const;
 
@@ -35,6 +38,8 @@ namespace Ken4lowEngine
 		bool IsShowBounds() const { return showBounds_; }
 		void SetShowObjectBounds(bool showObjectBounds) { showObjectBounds_ = showObjectBounds; }
 		bool IsShowObjectBounds() const { return showObjectBounds_; }
+		void SetShowOccludedBounds(bool showOccludedBounds) { showOccludedBounds_ = showOccludedBounds; }
+		bool IsShowOccludedBounds() const { return showOccludedBounds_; }
 		void SetAutoExcludeLargeObjects(bool enabled) { autoExcludeLargeObjects_ = enabled; MarkRebuildRequested(); }
 		bool IsAutoExcludeLargeObjects() const { return autoExcludeLargeObjects_; }
 		void SetChunkSize(float chunkSize) { chunkSize_ = chunkSize; }
@@ -65,6 +70,7 @@ namespace Ken4lowEngine
 		bool enabled_ = true;
 		bool showBounds_ = false;
 		bool showObjectBounds_ = false;
+		bool showOccludedBounds_ = false;
 		bool autoExcludeLargeObjects_ = true;
 		bool needsRebuild_ = false;
 		size_t debugSelectedMeshIndex_ = 0;

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -320,8 +320,11 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="Engine\Graphics\Culling\Frustum.cpp" />
     <ClCompile Include="ApplicationLayer\DebugTools\FrustumCulling\FrustumCullingDebugController.cpp" />
     <ClCompile Include="ApplicationLayer\DebugTools\StageChunk\StageChunkDebugController.cpp" />
+    <ClCompile Include="ApplicationLayer\DebugTools\Occlusion\OcclusionDebugController.cpp" />
     <ClCompile Include="Engine\Graphics\Culling\FrustumDebugRenderer.cpp" />
     <ClCompile Include="Engine\Graphics\Culling\FrustumCullingSystem.cpp" />
+    <ClCompile Include="Engine\Graphics\Culling\OcclusionCullingSystem.cpp" />
+    <ClCompile Include="Engine\Graphics\Culling\Occluder.cpp" />
     <ClCompile Include="Engine\Graphics\Descriptor\DSV\DSVManager.cpp" />
     <ClCompile Include="Engine\Graphics\Descriptor\RTV\RTVManager.cpp" />
     <ClCompile Include="Engine\Graphics\Descriptor\SRV\SRVManager.cpp" />
@@ -928,8 +931,11 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="Engine\Graphics\Culling\Frustum.h" />
     <ClInclude Include="ApplicationLayer\DebugTools\FrustumCulling\FrustumCullingDebugController.h" />
     <ClInclude Include="ApplicationLayer\DebugTools\StageChunk\StageChunkDebugController.h" />
+    <ClInclude Include="ApplicationLayer\DebugTools\Occlusion\OcclusionDebugController.h" />
     <ClInclude Include="Engine\Graphics\Culling\FrustumDebugRenderer.h" />
     <ClInclude Include="Engine\Graphics\Culling\FrustumCullingSystem.h" />
+    <ClInclude Include="Engine\Graphics\Culling\OcclusionCullingSystem.h" />
+    <ClInclude Include="Engine\Graphics\Culling\Occluder.h" />
     <ClInclude Include="Engine\Graphics\Culling\BoundingVolume.h" />
     <ClInclude Include="Engine\Graphics\Common\BlendModeType.h" />
     <ClInclude Include="Engine\Graphics\Common\DX12Include.h" />

--- a/Project/Ken4lowEngine.vcxproj.filters
+++ b/Project/Ken4lowEngine.vcxproj.filters
@@ -121,6 +121,9 @@
     <Filter Include="ApplicationLayer\DebugTools\StageChunk">
       <UniqueIdentifier>{ea618bf4-bd85-414f-85f7-7c6d7022f237}</UniqueIdentifier>
     </Filter>
+    <Filter Include="ApplicationLayer\DebugTools\Occlusion">
+      <UniqueIdentifier>{b7b62a46-4e32-4c54-81af-9a4f54ee1c44}</UniqueIdentifier>
+    </Filter>
 </ItemGroup>
   <ItemGroup>
     <ClCompile Include="WinMain.cpp" />
@@ -550,10 +553,19 @@
     <ClCompile Include="ApplicationLayer\DebugTools\StageChunk\StageChunkDebugController.cpp">
       <Filter>ApplicationLayer\DebugTools\StageChunk</Filter>
     </ClCompile>
+    <ClCompile Include="ApplicationLayer\DebugTools\Occlusion\OcclusionDebugController.cpp">
+      <Filter>ApplicationLayer\DebugTools\Occlusion</Filter>
+    </ClCompile>
     <ClCompile Include="Engine\Graphics\Culling\FrustumDebugRenderer.cpp">
       <Filter>Engine\Graphics\Culling</Filter>
     </ClCompile>
     <ClCompile Include="Engine\Graphics\Culling\FrustumCullingSystem.cpp">
+      <Filter>Engine\Graphics\Culling</Filter>
+    </ClCompile>
+    <ClCompile Include="Engine\Graphics\Culling\OcclusionCullingSystem.cpp">
+      <Filter>Engine\Graphics\Culling</Filter>
+    </ClCompile>
+    <ClCompile Include="Engine\Graphics\Culling\Occluder.cpp">
       <Filter>Engine\Graphics\Culling</Filter>
     </ClCompile>
     <ClCompile Include="Engine\Graphics\Descriptor\DSV\DSVManager.cpp">
@@ -1386,10 +1398,19 @@
     <ClInclude Include="ApplicationLayer\DebugTools\StageChunk\StageChunkDebugController.h">
       <Filter>ApplicationLayer\DebugTools\StageChunk</Filter>
     </ClInclude>
+    <ClInclude Include="ApplicationLayer\DebugTools\Occlusion\OcclusionDebugController.h">
+      <Filter>ApplicationLayer\DebugTools\Occlusion</Filter>
+    </ClInclude>
     <ClInclude Include="Engine\Graphics\Culling\FrustumDebugRenderer.h">
       <Filter>Engine\Graphics\Culling</Filter>
     </ClInclude>
     <ClInclude Include="Engine\Graphics\Culling\FrustumCullingSystem.h">
+      <Filter>Engine\Graphics\Culling</Filter>
+    </ClInclude>
+    <ClInclude Include="Engine\Graphics\Culling\OcclusionCullingSystem.h">
+      <Filter>Engine\Graphics\Culling</Filter>
+    </ClInclude>
+    <ClInclude Include="Engine\Graphics\Culling\Occluder.h">
       <Filter>Engine\Graphics\Culling</Filter>
     </ClInclude>
     <ClInclude Include="Engine\Graphics\Culling\BoundingVolume.h">


### PR DESCRIPTION
### Motivation
- カメラのフラスタム内だが壁などの遮蔽物の裏に隠れている `StageChunk` の描画をスキップし、不要描画を削減するための簡易 CPU 側 Occlusion Culling を実装する。誤カリングが許容できないため、安全側で「描画する」に倒す設計とする。

### Description
- 新規クラス `Occluder` を追加し、遮蔽物として扱う世界空間の AABB を保持するようにした (`Project/Engine/Graphics/Culling/Occluder.*`)。
- 新規クラス `OcclusionCullingSystem` を追加し、`Occluder` と `StageChunk` の `BoundingAABB` を `ViewProjection` でスクリーン空間へ投影して矩形被覆率（`coverageThreshold`）、深度比較（`depthBias`）およびマージン（`occlusionMargin`）で隠蔽判定する方式を実装した (`Project/Engine/Graphics/Culling/OcclusionCullingSystem.*`)。投影・深度に不確実性がある場合は安全に `false` を返すようにしている（誤カリング防止のための安全側設計で、一行コメントを処置意図説明として追加）。
- `Stage` / `StageChunkManager` に統合し、処理順は `Frustum Culling` → `StageChunk Culling` → `Occlusion Culling` として描画スキップを行うようにした (`Project/Engine/Scene/Level/Stage*.cpp`, `StageChunkManager.*`)。`StageChunk` に Occlusion 由来の状態フラグを追加してデバッグ表示を区別可能にした。
- 自動候補登録としてワールドコライダー `worldAABBs` から壁や大きな箱を自動で `Occluder` に追加する機能を追加し、手動登録も可能にした。ImGui用の `OcclusionDebugController` を追加し、日本語ラベルで `Occlusion Culling 有効`, `Occluder Bounds表示`, `Occluded Bounds表示`, `coverageThreshold`, `depthBias`, `occlusionMargin` と統計（`Occluder数` / `判定対象Chunk数` / `OcclusionでカリングされたChunk数`）を表示・編集できるようにした (`Project/ApplicationLayer/DebugTools/Occlusion/*`)。Wireframe の色分けで Occluder（黄）、FrustumでカリングされたChunk（赤）、OcclusionでカリングされたChunk（紫）を区別して表示する。
- Visual Studio プロジェクトファイルに新規ソース／ヘッダを追加登録した (`Project/Ken4lowEngine.vcxproj` / `.filters`)。

### Testing
- Visual Studio のプロジェクト XML が破損していないことを `Python xml.etree.ElementTree` でパースして確認済み（成功）。
- 新規 `Occluder.cpp` に対して `clang++ -std=c++20 -fsyntax-only` を投げて構文チェックを通過させた（成功）。
- `OcclusionCullingSystem.cpp` の包括的な構文チェックは試行したが、Linux 環境で Windows 固有ヘッダ（`d3d12.h` 等）が見つからないためビルド/構文チェックが途中停止した（環境依存で未成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff3c081d44832daf2b13e582600391)