### PR TITLE
Add player HP-driven post effect (red vignette & damage flash)

### DIFF
--- a/Project/ApplicationLayer/Character/Player/Player.cpp
+++ b/Project/ApplicationLayer/Character/Player/Player.cpp
@@ -698,6 +698,11 @@ void Player::ApplyDamageFeedback(const PlayerDamageComponent::DamageFeedback& fb
 
 	vfx_.OnDamaged(fb.damage, fb.maxHp);
 
+	if (onDamageTaken_)
+	{
+		onDamageTaken_();
+	}
+
 	if (fb.notifyPlayerHit)
 	{
 		if (auto* tr = GetWorldTransform())

--- a/Project/ApplicationLayer/Character/Player/Player.h
+++ b/Project/ApplicationLayer/Character/Player/Player.h
@@ -159,6 +159,7 @@ public: /// ---------- メンバ関数 ---------- ///
 	void SetOnFireSECallback(std::function<void()> cb) { audio_.onFire = std::move(cb); }
 	void SetOnReloadSECallback(std::function<void()> cb) { audio_.onReload = std::move(cb); }
 	void SetOnDeathSECallback(std::function<void()> cb) { audio_.onDeath = std::move(cb); }
+	void SetOnDamageTakenCallback(std::function<void()> cb) { onDamageTaken_ = std::move(cb); }
 
 	bool IsGameOverReady() const { return death_.IsGameOverReady(); }
 	bool ConsumeGameOverReady() { return death_.ConsumeGameOverReady(); }
@@ -289,6 +290,7 @@ private: /// ----------メンバ変数 ---------- ///
 	K4E::Vector3 spawnOffset_{ 0,0,0 };
 
 	FallDamageSettings fallDamageSettings_{};
+	std::function<void()> onDamageTaken_{};
 
 	PlayerAudioCallbacks audio_{};
 };

--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
@@ -4,6 +4,8 @@
 #include <SpriteManager.h>
 #include <SceneManager.h>
 #include <GameTimer.h>
+#include <PostEffectManager.h>
+#include <Player.h>
 
 #ifdef _DEBUG
 #include <DebugCamera.h>
@@ -27,6 +29,11 @@ void GamePlayScene::Initialize()
 	introDirector_.reset();
 	debugTools_.reset();
 	frustumCullingDebug_.reset();
+	if (hpPostEffectController_)
+	{
+		hpPostEffectController_->Finalize();
+		hpPostEffectController_.reset();
+	}
 
 	if (!fadeManager_)
 	{
@@ -79,10 +86,30 @@ void GamePlayScene::InitializeGameplayObjects()
 	frustumCullingDebug_ = std::make_unique<FrustumCullingDebugController>();
 	frustumCullingDebug_->Initialize();
 
+	InitializeHealthPostEffectController();
+
 	if (!fadeManager_)
 	{
 		fadeManager_ = std::make_unique<FadeManager>();
 		fadeManager_->Initialize();
+	}
+}
+
+
+void GamePlayScene::InitializeHealthPostEffectController()
+{
+	hpPostEffectController_ = std::make_unique<PlayerHealthPostEffectController>();
+	hpPostEffectController_->Initialize(K4E::PostEffectManager::GetInstance());
+
+	if (auto* player = world_ ? world_->GetCharacters().GetPlayer() : nullptr)
+	{
+		player->SetOnDamageTakenCallback([this]()
+			{
+				if (hpPostEffectController_)
+				{
+					hpPostEffectController_->NotifyDamageTaken();
+				}
+			});
 	}
 }
 
@@ -359,6 +386,11 @@ void GamePlayScene::UpdateWorld(float deltaTime)
 	{
 		frustumCullingDebug_->Update(deltaTime);
 	}
+
+	if (hpPostEffectController_)
+	{
+		hpPostEffectController_->Update(deltaTime, world_ ? world_->GetCharacters().GetPlayer() : nullptr);
+	}
 }
 
 /// -------------------------------------------------------------
@@ -513,6 +545,12 @@ void GamePlayScene::ReleaseGameplayObjects()
 	}
 	frustumCullingDebug_.reset();
 
+	if (hpPostEffectController_)
+	{
+		hpPostEffectController_->Finalize();
+		hpPostEffectController_.reset();
+	}
+
 	introDirector_.reset();
 
 	if (flow_)
@@ -544,6 +582,11 @@ void GamePlayScene::DrawImGui()
 	if (frustumCullingDebug_)
 	{
 		frustumCullingDebug_->DrawImGui();
+	}
+
+	if (hpPostEffectController_)
+	{
+		hpPostEffectController_->DrawImGui();
 	}
 #endif // USE_IMGUI
 }
@@ -586,6 +629,8 @@ void GamePlayScene::UpdateLoad()
 		debugTools_->Initialize();
 		frustumCullingDebug_ = std::make_unique<FrustumCullingDebugController>();
 		frustumCullingDebug_->Initialize();
