### PR TITLE
Fix enemy item drops and add debug forced-drop controls

### DIFF
--- a/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.cpp
+++ b/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.cpp
@@ -29,6 +29,7 @@ void CharacterWorld::Initialize(GameContext& ctx)
 	}
 
 	enemies_.clear();
+	notifiedKilledEnemies_.clear();
 }
 
 void CharacterWorld::Finalize()
@@ -120,6 +121,8 @@ Enemy& CharacterWorld::SpawnEnemyAt(const K4E::Vector3& position)
 
 void CharacterWorld::ClearEnemies()
 {
+	notifiedKilledEnemies_.clear();
+
 	if (ctx_.collisionManager_)
 	{
 		for (auto& e : enemies_)
@@ -136,11 +139,17 @@ void CharacterWorld::Update(float dt)
 
 	for (auto& e : enemies_)
 	{
-		const bool wasDead = e->IsDead();
+		const bool wasAlreadyNotified = notifiedKilledEnemies_.contains(e.get());
 		e->Update(dt);
-		if (!wasDead && e->IsDead() && onEnemyKilled_)
+
+		// 衝突更新で死亡した敵も次フレームに1回だけ通知して、ドロップ生成の取り逃しを防ぐ。
+		if (!wasAlreadyNotified && e->IsDead())
 		{
-			onEnemyKilled_(e->GetCenterPosition());
+			notifiedKilledEnemies_.insert(e.get());
+			if (onEnemyKilled_)
+			{
+				onEnemyKilled_(e->GetCenterPosition());
+			}
 		}
 	}
 
@@ -152,6 +161,7 @@ void CharacterWorld::Update(float dt)
 				{
 					if (e && e->IsRemovable())
 					{
+						notifiedKilledEnemies_.erase(e.get());
 						ctx_.collisionManager_->RemoveCollider(e.get());
 						return true;
 					}

--- a/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.h
+++ b/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.h
@@ -3,6 +3,7 @@
 #include <memory>
 #include <vector>
 #include <string>
+#include <unordered_set>
 
 #include "Player.h"
 #include "Enemy.h"
@@ -84,6 +85,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	// 敵の被弾エフェクトシステム
 	EnemyParticleEffectSystem enemyParticleEffectSystem_;
 	std::function<void(const K4E::Vector3&)> onEnemyKilled_{};
+	std::unordered_set<const Enemy*> notifiedKilledEnemies_;
 
 private: /// ---------- デバッグ用 ---------- ///
 

--- a/Project/ApplicationLayer/Item/ItemManager.cpp
+++ b/Project/ApplicationLayer/Item/ItemManager.cpp
@@ -1,3 +1,4 @@
+#define NOMINMAX
 #include "ItemManager.h"
 #include "Player.h"
 #include "CollisionManager.h"
@@ -7,6 +8,10 @@
 #endif
 
 #include <algorithm>
+#include <sstream>
+#include <string>
+
+#include <Windows.h>
 
 namespace K4E = ::Ken4lowEngine;
 
@@ -99,11 +104,18 @@ void ItemManager::SpawnAmmoSmall(const K4E::Vector3& position)
 
 void ItemManager::TryDropFromEnemyDeath(const K4E::Vector3& deathPosition)
 {
-	std::uniform_real_distribution<float> dist(0.0f, 1.0f);
-	const float roll = dist(rng_);
-
 	K4E::Vector3 dropPosition = deathPosition;
 	dropPosition.y += 0.5f;
+
+	if (forceEnemyDeathDrop_)
+	{
+		SpawnHealSmall(dropPosition);
+		lastDroppedItemType_ = ItemType::HealSmall;
+		return;
+	}
+
+	std::uniform_real_distribution<float> dist(0.0f, 1.0f);
+	const float roll = dist(rng_);
 
 	// ドロップ抽選は Heal → Ammo の順で合計確率を評価し、敵1体につき最大1個だけ出す。
 	if (roll < healDropChance_)
@@ -199,6 +211,7 @@ void ItemManager::DrawImGui()
 	ImGui::Text("Item数: %d", GetActiveItemCount());
 	ImGui::Text("HealSmall数: %d", GetActiveItemCount(ItemType::HealSmall));
 	ImGui::Text("AmmoSmall数: %d", GetActiveItemCount(ItemType::AmmoSmall));
+	ImGui::Checkbox("敵死亡時ドロップを必ず発生させる", &forceEnemyDeathDrop_);
 	float healDropPercent = healDropChance_ * 100.0f;
 	float ammoDropPercent = ammoDropChance_ * 100.0f;
 	if (ImGui::SliderFloat("Healドロップ確率", &healDropPercent, 0.0f, 100.0f, "%.0f%%"))
@@ -245,4 +258,12 @@ void ItemManager::SpawnConfigured(ItemType type, const K4E::Vector3& position)
 		registeredCollisionManager_->AddCollider(item.get());
 	}
 	items_.push_back(std::move(item));
+
+	std::ostringstream oss;
+	oss << "DropItem Spawned"
+		<< " ItemType=" << ToItemTypeName(type)
+		<< " SpawnPosition=(" << position.x << ", " << position.y << ", " << position.z << ")"
+		<< " ActiveItemCount=" << GetActiveItemCount()
+		<< "\n";
+	OutputDebugStringA(oss.str().c_str());
 }

--- a/Project/ApplicationLayer/Item/ItemManager.h
+++ b/Project/ApplicationLayer/Item/ItemManager.h
@@ -38,6 +38,7 @@ public: /// ---------- メンバ関数 ---------- ///
 	int GetHealAmount() const { return healAmount_; }
 	int GetAmmoAmount() const { return ammoAmount_; }
 	float GetPickupRadius() const { return pickupRadius_; }
+	bool IsForceEnemyDeathDropEnabled() const { return forceEnemyDeathDrop_; }
 	ItemType GetLastPickedItemType() const { return lastPickedItemType_; }
 	ItemType GetLastDroppedItemType() const { return lastDroppedItemType_; }
 
@@ -60,6 +61,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	float pickupRadius_ = 2.0f;
 	ItemType lastPickedItemType_ = ItemType::None;
 	ItemType lastDroppedItemType_ = ItemType::None;
+	bool forceEnemyDeathDrop_ = true;
 	CollisionManager* registeredCollisionManager_ = nullptr;
 
 	std::mt19937 rng_{ std::random_device{}() };

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
@@ -46,6 +46,7 @@ void GamePlayWorld::Initialize(GamePlayStageContext& stageContext)
 	ctx.bulletManager_ = bulletManager_.get();
 	characters_.Initialize(ctx);
 	itemManager_.Initialize();
+	itemManager_.RegisterColliders(collisionManager_.get());
 	characters_.SetEnemyKilledCallback([this](const K4E::Vector3& deathPosition)
 		{
 			itemManager_.TryDropFromEnemyDeath(deathPosition);


### PR DESCRIPTION
### Motivation
- Enemy death notifications could be missed when death is detected during collision update, causing `ItemManager::TryDropFromEnemyDeath` to never be called for some kills. 
- `ItemManager` wasn’t registered with the scene `CollisionManager` at initialization, so spawned items might not have their colliders registered. 
- Added temporary debug controls to force-perform drops and make drop tuning / spawn logging easy during verification.

### Description
- CharacterWorld: track per-enemy notifications with `std::unordered_set<const Enemy*> notifiedKilledEnemies_` and send the death callback at most once per enemy to avoid missed drop events (cleared on `ClearEnemies()` and when enemies are removed). (files: `CharacterWorld.h/cpp`).
- GamePlayWorld: register `ItemManager` colliders with the world `CollisionManager` during `Initialize()` so spawned items get their colliders added (`itemManager_.RegisterColliders(collisionManager_.get());`). (file: `GamePlayWorld.cpp`).
- ItemManager: add a debug `forceEnemyDeathDrop_` flag (default `true`) with an ImGui `Checkbox` to force `HealSmall` to spawn on enemy death for verification, allow adjusting drop chances via existing sliders, and apply a `y += 0.5f` spawn lift to avoid ground clipping; logs spawn events (`DropItem Spawned`, `ItemType`, `SpawnPosition`, `ActiveItemCount`) via `OutputDebugStringA` after spawn. (files: `ItemManager.h/cpp`).
- Minor includes and platform macros added to support `OutputDebugStringA` logging and prevent macro collisions (`#define NOMINMAX` and `#include <Windows.h>`). 
- A short in-code comment was added to explain the per-enemy one-time notification logic.

### Testing
- Ran `git diff --check` to ensure no whitespace / trivial diff issues, which passed. 
- Searched repository to verify inserted symbols and logging lines using `rg`/`rg -n`, which confirmed the new API calls and debug strings were present. 
- Attempted to build with `msbuild Project/Ken4lowEngine.sln` but `msbuild` is not available in this environment so a full compile could not be executed here (manual/local build recommended). 
- All code changes were committed (`Fix enemy item drops`) and basic static checks (file diffs and grep) succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ffef766f6c832d939f8bca5748d0a0)