### PR TITLE
雑魚敵AI：戦闘距離・弾速・被弾反応の改善とImGui調整項目追加

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/AI/EnemyEvadeController.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/AI/EnemyEvadeController.cpp
@@ -15,7 +15,8 @@ EnemyEvadeController::Plan EnemyEvadeController::Evaluate(const Input& input) co
 	const float coverNeed = std::clamp(input.coverBias * (0.6f + input.coverPreference * 0.9f) + panic, 0.0f, 1.8f);
 	const float attackNeed = std::clamp(input.aggression - (input.lowHp ? 0.25f : 0.0f), 0.0f, 1.0f);
 
-	if (coverNeed > 0.65f && (!input.canShoot || survivalNeed > attackNeed))
+	const bool allowRetreatReaction = input.lowHp || input.consecutiveHits >= 2;
+	if (allowRetreatReaction && coverNeed > 0.65f && (!input.canShoot || survivalNeed > attackNeed))
 	{
 		plan.mode = Mode::ToCover;
 		plan.radialBias = -1.0f;
@@ -23,7 +24,7 @@ EnemyEvadeController::Plan EnemyEvadeController::Evaluate(const Input& input) co
 		return plan;
 	}
 
-	if (survivalNeed > 0.55f)
+	if (allowRetreatReaction && survivalNeed > 0.55f)
 	{
 		plan.mode = Mode::Retreat;
 		plan.radialBias = -0.9f;
@@ -32,7 +33,7 @@ EnemyEvadeController::Plan EnemyEvadeController::Evaluate(const Input& input) co
 	}
 
 	plan.mode = Mode::Strafe;
-	plan.radialBias = -0.1f;
+	plan.radialBias = input.canShoot ? 0.0f : -0.1f;
 	plan.speedScale = 1.0f;
 	return plan;
 }

--- a/Project/ApplicationLayer/Character/Enemy/AI/EnemyRetreatController.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/AI/EnemyRetreatController.cpp
@@ -68,16 +68,22 @@ EnemyRetreatController::Plan EnemyRetreatController::EvaluatePlan(const Input& i
 
 	if (!input.canShoot)
 	{
-		if (plan.dangerMode)
+		if (input.distanceToTarget < input.idealRangeMin)
+		{
+			plan.radialBias = std::min(plan.radialBias, -0.85f);
+			plan.shouldPathChase = false;
+		}
+		else if (plan.dangerMode)
 		{
 			plan.radialBias = std::min(plan.radialBias, -0.45f);
+			plan.shouldPathChase = true;
 		}
 		else
 		{
 			plan.radialBias = std::max(plan.radialBias, -0.1f);
+			plan.shouldPathChase = true;
 		}
 		plan.speed = std::max(plan.speed, input.strafeSpeed);
-		plan.shouldPathChase = true;
 	}
 
 	return plan;

--- a/Project/ApplicationLayer/Character/Enemy/AI/EnemyRetreatDecisionMemory.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/AI/EnemyRetreatDecisionMemory.cpp
@@ -8,6 +8,7 @@ void EnemyRetreatDecisionMemory::Reset()
 	evalTimer_ = 0.0f;
 	retreatHoldTimer_ = 0.0f;
 	safeTimer_ = 0.0f;
+	cooldownTimer_ = 0.0f;
 }
 
 bool EnemyRetreatDecisionMemory::Update(const Input& input)
@@ -15,6 +16,10 @@ bool EnemyRetreatDecisionMemory::Update(const Input& input)
 	if (retreatHoldTimer_ > 0.0f)
 	{
 		retreatHoldTimer_ = std::max(0.0f, retreatHoldTimer_ - input.dt);
+	}
+	if (cooldownTimer_ > 0.0f)
+	{
+		cooldownTimer_ = std::max(0.0f, cooldownTimer_ - input.dt);
 	}
 
 	evalTimer_ -= input.dt;
@@ -27,7 +32,8 @@ bool EnemyRetreatDecisionMemory::Update(const Input& input)
 	const bool veryLowHp = input.hpRate <= config_.hpThreshold;
 	const bool pressuredByHits = input.inHitReaction && input.consecutiveHits >= 2;
 	const bool closeThreat = input.distanceToTarget <= (input.retreatDistance + config_.engageDistanceBias);
