### PR TITLE
Add enemy item drop system (HealSmall / AmmoSmall)

### DIFF
--- a/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.cpp
+++ b/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.cpp
@@ -136,7 +136,12 @@ void CharacterWorld::Update(float dt)
 
 	for (auto& e : enemies_)
 	{
+		const bool wasDead = e->IsDead();
 		e->Update(dt);
+		if (!wasDead && e->IsDead() && onEnemyKilled_)
+		{
+			onEnemyKilled_(e->GetCenterPosition());
+		}
 	}
 
 	if (ctx_.collisionManager_)

--- a/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.h
+++ b/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <functional>
 #include <memory>
 #include <vector>
 #include <string>
@@ -59,6 +60,7 @@ public: /// ---------- メンバ関数 ---------- ///
 
 	// 全消し
 	void ClearEnemies();
+	void SetEnemyKilledCallback(std::function<void(const K4E::Vector3&)> callback) { onEnemyKilled_ = std::move(callback); }
 
 	int GetEnemyCount() const { return static_cast<int>(enemies_.size()); }
 
@@ -81,6 +83,7 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	// 敵の被弾エフェクトシステム
 	EnemyParticleEffectSystem enemyParticleEffectSystem_;
+	std::function<void(const K4E::Vector3&)> onEnemyKilled_{};
 
 private: /// ---------- デバッグ用 ---------- ///
 

--- a/Project/ApplicationLayer/Character/Player/Component/PlayerDamageComponent.cpp
+++ b/Project/ApplicationLayer/Character/Player/Component/PlayerDamageComponent.cpp
@@ -13,6 +13,17 @@
 #include <Camera.h>
 #include <Vector3.h>
 
+
+void PlayerDamageComponent::Heal(float amount)
+{
+	if (amount <= 0.0f) return;
+	state_.hp += amount;
+	if (state_.hp > state_.maxHp)
+	{
+		state_.hp = state_.maxHp;
+	}
+}
+
 void PlayerDamageComponent::Tick(float dt)
 {
 	for (auto it = state_.recentBulletHits.begin(); it != state_.recentBulletHits.end(); )

--- a/Project/ApplicationLayer/Character/Player/Component/PlayerDamageComponent.h
+++ b/Project/ApplicationLayer/Character/Player/Component/PlayerDamageComponent.h
@@ -89,6 +89,7 @@ public:
 
 	float GetHP() const { return state_.hp; }
 	float GetMaxHP() const { return state_.maxHp; }
+	void Heal(float amount);
 
 	bool IsRecentBulletHit(uint32_t id) const
 	{

--- a/Project/ApplicationLayer/Character/Player/Component/PlayerWeaponComponent.cpp
+++ b/Project/ApplicationLayer/Character/Player/Component/PlayerWeaponComponent.cpp
@@ -427,6 +427,24 @@ void PlayerWeaponComponent::BuildInitialAmmoViewCacheFromMasterData()
 	}
 }
 
