### PR TITLE
Separate item effect application and add diagnostics for HealSmall/AmmoSmall

### DIFF
--- a/Project/ApplicationLayer/Character/Player/Component/PlayerWeaponComponent.cpp
+++ b/Project/ApplicationLayer/Character/Player/Component/PlayerWeaponComponent.cpp
@@ -180,6 +180,24 @@ PlayerWeaponComponent::AmmoView PlayerWeaponComponent::GetAmmoViewByHot_barIndex
 	return out;
 }
 
+
+bool PlayerWeaponComponent::CanCurrentWeaponRecoverAmmo() const
+{
+	if (!weaponLoaded_) return false;
+	if (weaponCategory_ == EWeaponCategory::Melee) return false;
+
+	return weaponSys_.Weapon().GetMaxReserveAmmo() > 0;
+}
+
+std::string PlayerWeaponComponent::GetCurrentWeaponName() const
+{
+	if (!weaponLoaded_) return "未ロード";
+
+	const FWeaponMasterData* data = weaponSys_.Database().FindByID(currentWeaponId_);
+	if (!data) return "不明";
+	return data->coreData.weaponName;
+}
+
 bool PlayerWeaponComponent::GetCurrentAdsViewTuning(float& outAdsFovDeg, float& outAdsTransitionSpeed) const
 {
 	if (!weaponLoaded_) return false;
@@ -434,10 +452,8 @@ int PlayerWeaponComponent::AddReserveAmmo(int amount)
 	if (weaponCategory_ == EWeaponCategory::Melee) return 0;
 
 	const int restored = weaponSys_.Weapon().AddReserveAmmo(amount);
-	if (restored > 0)
-	{
-		UpdateSelectedAmmoViewCache();
-	}
+	// 予備弾薬が満タンで増えない場合も、HUD診断用キャッシュを現在値へ同期する。
+	UpdateSelectedAmmoViewCache();
 	return restored;
 }
 

--- a/Project/ApplicationLayer/Character/Player/Component/PlayerWeaponComponent.h
+++ b/Project/ApplicationLayer/Character/Player/Component/PlayerWeaponComponent.h
@@ -58,6 +58,8 @@ public: /// ---------- メンバ関数 ---------- ///
 	const std::string& GetLoadError() const { return weaponLoadError_; }
 	bool IsMeleeCategory() const { return weaponCategory_ == EWeaponCategory::Melee; }
 	bool IsHeavyCategory() const { return weaponCategory_ == EWeaponCategory::Heavy; }
+	bool CanCurrentWeaponRecoverAmmo() const;
+	std::string GetCurrentWeaponName() const;
 
 	// HUD用
 	bool GetReloadUI(bool& outIsReloading, float& outReloadTimer, float& outReloadSec) const;

--- a/Project/ApplicationLayer/Character/Player/Player.h
+++ b/Project/ApplicationLayer/Character/Player/Player.h
@@ -132,6 +132,8 @@ public: /// ---------- メンバ関数 ---------- ///
 	int GetCurrentWeaponReserveAmmo() const { return weapon_.GetReserveAmmo(); }
 	int GetCurrentWeaponMaxReserveAmmo() const { return weapon_.GetMaxReserveAmmo(); }
 	bool AddCurrentWeaponAmmo(int amount) { return weapon_.AddCurrentWeaponAmmo(amount); }
+	bool CanCurrentWeaponRecoverAmmo() const { return weapon_.CanCurrentWeaponRecoverAmmo(); }
+	std::string GetCurrentWeaponName() const { return weapon_.GetCurrentWeaponName(); }
 
 	PlayerBrainComponent& GetBrainComponent() { return brainComponent_; }
 	const PlayerBrainComponent& GetBrainComponent() const { return brainComponent_; }

--- a/Project/ApplicationLayer/Item/Item.cpp
+++ b/Project/ApplicationLayer/Item/Item.cpp
@@ -130,6 +130,7 @@ void Item::OnCollision(K4E::Collider* other)
 
 	if (other->GetTypeID() == static_cast<uint32_t>(CollisionTypeIdDef::kPlayer))
 	{
-		ApplyTo(static_cast<Player*>(other));
+		// アイテム効果は ItemManager::ApplyItemEffect に集約し、当たり判定コールバックでは消費しない。
+		return;
 	}
 }

--- a/Project/ApplicationLayer/Item/Item.h
+++ b/Project/ApplicationLayer/Item/Item.h
@@ -22,6 +22,7 @@ public: /// ---------- メンバ関数 --------- ///
 	bool CheckCollisionWithPlayer(const K4E::Vector3& playerPos) const;
 	bool OnPickup(class Player& player);
 	void ApplyTo(class Player* player);
