### PR TITLE
Improve enemy damage awareness, add AI ImGui telemetry, and refine shoot/spacing behavior

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/Core/Enemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/Enemy.cpp
@@ -8,6 +8,7 @@
 #include "EnemyDeadState.h"
 
 #include <BulletManager.h>
+#include <Bullet.h>
 #include <CollisionManager.h>
 #include <CollisionTypeIdDef.h>
 
@@ -17,6 +18,10 @@
 #include <limits>
 #include <numbers>
 #include <random>
+
+#ifdef USE_IMGUI
+#include <imgui.h>
+#endif // USE_IMGUI
 
 using namespace Ken4lowEngine;
 
@@ -30,6 +35,18 @@ namespace
 		if (value < minVal) return minVal;
 		if (value > maxVal) return maxVal;
 		return value;
+	}
+
+	float Length(const Vector3& v)
+	{
+		return std::sqrt(v.x * v.x + v.y * v.y + v.z * v.z);
+	}
+
+	Vector3 NormalizeSafe(const Vector3& v, const Vector3& fallback = { 0.0f, 0.0f, 1.0f })
+	{
+		const float len = Length(v);
+		if (len < kEpsilon) return fallback;
+		return { v.x / len, v.y / len, v.z / len };
 	}
 
 	float LengthXZ(const Vector3& v)
@@ -107,6 +124,13 @@ void Enemy::Initialize()
 
 	memory_.lastSeenPos = GetCenterPosition();
 	memory_.timeSinceSeen = 9999.0f;
+	lastDamageHitPos_ = GetCenterPosition();
+	lastDamageDirection_ = { 0.0f, 0.0f, 0.0f };
+	lastAttackOrigin_ = GetCenterPosition();
+	lastDamageTimeSec_ = -1.0f;
+	aliveTimeSec_ = 0.0f;
+	hasDamageStimulus_ = false;
+	suppressNextDamageStimulus_ = false;
 
 	facing_.yawRad = 0.0f;
 	fireCooldown_ = 0.0f;
@@ -136,6 +160,7 @@ void Enemy::Initialize()
 
 void Enemy::Update(float deltaTime)
 {
+	aliveTimeSec_ += deltaTime;
 	UpdateNavigatorSource();
 	moveCommandedThisFrame_ = false;
 
@@ -199,6 +224,36 @@ void Enemy::Update(float deltaTime)
 	EnemyBase::Update(deltaTime);
 }
 