+bool PlayerWeaponComponent::AddCurrentWeaponAmmo(int amount)
+{
+	if (!weaponLoaded_) return false;
+	if (amount <= 0) return false;
+	if (weaponCategory_ == EWeaponCategory::Melee) return false;
+
+	auto& weapon = weaponSys_.Weapon();
+	auto& state = weapon.StateMutable();
+	const auto& params = weapon.Params();
+	const int maxReserveAmmo = std::max(0, params.maxReserveAmmo);
+	if (maxReserveAmmo <= 0) return false;
+
+	const int before = state.reserveAmmo;
+	state.reserveAmmo = std::min(maxReserveAmmo, state.reserveAmmo + amount);
+	UpdateSelectedAmmoViewCache();
+	return state.reserveAmmo != before;
+}
+
 void PlayerWeaponComponent::UpdateSelectedAmmoViewCache() const
 {
 	if (!weaponLoaded_) return;

--- a/Project/ApplicationLayer/Character/Player/Component/PlayerWeaponComponent.h
+++ b/Project/ApplicationLayer/Character/Player/Component/PlayerWeaponComponent.h
@@ -111,6 +111,8 @@ public: /// ---------- メンバ関数 ---------- ///
 
 	void SwitchWeaponCategoryByDelta(int delta);
 
+	bool AddCurrentWeaponAmmo(int amount);
+
 private: /// ---------- メンバ関数 ---------- ///
 
 	void TickWeapon(float dt);

--- a/Project/ApplicationLayer/Character/Player/Player.h
+++ b/Project/ApplicationLayer/Character/Player/Player.h
@@ -126,6 +126,8 @@ public: /// ---------- メンバ関数 ---------- ///
 
 	float GetHP() const { return damage_.GetHP(); }
 	float GetMaxHP() const { return damage_.GetMaxHP(); }
+	void Heal(float amount) { damage_.Heal(amount); }
+	bool AddCurrentWeaponAmmo(int amount) { return weapon_.AddCurrentWeaponAmmo(amount); }
 
 	PlayerBrainComponent& GetBrainComponent() { return brainComponent_; }
 	const PlayerBrainComponent& GetBrainComponent() const { return brainComponent_; }

--- a/Project/ApplicationLayer/Item/Item.cpp
+++ b/Project/ApplicationLayer/Item/Item.cpp
@@ -1,196 +1,135 @@
 #include "Item.h"
 #include "Player.h"
-#include "ScoreManager.h"
-#include "GpuParticleEmitter.h"   // EmitterInfo を使うため（必要なら）
-#include "GpuParticleType.h"      // GpuParticleType::Heal_Effect
-#include "BillboardMode.h"
 #include <CollisionTypeIdDef.h>
+
+#include <cmath>
+#include <string>
 
 namespace K4E = ::Ken4lowEngine;
 
-/// -------------------------------------------------------------
-///							初期化処理
-/// -------------------------------------------------------------
-void Item::Initialize(ItemType type, const K4E::Vector3& pos)
+namespace
+{
+	const char* GetModelPath(ItemType type)
+	{
+		switch (type)
+		{
+		case ItemType::HealSmall:
+		case ItemType::AmmoSmall:
+		case ItemType::NextStageKey:
+		default:
+			return "cube.gltf";
+		}
+	}
+}
+
+void Item::Initialize(ItemType type, const K4E::Vector3& pos, int healAmount, int ammoAmount, float pickupRadius)
 {
 	K4E::Collider::SetTypeID(static_cast<uint32_t>(CollisionTypeIdDef::kItem));
 	K4E::Collider::SetOBBHalfSize(scale_);
 
-	// アイテムの種類と位置を設定
 	type_ = type;
 	position_ = pos;
 	basePosition_ = pos;
+	active_ = (type_ != ItemType::None);
+	pickupRadius_ = pickupRadius;
+	healAmount_ = healAmount;
+	ammoAmount_ = ammoAmount;
+	lifetime_ = 0.0f;
+	floatTimer_ = 0.0f;
+	rotation_ = { 0.0f, 0.0f, 0.0f };
 
-	std::string modelPath; // モデルパス
 	object3d_ = std::make_unique<K4E::Object3D>();
-
-	// アイテムの種類に応じてモデルと色を設定
-	switch (type_)
-	{
-	case ItemType::HealSmall:
-		modelPath = "cube.gltf"; break;
-
-	case ItemType::AmmoSmall:
-		modelPath = "cube.gltf"; break;
-
-	case ItemType::ScoreBonus:
-		modelPath = "cube.gltf"; break;
-
-	case ItemType::PowerUp:
-		modelPath = "cube.gltf"; break;
-
-	case ItemType::ExperienceOrb:
-		modelPath = "cube.gltf"; break;
-
-	case ItemType::Coin:
-		modelPath = "cube.gltf"; break;
-
-	case ItemType::NextStageKey:
-		modelPath = "cube.gltf"; break;
-	}
-
-	object3d_->Initialize(modelPath);
+	object3d_->Initialize(GetModelPath(type_));
 	object3d_->SetTranslate(position_);
-	object3d_->SetScale(scale_); // サイズを設定
+	object3d_->SetScale(scale_);
 
-	// 条件によって色を変える（変更予定）
 	switch (type_)
 	{
 	case ItemType::HealSmall:
-		object3d_->SetColor({ 1.0f,0.0f,0.0f,1.0f }); // 赤色
+		object3d_->SetColor({ 1.0f, 0.0f, 0.0f, 1.0f });
 		break;
-
 	case ItemType::AmmoSmall:
-		object3d_->SetColor({ 0.0f, 0.0f, 1.0f, 1.0f }); // 青色
+		object3d_->SetColor({ 0.0f, 0.0f, 1.0f, 1.0f });
 		break;
-
-	case ItemType::ScoreBonus:
-		object3d_->SetColor({ 1.0f, 1.0f, 0.0f, 1.0f }); // 黄色
-		break;
-
-	case ItemType::PowerUp:
-		object3d_->SetColor({ 1.0f, 0.5f, 0.0f, 1.0f }); // オレンジ色
-		break;
-
-	case ItemType::ExperienceOrb:
-		object3d_->SetColor({ 0.5f, 0.0f, 0.5f, 1.0f }); // 紫色
-		break;
-
-	case ItemType::Coin:
-		object3d_->SetColor({ 1.0f, 0.84f, 0.0f, 1.0f }); // 金色
-		break;
-
 	case ItemType::NextStageKey:
-		object3d_->SetColor({ 0.0f, 1.0f, 1.0f, 1.0f }); // シアン色
+		object3d_->SetColor({ 0.0f, 1.0f, 1.0f, 1.0f });
+		break;
+	case ItemType::None:
+	default:
+		object3d_->SetColor({ 1.0f, 1.0f, 1.0f, 0.5f });
 		break;
 	}
 }
 
-/// -------------------------------------------------------------
-///							更新処理
-/// -------------------------------------------------------------
 void Item::Update(float deltaTime)
 {
-	// 収集済みなら更新しない
-	if (collected_) return;
+	if (!active_) return;
 
-	// ライフタイム更新
 	lifetime_ += deltaTime;
-
-	// 浮遊アニメーション：サイン波でY位置を変更
-	floatTimer_ += floatSpeed_ * deltaTime;  // フレーム前提。可変FPSなら deltaTime を使う
-	float floatOffset = std::sinf(floatTimer_) * floatAmplitude_;
+	floatTimer_ += floatSpeed_ * deltaTime;
+	const float floatOffset = std::sinf(floatTimer_) * floatAmplitude_;
 	position_.y = basePosition_.y + floatOffset + 1.0f;
-
-	// Y軸を中心に回転
 	rotation_.y += rotationSpeed_;
 
-	object3d_->SetTranslate(position_);
-	object3d_->SetRotate(rotation_);
-	object3d_->Update();
+	if (object3d_)
+	{
+		object3d_->SetTranslate(position_);
+		object3d_->SetRotate(rotation_);
+		object3d_->Update();
+	}
 
 	K4E::Collider::SetCenterPosition(position_);
 }
 
-/// -------------------------------------------------------------
-///							描画処理
-/// -------------------------------------------------------------
 void Item::Draw()
 {
-	if (!collected_ && object3d_) {
+	if (active_ && object3d_)
+	{
 		object3d_->Draw();
 	}
 }
 
-/// -------------------------------------------------------------
-///						プレイヤーとの当たり判定
-/// -------------------------------------------------------------
-bool Item::CheckCollisionWithPlayer(const K4E::Vector3& playerPos)
+bool Item::CheckCollisionWithPlayer(const K4E::Vector3& playerPos) const
 {
-	const float pickupRadius = 2.0f;
+	if (!active_) return false;
 	const K4E::Vector3 diff = position_ - playerPos;
-	// 距離^2 ≤ 半径^2
-	return K4E::Vector3::Length(diff) <= (pickupRadius * pickupRadius);
+	return K4E::Vector3::Length(diff) <= pickupRadius_;
 }
 
-/// -------------------------------------------------------------
-///						効果適用
-/// -------------------------------------------------------------
-void Item::ApplyTo(Player* player)
+bool Item::OnPickup(Player& player)
 {
-	if (collected_ || !player) return;
+	if (!active_) return false;
 
 	switch (type_)
 	{
 	case ItemType::HealSmall:
-	{
-		// ① 回復（値は仮）
-		//player->AddHP(300);
-
-		// ② 回復パーティクル（下→上の Emit はシェーダ側 type=21 で実装済み想定）
-		////auto* pm = K4E::GpuParticleManager::GetInstance();
-
-		//// エミッターを作ってなければ作る（1回だけ）
-		//K4E::GpuParticleEmitter* emitter = pm->GetEmitter("Heal_Effect");
-		//if (!emitter)
-		//{
-		//	K4E::GpuParticleEmitter::K4E::EmitterInfo info{};
-		//	info.textureFilePath = "Effects/white.dds"; // とりあえず既存の白テクでOK（後で差し替え）
-		//	info.radius = 1.5f;                // 正方形範囲の“半辺”として使う想定
-		//	info.loopCount = 0;
-		//	info.loopFrequency = 0.0f;
-		//	info.drawType = 0;                 // 0なら type を使う
-		//	info.type = K4E::GpuParticleType::Heal_Effect;
-		//	info.billboardMode = K4E::BillboardMode::K4E::Camera;
-
-		//	emitter = pm->CreateEmitter("Heal_Effect", info);
-		//}
-
-		//if (emitter)
-		//{
-		//	// プレイヤー位置にセットしてバースト
-		//	// ※ Player の位置取得はあなたの実装に合わせて差し替え
-		//	emitter->SetPosition(player->GetCenterPosition() - K4E::Vector3(0.0f, 2.0f, 0.0f));
-		//	emitter->RequestEmit(40); // まずは 30〜60 で調整
-		//}
+		player.Heal(static_cast<float>(healAmount_));
 		break;
-	}
-
-	// 他のアイテムもここに追加していける
+	case ItemType::AmmoSmall:
+		player.AddCurrentWeaponAmmo(ammoAmount_);
+		break;
+	case ItemType::NextStageKey:
+	case ItemType::None:
 	default:
 		break;
 	}
 
-	collected_ = true;
+	active_ = false;
+	return true;
 }
 
-/// -------------------------------------------------------------
-///						衝突時の処理
-/// -------------------------------------------------------------
+void Item::ApplyTo(Player* player)
+{
+	if (!player) return;
+	(void)OnPickup(*player);
+}
+
 void Item::OnCollision(K4E::Collider* other)
 {
+	if (!other) return;
+
 	if (other->GetTypeID() == static_cast<uint32_t>(CollisionTypeIdDef::kPlayer))
 	{
-		ApplyTo(static_cast<Player*>(other)); // 効果適用
+		ApplyTo(static_cast<Player*>(other));
 	}
 }

--- a/Project/ApplicationLayer/Item/Item.h
+++ b/Project/ApplicationLayer/Item/Item.h
@@ -4,8 +4,6 @@
 #include "Collider.h"
 #include "ItemType.h"
 
-#include <GpuParticleManager.h>
-
 #include <memory>
 
 namespace K4E = ::Ken4lowEngine;
@@ -17,73 +15,51 @@ class Item : public K4E::Collider
 {
 public: /// ---------- メンバ関数 --------- ///
 
-	// 初期化処理
-	void Initialize(ItemType type, const K4E::Vector3& pos);
-
-	// 更新処理
+	void Initialize(ItemType type, const K4E::Vector3& pos, int healAmount = 25, int ammoAmount = 30, float pickupRadius = 2.0f);
 	void Update(float deltaTime);
-
-	// 描画処理
 	void Draw();
 
-	// 衝突判定
-	bool CheckCollisionWithPlayer(const K4E::Vector3& playerPos);
+	bool CheckCollisionWithPlayer(const K4E::Vector3& playerPos) const;
+	bool OnPickup(class Player& player);
+	void ApplyTo(class Player* player);
 
-	// 効果適用
-	void ApplyTo(class Player* player); // 効果適用
-
-	// アイテムの種類を取得
-	bool IsCollected() const { return collected_; }
+	bool IsCollected() const { return !active_; }
 	bool IsExpired() const { return lifetime_ >= maxLifetime_; }
+	bool IsActive() const { return active_; }
+
+	ItemType GetType() const { return type_; }
+	const K4E::Vector3& GetPosition() const { return position_; }
+	float GetPickupRadius() const { return pickupRadius_; }
+	int GetHealAmount() const { return healAmount_; }
+	int GetAmmoAmount() const { return ammoAmount_; }
 
 public: /// ---------- オーバーライド ---------- ///
 
-	// 衝突時の処理
 	void OnCollision(K4E::Collider* other) override;
-
-	// 中心座標を取得
 	K4E::Vector3 GetCenterPosition() const override { return position_; }
-
-	// 中心座標を設定
 	void SetCenterPosition(const K4E::Vector3& pos) override { position_ = pos; }
-
-	K4E::Vector3 GetOBBHalfSize() const override { return scale_; } // アイテムの大きさに応じて調整}
+	K4E::Vector3 GetOBBHalfSize() const override { return scale_; }
 	void SetOBBHalfSize(const K4E::Vector3& halfSize) override { scale_ = halfSize; }
-
-	// 回転（オイラー角）取得・設定
 	K4E::Vector3 GetOrientation() const override { return rotation_; }
 	void SetOrientation(const K4E::Vector3& rot) override { rotation_ = rot; }
 
-	// アイテムの種類を取得
-	ItemType GetType() const { return type_; }
-
 private: /// ---------- メンバ変数 ---------- ///
 
-	// アイテムの種類
-	ItemType type_ = {};
-
-	// スプライト
-	std::unique_ptr<K4E::Object3D> object3d_;
-
-	// アイテムの位置
+	ItemType type_ = ItemType::None;
 	K4E::Vector3 position_ = {};
+	bool active_ = false;
+	float pickupRadius_ = 2.0f;
+	int healAmount_ = 25;
+	int ammoAmount_ = 30;
 
-	// 収集済みフラグ
-	bool collected_ = false;
-
-	// アイテムの大きさ（スケール）
-	K4E::Vector3 scale_ = { 0.4f, 0.4f, 0.4f }; // スケール（大きさ）設定
-
-	float floatTimer_ = 0.0f;     // サイン波用タイマー
-	float floatAmplitude_ = 0.6f; // 上下振幅（移動幅）
-	float floatSpeed_ = 4.0f;     // 周期スピード
-	K4E::Vector3 basePosition_;        // 元の位置（初期位置）
-
-	// 回転用の変数
-	K4E::Vector3 rotation_ = { 0.0f, 0.0f, 0.0f }; // 回転用の変数
-	// 回転速度
-	float rotationSpeed_ = 0.01f; // 回転速度（ラジアン単位）
-
+	std::unique_ptr<K4E::Object3D> object3d_;
+	K4E::Vector3 scale_ = { 0.4f, 0.4f, 0.4f };
+	float floatTimer_ = 0.0f;
+	float floatAmplitude_ = 0.6f;
+	float floatSpeed_ = 4.0f;
+	K4E::Vector3 basePosition_ = {};
+	K4E::Vector3 rotation_ = { 0.0f, 0.0f, 0.0f };
+	float rotationSpeed_ = 0.01f;
 	float lifetime_ = 0.0f;
-	const float maxLifetime_ = 999.0f; // 秒単位で存在限界時間
+	const float maxLifetime_ = 999.0f;
 };

--- a/Project/ApplicationLayer/Item/ItemManager.cpp
+++ b/Project/ApplicationLayer/Item/ItemManager.cpp
@@ -2,90 +2,247 @@
 #include "Player.h"
 #include "CollisionManager.h"
 
+#ifdef USE_IMGUI
+#include <imgui.h>
+#endif
+
+#include <algorithm>
+
 namespace K4E = ::Ken4lowEngine;
 
-/// -------------------------------------------------------------
-///							初期化処理
-/// -------------------------------------------------------------
+namespace
+{
+	const char* ToItemTypeName(ItemType type)
+	{
+		switch (type)
+		{
+		case ItemType::HealSmall: return "HealSmall";
+		case ItemType::AmmoSmall: return "AmmoSmall";
+		case ItemType::NextStageKey: return "NextStageKey";
+		case ItemType::None:
+		default: return "None";
+		}
+	}
+}
+
 void ItemManager::Initialize()
 {
-	// アイテムリストをクリア
-	items_.clear();
-
-	// 取得イベントリストをクリア
-	collectedEvents_.clear();
+	Clear();
 }
 
-/// -------------------------------------------------------------
-///							更新処理
-/// -------------------------------------------------------------
+void ItemManager::Update(float deltaTime)
+{
+	for (auto& item : items_)
+	{
+		item->Update(deltaTime);
+	}
+
+	RemoveInactiveItems();
+}
+
 void ItemManager::Update(Player* player, float deltaTime)
 {
-	(void)player;
-
-	// アイテムの更新とプレイヤーとの衝突判定
-	for (auto& item : items_) item->Update(deltaTime);
-
-	// 消える前に「何を拾ったか」記録
-	for (auto& item : items_)
+	Update(deltaTime);
+	if (player)
 	{
-		if (item->IsCollected())
-		{
-			collectedEvents_.push_back(item->GetType()); // 取得イベントを追加
-		}
+		CheckPickup(*player);
 	}
-
-	// 寿命切れまたは取得済みのアイテムを削除
-	items_.erase(std::remove_if(items_.begin(), items_.end(), [](const std::unique_ptr<Item>& item) {
-		return item->IsCollected() || item->IsExpired(); }), items_.end());
 }
 
-/// -------------------------------------------------------------
-///							描画処理
-/// -------------------------------------------------------------
 void ItemManager::Draw()
 {
-	// アイテムの描画
-	for (auto& item : items_) item->Draw();
-}
-
-/// -------------------------------------------------------------
-///						衝突判定を登録
-/// -------------------------------------------------------------
-void ItemManager::RegisterColliders(CollisionManager* collisionManager)
-{
-	// 収集されていないアイテムのコライダーを登録
 	for (auto& item : items_)
 	{
-		// 収集されていないアイテムのみ登録
-		if (!item->IsCollected())
+		item->Draw();
+	}
+}
+
+void ItemManager::RegisterColliders(CollisionManager* collisionManager)
+{
+	if (!collisionManager) return;
+
+	if (registeredCollisionManager_)
+	{
+		for (auto& item : items_)
 		{
-			collisionManager->AddCollider(item.get()); // コライダーを登録
+			if (item)
+			{
+				registeredCollisionManager_->RemoveCollider(item.get());
+			}
+		}
+	}
+
+	registeredCollisionManager_ = collisionManager;
+	for (auto& item : items_)
+	{
+		if (item && item->IsActive())
+		{
+			registeredCollisionManager_->AddCollider(item.get());
 		}
 	}
 }
 
-/// -------------------------------------------------------------
-///							スポーン処理
-/// -------------------------------------------------------------
 void ItemManager::Spawn(ItemType type, const K4E::Vector3& position)
 {
-	auto item = std::make_unique<Item>(); // アイテムを生成
-	item->Initialize(type, position);	  // 初期化
-	items_.push_back(std::move(item));	  // リストに追加
+	SpawnConfigured(type, position);
+}
+
+void ItemManager::SpawnHealSmall(const K4E::Vector3& position)
+{
+	SpawnConfigured(ItemType::HealSmall, position);
+}
+
+void ItemManager::SpawnAmmoSmall(const K4E::Vector3& position)
+{
+	SpawnConfigured(ItemType::AmmoSmall, position);
+}
+
+void ItemManager::TryDropFromEnemyDeath(const K4E::Vector3& deathPosition)
+{
+	std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+	const float roll = dist(rng_);
+
+	K4E::Vector3 dropPosition = deathPosition;
+	dropPosition.y += 0.5f;
+
+	// ドロップ抽選は Heal → Ammo の順で合計確率を評価し、敵1体につき最大1個だけ出す。
+	if (roll < healDropChance_)
+	{
+		SpawnHealSmall(dropPosition);
+		lastDroppedItemType_ = ItemType::HealSmall;
+	}
+	else if (roll < healDropChance_ + ammoDropChance_)
+	{
+		SpawnAmmoSmall(dropPosition);
+		lastDroppedItemType_ = ItemType::AmmoSmall;
+	}
+	else
+	{
+		lastDroppedItemType_ = ItemType::None;
+	}
+}
+
+void ItemManager::CheckPickup(Player& player)
+{
+	const K4E::Vector3 playerPos = player.GetCenterPosition();
+
+	for (auto& item : items_)
+	{
+		if (!item->IsActive()) continue;
+
+		if (item->CheckCollisionWithPlayer(playerPos) && item->OnPickup(player))
+		{
+			lastPickedItemType_ = item->GetType();
+			collectedEvents_.push_back(item->GetType());
+		}
+	}
+
+	RemoveInactiveItems();
+}
+
+void ItemManager::Clear()
+{
+	if (registeredCollisionManager_)
+	{
+		for (auto& item : items_)
+		{
+			if (item)
+			{
+				registeredCollisionManager_->RemoveCollider(item.get());
+			}
+		}
+	}
+	items_.clear();
+	collectedEvents_.clear();
+	lastPickedItemType_ = ItemType::None;
+	lastDroppedItemType_ = ItemType::None;
+	registeredCollisionManager_ = nullptr;
 }
 
 bool ItemManager::ConsumeCollected(ItemType type)
 {
-	// 取得イベントリストを検索
 	auto it = std::find(collectedEvents_.begin(), collectedEvents_.end(), type);
 	if (it != collectedEvents_.end())
 	{
-		// 見つかった場合、イベントを消費して true を返す
 		collectedEvents_.erase(it);
 		return true;
 	}
 
-	// 見つからなかった場合、false を返す
 	return false;
+}
+
+int ItemManager::GetActiveItemCount() const
+{
+	return static_cast<int>(std::count_if(items_.begin(), items_.end(), [](const std::unique_ptr<Item>& item)
+		{
+			return item && item->IsActive();
+		}));
+}
+
+int ItemManager::GetActiveItemCount(ItemType type) const
+{
+	return static_cast<int>(std::count_if(items_.begin(), items_.end(), [type](const std::unique_ptr<Item>& item)
+		{
+			return item && item->IsActive() && item->GetType() == type;
+		}));
+}
+
+void ItemManager::DrawImGui()
+{
+#ifdef USE_IMGUI
+	if (!ImGui::Begin("アイテム管理"))
+	{
+		ImGui::End();
+		return;
+	}
+
+	ImGui::Text("Item数: %d", GetActiveItemCount());
+	ImGui::Text("HealSmall数: %d", GetActiveItemCount(ItemType::HealSmall));
+	ImGui::Text("AmmoSmall数: %d", GetActiveItemCount(ItemType::AmmoSmall));
+	float healDropPercent = healDropChance_ * 100.0f;
+	float ammoDropPercent = ammoDropChance_ * 100.0f;
+	if (ImGui::SliderFloat("Healドロップ確率", &healDropPercent, 0.0f, 100.0f, "%.0f%%"))
+	{
+		healDropChance_ = healDropPercent / 100.0f;
+	}
+	if (ImGui::SliderFloat("Ammoドロップ確率", &ammoDropPercent, 0.0f, 100.0f, "%.0f%%"))
+	{
+		ammoDropChance_ = ammoDropPercent / 100.0f;
+	}
+	ImGui::DragInt("Heal回復量", &healAmount_, 1, 0, 999);
+	ImGui::DragInt("Ammo回復量", &ammoAmount_, 1, 0, 999);
+	ImGui::DragFloat("pickupRadius", &pickupRadius_, 0.1f, 0.1f, 20.0f, "%.2f");
+	ImGui::Text("最後に取得したItemType: %s", ToItemTypeName(lastPickedItemType_));
+	ImGui::Text("最後にドロップしたItemType: %s", ToItemTypeName(lastDroppedItemType_));
+
+	ImGui::End();
+#else
+	(void)this;
+#endif
+}
+
+void ItemManager::RemoveInactiveItems()
+{
+	items_.erase(std::remove_if(items_.begin(), items_.end(), [this](const std::unique_ptr<Item>& item)
+		{
+			const bool shouldRemove = !item || item->IsCollected() || item->IsExpired();
+			if (shouldRemove && item && registeredCollisionManager_)
+			{
+				registeredCollisionManager_->RemoveCollider(item.get());
+			}
+			return shouldRemove;
+		}), items_.end());
+}
+
+void ItemManager::SpawnConfigured(ItemType type, const K4E::Vector3& position)
+{
+	if (type == ItemType::None) return;
+
+	auto item = std::make_unique<Item>();
+	item->Initialize(type, position, healAmount_, ammoAmount_, pickupRadius_);
+	if (registeredCollisionManager_)
+	{
+		registeredCollisionManager_->AddCollider(item.get());
+	}
+	items_.push_back(std::move(item));
 }

--- a/Project/ApplicationLayer/Item/ItemManager.h
+++ b/Project/ApplicationLayer/Item/ItemManager.h
@@ -1,13 +1,13 @@
 #pragma once
-#include <vector>
 #include <memory>
+#include <random>
+#include <vector>
 #include "Item.h"
-#include "CollisionManager.h"
 
 namespace K4E = ::Ken4lowEngine;
 
-/// ---------- 前方宣言 ---------- ///
 class Player;
+class CollisionManager;
 
 /// -------------------------------------------------------------
 ///						アイテムマネージャークラス
@@ -16,29 +16,51 @@ class ItemManager
 {
 public: /// ---------- メンバ関数 ---------- ///
 
-	// 初期化処理
 	void Initialize();
-
-	// 更新処理
+	void Update(float deltaTime);
 	void Update(Player* player, float deltaTime);
-
-	// 描画処理
 	void Draw();
-
-	// 衝突判定を登録
 	void RegisterColliders(CollisionManager* collisionManager);
 
-	// スポーン処理
 	void Spawn(ItemType type, const K4E::Vector3& position);
+	void SpawnHealSmall(const K4E::Vector3& position);
+	void SpawnAmmoSmall(const K4E::Vector3& position);
+	void TryDropFromEnemyDeath(const K4E::Vector3& deathPosition);
+	void CheckPickup(Player& player);
+	void Clear();
 
-	// 取得イベントの消費
 	bool ConsumeCollected(ItemType type);
+	int GetActiveItemCount() const;
+	int GetActiveItemCount(ItemType type) const;
+
+	float GetHealDropChance() const { return healDropChance_; }
+	float GetAmmoDropChance() const { return ammoDropChance_; }
+	int GetHealAmount() const { return healAmount_; }
+	int GetAmmoAmount() const { return ammoAmount_; }
+	float GetPickupRadius() const { return pickupRadius_; }
+	ItemType GetLastPickedItemType() const { return lastPickedItemType_; }
+	ItemType GetLastDroppedItemType() const { return lastDroppedItemType_; }
+
+	void DrawImGui();
+
+private: /// ---------- メンバ関数 ---------- ///
+
+	void RemoveInactiveItems();
+	void SpawnConfigured(ItemType type, const K4E::Vector3& position);
 
 private: /// ---------- メンバ変数 ---------- ///
 
-	// アイテムリスト
 	std::vector<std::unique_ptr<Item>> items_;
-
-	// 取得イベントリスト
 	std::vector<ItemType> collectedEvents_;
+
+	float healDropChance_ = 0.25f;
+	float ammoDropChance_ = 0.35f;
+	int healAmount_ = 25;
+	int ammoAmount_ = 30;
+	float pickupRadius_ = 2.0f;
+	ItemType lastPickedItemType_ = ItemType::None;
+	ItemType lastDroppedItemType_ = ItemType::None;
+	CollisionManager* registeredCollisionManager_ = nullptr;
+
+	std::mt19937 rng_{ std::random_device{}() };
 };

--- a/Project/ApplicationLayer/Item/ItemType.h
+++ b/Project/ApplicationLayer/Item/ItemType.h
@@ -3,12 +3,8 @@
 /// ---------- アイテムの定義 ---------- ///
 enum class ItemType
 {
-	HealSmall,     // 小回復
-	AmmoSmall,     // 弾薬少量
-	ScoreBonus,    // スコア加算
-	PowerUp,       // 一時的な強化（後で）
-	ExperienceOrb, // 経験値オーブ（後で）
-	Coin,          // コイン（後で）
-	NextStageKey, // 次ステージへの鍵（後で）
-	None           // 無効
+	None = 0,
+	HealSmall,
+	AmmoSmall,
+	NextStageKey,
 };

--- a/Project/ApplicationLayer/Scene/GamePlayScene/DebugTools/GamePlayDebugTools.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/DebugTools/GamePlayDebugTools.cpp
@@ -118,6 +118,7 @@ void GamePlayDebugTools::DrawImGui(GamePlayWorld* world)
 
 	K4E::LightManager::GetInstance()->DrawImGui();
 	characters.DrawImGui();
+	world->DrawImGui();
 	stageChunkDebugController_.DrawImGui(world->GetStage());
 	occlusionDebugController_.DrawImGui(world->GetStage());
 

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
@@ -45,6 +45,11 @@ void GamePlayWorld::Initialize(GamePlayStageContext& stageContext)
 	ctx.collisionManager_ = collisionManager_.get();
 	ctx.bulletManager_ = bulletManager_.get();
 	characters_.Initialize(ctx);
+	itemManager_.Initialize();
+	characters_.SetEnemyKilledCallback([this](const K4E::Vector3& deathPosition)
+		{
+			itemManager_.TryDropFromEnemyDeath(deathPosition);
+		});
 
 	hudManager_ = std::make_unique<HUDManager>();
 	hudManager_->SetPlayer(characters_.GetPlayer());
@@ -121,6 +126,7 @@ void GamePlayWorld::Finalize()
 	hudManager_.reset();
 
 	EnemyBase::SetGlobalStageWorldAABBs(nullptr);
+	itemManager_.Clear();
 
 	characters_.Finalize();
 
@@ -147,6 +153,14 @@ void GamePlayWorld::Update(float deltaTime)
 	}
 
 	characters_.Update(deltaTime);
+	if (auto* player = characters_.GetPlayer())
+	{
+		itemManager_.Update(player, deltaTime);
+	}
+	else
+	{
+		itemManager_.Update(deltaTime);
+	}
 
 	UpdateShadowLightViewProjection();
 
@@ -283,6 +297,8 @@ void GamePlayWorld::Draw3D(bool hideCharactersDuringIntro)
 		bulletManager_->Draw();
 	}
 
