### PR TITLE
Improve occlusion culling debug diagnostics

### DIFF
--- a/Project/ApplicationLayer/DebugTools/Occlusion/OcclusionDebugController.cpp
+++ b/Project/ApplicationLayer/DebugTools/Occlusion/OcclusionDebugController.cpp
@@ -1,10 +1,81 @@
 #include "OcclusionDebugController.h"
 
+#include "OcclusionCullingSystem.h"
 #include "Stage.h"
 
 #ifdef USE_IMGUI
 #include <imgui.h>
 #endif
+
+namespace
+{
+#ifdef USE_IMGUI
+	const char* ToReasonText(K4E::OcclusionCullingSystem::DebugFailReason reason)
+	{
+		switch (reason)
+		{
+		case K4E::OcclusionCullingSystem::DebugFailReason::None:
+			return "判定成功 / Occluded";
+		case K4E::OcclusionCullingSystem::DebugFailReason::CoverageInsufficient:
+			return "coverage不足";
+		case K4E::OcclusionCullingSystem::DebugFailReason::DepthInsufficient:
+			return "depth条件不足";
+		case K4E::OcclusionCullingSystem::DebugFailReason::FrustumOutside:
+			return "Frustum外";
+		case K4E::OcclusionCullingSystem::DebugFailReason::InFrontOfOccluder:
+			return "Occluderより手前";
+		case K4E::OcclusionCullingSystem::DebugFailReason::NoOccluder:
+			return "有効なOccluderなし";
+		default:
+			return "不明";
+		}
+	}
+
+	ImVec2 ToScreenPoint(const K4E::OcclusionCullingSystem::ScreenRect& rect, float x, float y)
+	{
+		const ImGuiViewport* viewport = ImGui::GetMainViewport();
+		return ImVec2(
+			viewport->WorkPos.x + x * viewport->WorkSize.x,
+			viewport->WorkPos.y + y * viewport->WorkSize.y);
+	}
+
+	void DrawScreenRect(const K4E::OcclusionCullingSystem::ScreenRect& rect, ImU32 color, float thickness)
+	{
+		ImDrawList* drawList = ImGui::GetForegroundDrawList();
+		drawList->AddRect(
+			ToScreenPoint(rect, rect.minX, rect.minY),
+			ToScreenPoint(rect, rect.maxX, rect.maxY),
+			color,
+			0.0f,
+			0,
+			thickness);
+	}
+
+	void DrawDebugScreenRects(const K4E::OcclusionCullingSystem& occlusionSystem)
+	{
+		if (occlusionSystem.IsShowOccluderScreenRects())
+		{
+			for (const auto& occluderDebug : occlusionSystem.GetOccluderDebugInfos())
+			{
+				if (!occluderDebug.hasRect) { continue; }
+				DrawScreenRect(occluderDebug.rect, IM_COL32(255, 180, 16, 230), 2.0f);
+			}
+		}
+
+		if (occlusionSystem.IsShowChunkScreenRects())
+		{
+			for (const auto& chunkDebug : occlusionSystem.GetChunkDebugInfos())
+			{
+				if (!chunkDebug.hasRect) { continue; }
+				const ImU32 color = chunkDebug.occluded
+					? IM_COL32(190, 32, 255, 230)
+					: IM_COL32(64, 220, 96, 180);
+				DrawScreenRect(chunkDebug.rect, color, chunkDebug.occluded ? 2.5f : 1.0f);
+			}
+		}
+	}
+#endif
+}
 
 void OcclusionDebugController::DrawImGui(K4E::Stage* stage)
 {
@@ -15,9 +86,14 @@ void OcclusionDebugController::DrawImGui(K4E::Stage* stage)
 	bool enabled = occlusionSystem.IsEnabled();
 	bool showOccluderBounds = occlusionSystem.IsShowOccluderBounds();
 	bool showOccludedBounds = occlusionSystem.IsShowOccludedBounds();
+	bool showOccluderScreenRects = occlusionSystem.IsShowOccluderScreenRects();
+	bool showChunkScreenRects = occlusionSystem.IsShowChunkScreenRects();
 	float coverageThreshold = occlusionSystem.GetCoverageThreshold();
 	float depthBias = occlusionSystem.GetDepthBias();
 	float occlusionMargin = occlusionSystem.GetOcclusionMargin();
+	int selectedChunkId = occlusionSystem.GetDebugSelectedChunkId();
+
+	DrawDebugScreenRects(occlusionSystem);
 
 	ImGui::Begin("Occlusion Culling Debug");
 	if (ImGui::Checkbox("Occlusion Culling 有効", &enabled))
@@ -32,27 +108,87 @@ void OcclusionDebugController::DrawImGui(K4E::Stage* stage)
 	{
 		occlusionSystem.SetShowOccludedBounds(showOccludedBounds);
 	}
+	if (ImGui::Checkbox("Occluderスクリーン矩形表示", &showOccluderScreenRects))
+	{
+		occlusionSystem.SetShowOccluderScreenRects(showOccluderScreenRects);
+	}
+	if (ImGui::Checkbox("Chunkスクリーン矩形表示", &showChunkScreenRects))
+	{
+		occlusionSystem.SetShowChunkScreenRects(showChunkScreenRects);
+	}
 
-	if (ImGui::SliderFloat("coverageThreshold", &coverageThreshold, 0.0f, 1.0f))
+	ImGui::SeparatorText("判定パラメータ（推奨値調整）");
+	if (ImGui::SliderFloat("coverageThreshold", &coverageThreshold, 0.50f, 1.0f, "%.3f"))
 	{
 		occlusionSystem.SetCoverageThreshold(coverageThreshold);
 	}
-	if (ImGui::DragFloat("depthBias", &depthBias, 0.001f, 0.0f, 1.0f))
+	ImGui::SameLine();
+	if (ImGui::Button("coverage 推奨 0.98"))
+	{
+		occlusionSystem.SetCoverageThreshold(0.98f);
+	}
+	if (ImGui::DragFloat("depthBias", &depthBias, 0.001f, 0.0f, 0.20f, "%.3f"))
 	{
 		occlusionSystem.SetDepthBias(depthBias);
 	}
-	if (ImGui::DragFloat("occlusionMargin", &occlusionMargin, 0.001f, 0.0f, 0.25f))
+	ImGui::SameLine();
+	if (ImGui::Button("depth 推奨 0.020"))
+	{
+		occlusionSystem.SetDepthBias(0.020f);
+	}
+	if (ImGui::DragFloat("occlusionMargin", &occlusionMargin, 0.001f, 0.0f, 0.10f, "%.3f"))
 	{
 		occlusionSystem.SetOcclusionMargin(occlusionMargin);
 	}
+	ImGui::SameLine();
+	if (ImGui::Button("margin 推奨 0.020"))
+	{
+		occlusionSystem.SetOcclusionMargin(0.020f);
+	}
+	ImGui::TextWrapped("推奨値は安全確認用の出発点です。見えている物を消す場合は coverageThreshold / depthBias / occlusionMargin を大きくしてください。");
 
 	const auto& stats = occlusionSystem.GetStatistics();
-	ImGui::Separator();
+	ImGui::SeparatorText("統計 / 失敗理由");
 	ImGui::Text("Occluder数: %d", stats.occluderCount);
 	ImGui::Text("Occlusion判定対象Chunk数: %d", stats.testedChunkCount);
 	ImGui::Text("OcclusionでカリングされたChunk数: %d", stats.occludedChunkCount);
+	ImGui::Text("coverage不足: %d", stats.coverageFailedCount);
+	ImGui::Text("depth条件不足: %d", stats.depthFailedCount);
+	ImGui::Text("Frustum外: %d", stats.frustumOutsideCount);
+	ImGui::Text("Occluderより手前: %d", stats.inFrontOfOccluderCount);
+
+	ImGui::SeparatorText("選択中Chunk");
+	if (ImGui::DragInt("Chunk ID", &selectedChunkId, 1.0f, 0, 100000))
+	{
+		occlusionSystem.SetDebugSelectedChunkId(selectedChunkId);
+	}
+	if (const auto* selectedDebug = occlusionSystem.GetSelectedChunkDebugInfo())
+	{
+		ImGui::Text("coverage: %.3f / threshold %.3f", selectedDebug->bestCoverage, occlusionSystem.GetCoverageThreshold());
+		ImGui::Text("depthDelta: %.3f / bias %.3f", selectedDebug->bestDepthDelta, occlusionSystem.GetDepthBias());
+		ImGui::Text("判定結果: %s", selectedDebug->occluded ? "Occluded(Draw Skip)" : "Visible(Draw) ");
+		ImGui::Text("理由: %s", ToReasonText(selectedDebug->failReason));
+		if (selectedDebug->hasRect)
+		{
+			ImGui::Text("screenRect: (%.3f, %.3f) - (%.3f, %.3f)",
+				selectedDebug->rect.minX,
+				selectedDebug->rect.minY,
+				selectedDebug->rect.maxX,
+				selectedDebug->rect.maxY);
+		}
+		else
+		{
+			ImGui::Text("screenRect: 未生成");
+		}
+	}
+	else
+	{
+		ImGui::Text("指定IDのChunk Debug情報がありません。");
+	}
+
+	ImGui::Separator();
 	ImGui::TextWrapped("StageChunk Culling 後の Chunk Bounds をスクリーン矩形に投影し、Occluder に十分覆われ、かつ奥にある場合だけ Draw をスキップします。");
-	ImGui::TextWrapped("Frustum Culling のカリング Chunk は赤、Occlusion Culling のカリング Chunk は紫、Occluder は黄で表示します。");
+	ImGui::TextWrapped("Frustum Culling のカリング Chunk は赤、Occlusion Culling のカリング Chunk は紫、Occluder は黄で表示します。Update / Collision は止めず Draw だけをスキップします。");
 	ImGui::End();
 #else
 	(void)stage;

--- a/Project/Engine/Graphics/Culling/OcclusionCullingSystem.cpp
+++ b/Project/Engine/Graphics/Culling/OcclusionCullingSystem.cpp
@@ -33,6 +33,8 @@ namespace Ken4lowEngine
 	void OcclusionCullingSystem::ClearOccluders()
 	{
 		occluders_.clear();
+		chunkDebugInfos_.clear();
+		occluderDebugInfos_.clear();
 		statistics_ = {};
 	}
 
@@ -66,20 +68,46 @@ namespace Ken4lowEngine
 	{
 		statistics_ = {};
 		statistics_.occluderCount = static_cast<int>(occluders_.size());
+		chunkDebugInfos_.clear();
+		chunkDebugInfos_.reserve(chunks.size());
+		occluderDebugInfos_.clear();
+		occluderDebugInfos_.reserve(occluders_.size());
+
+		for (const Occluder& occluder : occluders_)
+		{
+			OccluderDebugInfo occluderDebug{};
+			occluderDebug.hasRect = occluder.IsEnabled() && ProjectAABB(occluder.GetWorldBounds(), viewProjection, occluderDebug.rect);
+			occluderDebugInfos_.push_back(occluderDebug);
+		}
 
 		for (StageChunk& chunk : chunks)
 		{
+			ChunkDebugInfo debugInfo{};
+			debugInfo.chunkId = chunk.GetChunkId();
 			chunk.SetOccludedByOcclusion(false);
-			if (!chunk.IsVisible()) { continue; }
-			++statistics_.testedChunkCount;
 
-			// Frustum/StageChunk 後に、完全に遮蔽物へ隠れた Chunk の Draw だけを安全側で止める。
-			if (enabled_ && IsOccluded(chunk.GetBounds(), viewProjection))
+			if (!chunk.IsVisible())
 			{
+				debugInfo.failReason = DebugFailReason::FrustumOutside;
+				++statistics_.frustumOutsideCount;
+				chunkDebugInfos_.push_back(debugInfo);
+				continue;
+			}
+
+			++statistics_.testedChunkCount;
+			debugInfo.tested = true;
+
+			// 判定詳細を保存して、Draw を止めた理由／止めなかった理由を ImGui で追跡できるようにする。
+			const bool wouldBeOccluded = EvaluateOcclusion(chunk.GetBounds(), viewProjection, debugInfo);
+			if (enabled_ && wouldBeOccluded)
+			{
+				debugInfo.occluded = true;
 				chunk.SetOccludedByOcclusion(true);
 				chunk.SetVisible(false);
 				++statistics_.occludedChunkCount;
 			}
+
+			chunkDebugInfos_.push_back(debugInfo);
 		}
 	}
 
@@ -110,13 +138,35 @@ namespace Ken4lowEngine
 		occlusionMargin_ = std::max(0.0f, margin);
 	}
 
