### PR TITLE
Centralize enemy drop roll in ItemManager (Heal/Ammo/None) with ImGui tuning and logging

### DIFF
--- a/Project/ApplicationLayer/Item/ItemManager.cpp
+++ b/Project/ApplicationLayer/Item/ItemManager.cpp
@@ -99,39 +99,71 @@ void ItemManager::SpawnHealSmall(const K4E::Vector3& position)
 
 void ItemManager::SpawnAmmoSmall(const K4E::Vector3& position)
 {
-	SpawnConfigured(ItemType::AmmoSmall, position);
+	K4E::Vector3 spawnPosition = position;
+	spawnPosition.y += 0.5f;
+	SpawnConfigured(ItemType::AmmoSmall, spawnPosition);
 }
 
 void ItemManager::TryDropFromEnemyDeath(const K4E::Vector3& deathPosition)
 {
+	TryDropEnemyItem(deathPosition);
+}
+
+void ItemManager::TryDropEnemyItem(const K4E::Vector3& deathPosition)
+{
 	K4E::Vector3 dropPosition = deathPosition;
 	dropPosition.y += 0.5f;
+	lastDropPosition_ = dropPosition;
 
-	if (forceEnemyDeathDrop_)
+	if (!enemyDeathDropEnabled_)
 	{
-		SpawnHealSmall(dropPosition);
-		lastDroppedItemType_ = ItemType::HealSmall;
+		lastDroppedItemType_ = ItemType::None;
+		LogDropRollResult(lastDroppedItemType_, dropPosition);
 		return;
+	}
+
+	lastDroppedItemType_ = RollEnemyDrop();
+	if (lastDroppedItemType_ != ItemType::None)
+	{
+		SpawnDropItem(lastDroppedItemType_, dropPosition);
+	}
+
+	LogDropRollResult(lastDroppedItemType_, dropPosition);
+}
+
+ItemType ItemManager::RollEnemyDrop()
+{
+	const float healRate = std::max(0.0f, healDropChance_);
+	const float ammoRate = std::max(0.0f, ammoDropChance_);
+	float totalDropRate = healRate + ammoRate;
+
+	if (totalDropRate <= 0.0f)
+	{
+		return forceEnemyDeathDrop_ ? ItemType::HealSmall : ItemType::None;
+	}
+
+	float effectiveHealRate = healRate;
+	float effectiveAmmoRate = ammoRate;
+	if (forceEnemyDeathDrop_ || totalDropRate > 1.0f)
+	{
+		effectiveHealRate = healRate / totalDropRate;
+		effectiveAmmoRate = ammoRate / totalDropRate;
 	}
 
 	std::uniform_real_distribution<float> dist(0.0f, 1.0f);
 	const float roll = dist(rng_);
 
-	// ドロップ抽選は Heal → Ammo の順で合計確率を評価し、敵1体につき最大1個だけ出す。
-	if (roll < healDropChance_)
+	// Heal/Ammo/None の抽選を ItemManager に集約し、シーン側に確率分岐を置かない。
+	if (roll < effectiveHealRate)
 	{
-		SpawnHealSmall(dropPosition);
-		lastDroppedItemType_ = ItemType::HealSmall;
+		return ItemType::HealSmall;
 	}
-	else if (roll < healDropChance_ + ammoDropChance_)
+	if (roll < effectiveHealRate + effectiveAmmoRate)
 	{
-		SpawnAmmoSmall(dropPosition);
-		lastDroppedItemType_ = ItemType::AmmoSmall;
+		return ItemType::AmmoSmall;
 	}
-	else
-	{
-		lastDroppedItemType_ = ItemType::None;
-	}
+
+	return ItemType::None;
 }
 
 void ItemManager::CheckPickup(Player& player)
@@ -168,6 +200,7 @@ void ItemManager::Clear()
 	collectedEvents_.clear();
 	lastPickedItemType_ = ItemType::None;
 	lastDroppedItemType_ = ItemType::None;
+	lastDropPosition_ = {};
 	registeredCollisionManager_ = nullptr;
 }
 
@@ -199,6 +232,11 @@ int ItemManager::GetActiveItemCount(ItemType type) const
 		}));
 }
 
+float ItemManager::GetNoneDropChance() const
+{
+	return std::max(0.0f, 1.0f - std::max(0.0f, healDropChance_) - std::max(0.0f, ammoDropChance_));
+}
+
 void ItemManager::DrawImGui()
 {
 #ifdef USE_IMGUI
@@ -208,25 +246,36 @@ void ItemManager::DrawImGui()
 		return;
 	}
 
