### PR TITLE
Add item idle and pickup visual effects

### DIFF
--- a/Project/ApplicationLayer/Item/Item.cpp
+++ b/Project/ApplicationLayer/Item/Item.cpp
@@ -2,6 +2,7 @@
 #include "Player.h"
 #include <CollisionTypeIdDef.h>
 
+#include <algorithm>
 #include <cmath>
 #include <string>
 
@@ -61,6 +62,21 @@ void Item::Initialize(ItemType type, const K4E::Vector3& pos, int healAmount, in
 	}
 }
 
+void Item::SetVisualAnimationSettings(float floatHeight, float floatSpeed, float rotationSpeed)
+{
+	floatAmplitude_ = std::max(0.0f, floatHeight);
+	floatSpeed_ = std::max(0.0f, floatSpeed);
+	rotationSpeed_ = rotationSpeed;
+}
+
+void Item::SetVisualColor(const K4E::Vector4& color)
+{
+	if (object3d_)
+	{
+		object3d_->SetColor(color);
+	}
+}
+
 void Item::Update(float deltaTime)
 {
 	if (!active_) return;
@@ -69,7 +85,7 @@ void Item::Update(float deltaTime)
 	floatTimer_ += floatSpeed_ * deltaTime;
 	const float floatOffset = std::sinf(floatTimer_) * floatAmplitude_;
 	position_.y = basePosition_.y + floatOffset + 1.0f;
-	rotation_.y += rotationSpeed_;
+	rotation_.y += rotationSpeed_ * deltaTime;
 
 	if (object3d_)
 	{

--- a/Project/ApplicationLayer/Item/Item.h
+++ b/Project/ApplicationLayer/Item/Item.h
@@ -3,6 +3,7 @@
 #include "Object3D.h"
 #include "Collider.h"
 #include "ItemType.h"
+#include "Vector4.h"
 
 #include <memory>
 
@@ -23,6 +24,8 @@ public: /// ---------- メンバ関数 --------- ///
 	bool OnPickup(class Player& player);
 	void ApplyTo(class Player* player);
 	void MarkCollected() { active_ = false; }
+	void SetVisualAnimationSettings(float floatHeight, float floatSpeed, float rotationSpeed);
+	void SetVisualColor(const K4E::Vector4& color);
 
 	bool IsCollected() const { return !active_; }
 	bool IsExpired() const { return lifetime_ >= maxLifetime_; }

--- a/Project/ApplicationLayer/Item/ItemManager.cpp
+++ b/Project/ApplicationLayer/Item/ItemManager.cpp
@@ -39,7 +39,13 @@ void ItemManager::Update(float deltaTime)
 {
 	for (auto& item : items_)
 	{
+		if (!item) continue;
+		ApplyVisualSettings(*item);
 		item->Update(deltaTime);
+		if (item->IsActive())
+		{
+			itemVisualEffect_.UpdateIdle(*item, deltaTime);
+		}
 	}
 
 	RemoveInactiveItems();
@@ -185,6 +191,8 @@ void ItemManager::CheckPickup(Player& player)
 			const bool consumePickedItem = effectApplied || (consumeItemWhenFull_ && lastItemEffectDebugInfo_.noEffectBecauseFull);
 			if (consumePickedItem)
 			{
+				itemVisualEffect_.PlayPickup(lastItemEffectDebugInfo_.itemType, item->GetPosition());
+				itemVisualEffect_.StopIdle(*item);
 				item->MarkCollected();
 				collectedEvents_.push_back(lastItemEffectDebugInfo_.itemType);
 			}
@@ -340,6 +348,7 @@ void ItemManager::Clear()
 	lastKnownMaxReserveAmmo_ = 0;
 	lastAmmoSmallReserveRestored_ = 0;
 	lastItemEffectDebugInfo_ = {};
+	itemVisualEffect_.Clear();
 	registeredCollisionManager_ = nullptr;
 }
 
@@ -435,6 +444,7 @@ void ItemManager::DrawImGui()
 	ImGui::Text("最後に取得したItemType: %s", ToItemTypeName(lastPickedItemType_));
 	ImGui::Text("最後にドロップしたItemType: %s", ToItemTypeName(lastDroppedItemType_));
 	ImGui::Text("最後のドロップ位置: (%.2f, %.2f, %.2f)", lastDropPosition_.x, lastDropPosition_.y, lastDropPosition_.z);
+	itemVisualEffect_.DrawImGui();
 
 	ImGui::End();
 #else
@@ -447,9 +457,13 @@ void ItemManager::RemoveInactiveItems()
 	items_.erase(std::remove_if(items_.begin(), items_.end(), [this](const std::unique_ptr<Item>& item)
 		{
 			const bool shouldRemove = !item || item->IsCollected() || item->IsExpired();
-			if (shouldRemove && item && registeredCollisionManager_)
+			if (shouldRemove && item)
 			{
-				registeredCollisionManager_->RemoveCollider(item.get());
+				itemVisualEffect_.StopIdle(*item);
+				if (registeredCollisionManager_)
+				{
+					registeredCollisionManager_->RemoveCollider(item.get());
+				}
 			}
 			return shouldRemove;
 		}), items_.end());
@@ -466,6 +480,8 @@ void ItemManager::SpawnConfigured(ItemType type, const K4E::Vector3& position)
 
 	auto item = std::make_unique<Item>();
 	item->Initialize(type, position, healAmount_, ammoAmount_, pickupRadius_);
+	ApplyVisualSettings(*item);
+	itemVisualEffect_.StartIdle(*item);
 	if (registeredCollisionManager_)
 	{
 		registeredCollisionManager_->AddCollider(item.get());
@@ -479,6 +495,13 @@ void ItemManager::SpawnConfigured(ItemType type, const K4E::Vector3& position)
 		<< " ActiveItemCount=" << GetActiveItemCount()
 		<< "\n";
 	OutputDebugStringA(oss.str().c_str());
+}
+
+void ItemManager::ApplyVisualSettings(Item& item)
+{
+	const auto& settings = itemVisualEffect_.GetSettings();
+	item.SetVisualAnimationSettings(settings.itemFloatHeight, settings.itemFloatSpeed, settings.itemRotationSpeed);
+	item.SetVisualColor(itemVisualEffect_.GetEffectColor(item.GetType()));
 }
 
 void ItemManager::LogDropRollResult(ItemType type, const K4E::Vector3& position) const

--- a/Project/ApplicationLayer/Item/ItemManager.h
+++ b/Project/ApplicationLayer/Item/ItemManager.h
@@ -4,6 +4,7 @@
 #include <string>
 #include <vector>
 #include "Item.h"
+#include "ItemVisualEffect.h"
 
 namespace K4E = ::Ken4lowEngine;
 
@@ -79,6 +80,7 @@ private: /// ---------- メンバ関数 ---------- ///
 	void SpawnConfigured(ItemType type, const K4E::Vector3& position);
 	void LogDropRollResult(ItemType type, const K4E::Vector3& position) const;
 	void LogItemEffectResult() const;
+	void ApplyVisualSettings(Item& item);
 
 private: /// ---------- メンバ変数 ---------- ///
 
@@ -102,6 +104,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	bool enemyDeathDropEnabled_ = true;
 	bool forceEnemyDeathDrop_ = false;
 	CollisionManager* registeredCollisionManager_ = nullptr;
+	ItemVisualEffect itemVisualEffect_;
 
 	std::mt19937 rng_{ std::random_device{}() };
 };

--- a/Project/ApplicationLayer/Item/ItemVisualEffect.cpp
+++ b/Project/ApplicationLayer/Item/ItemVisualEffect.cpp
@@ -1,0 +1,248 @@
+#include "ItemVisualEffect.h"
+
+#include "Item.h"
+#include "GpuParticleEmitter.h"
+#include "GpuParticleManager.h"
+
+#ifdef USE_IMGUI
+#include <imgui.h>
+#endif
+
+#include <algorithm>
+#include <cstdint>
+#include <sstream>
+
+namespace
+{
+	const char* ToItemEffectName(ItemType type)
+	{
+		switch (type)
+		{
+		case ItemType::HealSmall: return "HealSmall";
+		case ItemType::AmmoSmall: return "AmmoSmall";
+		case ItemType::NextStageKey: return "NextStageKey";
+		case ItemType::None:
+		default: return "None";
+		}
+	}
+}
+
+void ItemVisualEffect::StartIdle(const Item& item)
+{
+	if (item.GetType() == ItemType::None)
+	{
+		return;
+	}
+
+	IdleState& state = idleStates_[&item];
+	state.type = item.GetType();
+	state.emitTimer = 0.0f;
+	state.emitterName = BuildIdleEmitterName(item);
+}
+
+void ItemVisualEffect::StopIdle(const Item& item)
+{
+	auto it = idleStates_.find(&item);
+	if (it == idleStates_.end())
+	{
+		return;
+	}
+
+	if (auto* manager = K4E::GpuParticleManager::GetInstance())
+	{
+		manager->RemoveEmitter(it->second.emitterName);
+	}
+	idleStates_.erase(it);
+}
+
+void ItemVisualEffect::UpdateIdle(const Item& item, float deltaTime)
+{
+	if (!settings_.itemEffectEnabled || !settings_.idleEffectEnabled || settings_.idleParticleCount <= 0)
+	{
+		return;
+	}
+
+	auto it = idleStates_.find(&item);
+	if (it == idleStates_.end())
+	{
+		StartIdle(item);
+		it = idleStates_.find(&item);
+		if (it == idleStates_.end())
+		{
+			return;
+		}
+	}
+
+	IdleState& state = it->second;
+	state.emitTimer += deltaTime;
+	const float interval = std::max(0.05f, settings_.idleEmitInterval);
+	if (state.emitTimer < interval)
+	{
+		return;
+	}
+
+	state.emitTimer = 0.0f;
+	K4E::Vector3 emitPosition = item.GetPosition();
+	emitPosition.y += 0.25f;
+	// 常時演出は短い間隔の少量バーストにして、出しっぱなしでもGPU負荷が増えすぎないようにする。
+	EmitSpriteBurst(state.emitterName, GetIdleParticleType(state.type), emitPosition, static_cast<uint32_t>(settings_.idleParticleCount), 0.16f);
+	lastPlayedEffectName_ = std::string(ToItemEffectName(state.type)) + " 待機粒子";
+}
+
+void ItemVisualEffect::PlayPickup(ItemType type, const K4E::Vector3& position)
+{
+	if (!settings_.itemEffectEnabled || !settings_.pickupEffectEnabled || settings_.pickupParticleCount <= 0)
+	{
+		return;
+	}
+
+	K4E::Vector3 burstPosition = position;
+	burstPosition.y += 0.2f;
+	const std::string burstName = BuildPickupEmitterName(type);
+	const std::string ringName = BuildPickupRingEmitterName(type);
+	const float burstRadius = std::max(0.08f, settings_.pickupParticleSpeed * 0.035f);
+
+	EmitSpriteBurst(burstName, GetPickupParticleType(type), burstPosition, static_cast<uint32_t>(settings_.pickupParticleCount), burstRadius);
+	EmitSpriteBurst(ringName, K4E::GpuParticleType::Shockwave, burstPosition, 1, std::max(0.35f, settings_.pickupParticleSpeed * 0.12f));
+
+	lastPlayedEffectName_ = std::string(ToItemEffectName(type)) + " 取得バースト";
+}
+
+void ItemVisualEffect::Clear()
+{
+	if (auto* manager = K4E::GpuParticleManager::GetInstance())
+	{
+		for (const auto& [item, state] : idleStates_)
+		{
+			(void)item;
+			manager->RemoveEmitter(state.emitterName);
+		}
+	}
+	idleStates_.clear();
+	lastPlayedEffectName_ = "未再生";
+}
+
+void ItemVisualEffect::DrawImGui()
+{
+#ifdef USE_IMGUI
+	ImGui::SeparatorText("アイテム演出");
+	ImGui::Checkbox("アイテム演出有効", &settings_.itemEffectEnabled);
+	ImGui::Checkbox("待機演出有効", &settings_.idleEffectEnabled);
+	ImGui::Checkbox("取得演出有効", &settings_.pickupEffectEnabled);
+	ImGui::DragInt("待機粒子数", &settings_.idleParticleCount, 1, 0, 32);
+	ImGui::DragFloat("待機粒子発生間隔", &settings_.idleEmitInterval, 0.01f, 0.05f, 2.0f, "%.2f秒");
+	ImGui::DragInt("取得時粒子数", &settings_.pickupParticleCount, 1, 0, 128);
+	ImGui::DragFloat("取得時粒子速度", &settings_.pickupParticleSpeed, 0.1f, 0.1f, 20.0f, "%.2f");
+	ImGui::DragFloat("アイテム浮遊高さ", &settings_.itemFloatHeight, 0.01f, 0.0f, 2.0f, "%.2f");
+	ImGui::DragFloat("アイテム浮遊速度", &settings_.itemFloatSpeed, 0.05f, 0.0f, 10.0f, "%.2f");
+	ImGui::DragFloat("アイテム回転速度", &settings_.itemRotationSpeed, 0.05f, 0.0f, 10.0f, "%.2f");
+	ImGui::ColorEdit4("Heal演出色", &settings_.healEffectColor.x);
+	ImGui::ColorEdit4("Ammo演出色", &settings_.ammoEffectColor.x);
+	ImGui::Text("最後に再生したItem演出: %s", lastPlayedEffectName_.c_str());
+#else
+	(void)this;
+#endif
+}
+
+K4E::Vector4 ItemVisualEffect::GetEffectColor(ItemType type) const
+{
+	switch (type)
+	{
+	case ItemType::HealSmall:
+		return settings_.healEffectColor;
+	case ItemType::AmmoSmall:
+		return settings_.ammoEffectColor;
+	case ItemType::NextStageKey:
+		return { 0.25f, 1.0f, 1.0f, 1.0f };
+	case ItemType::None:
+	default:
+		return { 1.0f, 1.0f, 1.0f, 0.5f };
+	}
+}
+
+std::string ItemVisualEffect::BuildIdleEmitterName(const Item& item) const
+{
+	std::ostringstream oss;
+	oss << "ItemIdle_" << ToItemEffectName(item.GetType()) << "_" << reinterpret_cast<std::uintptr_t>(&item);
+	return oss.str();
+}
+
+std::string ItemVisualEffect::BuildPickupEmitterName(ItemType type)
+{
+	return std::string("ItemPickup_") + ToItemEffectName(type);
+}
+
+std::string ItemVisualEffect::BuildPickupRingEmitterName(ItemType type)
+{
+	return std::string("ItemPickupRing_") + ToItemEffectName(type);
+}
+
+K4E::GpuParticleType ItemVisualEffect::GetIdleParticleType(ItemType type) const
+{
+	switch (type)
+	{
+	case ItemType::HealSmall:
+		return K4E::GpuParticleType::Heal;
+	case ItemType::AmmoSmall:
+		return K4E::GpuParticleType::Spark;
+	case ItemType::NextStageKey:
+		return K4E::GpuParticleType::Ambient;
+	case ItemType::None:
+	default:
+		return K4E::GpuParticleType::Ambient;
+	}
+}
+
+K4E::GpuParticleType ItemVisualEffect::GetPickupParticleType(ItemType type) const
+{
+	switch (type)
+	{
+	case ItemType::HealSmall:
+		return K4E::GpuParticleType::Heal;
+	case ItemType::AmmoSmall:
+		return K4E::GpuParticleType::Spark;
+	case ItemType::NextStageKey:
+		return K4E::GpuParticleType::DeathBurstCore;
+	case ItemType::None:
+	default:
+		return K4E::GpuParticleType::Spark;
+	}
+}
+
+void ItemVisualEffect::EmitSpriteBurst(const std::string& emitterName, K4E::GpuParticleType particleType, const K4E::Vector3& position, uint32_t count, float radius)
+{
+	if (count == 0)
+	{
+		return;
+	}
+
+	auto* manager = K4E::GpuParticleManager::GetInstance();
+	if (!manager)
+	{
+		return;
+	}
+
+	K4E::GpuParticleEmitter* emitter = manager->GetEmitter(emitterName);
+	if (!emitter)
+	{
+		K4E::GpuParticleEmitter::EmitterInfo info{};
+		info.textureFilePath = "Effects/white.dds";
+		info.radius = radius;
+		info.loopCount = 0;
+		info.loopFrequency = 0.0f;
+		info.drawType = 0;
+		info.kind = K4E::GpuParticleKind::Sprite;
+		info.spriteType = particleType;
+		info.billboardFlags = K4E::BillboardMode::Camera;
+		emitter = manager->CreateEmitter(emitterName, info);
+	}
+
+	if (!emitter)
+	{
+		return;
+	}
+
+	emitter->GetInfoMutable().radius = radius;
+	emitter->SetPosition(position);
+	emitter->RequestEmit(count);
+}

--- a/Project/ApplicationLayer/Item/ItemVisualEffect.h
+++ b/Project/ApplicationLayer/Item/ItemVisualEffect.h
@@ -1,0 +1,69 @@
+#pragma once
+
+#include "ItemType.h"
+#include "Vector3.h"
+#include "Vector4.h"
+#include "GpuParticleType.h"
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+
+namespace K4E = ::Ken4lowEngine;
+
+class Item;
+
+/// -------------------------------------------------------------
+///						アイテム演出管理クラス
+/// -------------------------------------------------------------
+class ItemVisualEffect
+{
+public:
+	struct Settings
+	{
+		bool itemEffectEnabled = true;
+		bool idleEffectEnabled = true;
+		bool pickupEffectEnabled = true;
+		int idleParticleCount = 2;
+		float idleEmitInterval = 0.28f;
+		int pickupParticleCount = 18;
+		float pickupParticleSpeed = 4.5f;
+		float itemFloatHeight = 0.18f;
+		float itemFloatSpeed = 2.2f;
+		float itemRotationSpeed = 1.6f;
+		K4E::Vector4 healEffectColor = { 0.25f, 1.0f, 0.45f, 1.0f };
+		K4E::Vector4 ammoEffectColor = { 1.0f, 0.75f, 0.15f, 1.0f };
+	};
+
+	void StartIdle(const Item& item);
+	void StopIdle(const Item& item);
+	void UpdateIdle(const Item& item, float deltaTime);
+	void PlayPickup(ItemType type, const K4E::Vector3& position);
+	void Clear();
+	void DrawImGui();
+
+	Settings& GetSettings() { return settings_; }
+	const Settings& GetSettings() const { return settings_; }
+	K4E::Vector4 GetEffectColor(ItemType type) const;
+	const std::string& GetLastPlayedEffectName() const { return lastPlayedEffectName_; }
+
+private:
+	struct IdleState
+	{
+		ItemType type = ItemType::None;
+		float emitTimer = 0.0f;
+		std::string emitterName;
+	};
+
+	std::string BuildIdleEmitterName(const Item& item) const;
+	std::string BuildPickupEmitterName(ItemType type);
+	std::string BuildPickupRingEmitterName(ItemType type);
+	K4E::GpuParticleType GetIdleParticleType(ItemType type) const;
+	K4E::GpuParticleType GetPickupParticleType(ItemType type) const;
+	void EmitSpriteBurst(const std::string& emitterName, K4E::GpuParticleType particleType, const K4E::Vector3& position, uint32_t count, float radius);
+
+private:
+	Settings settings_{};
+	std::unordered_map<const Item*, IdleState> idleStates_;
+	std::string lastPlayedEffectName_ = "未再生";
+};

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -228,6 +228,10 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="ApplicationLayer\Item\ItemVisualEffect.cpp">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</ExcludedFromBuild>
+    </ClCompile>
     <ClCompile Include="ApplicationLayer\Scene\PhysicalScene\PhysicalScene.cpp">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</ExcludedFromBuild>
@@ -813,6 +817,10 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</ExcludedFromBuild>
     </ClInclude>
     <ClInclude Include="ApplicationLayer\Item\ItemManager.h">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</ExcludedFromBuild>
+    </ClInclude>
+    <ClInclude Include="ApplicationLayer\Item\ItemVisualEffect.h">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</ExcludedFromBuild>
     </ClInclude>

--- a/Project/Ken4lowEngine.vcxproj.filters
+++ b/Project/Ken4lowEngine.vcxproj.filters
@@ -166,6 +166,9 @@
     <ClCompile Include="ApplicationLayer\Item\ItemManager.cpp">
       <Filter>ApplicationLayer\Item</Filter>
     </ClCompile>
+    <ClCompile Include="ApplicationLayer\Item\ItemVisualEffect.cpp">
+      <Filter>ApplicationLayer\Item</Filter>
+    </ClCompile>
     <ClCompile Include="ApplicationLayer\Scene\StageSelectScene\GridStageSelector.cpp">
       <Filter>ApplicationLayer\Scene\StageSelectScene</Filter>
     </ClCompile>
@@ -919,6 +922,9 @@
       <Filter>ApplicationLayer\SceneManager\SceneManager</Filter>
     </ClInclude>
     <ClInclude Include="ApplicationLayer\Item\ItemManager.h">
+      <Filter>ApplicationLayer\Item</Filter>
+    </ClInclude>
+    <ClInclude Include="ApplicationLayer\Item\ItemVisualEffect.h">
       <Filter>ApplicationLayer\Item</Filter>
     </ClInclude>
     <ClInclude Include="ApplicationLayer\Scene\StageSelectScene\GridStageSelector.h">


### PR DESCRIPTION
### Motivation
- 敵撃破で出る `HealSmall` / `AmmoSmall` の視認性を上げるため、落ちている間の常時演出と取得時のリアクション演出を追加する。 
- 既存の GPU パーティクル基盤 (`GpuParticleManager` / `GpuParticleEmitter`) を活用して、将来的に MeshParticle に差し替えやすい形で実装する。 
- Item の取得判定/効果適用挙動は保持し、見た目処理は分離して軽量にする設計を採る。 

### Description
- 新規 `ItemVisualEffect` クラスを追加し、待機時の少量バースト（間欠パフ）と取得時の短いバースト＋Shockwaveリングを管理する機能を実装した (`Project/ApplicationLayer/Item/ItemVisualEffect.{h,cpp}`)。
- `Item` に見た目用のフックを追加して外部から設定可能にした：`SetVisualAnimationSettings` と `SetVisualColor` を追加し回転更新を `deltaTime` ベースに変更（軽量なアニメ制御のみを担当）。
- `ItemManager` に演出連携を追加し、出現時に待機演出開始、毎フレームの `Update` で演出更新、取得成功時に `PlayPickup` を再生して待機演出を停止、非アクティブ/削除時に待機演出を停止するようにした（取得ロジック自体は既存の `ApplyItemEffect` に依存し、失敗時は演出を出さない）。
- ImGui に日本語で調整項目を追加（`アイテム演出有効` / `待機演出有効` / `取得演出有効` / `待機粒子数` / `待機粒子発生間隔` / `取得時粒子数` / `取得時粒子速度` / `アイテム浮遊高さ` / `アイテム浮遊速度` / `アイテム回転速度` / `Heal演出色` / `Ammo演出色` / `最後に再生したItem演出`）。
- プロジェクトファイルに `.cpp/.h` を登録して Visual Studio でビルド対象に追加した (`Project/Ken4lowEngine.vcxproj` と `.filters`)。コメントで処理意図が分かる箇所を残している（視覚設定は Item 側に移譲、パーティクル発生は `EmitSpriteBurst` に集約）。

### Testing
- 実行した自動チェック: `git diff --check` の結果に問題なし（合格）。
- `Project/Ken4lowEngine.vcxproj` と `Project/Ken4lowEngine.vcxproj.filters` を XML パーサで読み取り検証し両ファイルとも正常（合格）。
- `clang++ -fsyntax-only` による構文チェックを試行したが、Linux コンテナに Windows DirectX ヘッダ（`d3d12.h`）が無いためパスできず構文チェックは環境制約で未完了（環境依存のためローカル/CI の Windows ビルドでの確認を推奨）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a000e2cefbc832d98426acc8bd21fda)