+	itemManager_.Draw();
+
 #ifdef _DEBUG
 	if (collisionManager_)
 	{
@@ -319,6 +335,11 @@ void GamePlayWorld::DrawHUD(bool hideDuringIntro)
 	{
 		hudManager_->Draw();
 	}
+}
+
+void GamePlayWorld::DrawImGui()
+{
+	itemManager_.DrawImGui();
 }
 
 void GamePlayWorld::SyncAfterPlayerSpawn()

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.h
@@ -8,6 +8,7 @@
 #include "GamePlayStageContext.h"
 #include <SkyBox.h>
 #include "EnemyHPBarManager.h"
+#include "ItemManager.h"
 
 #include <memory>
 
@@ -27,6 +28,7 @@ public: /// ---------- メンバ関数 ---------- ///
 	void Draw3D(bool hideCharactersDuringIntro);
 	void DrawShadow(bool hideCharactersDuringIntro);
 	void DrawHUD(bool hideDuringIntro);
+	void DrawImGui();
 
 	void SyncAfterPlayerSpawn();
 	void StartWaves();
@@ -82,6 +84,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	std::unique_ptr<HUDManager> hudManager_ = nullptr;
 
 	EnemyHPBarManager enemyHpBarManager_;
+	ItemManager itemManager_;
 
 	int prevWaveNumber_ = 0;
 	bool prevWaveInProgress_ = false;