-	ImGui::Text("Item数: %d", GetActiveItemCount());
+	ImGui::Text("Active Item数: %d", GetActiveItemCount());
 	ImGui::Text("HealSmall数: %d", GetActiveItemCount(ItemType::HealSmall));
 	ImGui::Text("AmmoSmall数: %d", GetActiveItemCount(ItemType::AmmoSmall));
-	ImGui::Checkbox("敵死亡時ドロップを必ず発生させる", &forceEnemyDeathDrop_);
+	ImGui::Checkbox("敵死亡時ドロップ有効", &enemyDeathDropEnabled_);
+	ImGui::Checkbox("必ず何か落とす", &forceEnemyDeathDrop_);
 	float healDropPercent = healDropChance_ * 100.0f;
 	float ammoDropPercent = ammoDropChance_ * 100.0f;
-	if (ImGui::SliderFloat("Healドロップ確率", &healDropPercent, 0.0f, 100.0f, "%.0f%%"))
+	if (ImGui::SliderFloat("HealSmallドロップ確率", &healDropPercent, 0.0f, 100.0f, "%.0f%%"))
 	{
 		healDropChance_ = healDropPercent / 100.0f;
 	}
-	if (ImGui::SliderFloat("Ammoドロップ確率", &ammoDropPercent, 0.0f, 100.0f, "%.0f%%"))
+	if (ImGui::SliderFloat("AmmoSmallドロップ確率", &ammoDropPercent, 0.0f, 100.0f, "%.0f%%"))
 	{
 		ammoDropChance_ = ammoDropPercent / 100.0f;
+	}
+	ImGui::Text("None確率表示: %.0f%%", GetNoneDropChance() * 100.0f);
+	if (healDropChance_ + ammoDropChance_ > 1.0f)
+	{
+		ImGui::TextColored(ImVec4(1.0f, 0.75f, 0.0f, 1.0f), "Heal+Ammoが100%%超過: 内部で正規化します");
+	}
+	if (forceEnemyDeathDrop_)
+	{
+		ImGui::Text("必ず何か落とすON: Noneは選ばれません");
 	}
 	ImGui::DragInt("Heal回復量", &healAmount_, 1, 0, 999);
 	ImGui::DragInt("Ammo回復量", &ammoAmount_, 1, 0, 999);
 	ImGui::DragFloat("pickupRadius", &pickupRadius_, 0.1f, 0.1f, 20.0f, "%.2f");
 	ImGui::Text("最後に取得したItemType: %s", ToItemTypeName(lastPickedItemType_));
 	ImGui::Text("最後にドロップしたItemType: %s", ToItemTypeName(lastDroppedItemType_));
+	ImGui::Text("最後のドロップ位置: (%.2f, %.2f, %.2f)", lastDropPosition_.x, lastDropPosition_.y, lastDropPosition_.z);
 
 	ImGui::End();
 #else
@@ -247,6 +296,11 @@ void ItemManager::RemoveInactiveItems()
 		}), items_.end());
 }
 