+
+		InitializeHealthPostEffectController();
 		++loadStep_;
 		break;
 
@@ -624,6 +669,11 @@ void GamePlayScene::UpdateUnload()
 			debugTools_.reset();
 		}
 		frustumCullingDebug_.reset();
+		if (hpPostEffectController_)
+		{
+			hpPostEffectController_->Finalize();
+			hpPostEffectController_.reset();
+		}
 		++unloadStep_;
 		break;
 

--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.h
@@ -8,6 +8,7 @@
 #include "GamePlayDebugTools.h"
 #include "FadeManager.h"
 #include "ApplicationLayer/DebugTools/FrustumCulling/FrustumCullingDebugController.h"
+#include "PostEffect/PlayerHealthPostEffectController.h"
 
 #include <memory>
 
@@ -80,6 +81,9 @@ private: /// ---------- 初期化 / 終了系 ---------- ///
 	// カーソル状態を通常に戻す
 	void RestoreCursorState();
 
+	// HP連動ポストエフェクトを初期化して被弾通知を接続する
+	void InitializeHealthPostEffectController();
+
 	// 生成済みオブジェクトの破棄
 	void ReleaseGameplayObjects();
 
@@ -148,6 +152,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	std::unique_ptr<GamePlayDebugTools> debugTools_;
 	std::unique_ptr<FrustumCullingDebugController> frustumCullingDebug_;
 	std::unique_ptr<FadeManager> fadeManager_;
+	std::unique_ptr<PlayerHealthPostEffectController> hpPostEffectController_;
 
 	// リトライ遷移制御
 	bool isRetryTransitionActive_ = false; // リトライ演出中か