-	bool OcclusionCullingSystem::IsOccluded(const BoundingAABB& bounds, const Matrix4x4& viewProjection) const
+	const OcclusionCullingSystem::ChunkDebugInfo* OcclusionCullingSystem::GetSelectedChunkDebugInfo() const
+	{
+		for (const ChunkDebugInfo& debugInfo : chunkDebugInfos_)
+		{
+			if (debugInfo.chunkId == debugSelectedChunkId_)
+			{
+				return &debugInfo;
+			}
+		}
+		return nullptr;
+	}
+
+	bool OcclusionCullingSystem::EvaluateOcclusion(const BoundingAABB& bounds, const Matrix4x4& viewProjection, ChunkDebugInfo& debugInfo)
 	{
 		ScreenRect targetRect{};
 		if (!ProjectAABB(bounds, viewProjection, targetRect))
 		{
+			debugInfo.failReason = DebugFailReason::FrustumOutside;
+			++statistics_.frustumOutsideCount;
 			return false;
 		}
+
+		debugInfo.rect = targetRect;
+		debugInfo.hasRect = true;
+
+		bool sawOccluder = false;
+		bool sawCoverageFailure = false;
+		bool sawDepthFailure = false;
+		bool sawInFrontFailure = false;
 
 		for (const Occluder& occluder : occluders_)
 		{
@@ -127,26 +177,62 @@ namespace Ken4lowEngine
 			{
 				continue;
 			}
+			sawOccluder = true;
 
-			if (targetRect.minDepth <= occluderRect.minDepth + depthBias_)
+			const ScreenRect safeOccluderRect = ApplyMargin(occluderRect, occlusionMargin_);
+			const bool validSafeRect = IsValidRect(safeOccluderRect);
+			const float coverage = validSafeRect ? CalculateCoverage(safeOccluderRect, targetRect) : 0.0f;
+			debugInfo.bestCoverage = std::max(debugInfo.bestCoverage, coverage);
+
+			const float depthDelta = targetRect.minDepth - occluderRect.minDepth;
+			debugInfo.bestDepthDelta = std::max(debugInfo.bestDepthDelta, depthDelta);
+			if (depthDelta <= 0.0f)
 			{
+				sawInFrontFailure = true;
+				continue;
+			}
+			if (depthDelta <= depthBias_)
+			{
+				sawDepthFailure = true;
+				continue;
+			}
+			if (!validSafeRect)
+			{
+				sawCoverageFailure = true;
 				continue;
 			}
 
-			ScreenRect safeOccluderRect = occluderRect;
-			safeOccluderRect.minX += occlusionMargin_;
-			safeOccluderRect.maxX -= occlusionMargin_;
-			safeOccluderRect.minY += occlusionMargin_;
-			safeOccluderRect.maxY -= occlusionMargin_;
-			if (safeOccluderRect.minX >= safeOccluderRect.maxX || safeOccluderRect.minY >= safeOccluderRect.maxY)
+			if (coverage >= coverageThreshold_)
 			{
-				continue;
-			}
-
-			if (CalculateCoverage(safeOccluderRect, targetRect) >= coverageThreshold_)
-			{
+				debugInfo.failReason = DebugFailReason::None;
 				return true;
 			}
+
+			sawCoverageFailure = true;
+		}
+
+		if (!sawOccluder)
+		{
+			debugInfo.failReason = DebugFailReason::NoOccluder;
+		}
+		else if (sawCoverageFailure)
+		{
+			debugInfo.failReason = DebugFailReason::CoverageInsufficient;
+			++statistics_.coverageFailedCount;
+		}
+		else if (sawDepthFailure)
+		{
+			debugInfo.failReason = DebugFailReason::DepthInsufficient;
+			++statistics_.depthFailedCount;
+		}
+		else if (sawInFrontFailure)
+		{
+			debugInfo.failReason = DebugFailReason::InFrontOfOccluder;
+			++statistics_.inFrontOfOccluderCount;
+		}
+		else
+		{
+			debugInfo.failReason = DebugFailReason::NoOccluder;
 		}
 
 		return false;
@@ -204,7 +290,22 @@ namespace Ken4lowEngine
 		outRect.maxX = std::clamp(outRect.maxX, 0.0f, 1.0f);
 		outRect.minY = std::clamp(outRect.minY, 0.0f, 1.0f);
 		outRect.maxY = std::clamp(outRect.maxY, 0.0f, 1.0f);
-		return outRect.minX < outRect.maxX && outRect.minY < outRect.maxY;
+		return IsValidRect(outRect);
+	}
+
+	OcclusionCullingSystem::ScreenRect OcclusionCullingSystem::ApplyMargin(const ScreenRect& rect, float margin)
+	{
+		ScreenRect result = rect;
+		result.minX += margin;
+		result.maxX -= margin;
+		result.minY += margin;
+		result.maxY -= margin;
+		return result;
+	}
+
+	bool OcclusionCullingSystem::IsValidRect(const ScreenRect& rect)
+	{
+		return rect.minX < rect.maxX && rect.minY < rect.maxY;
 	}
 
 	float OcclusionCullingSystem::CalculateCoverage(const ScreenRect& occluderRect, const ScreenRect& targetRect)