+	void MarkCollected() { active_ = false; }
 
 	bool IsCollected() const { return !active_; }
 	bool IsExpired() const { return lifetime_ >= maxLifetime_; }

--- a/Project/ApplicationLayer/Item/ItemManager.cpp
+++ b/Project/ApplicationLayer/Item/ItemManager.cpp
@@ -172,40 +172,151 @@ void ItemManager::CheckPickup(Player& player)
 
 	for (auto& item : items_)
 	{
-		if (!item->IsActive()) continue;
+		if (!item || !item->IsActive()) continue;
 
 		if (item->CheckCollisionWithPlayer(playerPos))
 		{
-			const ItemType pickupType = item->GetType();
-			const int reserveBefore = player.GetCurrentWeaponReserveAmmo();
+			lastItemEffectDebugInfo_ = {};
+			lastItemEffectDebugInfo_.pickupDetected = true;
+			lastItemEffectDebugInfo_.itemType = item->GetType();
+			lastPickedItemType_ = item->GetType();
 
-			if (item->OnPickup(player))
+			const bool effectApplied = ApplyItemEffect(*item, player);
+			const bool consumePickedItem = effectApplied || (consumeItemWhenFull_ && lastItemEffectDebugInfo_.noEffectBecauseFull);
+			if (consumePickedItem)
 			{
-				lastPickedItemType_ = pickupType;
-				lastKnownMagazineAmmo_ = player.GetCurrentWeaponMagazineAmmo();
-				lastKnownReserveAmmo_ = player.GetCurrentWeaponReserveAmmo();
-				lastKnownMaxReserveAmmo_ = player.GetCurrentWeaponMaxReserveAmmo();
-				lastAmmoSmallReserveRestored_ = (pickupType == ItemType::AmmoSmall)
-					? std::max(0, lastKnownReserveAmmo_ - reserveBefore)
-					: 0;
-				collectedEvents_.push_back(pickupType);
-
-				std::ostringstream oss;
-				oss << "Item Picked"
-					<< " ItemType=" << ToItemTypeName(pickupType)
-					<< " MagazineAmmo=" << lastKnownMagazineAmmo_
-					<< " ReserveAmmo=" << lastKnownReserveAmmo_
-					<< " MaxReserveAmmo=" << lastKnownMaxReserveAmmo_
-					<< " AmmoSmallAmount=" << ammoAmount_
-					<< " AmmoSmallReserveRestored=" << lastAmmoSmallReserveRestored_
-					<< "\n";
-				OutputDebugStringA(oss.str().c_str());
+				item->MarkCollected();
+				collectedEvents_.push_back(lastItemEffectDebugInfo_.itemType);
 			}
+
+			lastKnownMagazineAmmo_ = player.GetCurrentWeaponMagazineAmmo();
+			lastKnownReserveAmmo_ = player.GetCurrentWeaponReserveAmmo();
+			lastKnownMaxReserveAmmo_ = player.GetCurrentWeaponMaxReserveAmmo();
+			lastAmmoSmallReserveRestored_ = (lastItemEffectDebugInfo_.itemType == ItemType::AmmoSmall)
+				? std::max(0, lastItemEffectDebugInfo_.reserveAfter - lastItemEffectDebugInfo_.reserveBefore)
+				: 0;
+
+			LogItemEffectResult();
 		}
 	}
 
 	RemoveInactiveItems();
 }