--- a/Project/ApplicationLayer/Scene/GamePlayScene/PostEffect/PlayerHealthPostEffectController.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/PostEffect/PlayerHealthPostEffectController.cpp
@@ -1,0 +1,159 @@
+#define NOMINMAX
+#include "PlayerHealthPostEffectController.h"
+
+#include "Player.h"
+#include "PostEffectManager.h"
+
+#include <algorithm>
+
+#ifdef USE_IMGUI
+#include <imgui.h>
+#endif // USE_IMGUI
+
+namespace
+{
+	constexpr const char* kEffectName = "PlayerHealthPostEffect";
+}
+
+void PlayerHealthPostEffectController::Initialize(Ken4lowEngine::PostEffectManager* postEffectManager)
+{
+	postEffectManager_ = postEffectManager;
+	hpRate_ = 1.0f;
+	damageFlashIntensity_ = 0.0f;
+	elapsedTime_ = 0.0f;
+	ApplyToPostEffect();
+}
+
+void PlayerHealthPostEffectController::Finalize()
+{
+	if (postEffectManager_)
+	{
+		postEffectManager_->DisableEffect(kEffectName);
+	}
+	postEffectManager_ = nullptr;
+}
+
+void PlayerHealthPostEffectController::Update(float deltaTime, const Player* player)
+{
+	elapsedTime_ += deltaTime;
+
+	if (player && player->GetMaxHP() > 0.0f)
+	{
+		hpRate_ = std::clamp(player->GetHP() / player->GetMaxHP(), 0.0f, 1.0f);
+	}
+	else
+	{
+		hpRate_ = 1.0f;
+	}
+
+	// 被弾直後の赤フラッシュは毎フレーム少しずつ弱める。
+	damageFlashIntensity_ = std::max(0.0f, damageFlashIntensity_ - damageFlashDecaySpeed_ * deltaTime);
+	ApplyToPostEffect();
+}
+
+void PlayerHealthPostEffectController::DrawImGui()
+{
+#ifdef USE_IMGUI
+	if (!ImGui::Begin("HPポストエフェクト"))
+	{
+		ImGui::End();
+		return;
+	}
+
+	ImGui::Checkbox("HPポストエフェクト有効", &enabled_);
+	ImGui::SliderFloat("HP率", &hpRate_, 0.0f, 1.0f);
+	ImGui::SliderFloat("赤ビネット強度", &redVignetteStrength_, 0.0f, 1.0f);
+	ImGui::SliderFloat("被弾フラッシュ強度", &damageFlashStrength_, 0.0f, 1.0f);
+	ImGui::SliderFloat("被弾フラッシュ減衰速度", &damageFlashDecaySpeed_, 0.1f, 10.0f);
+	ImGui::SliderFloat("彩度低下", &desaturationStrength_, 0.0f, 1.0f);
+	ImGui::SliderFloat("暗さ", &darkenStrength_, 0.0f, 1.0f);
+	ImGui::SliderFloat("脈動速度", &pulseSpeed_, 0.0f, 12.0f);
+	ImGui::SliderFloat("脈動強度", &pulseIntensity_, 0.0f, 0.5f);
+	ImGui::SliderFloat("低HPしきい値", &lowHpThreshold_, 0.01f, 1.0f);
+	ImGui::SliderFloat("危険HPしきい値", &dangerHpThreshold_, 0.01f, 1.0f);
+	lowHpThreshold_ = std::max(lowHpThreshold_, dangerHpThreshold_ + 0.01f);
+	strongHpThreshold_ = std::clamp(strongHpThreshold_, dangerHpThreshold_ + 0.01f, lowHpThreshold_);
+
+	ApplyToPostEffect();
+	ImGui::End();
+#endif // USE_IMGUI
+}
+
+void PlayerHealthPostEffectController::NotifyDamageTaken()
+{
+	damageFlashIntensity_ = std::max(damageFlashIntensity_, damageFlashStrength_);
+	ApplyToPostEffect();
+}
+
+Ken4lowEngine::PlayerHealthPostEffect* PlayerHealthPostEffectController::GetEffect() const
+{
+	if (!postEffectManager_)
+	{
+		return nullptr;
+	}
+
+	return dynamic_cast<Ken4lowEngine::PlayerHealthPostEffect*>(postEffectManager_->GetEffect(kEffectName));
+}
+
+Ken4lowEngine::PlayerHealthPostEffect::Parameters PlayerHealthPostEffectController::BuildParameters() const
+{
+	Ken4lowEngine::PlayerHealthPostEffect::Parameters params{};
+	params.lowHealthVignetteIntensity = CalculateLowHealthVignetteIntensity();
+	params.damageFlashIntensity = std::clamp(damageFlashIntensity_, 0.0f, 1.0f);
+	params.vignetteColor = { 1.0f, 0.02f, 0.02f, 1.0f };
+
+	const float dangerRate01 = CalculateLowRate01(dangerHpThreshold_);
+	params.desaturation = std::clamp(desaturationStrength_ * dangerRate01, 0.0f, 0.35f);
+	params.darkenIntensity = std::clamp(darkenStrength_ * dangerRate01, 0.0f, 0.30f);
+	params.pulseSpeed = (hpRate_ <= dangerHpThreshold_) ? pulseSpeed_ : 0.0f;
+	params.pulseIntensity = (hpRate_ <= dangerHpThreshold_) ? pulseIntensity_ : 0.0f;
+
+	return params;
+}
+
+float PlayerHealthPostEffectController::CalculateLowHealthVignetteIntensity() const
+{
+	if (hpRate_ > lowHpThreshold_)
+	{
+		return 0.0f;
+	}
+
+	const float lowRate01 = CalculateLowRate01(lowHpThreshold_);
+	const float strongRate01 = CalculateLowRate01(strongHpThreshold_);
+	const float dangerRate01 = CalculateLowRate01(dangerHpThreshold_);
+	const float baseIntensity = 0.35f * lowRate01 + 0.45f * strongRate01 + 0.20f * dangerRate01;
+	return std::clamp(baseIntensity * redVignetteStrength_, 0.0f, 0.75f);
+}
+
+float PlayerHealthPostEffectController::CalculateLowRate01(float threshold) const
+{
+	if (threshold <= 0.0f || hpRate_ >= threshold)
+	{
+		return 0.0f;
+	}
+
+	return std::clamp((threshold - hpRate_) / threshold, 0.0f, 1.0f);
+}
+
+void PlayerHealthPostEffectController::ApplyToPostEffect()
+{
+	if (!postEffectManager_)
+	{
+		return;
+	}
+
+	if (enabled_)
+	{
+		postEffectManager_->EnableEffect(kEffectName);
+	}
+	else
+	{
+		postEffectManager_->DisableEffect(kEffectName);
+	}
+
+	if (auto* effect = GetEffect())
+	{
+		effect->SetParameters(BuildParameters());
+		effect->SetElapsedTime(elapsedTime_);
+	}
+}