--- a/Project/Engine/Graphics/Culling/OcclusionCullingSystem.h
+++ b/Project/Engine/Graphics/Culling/OcclusionCullingSystem.h
@@ -20,6 +20,47 @@ namespace Ken4lowEngine
 			int occluderCount = 0;
 			int testedChunkCount = 0;
 			int occludedChunkCount = 0;
+			int coverageFailedCount = 0;
+			int depthFailedCount = 0;
+			int frustumOutsideCount = 0;
+			int inFrontOfOccluderCount = 0;
+		};
+
+		struct ScreenRect
+		{
+			float minX = 0.0f;
+			float maxX = 0.0f;
+			float minY = 0.0f;
+			float maxY = 0.0f;
+			float minDepth = 1.0f;
+		};
+
+		enum class DebugFailReason
+		{
+			None,
+			CoverageInsufficient,
+			DepthInsufficient,
+			FrustumOutside,
+			InFrontOfOccluder,
+			NoOccluder
+		};
+
+		struct ChunkDebugInfo
+		{
+			int chunkId = -1;
+			ScreenRect rect{};
+			bool hasRect = false;
+			bool tested = false;
+			bool occluded = false;
+			float bestCoverage = 0.0f;
+			float bestDepthDelta = -1.0f;
+			DebugFailReason failReason = DebugFailReason::None;
+		};
+
+		struct OccluderDebugInfo
+		{
+			ScreenRect rect{};
+			bool hasRect = false;
 		};
 
 		void ClearOccluders();