-	const bool shouldEnterRetreat = veryLowHp && (closeThreat || pressuredByHits);
+	const bool hasLinePressure = !input.canShoot && input.distanceToTarget <= input.retreatDistance;
+	const bool shouldEnterRetreat = veryLowHp && cooldownTimer_ <= 0.0f && (closeThreat || pressuredByHits || hasLinePressure);
 
 	if (!retreating_ && shouldEnterRetreat)
 	{
@@ -60,6 +66,7 @@ bool EnemyRetreatDecisionMemory::Update(const Input& input)
 	{
 		retreating_ = false;
 		safeTimer_ = 0.0f;
+		cooldownTimer_ = std::max(0.0f, input.cooldownSec);
 	}
 
 	return retreating_;

--- a/Project/ApplicationLayer/Character/Enemy/AI/EnemyRetreatDecisionMemory.h
+++ b/Project/ApplicationLayer/Character/Enemy/AI/EnemyRetreatDecisionMemory.h
@@ -20,6 +20,7 @@ public:
 		float retreatDistance = 18.0f;
 		float returnDistance = 28.0f;
 		float decisionInterval = 0.2f;
+		float cooldownSec = 2.5f;
 		bool inHitReaction = false;
 		bool canShoot = true;
 		int consecutiveHits = 0;
@@ -36,4 +37,5 @@ private:
 	float evalTimer_ = 0.0f;
 	float retreatHoldTimer_ = 0.0f;
 	float safeTimer_ = 0.0f;
+	float cooldownTimer_ = 0.0f;
 };

--- a/Project/ApplicationLayer/Character/Enemy/Core/Enemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/Enemy.cpp
@@ -121,6 +121,9 @@ void Enemy::Initialize()
 	coverConfig.peekHideMinSec = cover_.peekHideMinSec;
 	coverConfig.peekHideMaxSec = cover_.peekHideMaxSec;
 	coverController_.SetConfig(coverConfig);
+	EnemyRetreatDecisionMemory::Config retreatConfig{};
+	retreatConfig.hpThreshold = survival_.lowHpThresholdRate;
+	retreatDecision_.SetConfig(retreatConfig);
 
 	memory_.lastSeenPos = GetCenterPosition();
 	memory_.timeSinceSeen = 9999.0f;
@@ -129,11 +132,13 @@ void Enemy::Initialize()
 	lastAttackOrigin_ = GetCenterPosition();
 	lastDamageTimeSec_ = -1.0f;
 	aliveTimeSec_ = 0.0f;
+	lastDeltaTimeSec_ = 0.0f;
 	hasDamageStimulus_ = false;
 	suppressNextDamageStimulus_ = false;
 
 	facing_.yawRad = 0.0f;
 	fireCooldown_ = 0.0f;
+	burstShotsRemaining_ = 0;
 	strafeDecisionTimer_ = 0.0f;
 	currentStrafeSign_ = 1.0f;
 	spawnPosition_ = GetCenterPosition();