--- a/Project/ApplicationLayer/Scene/GamePlayScene/PostEffect/PlayerHealthPostEffectController.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/PostEffect/PlayerHealthPostEffectController.h
@@ -1,0 +1,50 @@
+#pragma once
+#include "Effects/PlayerHealthPostEffect/PlayerHealthPostEffect.h"
+
+namespace Ken4lowEngine
+{
+	class PostEffectManager;
+}
+
+class Player;
+
+/// -------------------------------------------------------------
+/// プレイヤーHPから画面危機演出用パラメータを計算するクラス
+/// -------------------------------------------------------------
+class PlayerHealthPostEffectController
+{
+public:
+	void Initialize(Ken4lowEngine::PostEffectManager* postEffectManager);
+	void Finalize();
+	void Update(float deltaTime, const Player* player);
+	void DrawImGui();
+	void NotifyDamageTaken();
+
+	bool IsEnabled() const { return enabled_; }
+	float GetHpRate() const { return hpRate_; }
+
+private:
+	Ken4lowEngine::PlayerHealthPostEffect* GetEffect() const;
+	Ken4lowEngine::PlayerHealthPostEffect::Parameters BuildParameters() const;
+	float CalculateLowHealthVignetteIntensity() const;
+	float CalculateLowRate01(float threshold) const;
+	void ApplyToPostEffect();
+
+private:
+	Ken4lowEngine::PostEffectManager* postEffectManager_ = nullptr;
+	bool enabled_ = true;
+	float hpRate_ = 1.0f;
+	float elapsedTime_ = 0.0f;
+
+	float redVignetteStrength_ = 0.35f;
+	float damageFlashStrength_ = 0.28f;
+	float damageFlashDecaySpeed_ = 3.8f;
+	float desaturationStrength_ = 0.18f;
+	float darkenStrength_ = 0.16f;
+	float pulseSpeed_ = 5.0f;
+	float pulseIntensity_ = 0.18f;
+	float lowHpThreshold_ = 0.70f;
+	float dangerHpThreshold_ = 0.20f;
+	float strongHpThreshold_ = 0.40f;
+	float damageFlashIntensity_ = 0.0f;
+};

--- a/Project/Engine/Graphics/PostEffect/Effects/PlayerHealthPostEffect/PlayerHealthPostEffect.cpp
+++ b/Project/Engine/Graphics/PostEffect/Effects/PlayerHealthPostEffect/PlayerHealthPostEffect.cpp
@@ -1,0 +1,103 @@
+#include "PlayerHealthPostEffect.h"
+#include <DirectXCommon.h>
+#include <PostEffectPipelineBuilder.h>
+#include <ResourceManager.h>
+#include <UAVManager.h>
+
+#ifdef USE_IMGUI
+#include <imgui.h>
+#endif // USE_IMGUI
+
+namespace Ken4lowEngine
+{
+
+void PlayerHealthPostEffect::Initialize(DirectXCommon* dxCommon, PostEffectPipelineBuilder* builder)
+{
+	dxCommon_ = dxCommon;
+
+	computeRootSignature_ = builder->CreateComputeRootSignature();
+	computePipelineState_ = builder->CreateComputePipeline(PostEffectComputeShaderId::PlayerHealthCS, computeRootSignature_.Get());
+
+	constantBuffer_ = ResourceManager::CreateBufferResource(dxCommon_->GetDevice(), sizeof(EffectSetting));
+	constantBuffer_->Map(0, nullptr, reinterpret_cast<void**>(&setting_));
+	WriteToConstantBuffer();
+
+	constantBuffer_->SetName(L"PlayerHealthPostEffect::ConstantBuffer");
+	computeRootSignature_->SetName(L"PlayerHealthPostEffect::ComputeRootSignature");
+	computePipelineState_->SetName(L"PlayerHealthPostEffect::ComputePipelineState");
+}
+
+void PlayerHealthPostEffect::Finalize()
+{
+	if (constantBuffer_ && setting_)
+	{
+		constantBuffer_->Unmap(0, nullptr);
+		setting_ = nullptr;
+	}
+
+	constantBuffer_.Reset();
+	computePipelineState_.Reset();
+	computeRootSignature_.Reset();
+	dxCommon_ = nullptr;
+}
+
+void PlayerHealthPostEffect::Apply(ID3D12GraphicsCommandList* commandList, uint32_t srvIndex, uint32_t uavIndex, uint32_t dsvIndex)
+{
+	(void)dsvIndex;
+
+	WriteToConstantBuffer();
+
+	commandList->SetComputeRootSignature(computeRootSignature_.Get());
+	commandList->SetPipelineState(computePipelineState_.Get());
+	commandList->SetComputeRootDescriptorTable(0, UAVManager::GetInstance()->GetGPUDescriptorHandle(srvIndex));
+	commandList->SetComputeRootDescriptorTable(1, UAVManager::GetInstance()->GetGPUDescriptorHandle(uavIndex));
+	commandList->SetComputeRootConstantBufferView(2, constantBuffer_->GetGPUVirtualAddress());
+
+	const uint32_t threadGroupSizeX = 8;
+	const uint32_t threadGroupSizeY = 8;
+	const uint32_t width = dxCommon_->GetClientWidth();
+	const uint32_t height = dxCommon_->GetClientHeight();
+	const uint32_t groupCountX = (width + threadGroupSizeX - 1) / threadGroupSizeX;
+	const uint32_t groupCountY = (height + threadGroupSizeY - 1) / threadGroupSizeY;
+
+	commandList->Dispatch(groupCountX, groupCountY, 1);
+}
+
+void PlayerHealthPostEffect::DrawImGui()
+{
+#ifdef USE_IMGUI
+	ImGui::Text("PlayerHealthPostEffect は PlayerHealthPostEffectController から制御します");
+	ImGui::Text("Vignette %.2f / Flash %.2f", parameters_.lowHealthVignetteIntensity, parameters_.damageFlashIntensity);
+#endif // USE_IMGUI
+}
+
+void PlayerHealthPostEffect::SetParameters(const Parameters& parameters)
+{
+	parameters_ = parameters;
+	WriteToConstantBuffer();
+}
+
+void PlayerHealthPostEffect::SetElapsedTime(float elapsedTime)
+{
+	elapsedTime_ = elapsedTime;
+	WriteToConstantBuffer();
+}
+
+void PlayerHealthPostEffect::WriteToConstantBuffer()
+{
+	if (!setting_)
+	{
+		return;
+	}
+
+	setting_->vignetteColor = parameters_.vignetteColor;
+	setting_->lowHealthVignetteIntensity = parameters_.lowHealthVignetteIntensity;
+	setting_->damageFlashIntensity = parameters_.damageFlashIntensity;
+	setting_->desaturation = parameters_.desaturation;
+	setting_->darkenIntensity = parameters_.darkenIntensity;
+	setting_->pulseSpeed = parameters_.pulseSpeed;
+	setting_->pulseIntensity = parameters_.pulseIntensity;
+	setting_->elapsedTime = elapsedTime_;
+}
+
+} // namespace Ken4lowEngine