@@ -34,36 +75,43 @@ namespace Ken4lowEngine
 		bool IsShowOccluderBounds() const { return showOccluderBounds_; }
 		void SetShowOccludedBounds(bool visible) { showOccludedBounds_ = visible; }
 		bool IsShowOccludedBounds() const { return showOccludedBounds_; }
+		void SetShowOccluderScreenRects(bool visible) { showOccluderScreenRects_ = visible; }
+		bool IsShowOccluderScreenRects() const { return showOccluderScreenRects_; }
+		void SetShowChunkScreenRects(bool visible) { showChunkScreenRects_ = visible; }
+		bool IsShowChunkScreenRects() const { return showChunkScreenRects_; }
 		void SetCoverageThreshold(float threshold);
 		float GetCoverageThreshold() const { return coverageThreshold_; }
 		void SetDepthBias(float depthBias);
 		float GetDepthBias() const { return depthBias_; }
 		void SetOcclusionMargin(float margin);
 		float GetOcclusionMargin() const { return occlusionMargin_; }
+		void SetDebugSelectedChunkId(int chunkId) { debugSelectedChunkId_ = chunkId; }
+		int GetDebugSelectedChunkId() const { return debugSelectedChunkId_; }
+		const ChunkDebugInfo* GetSelectedChunkDebugInfo() const;
 		const Statistics& GetStatistics() const { return statistics_; }
 		const std::vector<Occluder>& GetOccluders() const { return occluders_; }