### PR DESCRIPTION
### Motivation
- Provide a lightweight item drop system so enemies can drop healing or ammo pickups on death using the existing Item concept. 
- Keep GamePlayScene/world code small by delegating spawn/pickup logic to an ItemManager and wire minimal hooks from enemy death to the manager.
- Only implement HealSmall / AmmoSmall behavior for now and leave other item types (score/coin/exp/powerup) out of scope.

### Description
- Reduced `ItemType` to the minimal set (`None, HealSmall, AmmoSmall, NextStageKey`) and removed unused legacy entries. 
- Reworked `Item` to own type/position/active/pickupRadius/healAmount/ammoAmount and added `Initialize`, `Update`, `Draw`, `CheckCollisionWithPlayer`, `OnPickup` and `ApplyTo` to implement float animation, pickup detection and effect application. 
- Implemented `ItemManager` (spawn helpers `SpawnHealSmall`/`SpawnAmmoSmall`, `TryDropFromEnemyDeath`, `Update`, `Draw`, `RegisterColliders`, `CheckPickup`, `Clear`, `GetActiveItemCount`, ImGui panel) and a simple drop table with configured chances (Heal 25%, Ammo 35%, rest none). 
- Added a killed-enemy callback in `CharacterWorld` and connected it from `GamePlayWorld` to call the `ItemManager` so enemies drop items at their death position (with a small +0.5f Y offset). 
- Hooked pickups into player systems with minimal changes: added `Heal(float)` in player damage component and `AddCurrentWeaponAmmo(int)` in the player/weapon component to clamp values to their maxima; `Item::OnPickup` calls these. 
- Exposed Item diagnostics in ImGui: total items, counts per type, heal/ammo drop % and amounts, pickup radius and last picked/dropped type; added `GamePlayWorld::DrawImGui()` to show the panel in debug UI. 

### Testing
- Ran repository static/document searches to validate removal of unused item enums and to locate modified integration points; these checks passed and confirm references were updated. 
- Performed repository integrity checks and whitespace/error checks; no issues were reported. 
- Did not run a full build in this environment because Windows build tools were not available in the container, so binary/compile validation was not executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffebde944c832da0435112739cd105)