+
+void Enemy::DrawImGui()
+{
+	EnemyBase::DrawImGui();
+
+#ifdef USE_IMGUI
+	const Vector3 targetPos = GetTargetPosition();
+	const bool hasTarget = HasTarget();
+	const bool hasLos = HasTargetLineOfSight();
+	const bool canAttack = CanAttackTarget();
+	const float lastHitElapsed = (lastDamageTimeSec_ >= 0.0f) ? (aliveTimeSec_ - lastDamageTimeSec_) : -1.0f;
+
+	if (ImGui::TreeNode("Enemy AI Debug"))
+	{
+		ImGui::Text("AI State: %s", GetCurrentAIStateName());
+		ImGui::Text("Target Aware: %s", IsTargetAware() ? "true" : "false");
+		ImGui::Text("Line Of Sight: %s", hasLos ? "true" : "false");
+		ImGui::Text("Last Hit Time: %.2f sec", lastHitElapsed);
+		ImGui::Text("Last Player Pos: %.2f, %.2f, %.2f", memory_.lastSeenPos.x, memory_.lastSeenPos.y, memory_.lastSeenPos.z);
+		ImGui::Text("Can Attack: %s", canAttack ? "true" : "false");
+		ImGui::Separator();
+		ImGui::Text("Has Target: %s", hasTarget ? "true" : "false");
+		ImGui::Text("Target Pos: %.2f, %.2f, %.2f", targetPos.x, targetPos.y, targetPos.z);
+		ImGui::Text("Last Hit Pos: %.2f, %.2f, %.2f", lastDamageHitPos_.x, lastDamageHitPos_.y, lastDamageHitPos_.z);
+		ImGui::Text("Last Attack Dir: %.2f, %.2f, %.2f", lastDamageDirection_.x, lastDamageDirection_.y, lastDamageDirection_.z);
+		ImGui::TreePop();
+	}
+#endif // USE_IMGUI
+}
+
 void Enemy::ChangeState(std::unique_ptr<IEnemyState> nextState)
 {
 	if (state_) state_->Exit(*this);
@@ -214,6 +269,34 @@ void Enemy::ChangeStateToCombatMove() { ChangeState(std::make_unique<EnemyCombat
 void Enemy::ChangeStateToShoot() { ChangeState(std::make_unique<EnemyShootState>()); }
 void Enemy::ChangeStateToSearch() { ChangeState(std::make_unique<EnemySearchState>()); }
 void Enemy::ChangeStateToDead() { ChangeState(std::make_unique<EnemyDeadState>()); }
+
+
+const char* Enemy::GetCurrentAIStateName() const
+{
+	return state_ ? state_->GetStateName() : "None";
+}
+
+bool Enemy::IsTargetAware() const
+{
+	const bool recentlyDamaged = hasDamageStimulus_ && lastDamageTimeSec_ >= 0.0f && (aliveTimeSec_ - lastDamageTimeSec_) <= combat_.searchDuration;
+	return HasTarget() && (memory_.timeSinceSeen <= perception_.loseSightGraceSec || hitReactionTimer_ > 0.0f || recentlyDamaged);
+}
+
+bool Enemy::HasTargetLineOfSight() const
+{
+	if (!HasTarget()) return false;
+
+	Vector3 eye = GetCenterPosition();
+	eye.y += perception_.eyeHeight;
+	Vector3 targetEye = GetTargetPosition();
+	targetEye.y += perception_.targetEyeHeight;
+	return HasLineOfSight(eye, targetEye);
+}
+
+bool Enemy::CanAttackTarget() const
+{
+	return HasTarget() && CanShootTarget(GetTargetPosition()) && fireCooldown_ <= 0.0f && !IsDead();
+}
 
 K4E::Vector3 Enemy::GetTargetPosition() const
 {
@@ -439,9 +522,57 @@ void Enemy::FireAt(const K4E::Vector3& targetPos)
 		static_cast<uint32_t>(CollisionTypeIdDef::kEnemyBullet));
 }
 
+void Enemy::TakeDamage(int amount)
+{
+	if (IsDead()) return;
+	if (!suppressNextDamageStimulus_)
+	{
+		RegisterDamageStimulus(GetCenterPosition(), GetCenterPosition(), { 0.0f, 0.0f, 0.0f });
+	}
+	EnemyBase::TakeDamage(amount);
+	if (IsDead()) ChangeStateToDead();
+}
+
+void Enemy::TakeDamage(int amount, const K4E::Vector3& hitDir, float hitPower)
+{
+	if (IsDead()) return;
+	if (!suppressNextDamageStimulus_)
+	{
+		const Vector3 attackOrigin = GetCenterPosition() - NormalizeXZ(hitDir) * perception_.viewRange;
+		RegisterDamageStimulus(GetCenterPosition(), attackOrigin, hitDir);
+	}
+	EnemyBase::TakeDamage(amount, hitDir, hitPower);
+	if (IsDead()) ChangeStateToDead();
+}
+
 void Enemy::OnBulletHit(K4E::Collider* bulletCollider)
 {
+	if (IsDead()) return;
+
+	Vector3 hitPos = GetCenterPosition();
+	Vector3 attackOrigin = GetCenterPosition();
+	Vector3 hitDir{ 0.0f, 0.0f, 0.0f };
+
+	if (bulletCollider)
+	{
+		hitPos = bulletCollider->GetCenterPosition();
+		attackOrigin = hitPos;
+		const Segment bulletSegment = bulletCollider->GetSegment();
+		if (Length(bulletSegment.diff) > kEpsilon)
+		{
+			hitDir = bulletSegment.diff;
+		}
+
+		if (auto* bullet = bulletCollider->GetOwner<Bullet>())
+		{
+			attackOrigin = bullet->GetShooterPosition();
+		}
+	}
+
+	RegisterDamageStimulus(hitPos, attackOrigin, hitDir);
+	suppressNextDamageStimulus_ = true;
 	EnemyBase::OnBulletHit(bulletCollider);
+	suppressNextDamageStimulus_ = false;
 
 	if (!IsDead())
 	{
@@ -452,6 +583,40 @@ void Enemy::OnBulletHit(K4E::Collider* bulletCollider)
 	}
 
 	if (IsDead()) ChangeStateToDead();
+}
+
+
+void Enemy::RegisterDamageStimulus(const K4E::Vector3& hitPos, const K4E::Vector3& attackOrigin, const K4E::Vector3& hitDir)
+{
+	lastDamageHitPos_ = hitPos;
+	lastDamageDirection_ = NormalizeSafe(hitDir, attackOrigin - GetCenterPosition());
+	lastAttackOrigin_ = attackOrigin;
+	lastDamageTimeSec_ = aliveTimeSec_;
+	hasDamageStimulus_ = true;
+
+	Vector3 investigatePos = attackOrigin;
+	if (LengthXZ(investigatePos - GetCenterPosition()) <= kEpsilon && LengthXZ(lastDamageDirection_) > kEpsilon)
+	{
+		investigatePos = GetCenterPosition() - lastDamageDirection_ * perception_.viewRange;
+	}
+
+	// 被弾したら視認前でも最後に攻撃された方向を索敵地点として記憶する。
+	RememberLastSeenTarget(investigatePos);
+
+	if (!IsDead() && HasTarget())
+	{
+		const Vector3 targetPos = GetTargetPosition();
+		const float distToTarget = GetDistanceToTarget();
+		if (CanSeeTarget(targetPos, distToTarget))
+		{
+			RememberLastSeenTarget(targetPos);
+			ChangeStateToCombatMove();
+		}
+		else
+		{
+			ChangeStateToSearch();
+		}
+	}
 }
 
 void Enemy::UpdateNavigatorSource()

--- a/Project/ApplicationLayer/Character/Enemy/Core/Enemy.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/Enemy.h
@@ -159,6 +159,9 @@ public: /// ---------- メンバ関数 ---------- ///
 	void Initialize() override;
 
 	void Update(float deltaTime) override;
+	void DrawImGui() override;
+	void TakeDamage(int amount) override;
+	void TakeDamage(int amount, const K4E::Vector3& hitDir, float hitPower) override;
 
 public: /// ---------- 外部からのアクセス ---------- ///
 
@@ -179,6 +182,10 @@ public: /// ---------- 状態管理 ---------- ///
 public: /// ---------- アクセサ ---------- ///
 
 	bool HasTarget() const { return target_ != nullptr; }
+	const char* GetCurrentAIStateName() const;
+	bool IsTargetAware() const;
+	bool HasTargetLineOfSight() const;
+	bool CanAttackTarget() const;
 	K4E::Vector3 GetTargetPosition() const;
 	float GetDistanceToTarget() const;
 
@@ -288,6 +295,7 @@ private: /// ---------- 内部処理 ---------- ///
 	void PickNextWanderTarget();
 	void TryStepJump(const K4E::Vector3& moveDirection);
 	void UpdateTraitProfile();
+	void RegisterDamageStimulus(const K4E::Vector3& hitPos, const K4E::Vector3& attackOrigin, const K4E::Vector3& hitDir);
 
 private: /// ---------- メンバ変数 ---------- ///
 
@@ -313,6 +321,14 @@ private: /// ---------- メンバ変数 ---------- ///
 	EnemyMemory memory_{};
 
 	EnemyFacing facing_{};
+
+	K4E::Vector3 lastDamageHitPos_{ 0.0f, 0.0f, 0.0f };
+	K4E::Vector3 lastDamageDirection_{ 0.0f, 0.0f, 0.0f };
+	K4E::Vector3 lastAttackOrigin_{ 0.0f, 0.0f, 0.0f };
+	float lastDamageTimeSec_ = -1.0f;
+	float aliveTimeSec_ = 0.0f;
+	bool hasDamageStimulus_ = false;
+	bool suppressNextDamageStimulus_ = false;
 
 	EnemyAStarNavigator navigator_{};
 

--- a/Project/ApplicationLayer/Character/Enemy/State/EnemyCombatMoveState.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/State/EnemyCombatMoveState.cpp
@@ -128,7 +128,7 @@ void EnemyCombatMoveState::Update(Enemy& enemy, float deltaTime)
 	enemy.PlayMoveAnimation(speed);
 
 	const float shootRange = dangerMode ? enemy.GetLowHpShootRange() : enemy.GetFireRange();
-	if (!inHitReaction && distToTarget <= shootRange && canShoot)
+	if (!inHitReaction && distToTarget >= enemy.GetIdealRangeMin() && distToTarget <= shootRange && canShoot)
 	{
 		enemy.ChangeStateToShoot();
 		return;

--- a/Project/ApplicationLayer/Character/Enemy/State/EnemyShootState.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/State/EnemyShootState.cpp
@@ -54,7 +54,8 @@ void EnemyShootState::Update(Enemy& enemy, float deltaTime)
 		const float stayLimit = lowHp ? enemy.GetLowHpShootStaySec() : enemy.GetShootMaxStaySec();
 
 		const bool canShootNow = enemy.CanShootTargetPublic(targetPos);
-		if (inHitReaction || distToTarget > allowedShootRange || !canShootNow)
+		// 適正射撃距離から外れたら、撃ち続けず位置取り状態へ戻す。
+		if (inHitReaction || distToTarget < enemy.GetIdealRangeMin() || distToTarget > allowedShootRange || !canShootNow)
 		{
 			enemy.ChangeStateToCombatMove();
 			return;

--- a/docs/enemy_ai_review.md
+++ b/docs/enemy_ai_review.md
@@ -1,0 +1,132 @@
+# Wave Enemy AI Review and Incremental Improvement Plan
+
+## 1. Current code review
+
+### Enemy / EnemyBase responsibilities
+- `EnemyBase` owns the reusable physical/visual enemy foundation: collider behavior, humanoid model pieces, HP, damage, hit flash, death break-apart, and bullet collision dispatch.
+- `Enemy` owns tactical behavior on top of `EnemyBase`: finite-state machine, perception, firing, movement, A* assisted waypointing, cover selection, evade/retreat/stuck controllers, and animation state.
+- The current split is mostly healthy: death, HP bar compatibility, and collider lifetime remain in `EnemyBase`, while FPS combat decisions stay in `Enemy` and state classes.
+
+### Current state management
+- The active states are `Idle`, `CombatMove`, `Shoot`, `Search`, and `Dead`.
+- `Idle` wanders and transitions to `CombatMove` when the player is seen.
+- `CombatMove` updates last-seen memory, evaluates retreat/evade/cover plans, repositions when LOS is blocked, and enters `Shoot` when distance and LOS allow.
+- `Shoot` fires only while the target remains visible/shootable and periodically returns to `CombatMove` for repositioning.
+- `Search` moves toward the last seen/investigation point and sweeps locally until the search timer expires.
+
+### Wave / scene integration
+- `WaveManager` currently only spawns positions; it has no enemy role, trait, weapon, or squad metadata.
+- `CharacterWorld` injects target, bullet manager, collision manager, and effect system into each spawned enemy.
+- `GamePlayScene` can stay lean if wave role data is converted into an `EnemySpawnRequest` and interpreted inside `CharacterWorld` / enemy setup code.
+
+## 2. Problem list
+
+1. **Damage awareness was incomplete**: base bullet damage reduced HP and played effects, but AI memory/debug data did not consistently preserve attack origin or force a search/combat response when the player was behind cover.
+2. **Shoot state could keep fighting at bad spacing**: LOS/fire range existed, but too-close spacing was not a hard reason to leave `Shoot`.
+3. **Debug visibility was insufficient**: there was no consolidated per-enemy ImGui panel for current AI state, LOS, last hit time, last known player position, and attack availability.
+4. **Weapon-counterplay is not yet represented**: player weapon state exists elsewhere, but enemy tactical inputs do not yet consume weapon category, reload state, or ammo pressure.
+5. **Wave roles are not data-driven**: all wave enemies are spawned as the same `Enemy` behavior profile.
+6. **Navigation is pragmatic but not authored**: AABB-based A* and stuck recovery exist, but there are no designer-authored lanes, cover nodes, or stage tactical annotations.
+
+## 3. Priority improvements
+
+### P0: Minimal FPS readability
+- On damage, record hit position, attack origin/direction, and enter combat/search immediately.
+- Require LOS for shooting and leave `Shoot` if the target is too close or too far.
+- Add ImGui AI telemetry per enemy.
+
+### P1: Tunable combat feel
+- Introduce a small `EnemyCombatTuning` data asset/profile for fire interval, burst count, accuracy cone, ideal range, retreat threshold, and reaction time.
+- Add burst fire and reload windows to prevent perfectly regular single shots.
+- Add suppression-style movement: if recently hit, strafe/retreat or move to cover for a short duration.
+
+### P2: Cover and navigation authoring
+- Add lightweight `StageTacticalNode` / `CoverPoint` authoring: position, normal, exposure direction, radius, tags.
+- Let `EnemyCoverSelector` prefer authored cover points before sampling around the enemy.
+- Add waypoint lanes or grid cells per stage before considering full NavMesh.
+
+### P3: Weapon-aware AI
+- Expose a read-only `PlayerWeaponSnapshot`: weapon category, effective range, reload state, ammo in magazine, recently fired, and muzzle direction.
+- Add enemy reactions:
+  - melee/shotgun: backpedal, split laterally, avoid clustering.
+  - rifle/sniper: prefer hard cover and short peeks.
+  - player reload/empty: rush or wide-flank.
+
+### P4: Wave roles and squads
+- Extend wave data with enemy role (`Rush`, `Shooter`, `Cover`, `Tank`, `Support`) and optional squad id.
+- Map roles to trait profiles and combat tunings during `CharacterWorld::SpawnEnemy`.
+- Add simple squad spacing to avoid all enemies taking the same cover or path.
+
+## 4. Classes to add/change
+
+### Change existing
+- `Enemy`: owns current tactical state and should keep receiving only compact inputs/snapshots.
+- `EnemyBase`: keep damage/death/visual ownership; avoid adding combat decisions here.
+- `EnemyCombatMoveState` / `EnemyShootState` / `EnemySearchState`: continue to host state-specific transitions.
+- `WaveManager`: extend spawn entries with enemy role and profile id later.
+- `CharacterWorld`: translate wave spawn requests into initialized enemy profiles.
+
+### Add later
+- `EnemyPerception`: LOS/FOV/last-known-position and damage stimulus memory.
+- `EnemyCombatController`: burst/reload/accuracy/fire permission decisions.
+- `EnemyNavigation`: waypoint/grid/cover path planning wrapper.
+- `EnemyTacticalProfile`: role-level ranges, aggression, cover preference, weapon behavior.
+- `PlayerWeaponSnapshot`: safe read-only player weapon context for AI.
+- `StageTacticalNode` / `CoverPoint`: designer-authored navigation/cover hints.
+
+## 5. Proposed state transition model
+
+```text
+Idle
+  -> CombatMove        when player is seen
+  -> Search            when damaged but player is not visible
+
+Search
+  -> CombatMove        when player is reacquired
+  -> Idle              when search timer expires
+  -> Dead              when HP reaches 0
+
+CombatMove
+  -> Shoot             when LOS is clear, target is within ideal/fire range, and cooldown allows
+  -> Search            when target is lost beyond grace time
+  -> CombatMove        while approaching, retreating, strafing, or moving to cover
+  -> Dead              when HP reaches 0
+
+Shoot
+  -> CombatMove        when too close, too far, LOS blocked, hit reaction, stay timer exceeded, or low HP retreat triggers
+  -> Search            when target is lost
+  -> Dead              when HP reaches 0
+
+Dead
+  -> removable cleanup after death visual finishes
+```
+
+## 6. Minimal implementation steps for a more FPS-like fight
+
+1. Add damage stimulus memory and immediate hostility/search transitions.
+2. Gate attacks through `CanShootTarget` so world LOS blocks shooting.
+3. Force `Shoot` to exit when the target is closer than ideal range, letting `CombatMove` backpedal/strafe.
+4. Keep `CombatMove` as the spacing state: approach if too far, retreat if too close, strafe when in band.
+5. Add per-enemy ImGui telemetry to tune distance bands and LOS behavior.
+
+## 7. Roadmap for pathfinding, cover, and weapon reactions
+
+### Step A: Current-code friendly pathing
+- Continue using `EnemyAStarNavigator` plus stuck recovery.
+- Add stage-authored waypoint nodes only for problematic rooms/corridors.
+- Cache node-to-node visibility and simple neighbor links.
+
+### Step B: Cover MVP
+- Start with sampled cover positions around the enemy/player using existing world AABBs.
+- Add authored `CoverPoint`s for reliable designer control.
+- Implement peek cycle as: move to cover -> hide -> peek offset -> shoot burst -> hide.
+
+### Step C: Weapon reactions
+- Add `PlayerWeaponSnapshot` and update it once per frame from player weapon code.
+- Feed only the snapshot into enemy AI; do not let enemies depend directly on player internals.
+- Add low-risk reactions first: reload rush, shotgun backpedal, rifle cover preference.
+
+### Step D: Wave roles
+- Extend `WaveSpawnEntry` with `EnemyRole role` and `std::string profileId`.
+- Use roles to choose trait/combat/nav profiles.
+- Add mixed waves: early `Rush + Shooter`, mid `Cover + Shooter`, late `Tank + Support + flanker`.


### PR DESCRIPTION
### Motivation
- Make wave enemies respond more believably to being shot (immediately become hostile, investigate attack direction) so fights feel like FPS duels.
- Expose per-enemy AI telemetry (ImGui) to tune and observe state/LOS/last-hit data during iteration.
- Prevent enemies from blindly staying in shoot state when spacing is bad (too close / LOS lost), improving tactical movement without large system changes.

### Description
- Record damage stimulus: added fields (`lastDamageHitPos_`, `lastDamageDirection_`, `lastAttackOrigin_`, `lastDamageTimeSec_`, `aliveTimeSec_`, `hasDamageStimulus_`, `suppressNextDamageStimulus_`) and the helper `RegisterDamageStimulus` to store hit position/origin/direction and update last-seen memory.
- Make `Enemy` react on damage: updated `TakeDamage` overloads and `OnBulletHit` to call `RegisterDamageStimulus`, set hit reaction timers, and transition to `CombatMove` or `Search` based on visibility; added small guard to avoid double-stimulus from the same bullet.
- Add AI debug UI: implement `DrawImGui()` (under `USE_IMGUI`) and accessors (`GetCurrentAIStateName`, `IsTargetAware`, `HasTargetLineOfSight`, `CanAttackTarget`) to show current AI state, LOS, last-hit elapsed time, last-known player position and attack info.
- Adjust shoot/spacing logic: require being inside the ideal range to enter `Shoot` from `CombatMove` and make `Shoot` exit when target is closer than `idealRangeMin` (or out of LOS/fire range), letting `CombatMove` handle spacing (backpedal/strafe).
- Minor utilities: added `Length`/`NormalizeSafe` helpers and included `Bullet.h` usage for attacker origin when available.
- Documentation: added `docs/enemy_ai_review.md` with code review, problems, prioritized improvements, class change list, state transition proposal, and a staged roadmap for pathfinding/cover/weapon reactions.

### Testing
- Ran `git diff --check` to verify there are no whitespace/patch errors (succeeded).
- Performed a C++ syntax-only check attempt with `g++ -std=c++20 -fsyntax-only` for the modified files, but full syntax check was blocked in this Linux environment due to missing DirectX SDK headers (`d3d12.h`), so build verification was not completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff5d2ba09c832d8c0d75eade515061)