+		const std::vector<ChunkDebugInfo>& GetChunkDebugInfos() const { return chunkDebugInfos_; }
+		const std::vector<OccluderDebugInfo>& GetOccluderDebugInfos() const { return occluderDebugInfos_; }
 
 	private:
-		struct ScreenRect
-		{
-			float minX = 0.0f;
-			float maxX = 0.0f;
-			float minY = 0.0f;
-			float maxY = 0.0f;
-			float minDepth = 1.0f;
-		};
-
-		bool IsOccluded(const BoundingAABB& bounds, const Matrix4x4& viewProjection) const;
+		bool EvaluateOcclusion(const BoundingAABB& bounds, const Matrix4x4& viewProjection, ChunkDebugInfo& debugInfo);
 		bool ProjectAABB(const BoundingAABB& bounds, const Matrix4x4& viewProjection, ScreenRect& outRect) const;
+		static ScreenRect ApplyMargin(const ScreenRect& rect, float margin);
+		static bool IsValidRect(const ScreenRect& rect);
 		static float CalculateCoverage(const ScreenRect& occluderRect, const ScreenRect& targetRect);
 
 		std::vector<Occluder> occluders_{};
+		std::vector<ChunkDebugInfo> chunkDebugInfos_{};
+		std::vector<OccluderDebugInfo> occluderDebugInfos_{};
 		Statistics statistics_{};
 		bool enabled_ = false;
 		bool showOccluderBounds_ = false;
 		bool showOccludedBounds_ = false;