+
+bool ItemManager::ApplyItemEffect(Item& item, Player& player)
+{
+	ItemEffectDebugInfo& info = lastItemEffectDebugInfo_;
+	info.itemType = item.GetType();
+	info.effectApplied = false;
+	info.failReason.clear();
+	info.noEffectBecauseFull = false;
+	info.hpBefore = player.GetHP();
+	info.hpAfter = info.hpBefore;
+	info.maxHp = player.GetMaxHP();
+	info.reserveBefore = player.GetCurrentWeaponReserveAmmo();
+	info.reserveAfter = info.reserveBefore;
+	info.maxReserve = player.GetCurrentWeaponMaxReserveAmmo();
+	info.magazineAmmo = player.GetCurrentWeaponMagazineAmmo();
+	info.currentWeaponName = player.GetCurrentWeaponName();
+	info.currentWeaponAmmoRecoverable = player.CanCurrentWeaponRecoverAmmo();
+	info.hudMagazineAmmo = 0;
+	info.hudReserveAmmo = 0;
+
+	// 取得判定と効果適用を分離し、増加量を比較して成功/失敗理由を残す。
+	switch (item.GetType())
+	{
+	case ItemType::HealSmall:
+		if (item.GetHealAmount() <= 0)
+		{
+			info.failReason = "HealSmall回復量が0以下です";
+			break;
+		}
+		if (info.hpBefore >= info.maxHp)
+		{
+			info.failReason = "HPが最大値のため回復しませんでした";
+			info.noEffectBecauseFull = true;
+			break;
+		}
+		player.Heal(static_cast<float>(item.GetHealAmount()));
+		info.hpAfter = player.GetHP();
+		info.effectApplied = info.hpAfter > info.hpBefore;
+		if (!info.effectApplied)
+		{
+			info.failReason = "Heal処理後もHPが増えませんでした";
+		}
+		break;
+
+	case ItemType::AmmoSmall:
+		if (item.GetAmmoAmount() <= 0)
+		{
+			info.failReason = "AmmoSmall回復量が0以下です";
+			break;
+		}
+		if (!info.currentWeaponAmmoRecoverable)
+		{
+			info.failReason = "現在装備中武器は弾薬回復対象ではありません";
+			break;
+		}
+		if (info.maxReserve <= 0)
+		{
+			info.failReason = "最大予備弾薬が0以下です";
+			break;
+		}
+		if (info.reserveBefore >= info.maxReserve)
+		{
+			info.failReason = "予備弾薬が最大値のため回復しませんでした";
+			info.noEffectBecauseFull = true;
+			break;
+		}
+		(void)player.AddReserveAmmo(item.GetAmmoAmount());
+		info.reserveAfter = player.GetCurrentWeaponReserveAmmo();
+		info.magazineAmmo = player.GetCurrentWeaponMagazineAmmo();
+		info.maxReserve = player.GetCurrentWeaponMaxReserveAmmo();
+		info.effectApplied = info.reserveAfter > info.reserveBefore;
+		if (!info.effectApplied)
+		{
+			info.failReason = "AddReserveAmmo後も予備弾薬が増えませんでした";
+		}
+		break;
+
+	case ItemType::NextStageKey:
+		info.effectApplied = true;
+		break;
+
+	case ItemType::None:
+	default:
+		info.failReason = "未対応のItemTypeです";
+		break;
+	}
+
+	if (info.hpAfter == info.hpBefore)
+	{
+		info.hpAfter = player.GetHP();
+	}
+	if (info.reserveAfter == info.reserveBefore)
+	{
+		info.reserveAfter = player.GetCurrentWeaponReserveAmmo();
+	}
+	info.maxHp = player.GetMaxHP();
+	info.maxReserve = player.GetCurrentWeaponMaxReserveAmmo();
+	info.magazineAmmo = player.GetCurrentWeaponMagazineAmmo();
+
+	WeaponSlot::HudSnapshot hud{};
+	if (player.GetWeaponSlotHUD(hud) && hud.selectedIndex >= 0 && hud.selectedIndex < WeaponSlot::kSlotCount)
+	{
+		const auto& selected = hud.slotStates[hud.selectedIndex];
+		info.hudMagazineAmmo = selected.ammoInfo.currentAmmo;
+		info.hudReserveAmmo = selected.ammoInfo.reserveAmmo;
+	}
+
+	if (info.effectApplied)
+	{
+		info.failReason = "なし";
+	}
+
+	return info.effectApplied;
+}
+
 
 void ItemManager::Clear()
 {
@@ -228,6 +339,7 @@ void ItemManager::Clear()
 	lastKnownReserveAmmo_ = 0;
 	lastKnownMaxReserveAmmo_ = 0;
 	lastAmmoSmallReserveRestored_ = 0;
+	lastItemEffectDebugInfo_ = {};
 	registeredCollisionManager_ = nullptr;
 }
 
@@ -305,6 +417,21 @@ void ItemManager::DrawImGui()
 	ImGui::Text("最大予備弾薬: %d", lastKnownMaxReserveAmmo_);
 	ImGui::Text("AmmoSmall回復量: %d", ammoAmount_);
 	ImGui::Text("AmmoSmall取得時に回復した予備弾薬量: %d", lastAmmoSmallReserveRestored_);