+void ItemManager::SpawnDropItem(ItemType type, const K4E::Vector3& position)
+{
+	SpawnConfigured(type, position);
+}
+
 void ItemManager::SpawnConfigured(ItemType type, const K4E::Vector3& position)
 {
 	if (type == ItemType::None) return;
@@ -261,6 +315,17 @@ void ItemManager::SpawnConfigured(ItemType type, const K4E::Vector3& position)
 
 	std::ostringstream oss;
 	oss << "DropItem Spawned"
+		<< " ItemType=" << ToItemTypeName(type)
+		<< " SpawnPosition=(" << position.x << ", " << position.y << ", " << position.z << ")"
+		<< " ActiveItemCount=" << GetActiveItemCount()
+		<< "\n";
+	OutputDebugStringA(oss.str().c_str());
+}
+
+void ItemManager::LogDropRollResult(ItemType type, const K4E::Vector3& position) const
+{
+	std::ostringstream oss;
+	oss << "Drop Roll Result"
 		<< " ItemType=" << ToItemTypeName(type)
 		<< " SpawnPosition=(" << position.x << ", " << position.y << ", " << position.z << ")"
 		<< " ActiveItemCount=" << GetActiveItemCount()

--- a/Project/ApplicationLayer/Item/ItemManager.h
+++ b/Project/ApplicationLayer/Item/ItemManager.h
@@ -26,6 +26,8 @@ public: /// ---------- メンバ関数 ---------- ///
 	void SpawnHealSmall(const K4E::Vector3& position);
 	void SpawnAmmoSmall(const K4E::Vector3& position);
 	void TryDropFromEnemyDeath(const K4E::Vector3& deathPosition);
+	void TryDropEnemyItem(const K4E::Vector3& deathPosition);
+	ItemType RollEnemyDrop();
 	void CheckPickup(Player& player);
 	void Clear();
 
@@ -35,19 +37,24 @@ public: /// ---------- メンバ関数 ---------- ///
 
 	float GetHealDropChance() const { return healDropChance_; }
 	float GetAmmoDropChance() const { return ammoDropChance_; }
+	float GetNoneDropChance() const;
 	int GetHealAmount() const { return healAmount_; }
 	int GetAmmoAmount() const { return ammoAmount_; }
 	float GetPickupRadius() const { return pickupRadius_; }
+	bool IsEnemyDeathDropEnabled() const { return enemyDeathDropEnabled_; }
 	bool IsForceEnemyDeathDropEnabled() const { return forceEnemyDeathDrop_; }
 	ItemType GetLastPickedItemType() const { return lastPickedItemType_; }
 	ItemType GetLastDroppedItemType() const { return lastDroppedItemType_; }
+	const K4E::Vector3& GetLastDropPosition() const { return lastDropPosition_; }
 
 	void DrawImGui();
 
 private: /// ---------- メンバ関数 ---------- ///
 
 	void RemoveInactiveItems();
+	void SpawnDropItem(ItemType type, const K4E::Vector3& position);
 	void SpawnConfigured(ItemType type, const K4E::Vector3& position);
+	void LogDropRollResult(ItemType type, const K4E::Vector3& position) const;
 
 private: /// ---------- メンバ変数 ---------- ///
 
@@ -61,7 +68,9 @@ private: /// ---------- メンバ変数 ---------- ///
 	float pickupRadius_ = 2.0f;
 	ItemType lastPickedItemType_ = ItemType::None;
 	ItemType lastDroppedItemType_ = ItemType::None;
-	bool forceEnemyDeathDrop_ = true;
+	K4E::Vector3 lastDropPosition_ = {};
+	bool enemyDeathDropEnabled_ = true;
+	bool forceEnemyDeathDrop_ = false;
 	CollisionManager* registeredCollisionManager_ = nullptr;
 
 	std::mt19937 rng_{ std::random_device{}() };


### PR DESCRIPTION
### Motivation
- 敵撃破時のドロップ抽選責務をシーン/Enemyから切り離して `ItemManager` に集約するため。 
- HealSmall / AmmoSmall / None の3結果を扱い、確率調整や「必ず落とす」などのデバッグ設定を可能にするため。 
- AmmoSmall を敵位置より少し上に出して見分けやすくし、デバッグしやすいログを出すため。

### Description
- `ItemManager` に `TryDropEnemyItem()`, `RollEnemyDrop()`, `SpawnDropItem()`, `LogDropRollResult()` を追加し、ドロップ抽選と生成を一か所にまとめた。フィールドとして `enemyDeathDropEnabled_`, `lastDropPosition_` を追加し `forceEnemyDeathDrop_` のデフォルトを OFF にした。 (変更対象: `Project/ApplicationLayer/Item/ItemManager.h` / `ItemManager.cpp`)
- 抽選は 0.0f〜1.0f の乱数を使用し、Heal/Ammo の合計が 1.0f を超えるか `forceEnemyDeathDrop_` が有効な場合は内部で比率正規化して None を排除するロジックを実装した。None の自然発生もサポートする。 
- `SpawnAmmoSmall()` は spawn.y += 0.5f を適用して少し上に出すように変更し、既存の `Item::OnPickup` / `Player::AddCurrentWeaponAmmo` により弾薬回復と HUD 更新は既存処理で行われることを維持した。 
- ImGui デバッグを拡張し `敵死亡時ドロップ有効` / `必ず何か落とす` / `HealSmallドロップ確率` / `AmmoSmallドロップ確率` / `None確率表示` / `Heal回復量` / `Ammo回復量` / `最後のドロップ位置` / `Active Item数` などを表示・調整可能にした。 
- スポーン／抽選で確認しやすいログを追加し、`Drop Roll Result` と `DropItem Spawned` に `ItemType`, `SpawnPosition`, `ActiveItemCount` を出力するようにした。

### Testing
- `git diff --check` を実行して差分の基本チェックを行った（問題なし）。
- プロジェクト内で追加した ImGui ラベルやログ文字列が存在するか `rg` で検索して検証した（該当箇所を確認）。
- 変更が敵死亡コールバック経路 (`CharacterWorld` -> `GamePlayWorld` -> `ItemManager::TryDropFromEnemyDeath`) にフックされていることをコード上で確認した（静的確認）。
- 実機ビルド/ランはこの環境で Windows/MSBuild 等のビルドツールが利用できなかったため実行していない（ビルドは未実行）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69fff2978c18832d97081c9418f16c8e)