--- a/Project/Engine/Graphics/PostEffect/Effects/PlayerHealthPostEffect/PlayerHealthPostEffect.h
+++ b/Project/Engine/Graphics/PostEffect/Effects/PlayerHealthPostEffect/PlayerHealthPostEffect.h
@@ -1,0 +1,62 @@
+#pragma once
+#include "IPostEffect.h"
+#include "Vector4.h"
+
+namespace Ken4lowEngine
+{
+
+/// -------------------------------------------------------------
+///       プレイヤーHP連動ポストエフェクト
+/// -------------------------------------------------------------
+class PlayerHealthPostEffect : public IPostEffect
+{
+public:
+	struct Parameters
+	{
+		float lowHealthVignetteIntensity = 0.0f;
+		float damageFlashIntensity = 0.0f;
+		Vector4 vignetteColor = { 1.0f, 0.0f, 0.0f, 1.0f };
+		float desaturation = 0.0f;
+		float darkenIntensity = 0.0f;
+		float pulseSpeed = 0.0f;
+		float pulseIntensity = 0.0f;
+	};
+
+private:
+	struct EffectSetting
+	{
+		Vector4 vignetteColor = { 1.0f, 0.0f, 0.0f, 1.0f };
+		float lowHealthVignetteIntensity = 0.0f;
+		float damageFlashIntensity = 0.0f;
+		float desaturation = 0.0f;
+		float darkenIntensity = 0.0f;
+		float pulseSpeed = 0.0f;
+		float pulseIntensity = 0.0f;
+		float elapsedTime = 0.0f;
+		float padding = 0.0f;
+	};
+
+public:
+	void Initialize(DirectXCommon* dxCommon, PostEffectPipelineBuilder* builder) override;
+	void Finalize() override;
+	void Apply(ID3D12GraphicsCommandList* commandList, uint32_t srvIndex, uint32_t uavIndex, uint32_t dsvIndex) override;
+	void DrawImGui() override;
+
+	void SetParameters(const Parameters& parameters);
+	const Parameters& GetParameters() const { return parameters_; }
+	void SetElapsedTime(float elapsedTime);
+
+private:
+	void WriteToConstantBuffer();
+
+private:
+	DirectXCommon* dxCommon_ = nullptr;
+	Microsoft::WRL::ComPtr<ID3D12PipelineState> computePipelineState_;
+	Microsoft::WRL::ComPtr<ID3D12RootSignature> computeRootSignature_;
+	Microsoft::WRL::ComPtr<ID3D12Resource> constantBuffer_;
+	EffectSetting* setting_ = nullptr;
+	Parameters parameters_{};
+	float elapsedTime_ = 0.0f;
+};
+
+} // namespace Ken4lowEngine

--- a/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.cpp
+++ b/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.cpp
@@ -26,6 +26,7 @@
 #include <AbsorbEffect.h>
 #include <DepthOutlineEffect.h>
 #include <PixelateEffect.h>
+#include "Effects/PlayerHealthPostEffect/PlayerHealthPostEffect.h"
 
 namespace Ken4lowEngine
 {
@@ -84,6 +85,7 @@ namespace Ken4lowEngine
 			{ "AbsorbEffect",			{ [] { return std::make_unique<AbsorbEffect>(); },           false, 9, "Visual" } },
 			{ "DepthOutLineEffect",		{ [] { return std::make_unique<DepthOutlineEffect>(CameraManager::GetInstance()->GetMainCamera()); }, false, 10, "Visual"} },
 			{ "PixelateEffect",			{ [] { return std::make_unique<PixelateEffect>(); },		 false, 11, "Visual" } },
+			{ "PlayerHealthPostEffect",	{ [] { return std::make_unique<PlayerHealthPostEffect>(); }, false, 12, "Color" } },
 		};
 
 		// ファクトリー関数を使ってエフェクトを生成