+	ImGui::Checkbox("満タン時もItemを消す", &consumeItemWhenFull_);
+	ImGui::SeparatorText("最後のItem取得診断");
+	ImGui::Text("最後に拾ったItemType: %s", ToItemTypeName(lastItemEffectDebugInfo_.itemType));
+	ImGui::Text("Item取得判定: %s", lastItemEffectDebugInfo_.pickupDetected ? "true" : "false");
+	ImGui::Text("効果適用成功: %s", lastItemEffectDebugInfo_.effectApplied ? "true" : "false");
+	ImGui::TextWrapped("効果適用失敗理由: %s", lastItemEffectDebugInfo_.failReason.c_str());
+	ImGui::Text("取得前HP: %.1f", lastItemEffectDebugInfo_.hpBefore);
+	ImGui::Text("取得後HP: %.1f", lastItemEffectDebugInfo_.hpAfter);
+	ImGui::Text("最大HP: %.1f", lastItemEffectDebugInfo_.maxHp);
+	ImGui::Text("取得前予備弾薬: %d", lastItemEffectDebugInfo_.reserveBefore);
+	ImGui::Text("取得後予備弾薬: %d", lastItemEffectDebugInfo_.reserveAfter);
+	ImGui::Text("最大予備弾薬: %d", lastItemEffectDebugInfo_.maxReserve);
+	ImGui::Text("現在武器名: %s", lastItemEffectDebugInfo_.currentWeaponName.c_str());
+	ImGui::Text("現在武器が弾薬回復可能か: %s", lastItemEffectDebugInfo_.currentWeaponAmmoRecoverable ? "true" : "false");
+	ImGui::Text("HUD表示弾薬: %d / %d", lastItemEffectDebugInfo_.hudMagazineAmmo, lastItemEffectDebugInfo_.hudReserveAmmo);
 	ImGui::Text("最後に取得したItemType: %s", ToItemTypeName(lastPickedItemType_));
 	ImGui::Text("最後にドロップしたItemType: %s", ToItemTypeName(lastDroppedItemType_));
 	ImGui::Text("最後のドロップ位置: (%.2f, %.2f, %.2f)", lastDropPosition_.x, lastDropPosition_.y, lastDropPosition_.z);
@@ -361,6 +488,30 @@ void ItemManager::LogDropRollResult(ItemType type, const K4E::Vector3& position)
 		<< " ItemType=" << ToItemTypeName(type)
 		<< " SpawnPosition=(" << position.x << ", " << position.y << ", " << position.z << ")"
 		<< " ActiveItemCount=" << GetActiveItemCount()
+		<< "\n";
+	OutputDebugStringA(oss.str().c_str());
+}
+
+
+void ItemManager::LogItemEffectResult() const
+{
+	const ItemEffectDebugInfo& info = lastItemEffectDebugInfo_;
+	std::ostringstream oss;
+	oss << "Item取得診断"
+		<< " 最後に拾ったItemType=" << ToItemTypeName(info.itemType)
+		<< " Item取得判定=" << (info.pickupDetected ? "true" : "false")
+		<< " 効果適用成功=" << (info.effectApplied ? "true" : "false")
+		<< " 効果適用失敗理由=" << info.failReason
+		<< " 取得前HP=" << info.hpBefore
+		<< " 取得後HP=" << info.hpAfter
+		<< " 最大HP=" << info.maxHp
+		<< " 取得前予備弾薬=" << info.reserveBefore
+		<< " 取得後予備弾薬=" << info.reserveAfter
+		<< " 最大予備弾薬=" << info.maxReserve
+		<< " 現在武器名=" << info.currentWeaponName
+		<< " 現在武器が弾薬回復可能か=" << (info.currentWeaponAmmoRecoverable ? "true" : "false")
+		<< " HUD表示弾薬=" << info.hudMagazineAmmo << "/" << info.hudReserveAmmo
+		<< " 満タン時もItemを消す=" << (consumeItemWhenFull_ ? "true" : "false")
 		<< "\n";
 	OutputDebugStringA(oss.str().c_str());
 }

--- a/Project/ApplicationLayer/Item/ItemManager.h
+++ b/Project/ApplicationLayer/Item/ItemManager.h
@@ -1,6 +1,7 @@
 #pragma once
 #include <memory>
 #include <random>
+#include <string>
 #include <vector>
 #include "Item.h"
 