@@ -160,6 +165,7 @@ void Enemy::Initialize()
 
 void Enemy::Update(float deltaTime)
 {
+	lastDeltaTimeSec_ = deltaTime;
 	aliveTimeSec_ += deltaTime;
 	UpdateNavigatorSource();
 	moveCommandedThisFrame_ = false;
@@ -234,17 +240,41 @@ void Enemy::DrawImGui()
 	const bool hasTarget = HasTarget();
 	const bool hasLos = HasTargetLineOfSight();
 	const bool canAttack = CanAttackTarget();
-	const float lastHitElapsed = (lastDamageTimeSec_ >= 0.0f) ? (aliveTimeSec_ - lastDamageTimeSec_) : -1.0f;
+	const float lastHitElapsed = GetLastDamageElapsedSec();
+	float accuracyConeDeg = combat_.accuracyConeRad * (180.0f / kPi);
 
-	if (ImGui::TreeNode("Enemy AI Debug"))
+	if (ImGui::TreeNode("雑魚敵AIデバッグ"))
 	{
-		ImGui::Text("AI State: %s", GetCurrentAIStateName());
-		ImGui::Text("Target Aware: %s", IsTargetAware() ? "true" : "false");
-		ImGui::Text("Line Of Sight: %s", hasLos ? "true" : "false");
-		ImGui::Text("Last Hit Time: %.2f sec", lastHitElapsed);
-		ImGui::Text("Last Player Pos: %.2f, %.2f, %.2f", memory_.lastSeenPos.x, memory_.lastSeenPos.y, memory_.lastSeenPos.z);
-		ImGui::Text("Can Attack: %s", canAttack ? "true" : "false");
+		ImGui::Text("現在のAI状態: %s", GetCurrentAIStateName());
+		ImGui::Text("ターゲット認識中: %s", IsTargetAware() ? "true" : "false");
+		ImGui::Text("射線あり: %s", hasLos ? "true" : "false");
+		ImGui::Text("現在距離: %.2f", GetDistanceToTarget());
+		ImGui::Text("最後に被弾した時間: %.2f sec", lastHitElapsed);
+		ImGui::Text("被弾後に敵対中: %s", IsHostileFromDamage() ? "true" : "false");
+		ImGui::Text("退避中: %s", IsRetreating() ? "true" : "false");
 		ImGui::Separator();
+		// FPSらしい距離維持と弾速を実行中に調整するためのデバッグ項目です。
+		ImGui::SliderFloat("最小戦闘距離", &combat_.minCombatRange, 1.0f, 30.0f);
+		ImGui::SliderFloat("理想戦闘距離", &combat_.idealCombatRange, combat_.minCombatRange, 40.0f);
+		ImGui::SliderFloat("最大戦闘距離", &combat_.maxCombatRange, combat_.idealCombatRange, 60.0f);
+		ImGui::SliderFloat("後退距離", &combat_.retreatRange, 0.5f, combat_.minCombatRange);
+		ImGui::SliderFloat("敵弾速度", &combat_.bulletSpeed, 5.0f, 80.0f);
+		if (ImGui::SliderFloat("命中ブレ", &accuracyConeDeg, 0.0f, 12.0f, "%.2f deg"))
+		{
+			combat_.accuracyConeRad = ToRadians(accuracyConeDeg);
+		}
+		ImGui::SliderFloat("射撃間隔", &combat_.fireInterval, 0.05f, 2.0f);
+		ImGui::SliderInt("バースト数", &combat_.burstCount, 1, 8);
+		ImGui::SliderFloat("退避クールダウン", &survival_.retreatCooldown, 0.0f, 8.0f);
+		ImGui::SliderFloat("HP低下退避しきい値", &survival_.lowHpThresholdRate, 0.05f, 0.95f);
+		combat_.fireRange = combat_.maxCombatRange;
+		combat_.attackRange = std::max(combat_.attackRange, combat_.maxCombatRange);
+		combat_.idealRangeMin = combat_.minCombatRange;
+		combat_.idealRangeMax = combat_.maxCombatRange;
+		combat_.tooCloseRange = combat_.retreatRange;
+		combat_.tooFarRange = combat_.maxCombatRange;
+		ImGui::Separator();
+		ImGui::Text("Can Attack: %s", canAttack ? "true" : "false");
 		ImGui::Text("Has Target: %s", hasTarget ? "true" : "false");
 		ImGui::Text("Target Pos: %.2f, %.2f, %.2f", targetPos.x, targetPos.y, targetPos.z);
 		ImGui::Text("Last Hit Pos: %.2f, %.2f, %.2f", lastDamageHitPos_.x, lastDamageHitPos_.y, lastDamageHitPos_.z);
@@ -482,8 +512,8 @@ void Enemy::FireAt(const K4E::Vector3& targetPos)
 	aimInput.movementSpeed = LengthXZ(GetVelocity());
 	aimInput.lowHp = IsLowHp();
 	aimInput.inHitReaction = IsInHitReaction();
-	aimInput.baseSpreadRad = 0.008f;
-	aimInput.maxSpreadRad = 0.12f;
+	aimInput.baseSpreadRad = combat_.accuracyConeRad;
+	aimInput.maxSpreadRad = std::max(combat_.accuracyConeRad, 0.16f);
 	aimInput.distanceSpreadWeight = 0.95f;
 	aimInput.moveSpreadWeight = 0.85f;
 	aimInput.stressSpreadWeight = 0.7f;
@@ -509,7 +539,11 @@ void Enemy::FireAt(const K4E::Vector3& targetPos)
 	constexpr float kMuzzleForwardOffset = 1.2f;
 	muzzle = muzzle + forward * kMuzzleForwardOffset;
 
-	fireCooldown_ = combat_.fireInterval * traits_.fireIntervalScale;
+	if (burstShotsRemaining_ <= 0) burstShotsRemaining_ = std::max(1, combat_.burstCount);
+	--burstShotsRemaining_;
+	fireCooldown_ = (burstShotsRemaining_ > 0)
+		? std::min(0.12f, combat_.fireInterval * 0.35f)
+		: combat_.fireInterval * traits_.fireIntervalScale;
 
 	bulletManager_->Spawn(
 		muzzle,
@@ -614,7 +648,7 @@ void Enemy::RegisterDamageStimulus(const K4E::Vector3& hitPos, const K4E::Vector
 		}
 		else
 		{
-			ChangeStateToSearch();
+			ChangeStateToCombatMove();
 		}
 	}
 }
@@ -702,7 +736,8 @@ bool Enemy::CanShootTarget(const K4E::Vector3& targetPos) const
 	diff.y = 0.0f;
 
 	const float distSq = diff.x * diff.x + diff.z * diff.z;
-	if (distSq > (combat_.fireRange * combat_.fireRange)) return false;
+	if (distSq < (combat_.minCombatRange * combat_.minCombatRange)) return false;
+	if (distSq > (combat_.maxCombatRange * combat_.maxCombatRange)) return false;
 
 	Vector3 muzzle = selfPos;
 	muzzle.y += combat_.muzzleHeight;
@@ -715,10 +750,10 @@ EnemyRetreatController::Plan Enemy::EvaluateRetreatPlan(float distToTarget, bool
 {
 	EnemyRetreatController::Input input{};
 	input.distanceToTarget = distToTarget;
-	input.idealRangeMin = combat_.idealRangeMin;
-	input.idealRangeMax = combat_.idealRangeMax;
-	input.tooCloseRange = combat_.tooCloseRange;
-	input.tooFarRange = combat_.tooFarRange;
+	input.idealRangeMin = combat_.minCombatRange;
+	input.idealRangeMax = combat_.maxCombatRange;
+	input.tooCloseRange = combat_.retreatRange;
+	input.tooFarRange = combat_.maxCombatRange;
 	input.lowHpRetreatDistance = survival_.lowHpRetreatDistance;
 	input.lowHpReturnDistance = survival_.lowHpReturnDistance;
 	input.approachSpeed = movement_.approachSpeed;
@@ -726,20 +761,24 @@ EnemyRetreatController::Plan Enemy::EvaluateRetreatPlan(float distToTarget, bool
 	input.strafeSpeed = movement_.strafeSpeed;
 	input.lowHpRetreatSpeedScale = survival_.lowHpRetreatSpeedScale;
 	input.hitReactionMoveWeight = reaction_.hitReactionMoveWeight + (1.0f - traits_.aggression) * 0.25f;
+	EnemyRetreatDecisionMemory::Config retreatConfig{};
+	retreatConfig.hpThreshold = survival_.lowHpThresholdRate;
+	retreatDecision_.SetConfig(retreatConfig);
 	EnemyRetreatDecisionMemory::Input retreatInput{};
-	retreatInput.dt = 0.0f;
+	retreatInput.dt = lastDeltaTimeSec_;
 	retreatInput.hpRate = GetHpRate();
 	retreatInput.distanceToTarget = distToTarget;
 	retreatInput.retreatDistance = survival_.lowHpRetreatDistance;
 	retreatInput.returnDistance = survival_.lowHpReturnDistance;
 	retreatInput.decisionInterval = survival_.retreatDecisionInterval;
+	retreatInput.cooldownSec = survival_.retreatCooldown;
 	retreatInput.inHitReaction = IsInHitReaction();
 	retreatInput.canShoot = canShoot;
 	retreatInput.consecutiveHits = consecutiveHitCount_;
 	const bool retreating = retreatDecision_.Update(retreatInput);
 	input.isLowHp = retreating;
 	input.inHitReaction = IsInHitReaction();
-	if (consecutiveHitCount_ < 2)
+	if (consecutiveHitCount_ < 2 || !retreating)
 	{
 		input.inHitReaction = false;
 	}
@@ -857,6 +896,12 @@ void Enemy::UpdateTraitProfile()
 	movement_.strafeSwitchMinSec *= RandomRange(0.92f, 1.08f);
 	movement_.strafeSwitchMaxSec *= RandomRange(0.94f, 1.14f);
 	combat_.fireInterval *= (0.95f + cautiousness * 0.08f);
+	combat_.fireRange = combat_.maxCombatRange;
+	combat_.attackRange = std::max(combat_.attackRange, combat_.maxCombatRange);
+	combat_.idealRangeMin = combat_.minCombatRange;
+	combat_.idealRangeMax = combat_.maxCombatRange;
+	combat_.tooCloseRange = combat_.retreatRange;
+	combat_.tooFarRange = combat_.maxCombatRange;
 	reaction_.coverBias = Clamp(reaction_.coverBias + (traits_.coverPreference - 0.5f) * 0.25f, 0.45f, 0.82f);
 	reaction_.evadeWeight = Clamp(reaction_.evadeWeight + cautiousness * 0.08f, 0.58f, 0.84f);
 }

--- a/Project/ApplicationLayer/Character/Enemy/Core/Enemy.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/Enemy.h
@@ -56,16 +56,22 @@ private: /// ---------- 構造体 ---------- ///
 	// 移動 / 戦闘の設定
 	struct EnemyCombatConfig
 	{
-		float attackRange = 24.0f;   // 戦闘を継続する最大距離の目安
-		float fireRange = 21.0f;     // 射線が通るときに実際に撃つ距離
-		float idealRangeMin = 10.0f; // 通常時の適正距離(近側)
-		float idealRangeMax = 17.5f; // 通常時の適正距離(遠側)
-		float tooCloseRange = 7.0f;  // 近すぎるので優先的に離脱
-		float tooFarRange = 25.0f;   // 遠すぎるので優先的に接近
-		float fireInterval = 0.35f;  // 攻撃間隔（秒）
-		float bulletSpeed = 18.0f;   // 弾の速度
-		float bulletLifeSec = 3.0f;  // 弾の寿命（秒）
-		int   bulletDamage = 5;      // 弾のダメージ
+		float attackRange = 26.0f;       // 戦闘を継続する最大距離の目安
+		float fireRange = 23.0f;         // 射線が通るときに実際に撃つ距離
+		float minCombatRange = 9.0f;     // これより近い場合は撃たずに距離を取る
+		float idealCombatRange = 15.0f;  // 銃撃戦で維持したい中心距離
+		float maxCombatRange = 23.0f;    // これより遠い場合は射撃可能距離まで前進する
+		float retreatRange = 7.0f;       // 強制後退を開始する距離
+		float idealRangeMin = 10.0f;     // 互換用: 通常時の適正距離(近側)
+		float idealRangeMax = 17.5f;     // 互換用: 通常時の適正距離(遠側)
+		float tooCloseRange = 7.0f;      // 互換用: 近すぎるので優先的に離脱
+		float tooFarRange = 25.0f;       // 互換用: 遠すぎるので優先的に接近
+		float fireInterval = 0.35f;      // 攻撃間隔（秒）
+		float bulletSpeed = 32.0f;       // 弾の速度
+		float accuracyConeRad = 0.045f;  // 弾速上昇に合わせた命中ブレ（ラジアン）
+		int   burstCount = 3;            // 1回の射撃判断で撃つ弾数
+		float bulletLifeSec = 3.0f;      // 弾の寿命（秒）
+		int   bulletDamage = 5;          // 弾のダメージ
 		float muzzleHeight = 1.2f;   // マズルの高さ
 		float searchDuration = 5.0f; // 索敵状態の滞在時間
 		float losRepositionEvalSec = 0.35f; // 射線調整の再評価間隔
@@ -76,7 +82,8 @@ private: /// ---------- 構造体 ---------- ///
 	// 低HP時の生存行動の設定
 	struct EnemySurvivalConfig
 	{
-		float lowHpThresholdRate = 0.5f;
+		float lowHpThresholdRate = 0.35f;
+		float retreatCooldown = 2.5f;
 		float lowHpRetreatDistance = 20.0f;
 		float lowHpReturnDistance = 28.0f;
 		float lowHpRetreatSpeedScale = 1.45f;
@@ -219,10 +226,14 @@ public: /// ---------- アクセサ ---------- ///
 	float GetAttackRange() const { return combat_.attackRange; }
 	float GetFireRange() const { return combat_.fireRange; }
 
-	float GetIdealRangeMin() const { return combat_.idealRangeMin; }
-	float GetIdealRangeMax() const { return combat_.idealRangeMax; }
-	float GetTooCloseRange() const { return combat_.tooCloseRange; }
-	float GetTooFarRange() const { return combat_.tooFarRange; }
+	float GetMinCombatRange() const { return combat_.minCombatRange; }
+	float GetIdealCombatRange() const { return combat_.idealCombatRange; }
+	float GetMaxCombatRange() const { return combat_.maxCombatRange; }
+	float GetRetreatRange() const { return combat_.retreatRange; }
+	float GetIdealRangeMin() const { return combat_.minCombatRange; }
+	float GetIdealRangeMax() const { return combat_.maxCombatRange; }
+	float GetTooCloseRange() const { return combat_.retreatRange; }
+	float GetTooFarRange() const { return combat_.maxCombatRange; }
 	float GetSearchDuration() const { return combat_.searchDuration; }
 	float GetLosRepositionEvalSec() const { return combat_.losRepositionEvalSec; }
 	float GetShootRepositionEvalSec() const { return combat_.shootRepositionEvalSec; }
@@ -234,6 +245,9 @@ public: /// ---------- アクセサ ---------- ///
 	float GetStrafeSpeed() const { return movement_.strafeSpeed; }
 	float GetSearchMoveSpeed() const { return movement_.searchMoveSpeed; }
 	float GetFireInterval() const { return combat_.fireInterval; }
+	float GetEnemyBulletSpeed() const { return combat_.bulletSpeed; }
+	float GetAccuracyConeRad() const { return combat_.accuracyConeRad; }
+	int GetBurstCount() const { return combat_.burstCount; }
 	float GetLosProbeDistance() const { return movement_.losProbeDistance; }
 	float GetTacticalBlend() const { return movement_.tacticalBlend; }
 	float GetShootMicroStrafeSpeed() const { return movement_.shootMicroStrafeSpeed; }
@@ -243,10 +257,14 @@ public: /// ---------- アクセサ ---------- ///
 	float GetLowHpRetreatSpeedScale() const { return survival_.lowHpRetreatSpeedScale; }
 	float GetLowHpShootRange() const { return survival_.lowHpShootRange; }
 	float GetRetreatDecisionInterval() const { return survival_.retreatDecisionInterval; }
+	float GetRetreatCooldown() const { return survival_.retreatCooldown; }
+	float GetLowHpThresholdRate() const { return survival_.lowHpThresholdRate; }
 	float GetCoverRepathInterval() const { return cover_.coverRepathInterval; }
 	float GetCoverStayTime() const { return cover_.coverStayTime; }
 	bool IsLowHp() const { return GetHpRate() <= survival_.lowHpThresholdRate; }
 	bool IsRetreating() const { return retreatDecision_.IsRetreating(); }
+	bool IsHostileFromDamage() const { return hasDamageStimulus_ && lastDamageTimeSec_ >= 0.0f && (aliveTimeSec_ - lastDamageTimeSec_) <= combat_.searchDuration; }
+	float GetLastDamageElapsedSec() const { return (lastDamageTimeSec_ >= 0.0f) ? (aliveTimeSec_ - lastDamageTimeSec_) : -1.0f; }
 	bool IsInHitReaction() const { return hitReactionTimer_ > 0.0f; }
 	float GetHitReactionMoveWeight() const { return reaction_.hitReactionMoveWeight; }
 	float GetEvadeWeight() const { return reaction_.evadeWeight; }
@@ -327,6 +345,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	K4E::Vector3 lastAttackOrigin_{ 0.0f, 0.0f, 0.0f };
 	float lastDamageTimeSec_ = -1.0f;
 	float aliveTimeSec_ = 0.0f;
+	float lastDeltaTimeSec_ = 0.0f;
 	bool hasDamageStimulus_ = false;
 	bool suppressNextDamageStimulus_ = false;
 
@@ -348,6 +367,7 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	std::unique_ptr<IEnemyState> state_ = nullptr;
 	float fireCooldown_ = 0.0f;
+	int burstShotsRemaining_ = 0;
 	float strafeDecisionTimer_ = 0.0f;
 	float currentStrafeSign_ = 1.0f;
 	K4E::Vector3 spawnPosition_{ 0.0f, 0.0f, 0.0f };

--- a/Project/ApplicationLayer/Character/Enemy/State/EnemyCombatMoveState.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/State/EnemyCombatMoveState.cpp
@@ -64,7 +64,14 @@ void EnemyCombatMoveState::Update(Enemy& enemy, float deltaTime)
 			losRepositionTimer_ = enemy.GetLosRepositionEvalSec();
 		}
 
-		radialBias = dangerMode ? std::min(radialBias, -0.4f) : std::max(radialBias, -0.1f);
+		if (distToTarget < enemy.GetMinCombatRange())
+		{
+			radialBias = std::min(radialBias, -0.85f);
+		}
+		else
+		{
+			radialBias = dangerMode ? std::min(radialBias, -0.4f) : std::max(radialBias, -0.1f);
+		}
 		speed = std::max(speed, enemy.GetStrafeSpeed());
 		shouldPathChase = true;
 	}
@@ -127,8 +134,8 @@ void EnemyCombatMoveState::Update(Enemy& enemy, float deltaTime)
 	}
 	enemy.PlayMoveAnimation(speed);
 
-	const float shootRange = dangerMode ? enemy.GetLowHpShootRange() : enemy.GetFireRange();
-	if (!inHitReaction && distToTarget >= enemy.GetIdealRangeMin() && distToTarget <= shootRange && canShoot)
+	const float shootRange = dangerMode ? enemy.GetLowHpShootRange() : enemy.GetMaxCombatRange();
+	if (distToTarget >= enemy.GetMinCombatRange() && distToTarget <= shootRange && canShoot)
 	{
 		enemy.ChangeStateToShoot();
 		return;

--- a/Project/ApplicationLayer/Character/Enemy/State/EnemySearchState.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/State/EnemySearchState.cpp
@@ -46,7 +46,7 @@ void EnemySearchState::Update(Enemy& enemy, float deltaTime)
 
 	const Vector3 lastSeen = enemy.GetLastSeenTargetPosition();
 	const float distToLastSeen = DistXZ(enemy.GetCenterPosition(), lastSeen);
-	const bool dangerMode = enemy.IsLowHp() || enemy.IsInHitReaction();
+	const bool dangerMode = enemy.IsRetreating();
 	const float searchSpeed = dangerMode
 		? enemy.GetSearchMoveSpeed() * 0.85f
 		: enemy.GetSearchMoveSpeed();

--- a/Project/ApplicationLayer/Character/Enemy/State/EnemyShootState.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/State/EnemyShootState.cpp
@@ -27,6 +27,7 @@ void EnemyShootState::Update(Enemy& enemy, float deltaTime)
 	const float distToTarget = enemy.GetDistanceToTarget();
 	const bool inHitReaction = enemy.IsInHitReaction();
 	const bool lowHp = enemy.IsRetreating();
+	const bool tooCloseToShoot = distToTarget < enemy.GetMinCombatRange();
 	const bool canSee = enemy.CanSeeTargetPublic(targetPos, distToTarget);
 
 	if (canSee)
@@ -40,7 +41,8 @@ void EnemyShootState::Update(Enemy& enemy, float deltaTime)
 	}
 
 	// 低HP時は早めに離脱。単発被弾だけでは即撤退しない。
-	if ((inHitReaction && enemy.GetConsecutiveHitCount() >= 2 && stayTimer_ > 0.05f) ||
+	if (tooCloseToShoot ||
+		(inHitReaction && lowHp && enemy.GetConsecutiveHitCount() >= 2 && stayTimer_ > 0.05f) ||
 		(lowHp && distToTarget < enemy.GetLowHpRetreatDistance()))
 	{
 		enemy.ChangeStateToCombatMove();
@@ -50,12 +52,12 @@ void EnemyShootState::Update(Enemy& enemy, float deltaTime)
 	if (reevalTimer_ <= 0.0f)
 	{
 		reevalTimer_ = enemy.GetShootRepositionEvalSec();
-		const float allowedShootRange = lowHp ? enemy.GetLowHpShootRange() : enemy.GetFireRange();
+		const float allowedShootRange = lowHp ? enemy.GetLowHpShootRange() : enemy.GetMaxCombatRange();
 		const float stayLimit = lowHp ? enemy.GetLowHpShootStaySec() : enemy.GetShootMaxStaySec();
 
 		const bool canShootNow = enemy.CanShootTargetPublic(targetPos);
 		// 適正射撃距離から外れたら、撃ち続けず位置取り状態へ戻す。
-		if (inHitReaction || distToTarget < enemy.GetIdealRangeMin() || distToTarget > allowedShootRange || !canShootNow)
+		if (distToTarget < enemy.GetMinCombatRange() || distToTarget > allowedShootRange || !canShootNow)
 		{
 			enemy.ChangeStateToCombatMove();
 			return;
@@ -78,7 +80,7 @@ void EnemyShootState::Update(Enemy& enemy, float deltaTime)
 	enemy.MoveTacticalAround(targetPos, enemy.GetCurrentStrafeSign(), retreatBias, moveSpeed);
 	enemy.FaceTo(targetPos);
 	enemy.PlayShootAnimation();
-	if (!inHitReaction) enemy.FireAt(targetPos);
+	enemy.FireAt(targetPos);
 }
 
 void EnemyShootState::Exit(Enemy& enemy)


### PR DESCRIPTION
### Motivation
- FPSらしい撃ち合いにするため、銃を持った敵が近づきすぎて撃つ挙動を避け、適正距離で撃ち合うようにするための調整を入れました。
- 敵弾の弾速を上げて撃ち合いの圧を高めつつ、命中ブレを導入して理不尽な必中を避けます。\n- 被弾時にただ逃げるだけでなく敵対・反撃・警戒する挙動にし、低HP時のみ退避しやすくする狙いです。

### Description
- 敵の戦闘パラメータに `minCombatRange` / `idealCombatRange` / `maxCombatRange` / `retreatRange` を追加しデフォルトを設定しました（弾速デフォルトを `32.0f` に引き上げ、`accuracyConeRad` / `burstCount` を追加）。（`EnemyCombatConfig`）
- 射撃可否判定を `CanShootTarget` で距離の下限・上限で判定するよう変更し、近すぎたら撃たず `CombatMove` で距離を取る・横移動・遮蔽移動を行う制御を追加しました（`EnemyCombatMoveState` / `EnemyShootState` の遷移強化）。
- `FireAt` にバースト処理と狙いのブレ（`accuracyConeRad` を `EnemyAimController` に渡す）を反映し、バースト内の短いインターバルと射撃間隔調整を実装しました（`burstShotsRemaining_` 管理）。
- 被弾処理で攻撃者方向・被弾位置・攻撃元を記録する実装は維持しつつ、被弾直後は基本的に敵対して `CombatMove` に入るように変更し、即逃走しない挙動にしました（`RegisterDamageStimulus` の遷移調整）。
- 退避ロジックを `EnemyRetreatDecisionMemory` 側で強化し、HP率・距離・射線の有無・連続被弾・クールダウン（`retreatCooldown`）を考慮して退避の発生と解除を制御するようにしました。\n- `EnemyEvadeController` と `EnemyRetreatController` の評価ロジックを微調整し、単発被弾では攻撃継続／横移動を優先し、低HPや圧力時のみ退避/遮蔽を優先するようにしました。 
- ImGui のデバッグ/調整パネルを日本語表示で拡張し、現在のAI状態・ターゲット認識・射線有無・現在距離・最小/理想/最大戦闘距離・後退距離・敵弾速度・命中ブレ（度表示）・射撃間隔・バースト数・最後に被弾した時間・被弾後に敵対中・退避中・退避クールダウン・HP低下退避しきい値を操作/確認できるようにしました（`Enemy::DrawImGui`）。
- 実装中、既存の `Enemy` / `EnemyBase` / `IEnemyState` 構成を壊さないよう既存アクセサやステート遷移構造を保持しつつ必要なメンバとアクセサを追加しました（1行コメントをImGui項目に追加／要所に意図が分かる形で変更）。

### Testing
- `git diff --check` を実行し問題ありませんでした（成功）。
- AI関連小モジュールの構文チェックを `clang++ -std=c++20 -fsyntax-only -IProject/Engine/Math/Vector -IProject/ApplicationLayer/Character/Enemy/AI Project/.../EnemyRetreatDecisionMemory.cpp Project/.../EnemyRetreatController.cpp Project/.../EnemyEvadeController.cpp Project/.../EnemyAimController.cpp` で実行し成功しました（AI/AI-support ファイルの構文はOK）。
- プロジェクト全体の敵周りファイルを対象にしたフル構文チェックを試みましたが、この環境では DirectX ヘッダ `d3d12.h` が存在しないためフル構文チェック（`Enemy.cpp` 等を含む）は実行できませんでした（環境依存の外部ヘッダ欠如による制約）。
- 実動作確認（プレイテスト）は行っていませんので、現場でパラメータを ImGui で微調整しながら動作確認をお願いします。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff60c4dc6c832d8a08a7dbcd40bd8a)