@@ -311,7 +313,7 @@ namespace Ken4lowEngine
 			auto& inRT = renderTargets_[src]; // 入力レンダーテクスチャ
 			auto& outRT = renderTargets_[dst]; // 出力レンダーテクスチャ
 
-			if (name == "GrayScaleEffect" || name == "RandomEffect" || name == "DissolveEffect" || name == "VignetteEffect" || name == "GaussianFilterEffect" || name == "RadialBlurEffect" || name == "LuminanceOutlineEffect" || name == "SmoothingEffect" || name == "PixelateEffect")
+			if (name == "GrayScaleEffect" || name == "RandomEffect" || name == "DissolveEffect" || name == "VignetteEffect" || name == "GaussianFilterEffect" || name == "RadialBlurEffect" || name == "LuminanceOutlineEffect" || name == "SmoothingEffect" || name == "PixelateEffect" || name == "PlayerHealthPostEffect")
 			{
 				Transition(inRT, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
 				Transition(outRT, D3D12_RESOURCE_STATE_UNORDERED_ACCESS);

--- a/Project/Engine/Graphics/Shader/Manifest/PostEffectShaderManifest.h
+++ b/Project/Engine/Graphics/Shader/Manifest/PostEffectShaderManifest.h
@@ -31,6 +31,7 @@ namespace Ken4lowEngine
 		SmoothingCS,
 		DissolveCS,
 		LuminanceOutlineCS,
+		PlayerHealthCS,
 	};
 
 	/// -------------------------------------------------------------
@@ -207,6 +208,19 @@ namespace Ken4lowEngine
 				static const ShaderDescriptor desc{
 					L"LuminanceOutlineEffectCS",
 					L"Resources/Shaders/PostEffect/LuminanceOutlineEffect.CS.hlsl",
+					L"main",
+					L"cs_6_6",
+					ShaderStage::Compute,
+					RootSignatureType::Compute
+				};
+				return desc;
+			}
+
+			case PostEffectComputeShaderId::PlayerHealthCS:
+			{
+				static const ShaderDescriptor desc{
+					L"PlayerHealthPostEffectCS",
+					L"Resources/Shaders/PostEffect/PlayerHealthPostEffect.CS.hlsl",
 					L"main",
 					L"cs_6_6",
 					ShaderStage::Compute,

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -279,6 +279,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\Camera\GamePlayIntroDirector.cpp" />
     <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\Core\GamePlayStageContext.cpp" />
     <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\World\GamePlayWorld.cpp" />
+    <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\PostEffect\PlayerHealthPostEffectController.cpp" />
     <ClCompile Include="ApplicationLayer\Character\Boss\BehaviorTree\IBTNode.cpp" />
     <ClCompile Include="ApplicationLayer\Character\Boss\Derived\GuardianBoss\GuardianBoss.cpp" />
     <ClCompile Include="ApplicationLayer\Character\Boss\BaseTypes\HumanoidBossBase.cpp" />
@@ -350,6 +351,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="Engine\Graphics\PostEffect\Effects\LuminanceOutlineEffect\LuminanceOutlineEffect.cpp" />
     <ClCompile Include="Engine\Graphics\PostEffect\Effects\NormalEffect\NormalEffect.cpp" />
     <ClCompile Include="Engine\Graphics\PostEffect\Effects\PixelateEffect\PixelateEffect.cpp" />
+    <ClCompile Include="Engine\Graphics\PostEffect\Effects\PlayerHealthPostEffect\PlayerHealthPostEffect.cpp" />
     <ClCompile Include="Engine\Graphics\PostEffect\Effects\RadialBlurEffect\RadialBlurEffect.cpp" />
     <ClCompile Include="Engine\Graphics\PostEffect\Effects\RandomEffect\RandomEffect.cpp" />
     <ClCompile Include="Engine\Graphics\PostEffect\Effects\SmoothingEffect\SmoothingEffect.cpp" />
@@ -532,6 +534,14 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </FxCompile>
     <FxCompile Include="Resources\Shaders\PostEffect\LuminanceOutlineEffect.CS.hlsl">
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Compute</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">4.0</ShaderModel>
+      <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Compute</ShaderType>
+      <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Release|x64'">4.0</ShaderModel>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </FxCompile>
+    <FxCompile Include="Resources\Shaders\PostEffect\PlayerHealthPostEffect.CS.hlsl">
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">Compute</ShaderType>
       <ShaderModel Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">4.0</ShaderModel>
       <ShaderType Condition="'$(Configuration)|$(Platform)'=='Release|x64'">Compute</ShaderType>
@@ -887,6 +897,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\Camera\GamePlayIntroDirector.h" />
     <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\Core\GamePlayStageContext.h" />
     <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\World\GamePlayWorld.h" />
+    <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\PostEffect\PlayerHealthPostEffectController.h" />
     <ClInclude Include="ApplicationLayer\Character\Boss\Attacks\IBossAttack.h" />
     <ClInclude Include="ApplicationLayer\Character\Boss\BehaviorTree\IBTNode.h" />
     <ClInclude Include="ApplicationLayer\Character\Boss\Derived\GuardianBoss\GuardianBoss.h" />
@@ -969,6 +980,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="Engine\Graphics\PostEffect\Effects\LuminanceOutlineEffect\LuminanceOutlineEffect.h" />
     <ClInclude Include="Engine\Graphics\PostEffect\Effects\NormalEffect\NormalEffect.h" />
     <ClInclude Include="Engine\Graphics\PostEffect\Effects\PixelateEffect\PixelateEffect.h" />
+    <ClInclude Include="Engine\Graphics\PostEffect\Effects\PlayerHealthPostEffect\PlayerHealthPostEffect.h" />
     <ClInclude Include="Engine\Graphics\PostEffect\Effects\RadialBlurEffect\RadialBlurEffect.h" />
     <ClInclude Include="Engine\Graphics\PostEffect\Effects\RandomEffect\RandomEffect.h" />
     <ClInclude Include="Engine\Graphics\PostEffect\Effects\SmoothingEffect\SmoothingEffect.h" />

--- a/Project/Ken4lowEngine.vcxproj.filters
+++ b/Project/Ken4lowEngine.vcxproj.filters
@@ -106,6 +106,9 @@
     <FxCompile Include="Resources\Shaders\PostEffect\PixelateEffect.CS.hlsl">
       <Filter>Shader\ComputeShader</Filter>
     </FxCompile>
+    <FxCompile Include="Resources\Shaders\PostEffect\PlayerHealthPostEffect.CS.hlsl">
+      <Filter>Shader\ComputeShader</Filter>
+    </FxCompile>
     <FxCompile Include="Resources\Shaders\GpuParticle\GpuParticleMesh.VS.hlsl">
       <Filter>Shader\VertexShader</Filter>
     </FxCompile>
@@ -143,6 +146,9 @@
       <Filter>ApplicationLayer\EffectLayer</Filter>
     </ClCompile>
     <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\GamePlayScene.cpp">
+      <Filter>ApplicationLayer\Scene\GamePlayScene</Filter>
+    </ClCompile>
+    <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\PostEffect\PlayerHealthPostEffectController.cpp">
       <Filter>ApplicationLayer\Scene\GamePlayScene</Filter>
     </ClCompile>
     <ClCompile Include="ApplicationLayer\Scene\PhysicalScene\PhysicalScene.cpp">
@@ -610,6 +616,9 @@
     <ClCompile Include="Engine\Graphics\PostEffect\Effects\PixelateEffect\PixelateEffect.cpp">
       <Filter>Engine\Graphics\PostEffect\Effects</Filter>
     </ClCompile>
+    <ClCompile Include="Engine\Graphics\PostEffect\Effects\PlayerHealthPostEffect\PlayerHealthPostEffect.cpp">
+      <Filter>Engine\Graphics\PostEffect\Effects</Filter>
+    </ClCompile>
     <ClCompile Include="Engine\Graphics\PostEffect\Effects\RadialBlurEffect\RadialBlurEffect.cpp">
       <Filter>Engine\Graphics\PostEffect\Effects</Filter>
     </ClCompile>
@@ -886,6 +895,9 @@
       <Filter>ApplicationLayer\EffectLayer</Filter>
     </ClInclude>
     <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\GamePlayScene.h">
+      <Filter>ApplicationLayer\Scene\GamePlayScene</Filter>
+    </ClInclude>
+    <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\PostEffect\PlayerHealthPostEffectController.h">
       <Filter>ApplicationLayer\Scene\GamePlayScene</Filter>
     </ClInclude>
     <ClInclude Include="ApplicationLayer\Scene\PhysicalScene\PhysicalScene.h">
@@ -1465,6 +1477,9 @@
       <Filter>Engine\Graphics\PostEffect\Effects</Filter>
     </ClInclude>
     <ClInclude Include="Engine\Graphics\PostEffect\Effects\PixelateEffect\PixelateEffect.h">
+      <Filter>Engine\Graphics\PostEffect\Effects</Filter>
+    </ClInclude>
+    <ClInclude Include="Engine\Graphics\PostEffect\Effects\PlayerHealthPostEffect\PlayerHealthPostEffect.h">
       <Filter>Engine\Graphics\PostEffect\Effects</Filter>
     </ClInclude>
     <ClInclude Include="Engine\Graphics\PostEffect\Effects\RadialBlurEffect\RadialBlurEffect.h">

--- a/Project/Resources/Shaders/PostEffect/PlayerHealthPostEffect.CS.hlsl
+++ b/Project/Resources/Shaders/PostEffect/PlayerHealthPostEffect.CS.hlsl
@@ -1,0 +1,52 @@
+// プレイヤーHP低下時の赤ビネット / 被弾フラッシュ用コンピュートシェーダー
+
+struct PlayerHealthSetting
+{
+    float4 vignetteColor;
+    float lowHealthVignetteIntensity;
+    float damageFlashIntensity;
+    float desaturation;
+    float darkenIntensity;
+    float pulseSpeed;
+    float pulseIntensity;
+    float elapsedTime;
+    float padding;
+};
+
+RWTexture2D<float4> gOutputTexture : register(u0);
+Texture2D<float4> gInputTexture : register(t0);
+ConstantBuffer<PlayerHealthSetting> gSetting : register(b0);
+
+[numthreads(8, 8, 1)]
+void main(uint3 DTid : SV_DispatchThreadID)
+{
+    uint w, h;
+    gOutputTexture.GetDimensions(w, h);
+    if (DTid.x >= w || DTid.y >= h)
+    {
+        return;
+    }
+
+    float4 color = gInputTexture.Load(int3(DTid.xy, 0));
+    float2 uv = (float2(DTid.xy) + 0.5f) / float2(w, h);
+    float2 centered = (uv - 0.5f) * float2((float)w / max((float)h, 1.0f), 1.0f);
+    float edge = smoothstep(0.28f, 0.74f, length(centered));
+
+    float pulse = 0.0f;
+    if (gSetting.pulseSpeed > 0.0f && gSetting.pulseIntensity > 0.0f)
+    {
+        pulse = (sin(gSetting.elapsedTime * gSetting.pulseSpeed) * 0.5f + 0.5f) * gSetting.pulseIntensity;
+    }
+
+    float vignetteAmount = saturate(gSetting.lowHealthVignetteIntensity * (1.0f + pulse));
+    float3 result = color.rgb;
+
+    float luminance = dot(result, float3(0.299f, 0.587f, 0.114f));
+    result = lerp(result, luminance.xxx, saturate(gSetting.desaturation));
+    result *= (1.0f - saturate(gSetting.darkenIntensity) * edge);
+
+    result = lerp(result, gSetting.vignetteColor.rgb, saturate(edge * vignetteAmount * gSetting.vignetteColor.a));
+    result = lerp(result, gSetting.vignetteColor.rgb, saturate(gSetting.damageFlashIntensity));
+
+    gOutputTexture[DTid.xy] = float4(saturate(result), color.a);
+}


### PR DESCRIPTION
### Motivation
- プレイヤーのHP残量や被弾直後の状態に応じて画面に危機感を伝えるポストエフェクトを追加するため。 
- まずは赤いビネット表現を優先し、被弾直後に一瞬の赤フラッシュを出せるようにするため。 
- ゲームプレイ側（GamePlayScene）を肥大化させないよう、演出計算を専用コントローラに分離するため。 
- 調整しやすくするため ImGui に日本語の設定項目を追加するため。 

### Description
- 新規に `PlayerHealthPostEffect`（`Engine/Graphics/PostEffect/Effects/PlayerHealthPostEffect`）を追加し、`lowHealthVignetteIntensity`/`damageFlashIntensity`/`vignetteColor`/`desaturation`/`darkenIntensity`/`pulseSpeed`/`pulseIntensity` を受け取るコンピュートシェーダー (`PlayerHealthPostEffect.CS.hlsl`) と定数バッファを実装しました。 
- 新規に `PlayerHealthPostEffectController` を追加し、Player の現在HP/最大HPから HP率を計算して各種パラメータを算出し `PlayerHealthPostEffect` に渡す責務を持たせ、`NotifyDamageTaken()` で被弾フラッシュを起動して時間で減衰させる処理を実装しました（ImGui 日本語項目を含む）。 
- Player 側に `SetOnDamageTakenCallback()` を追加し、被弾時にコントローラへ通知するよう接続、さらに `GamePlayScene` へコントローラの初期化/更新/Finalize 呼び出しを組み込みました（演算はコントローラへ委譲）。 
- `PostEffectManager` と `PostEffectShaderManifest` に本エフェクトを登録し、Visual Studio の `Project` / `filters` エントリを更新してビルド資産に追加しました。コード内に処理意図が分かる短いコメントも追加しています。 

### Testing
- 実行した自動検査として `git diff --check` を実行し問題ないことを確認しました（成功）。 
- プロジェクトファイルの整合性を Python の XML パーサで検査するために `python3` を用いて `Project/Ken4lowEngine.vcxproj` と `Project/Ken4lowEngine.vcxproj.filters` を `xml.etree.ElementTree.parse()` で読み込み、パースに成功することを確認しました（成功）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ff6633641c832d943b3d4adbd2adfc)