@@ -16,6 +17,26 @@ class ItemManager
 {
 public: /// ---------- メンバ関数 ---------- ///
 
+	struct ItemEffectDebugInfo
+	{
+		ItemType itemType = ItemType::None;
+		bool pickupDetected = false;
+		bool effectApplied = false;
+		bool noEffectBecauseFull = false;
+		std::string failReason = "未取得";
+		float hpBefore = 0.0f;
+		float hpAfter = 0.0f;
+		float maxHp = 0.0f;
+		int reserveBefore = 0;
+		int reserveAfter = 0;
+		int maxReserve = 0;
+		int magazineAmmo = 0;
+		int hudMagazineAmmo = 0;
+		int hudReserveAmmo = 0;
+		std::string currentWeaponName = "未取得";
+		bool currentWeaponAmmoRecoverable = false;
+	};
+
 	void Initialize();
 	void Update(float deltaTime);
 	void Update(Player* player, float deltaTime);
@@ -29,6 +50,7 @@ public: /// ---------- メンバ関数 ---------- ///
 	void TryDropEnemyItem(const K4E::Vector3& deathPosition);
 	ItemType RollEnemyDrop();
 	void CheckPickup(Player& player);
+	bool ApplyItemEffect(Item& item, Player& player);
 	void Clear();
 
 	bool ConsumeCollected(ItemType type);
@@ -46,6 +68,7 @@ public: /// ---------- メンバ関数 ---------- ///
 	ItemType GetLastPickedItemType() const { return lastPickedItemType_; }
 	ItemType GetLastDroppedItemType() const { return lastDroppedItemType_; }
 	const K4E::Vector3& GetLastDropPosition() const { return lastDropPosition_; }
+	const ItemEffectDebugInfo& GetLastItemEffectDebugInfo() const { return lastItemEffectDebugInfo_; }
 
 	void DrawImGui();
 
@@ -55,6 +78,7 @@ private: /// ---------- メンバ関数 ---------- ///
 	void SpawnDropItem(ItemType type, const K4E::Vector3& position);
 	void SpawnConfigured(ItemType type, const K4E::Vector3& position);
 	void LogDropRollResult(ItemType type, const K4E::Vector3& position) const;
+	void LogItemEffectResult() const;
 
 private: /// ---------- メンバ変数 ---------- ///
 
@@ -70,6 +94,8 @@ private: /// ---------- メンバ変数 ---------- ///
 	int lastKnownReserveAmmo_ = 0;
 	int lastKnownMaxReserveAmmo_ = 0;
 	int lastAmmoSmallReserveRestored_ = 0;
+	ItemEffectDebugInfo lastItemEffectDebugInfo_{};
+	bool consumeItemWhenFull_ = false;
 	ItemType lastPickedItemType_ = ItemType::None;
 	ItemType lastDroppedItemType_ = ItemType::None;
 	K4E::Vector3 lastDropPosition_ = {};


### PR DESCRIPTION
### Motivation
- 調査で、アイテム取得判定は通るが効果適用が失敗している/HUDに反映されていないケースがあるため、判定と効果適用を分離して原因を特定できるようにする。 
- `AmmoSmall` はマガジンではなく予備弾薬を回復する仕様なので、回復対象・HUD同期・最大値処理を明確化する必要がある。 

### Description
- `ItemManager::ApplyItemEffect(Item&, Player&)` を追加し効果適用を分離して `bool` を返すようにしたことで成功/失敗を判定可能にした。 
- 取得時に効果適用が失敗した場合はデフォルトでアイテムを消さない挙動にし、ImGuiで切り替え可能なフラグ `consumeItemWhenFull_`（表示ラベル: "満タン時もItemを消す"）を追加した。 
- HealSmall は取得前後の `HP` を比較、AmmoSmall は `AddReserveAmmo` を呼んで予備弾薬のみを回復し、回復量/最大値/失敗理由を `ItemEffectDebugInfo` に保持して `ImGui` と `OutputDebugStringA` に日本語で出力するようにした。 
- 当たり判定側でアイテムを直接消費しないように `Item::OnCollision` を変更し、消費処理は `ItemManager` 側に集約した。 
- デバッグのために `Item::MarkCollected()` を追加し、`PlayerWeaponComponent` に `CanCurrentWeaponRecoverAmmo()` と `GetCurrentWeaponName()` を追加して回復可否や武器名を診断できるようにし、`AddReserveAmmo` 実行後は HUD 用キャッシュを必ず同期するようにした。 
- ImGuiには日本語で以下を追加表示: 最後に拾った `ItemType`、取得判定、効果適用成功/失敗理由、取得前/後HP、最大HP、取得前/後予備弾薬、最大予備弾薬、現在武器名、現在武器が弾薬回復可能か、HUD表示弾薬（mag/res）。 

### Testing
- `git diff --check` を実行し差分チェックに問題がないことを確認しました（成功）。
- ソリューションのビルドは環境に `msbuild` が無く実行できなかったためビルド実行は行えませんでした（環境エラー: `msbuild: command not found`）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a000b5006a0832da181e41f2b106319)