### PR TITLE
Enemy AI: add burst / magazine / reload behavior and accuracy tuning

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/Core/Enemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/Enemy.cpp
@@ -139,6 +139,9 @@ void Enemy::Initialize()
 	facing_.yawRad = 0.0f;
 	fireCooldown_ = 0.0f;
 	burstShotsRemaining_ = 0;
+	currentAmmo_ = combat_.magazineSize;
+	isReloading_ = false;
+	reloadTimer_ = 0.0f;
 	strafeDecisionTimer_ = 0.0f;
 	currentStrafeSign_ = 1.0f;
 	spawnPosition_ = GetCenterPosition();
@@ -198,6 +201,7 @@ void Enemy::Update(float deltaTime)
 		fireCooldown_ -= deltaTime;
 		if (fireCooldown_ < 0.0f) fireCooldown_ = 0.0f;
 	}
+	UpdateReloadTimer(deltaTime);
 
 	if (state_) state_->Update(*this, deltaTime);
 
@@ -242,12 +246,16 @@ void Enemy::DrawImGui()
 	const bool canAttack = CanAttackTarget();
 	const float lastHitElapsed = GetLastDamageElapsedSec();
 	float accuracyConeDeg = combat_.accuracyConeRad * (180.0f / kPi);
+	float aimErrorAngleDeg = combat_.aimErrorAngleRad * (180.0f / kPi);
+	const bool inProperRange = hasTarget && GetDistanceToTarget() >= combat_.minCombatRange && GetDistanceToTarget() <= combat_.maxCombatRange;
 
 	if (ImGui::TreeNode("雑魚敵AIデバッグ"))
 	{
 		ImGui::Text("現在のAI状態: %s", GetCurrentAIStateName());
 		ImGui::Text("ターゲット認識中: %s", IsTargetAware() ? "true" : "false");
 		ImGui::Text("射線あり: %s", hasLos ? "true" : "false");
+		ImGui::Text("射撃可能: %s", canAttack ? "true" : "false");
+		ImGui::Text("適正距離内: %s", inProperRange ? "true" : "false");
 		ImGui::Text("現在距離: %.2f", GetDistanceToTarget());
 		ImGui::Text("最後に被弾した時間: %.2f sec", lastHitElapsed);
 		ImGui::Text("被弾後に敵対中: %s", IsHostileFromDamage() ? "true" : "false");
@@ -258,13 +266,28 @@ void Enemy::DrawImGui()
 		ImGui::SliderFloat("理想戦闘距離", &combat_.idealCombatRange, combat_.minCombatRange, 40.0f);
 		ImGui::SliderFloat("最大戦闘距離", &combat_.maxCombatRange, combat_.idealCombatRange, 60.0f);
 		ImGui::SliderFloat("後退距離", &combat_.retreatRange, 0.5f, combat_.minCombatRange);
-		ImGui::SliderFloat("敵弾速度", &combat_.bulletSpeed, 5.0f, 80.0f);
+		ImGui::SliderFloat("敵弾速度", &combat_.enemyBulletSpeed, 5.0f, 100.0f);
 		if (ImGui::SliderFloat("命中ブレ", &accuracyConeDeg, 0.0f, 12.0f, "%.2f deg"))
 		{
 			combat_.accuracyConeRad = ToRadians(accuracyConeDeg);
 		}
+		if (ImGui::SliderFloat("照準誤差角", &aimErrorAngleDeg, 0.0f, 8.0f, "%.2f deg"))
+		{
+			combat_.aimErrorAngleRad = ToRadians(aimErrorAngleDeg);
+		}
 		ImGui::SliderFloat("射撃間隔", &combat_.fireInterval, 0.05f, 2.0f);
-		ImGui::SliderInt("バースト数", &combat_.burstCount, 1, 8);
+		ImGui::SliderInt("バースト数", &combat_.burstCount, 1, 12);
+		ImGui::SliderFloat("バースト間隔", &combat_.burstInterval, 0.03f, 0.5f);
+		ImGui::SliderFloat("バースト待機時間", &combat_.postBurstWait, 0.0f, 3.0f);
+		if (ImGui::SliderInt("マガジン弾数", &combat_.magazineSize, 1, 60))
+		{
+			currentAmmo_ = std::min(currentAmmo_, combat_.magazineSize);
+		}
+		ImGui::Text("現在弾数: %d", currentAmmo_);
+		ImGui::SliderFloat("リロード時間", &combat_.reloadTime, 0.1f, 6.0f);
+		ImGui::Text("リロード中: %s", isReloading_ ? "true" : "false");
+		ImGui::Text("リロード残り時間: %.2f", reloadTimer_);
+		ImGui::Checkbox("リロード中移動", &combat_.reloadMoveEnabled);
 		ImGui::SliderFloat("退避クールダウン", &survival_.retreatCooldown, 0.0f, 8.0f);
 		ImGui::SliderFloat("HP低下退避しきい値", &survival_.lowHpThresholdRate, 0.05f, 0.95f);
 		combat_.fireRange = combat_.maxCombatRange;
@@ -325,7 +348,7 @@ bool Enemy::HasTargetLineOfSight() const
 
 bool Enemy::CanAttackTarget() const
 {
-	return HasTarget() && CanShootTarget(GetTargetPosition()) && fireCooldown_ <= 0.0f && !IsDead();
+	return HasTarget() && CanShootTarget(GetTargetPosition()) && CanStartShooting() && !IsDead();
 }
 
 K4E::Vector3 Enemy::GetTargetPosition() const
@@ -498,7 +521,7 @@ void Enemy::FaceTo(const K4E::Vector3& targetPos)
 
 void Enemy::FireAt(const K4E::Vector3& targetPos)
 {
-	if (fireCooldown_ > 0.0f || !bulletManager_) return;
+	if (!CanStartShooting() || !bulletManager_) return;
 
 	Vector3 muzzle = GetCenterPosition();
 	muzzle.y += combat_.muzzleHeight;
@@ -512,12 +535,12 @@ void Enemy::FireAt(const K4E::Vector3& targetPos)
 	aimInput.movementSpeed = LengthXZ(GetVelocity());
 	aimInput.lowHp = IsLowHp();
 	aimInput.inHitReaction = IsInHitReaction();
-	aimInput.baseSpreadRad = combat_.accuracyConeRad;
-	aimInput.maxSpreadRad = std::max(combat_.accuracyConeRad, 0.16f);
-	aimInput.distanceSpreadWeight = 0.95f;
-	aimInput.moveSpreadWeight = 0.85f;
-	aimInput.stressSpreadWeight = 0.7f;
-	aimInput.stableBonusWeight = 0.55f;
+	aimInput.baseSpreadRad = combat_.accuracyConeRad + combat_.aimErrorAngleRad;
+	aimInput.maxSpreadRad = std::max(aimInput.baseSpreadRad, 0.11f);
+	aimInput.distanceSpreadWeight = 0.55f;
+	aimInput.moveSpreadWeight = 0.65f;
+	aimInput.stressSpreadWeight = 0.45f;
+	aimInput.stableBonusWeight = 0.65f;
 	aimInput.traits = &traits_;
 	const Vector3 aim = aimController_.BuildAimPoint(aimInput);
 
@@ -541,19 +564,80 @@ void Enemy::FireAt(const K4E::Vector3& targetPos)
 
 	if (burstShotsRemaining_ <= 0) burstShotsRemaining_ = std::max(1, combat_.burstCount);
 	--burstShotsRemaining_;
-	fireCooldown_ = (burstShotsRemaining_ > 0)
-		? std::min(0.12f, combat_.fireInterval * 0.35f)
-		: combat_.fireInterval * traits_.fireIntervalScale;
+	--currentAmmo_;
+
+	// バースト上限・弾切れ・通常間隔をまとめて管理し、撃ちっぱなしに見えないテンポを作る。
+	if (currentAmmo_ <= 0)
+	{
+		currentAmmo_ = 0;
+		StartReload();
+	}
+	else
+	{
+		const bool burstContinues = burstShotsRemaining_ > 0;
+		fireCooldown_ = burstContinues
+			? std::max(combat_.burstInterval, combat_.fireInterval)
+			: std::max(combat_.postBurstWait, combat_.fireInterval * traits_.fireIntervalScale);
+	}
 
 	bulletManager_->Spawn(
 		muzzle,
 		dir,
-		combat_.bulletSpeed,
+		combat_.enemyBulletSpeed,
 		combat_.bulletDamage,
 		combat_.bulletLifeSec,
 		GetCenterPosition(),
 		GetUniqueID(),
 		static_cast<uint32_t>(CollisionTypeIdDef::kEnemyBullet));
+}
+
+void Enemy::UpdateReloadMove(const K4E::Vector3& targetPos, float deltaTime)
+{
+	if (!combat_.reloadMoveEnabled)
+	{
+		StopMove();
+		FaceTo(targetPos);
+		return;
+	}
+
+	UpdateStrafeDecision(deltaTime);
+	Vector3 coverPos{};
+	if (TryFindCoverPosition(targetPos, true, coverPos))
+	{
+		MoveTowardsPath(coverPos, movement_.retreatSpeed, deltaTime);
+		return;
+	}
+
+	const float distToTarget = GetDistanceToTarget();
+	const float radialBias = (distToTarget < combat_.idealCombatRange) ? -1.0f : -0.55f;
+	MoveTacticalAround(targetPos, currentStrafeSign_, radialBias, movement_.retreatSpeed);
+}
+
+bool Enemy::CanStartShooting() const
+{
+	return fireCooldown_ <= 0.0f && !isReloading_ && currentAmmo_ > 0;
+}
+
+void Enemy::StartReload()
+{
+	if (isReloading_) return;
+	isReloading_ = true;
+	reloadTimer_ = std::max(0.01f, combat_.reloadTime);
+	fireCooldown_ = reloadTimer_;
+	burstShotsRemaining_ = 0;
+}
+
+void Enemy::UpdateReloadTimer(float deltaTime)
+{
+	if (!isReloading_) return;
+
+	reloadTimer_ -= deltaTime;
+	if (reloadTimer_ > 0.0f) return;
+
+	isReloading_ = false;
+	reloadTimer_ = 0.0f;
+	currentAmmo_ = std::max(1, combat_.magazineSize);
+	fireCooldown_ = std::max(fireCooldown_, combat_.postBurstWait * 0.35f);
 }
 
 void Enemy::TakeDamage(int amount)

--- a/Project/ApplicationLayer/Character/Enemy/Core/Enemy.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/Enemy.h
@@ -66,10 +66,16 @@ private: /// ---------- 構造体 ---------- ///
 		float idealRangeMax = 17.5f;     // 互換用: 通常時の適正距離(遠側)
 		float tooCloseRange = 7.0f;      // 互換用: 近すぎるので優先的に離脱
 		float tooFarRange = 25.0f;       // 互換用: 遠すぎるので優先的に接近
-		float fireInterval = 0.35f;      // 攻撃間隔（秒）
-		float bulletSpeed = 32.0f;       // 弾の速度
-		float accuracyConeRad = 0.045f;  // 弾速上昇に合わせた命中ブレ（ラジアン）
-		int   burstCount = 3;            // 1回の射撃判断で撃つ弾数
+		float fireInterval = 0.22f;      // バースト中の1発ごとの射撃間隔（秒）
+		float enemyBulletSpeed = 48.0f;       // 弾の速度
+		float accuracyConeRad = 0.026f;  // 距離・移動補正前の命中ブレ（ラジアン）
+		float aimErrorAngleRad = 0.018f; // 固定の照準誤差（ラジアン）
+		int   burstCount = 4;            // 1回の攻撃で撃つ最大弾数
+		float burstInterval = 0.10f;     // バースト内の最短発射間隔（秒）
+		float postBurstWait = 0.75f;     // バースト後の待機時間（秒）
+		int   magazineSize = 12;         // マガジン弾数
+		float reloadTime = 1.85f;        // リロード時間（秒）
+		bool  reloadMoveEnabled = true;  // リロード中に移動するか
 		float bulletLifeSec = 3.0f;      // 弾の寿命（秒）
 		int   bulletDamage = 5;          // 弾のダメージ
 		float muzzleHeight = 1.2f;   // マズルの高さ
@@ -208,6 +214,9 @@ public: /// ---------- アクセサ ---------- ///
 
 	void FaceTo(const K4E::Vector3& targetPos);
 	void FireAt(const K4E::Vector3& targetPos);
+	void UpdateReloadMove(const K4E::Vector3& targetPos, float deltaTime);
+	bool CanStartShooting() const;
+	void StartReload();
 
 	void RememberLastSeenTarget(const K4E::Vector3& targetPos)
 	{
@@ -245,9 +254,18 @@ public: /// ---------- アクセサ ---------- ///
 	float GetStrafeSpeed() const { return movement_.strafeSpeed; }
 	float GetSearchMoveSpeed() const { return movement_.searchMoveSpeed; }
 	float GetFireInterval() const { return combat_.fireInterval; }
-	float GetEnemyBulletSpeed() const { return combat_.bulletSpeed; }
+	float GetEnemyBulletSpeed() const { return combat_.enemyBulletSpeed; }
 	float GetAccuracyConeRad() const { return combat_.accuracyConeRad; }
+	float GetAimErrorAngleRad() const { return combat_.aimErrorAngleRad; }
 	int GetBurstCount() const { return combat_.burstCount; }
+	float GetBurstInterval() const { return combat_.burstInterval; }
+	float GetPostBurstWait() const { return combat_.postBurstWait; }
+	int GetMagazineSize() const { return combat_.magazineSize; }
+	int GetCurrentAmmo() const { return currentAmmo_; }
+	float GetReloadTime() const { return combat_.reloadTime; }
+	bool IsReloading() const { return isReloading_; }
+	float GetReloadTimer() const { return reloadTimer_; }
+	bool IsReloadMoveEnabled() const { return combat_.reloadMoveEnabled; }
 	float GetLosProbeDistance() const { return movement_.losProbeDistance; }
 	float GetTacticalBlend() const { return movement_.tacticalBlend; }
 	float GetShootMicroStrafeSpeed() const { return movement_.shootMicroStrafeSpeed; }
@@ -314,6 +332,7 @@ private: /// ---------- 内部処理 ---------- ///
 	void TryStepJump(const K4E::Vector3& moveDirection);
 	void UpdateTraitProfile();
 	void RegisterDamageStimulus(const K4E::Vector3& hitPos, const K4E::Vector3& attackOrigin, const K4E::Vector3& hitDir);
+	void UpdateReloadTimer(float deltaTime);
 
 private: /// ---------- メンバ変数 ---------- ///
 
@@ -368,6 +387,9 @@ private: /// ---------- メンバ変数 ---------- ///
 	std::unique_ptr<IEnemyState> state_ = nullptr;
 	float fireCooldown_ = 0.0f;
 	int burstShotsRemaining_ = 0;
+	int currentAmmo_ = 0;
+	bool isReloading_ = false;
+	float reloadTimer_ = 0.0f;
 	float strafeDecisionTimer_ = 0.0f;
 	float currentStrafeSign_ = 1.0f;
 	K4E::Vector3 spawnPosition_{ 0.0f, 0.0f, 0.0f };

--- a/Project/ApplicationLayer/Character/Enemy/State/EnemyCombatMoveState.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/State/EnemyCombatMoveState.cpp
@@ -42,6 +42,7 @@ void EnemyCombatMoveState::Update(Enemy& enemy, float deltaTime)
 	coverStayTimer_ -= deltaTime;
 
 	bool canShoot = enemy.CanShootTargetPublic(targetPos);
+	bool canFireNow = canShoot && enemy.CanStartShooting();
 	const auto retreatPlan = enemy.EvaluateRetreatPlan(distToTarget, canShoot);
 	const auto evadePlan = enemy.EvaluateEvadePlan(canShoot);
 	const bool dangerMode = retreatPlan.dangerMode;
@@ -111,6 +112,7 @@ void EnemyCombatMoveState::Update(Enemy& enemy, float deltaTime)
 			enemy.MoveTowardsPath(coverAction.moveTarget, speed, deltaTime);
 			coverStayTimer_ = enemy.GetCoverStayTime();
 			canShoot = canShoot || enemy.ShouldShootFromCover(coverAction);
+			canFireNow = canShoot && enemy.CanStartShooting();
 		}
 		else
 		{
@@ -135,7 +137,7 @@ void EnemyCombatMoveState::Update(Enemy& enemy, float deltaTime)
 	enemy.PlayMoveAnimation(speed);
 
 	const float shootRange = dangerMode ? enemy.GetLowHpShootRange() : enemy.GetMaxCombatRange();
-	if (distToTarget >= enemy.GetMinCombatRange() && distToTarget <= shootRange && canShoot)
+	if (distToTarget >= enemy.GetMinCombatRange() && distToTarget <= shootRange && canFireNow)
 	{
 		enemy.ChangeStateToShoot();
 		return;

--- a/Project/ApplicationLayer/Character/Enemy/State/EnemyShootState.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/State/EnemyShootState.cpp
@@ -30,6 +30,18 @@ void EnemyShootState::Update(Enemy& enemy, float deltaTime)
 	const bool tooCloseToShoot = distToTarget < enemy.GetMinCombatRange();
 	const bool canSee = enemy.CanSeeTargetPublic(targetPos, distToTarget);
 
+	if (enemy.IsReloading())
+	{
+		// リロード中は射撃を止め、遮蔽候補がなければ横移動や後退で被弾面積をずらす。
+		enemy.UpdateReloadMove(targetPos, deltaTime);
+		enemy.PlayMoveAnimation(enemy.GetRetreatSpeed());
+		if (tooCloseToShoot)
+		{
+			enemy.ChangeStateToCombatMove();
+		}
+		return;
+	}
+
 	if (canSee)
 	{
 		enemy.RememberLastSeenTarget(targetPos);
@@ -80,7 +92,10 @@ void EnemyShootState::Update(Enemy& enemy, float deltaTime)
 	enemy.MoveTacticalAround(targetPos, enemy.GetCurrentStrafeSign(), retreatBias, moveSpeed);
 	enemy.FaceTo(targetPos);
 	enemy.PlayShootAnimation();
-	enemy.FireAt(targetPos);
+	if (enemy.CanStartShooting())
+	{
+		enemy.FireAt(targetPos);
+	}
 }
 
 void EnemyShootState::Exit(Enemy& enemy)


### PR DESCRIPTION
### Motivation
- Make雑魚敵の射撃 feel more like FPS combat by adding burst firing, magazines and reloads so enemies don’t fire continuously and create rhythm in shoot/move/cover behavior.
- Improve threat balance by increasing bullet speed and refining accuracy so enemies are a credible but fair threat depending on distance and movement.
- Allow safer reloading behavior so enemies can move toward cover or retreat while reloading instead of standing and firing indefinitely.

### Description
- Added new combat tuning fields to `EnemyCombatConfig`: `enemyBulletSpeed`, `accuracyConeRad`, `aimErrorAngleRad`, `fireInterval`, `burstInterval`, `postBurstWait`, `burstCount`, `magazineSize`, `reloadTime`, and `reloadMoveEnabled` and adjusted default values for more responsive FPS feel.
- Introduced per-enemy state variables `currentAmmo_`, `isReloading_`, and `reloadTimer_` and new methods `CanStartShooting()`, `StartReload()`, `UpdateReloadTimer()`, and `UpdateReloadMove()` in `Enemy` to manage ammo and reload lifecycle.
- Modified `Enemy::FireAt` to decrement `currentAmmo_`, respect `burstCount`/`burstInterval`/`postBurstWait`, trigger reload when empty, and use `enemyBulletSpeed` and combined spread (`accuracyConeRad + aimErrorAngleRad`) for aim calculations.
- Prevented shooting while reloading and gated `Shoot`/`CombatMove` transitions on `CanStartShooting()`, and added reload-time movement toward cover or tactical retreat/strafe via `UpdateReloadMove()`; preserved existing state architecture and added a short explanatory comment in `EnemyShootState` about reload behavior.
- Expanded Japanese ImGui debug panel to expose and tune: enemy bullet speed, accuracy, aim error angle, fire interval, burst count/interval/post-burst wait, magazine size/current ammo, reload time, reload state and remaining time, reload-move toggle, current AI state, LOS and firing permission telemetry.

### Testing
- Ran `git diff --check` to verify there are no whitespace/index errors and it passed.
- Attempted to build with `msbuild Project/Ken4lowEngine.sln /p:Configuration=Debug /p:Platform=x64` but the build tool was not available in this environment (`msbuild: command not found`), so a full compile/run test was not performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff63b76548832d86a46cf8a723914e)