+		bool showOccluderScreenRects_ = false;
+		bool showChunkScreenRects_ = false;
 		float coverageThreshold_ = 0.98f;
 		float depthBias_ = 0.02f;
 		float occlusionMargin_ = 0.02f;
+		int debugSelectedChunkId_ = 0;
 	};
 }


### PR DESCRIPTION
### Motivation
- 現状の簡易 Occlusion Culling は `Occluder` と Chunk の Bounds は表示できるが、どの理由で除外されているか分かりづらく、`occludedChunkCount` が0のまま挙動確認が困難だった。 
- Occluder / Chunk のスクリーン矩形や除外理由（coverage不足 / depth不足 / Frustum外 / Occluderより手前）を可視化して、判定チューニングを容易にしたい。 
- Draw のみを安全側でスキップする方針は維持しつつ、ImGui で閾値を試しやすくする必要があった。 

### Description
- `OcclusionCullingSystem` に `ChunkDebugInfo` / `OccluderDebugInfo` / `DebugFailReason` を追加し、フレーム毎に検証結果とスクリーン矩形を蓄積するようにした（主な変更: `OcclusionCullingSystem.h` / `OcclusionCullingSystem.cpp`）。
- 判定ロジックを `EvaluateOcclusion` に分離して、coverage と depth のベスト値を記録し、失敗理由ごとの統計カウンタを増設して分類できるようにした（`coverageFailedCount`, `depthFailedCount`, `frustumOutsideCount`, `inFrontOfOccluderCount`）。
- ImGui 側にスクリーン矩形表示（前景描画）と選択Chunkの詳細表示、`coverageThreshold` / `depthBias` / `occlusionMargin` の推奨値ボタンを追加し、Occluder は黄、Occlusionで除外されたChunkは紫、通常Chunkは緑で矩形をオーバーレイ表示するようにした（`OcclusionDebugController.cpp`）。
- 安全性を維持するため Draw のみを止める実装を維持し、処理意図が分かる1行コメント（例: 判定詳細を保存する意図のコメント）をコード内に追加した。

### Testing
- 実行した差分チェックとして `git diff --check` を実行し問題は検出されませんでした（成功）。
- ソースの静的構文確認として `g++ -std=c++20 -fsyntax-only ... Project/Engine/Graphics/Culling/OcclusionCullingSystem.cpp` を試行しましたが、ホスト環境に Windows DirectX ヘッダ（`d3d12.h`）が無いため構文チェックは環境制約で実行できませんでした（ブロック）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff409ab634832d96f67b562ac8079c)