### PR TITLE
ImGui のフレーム処理と DockSpace を ImGuiManager に集約

### DIFF
--- a/Project/ApplicationLayer/DebugTools/Occlusion/OcclusionDebugController.cpp
+++ b/Project/ApplicationLayer/DebugTools/Occlusion/OcclusionDebugController.cpp
@@ -34,10 +34,11 @@ namespace
 	ImVec2 ToScreenPoint(const K4E::OcclusionCullingSystem::ScreenRect& rect, float x, float y)
 	{
 		(void)rect; // rectは将来の拡張で使うかもなので一応引数に残す
-		const ImGuiViewport* viewport = ImGui::GetMainViewport();
+		// DirectX12のD3D12_VIEWPORTと区別するためImGui側のViewport名を明示する
+		const ImGuiViewport* imguiMainViewport = ImGui::GetMainViewport();
 		return ImVec2(
-			viewport->WorkPos.x + x * viewport->WorkSize.x,
-			viewport->WorkPos.y + y * viewport->WorkSize.y);
+			imguiMainViewport->WorkPos.x + x * imguiMainViewport->WorkSize.x,
+			imguiMainViewport->WorkPos.y + y * imguiMainViewport->WorkSize.y);
 	}
 
 	void DrawScreenRect(const K4E::OcclusionCullingSystem::ScreenRect& rect, ImU32 color, float thickness)

--- a/Project/Engine/DebugTools/ImGui/ImGuiManager.cpp
+++ b/Project/Engine/DebugTools/ImGui/ImGuiManager.cpp
@@ -4,6 +4,8 @@
 #include "DirectXCommon.h"
 #include "SRVManager.h"
 
+#include <stdexcept>
+
 namespace Ken4lowEngine
 {
 
@@ -47,8 +49,10 @@ namespace Ken4lowEngine
 		// フォントの設定
 		io.Fonts->AddFontFromFileTTF("Resources/Fonts/NotoSansJP-VariableFont_wght.ttf", 18.0f, nullptr, io.Fonts->GetGlyphRangesJapanese()); // 日本語フォントの追加
 
-		// Dockingを有効にする
+		// ImGuiウィンドウをエンジンのメインウィンドウ内でドッキングできるようにする
 		io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
+		// 今回は別OSウィンドウ化を避けるため Multi-Viewport は明示的に無効のままにする
+		io.ConfigFlags &= ~ImGuiConfigFlags_ViewportsEnable;
 
 		ImGui::StyleColorsDark();					  // ImGuiスタイルの設定
 		ImGui_ImplWin32_Init(winApp->GetHwnd());	  // Win32バックエンドの初期化
@@ -70,13 +74,26 @@ namespace Ken4lowEngine
 	void ImGuiManager::BeginFrame()
 	{
 #ifdef USE_IMGUI
-		//ImGuiを使う
+		// ImGuiバックエンドとコンテキストのフレーム開始をManagerに集約する
 		ImGui_ImplDX12_NewFrame();
 		ImGui_ImplWin32_NewFrame();
 		ImGui::NewFrame();
+		DrawDockSpace();
 #endif // USE_IMGUI
 	}
 
+
+
+	/// -------------------------------------------------------------
+	///						DockSpace描画処理
+	/// -------------------------------------------------------------
+	void ImGuiManager::DrawDockSpace()
+	{
+#ifdef USE_IMGUI
+		// 既存描画の見た目を変えないよう中央ノードは透過したDockSpaceを毎フレーム用意する
+		ImGui::DockSpaceOverViewport(0, ImGui::GetMainViewport(), ImGuiDockNodeFlags_PassthruCentralNode);
+#endif // USE_IMGUI
+	}
 
 
 	/// -------------------------------------------------------------
@@ -85,7 +102,7 @@ namespace Ken4lowEngine
 	void ImGuiManager::EndFrame()
 	{
 #ifdef USE_IMGUI
-		//ImGuiの内部コマンドを生成する
+		// ImGuiの内部描画コマンド生成をManagerに集約する
 		ImGui::Render();
 #endif // USE_IMGUI
 	}
@@ -102,11 +119,10 @@ namespace Ken4lowEngine
 
 		ComPtr<ID3D12GraphicsCommandList> commandList = dxCommon->GetCommandManager()->GetCommandList();
 
-		/*-----ImGuiを描画する-----*/
+		// ImGui描画に必要なSRVヒープ設定をManagerに集約する
 		SRVManager::GetInstance()->PreDraw();
 
-		/*-----ImGuiを描画する-----*/
-		//実際のcommandListのImGuiの描画コマンドを積む
+		// 実際のcommandListにImGuiの描画コマンドを積む処理をManagerに集約する
 		ImGui_ImplDX12_RenderDrawData(ImGui::GetDrawData(), commandList.Get());
 #endif // USE_IMGUI
 	}
@@ -114,7 +130,25 @@ namespace Ken4lowEngine
 
 
 	/// -------------------------------------------------------------
-	///							終了処理
+	///					Win32メッセージ処理
+	/// -------------------------------------------------------------
+	bool ImGuiManager::ProcessWin32Message(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam)
+	{
+#ifdef USE_IMGUI
+		// Win32バックエンド固有のメッセージ処理をManagerに集約する
+		return ImGui_ImplWin32_WndProcHandler(hwnd, msg, wparam, lparam) != 0;
+#else
+		(void)hwnd;
+		(void)msg;
+		(void)wparam;
+		(void)lparam;
+		return false;
+#endif // USE_IMGUI
+	}
+
+
+	/// -------------------------------------------------------------
+	///						終了処理
 	/// -------------------------------------------------------------
 	void ImGuiManager::Finalize()
 	{
@@ -126,6 +160,7 @@ namespace Ken4lowEngine
 			srvIndex_ = UINT32_MAX; // 無効な状態にリセット
 		}
 
+		// ImGuiバックエンドとコンテキストの終了処理をManagerに集約する
 		ImGui_ImplDX12_Shutdown();
 		ImGui_ImplWin32_Shutdown();
 		ImGui::DestroyContext();

--- a/Project/Engine/DebugTools/ImGui/ImGuiManager.h
+++ b/Project/Engine/DebugTools/ImGui/ImGuiManager.h
@@ -66,9 +66,16 @@ namespace Ken4lowEngine
 		/// ・ImGui_ImplDX12_NewFrame()<br/>
 		/// ・ImGui_ImplWin32_NewFrame()<br/>
 		/// ・ImGui::NewFrame()<br/>
+		/// ・DrawDockSpace()<br/>
 		/// を呼び出し、このあと ImGui ウィジェットの記述が行える状態にします。
 		/// </summary>
 		void BeginFrame();
+
+		/// <summary>
+		/// メイン ImGui Viewport 全体に DockSpace を描画します。<br/>
+		/// DirectX12 の D3D12_VIEWPORT と混同しないよう、ImGui 側の Viewport に限定した処理です。
+		/// </summary>
+		void DrawDockSpace();
 
 		/// <summary>
 		/// 1 フレーム分の ImGui の終了処理を行います。<br/>
@@ -85,6 +92,12 @@ namespace Ken4lowEngine
 		/// DirectX の通常の描画コマンドの後や、ポストエフェクトの後に呼び出す想定です。
 		/// </summary>
 		void Draw();
+
+		/// <summary>
+		/// Win32 メッセージを ImGui に渡します。<br/>
+		/// WinApp が ImGui バックエンドへ直接依存しないようにするための窓口です。
+		/// </summary>
+		bool ProcessWin32Message(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam);
 
 		/// <summary>
 		/// ImGui の終了処理を行います。<br/>

--- a/Project/Engine/Platform/Windows/WinApp.cpp
+++ b/Project/Engine/Platform/Windows/WinApp.cpp
@@ -5,10 +5,7 @@
 #include <cstddef>
 
 #ifdef USE_IMGUI
-#include <imgui_impl_win32.h>
-
-/// ---------- ImGuiのウィンドウプロシージャ ---------- ///
-extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
+#include <ImGuiManager.h>
 #endif // USE_IMGUI
 
 namespace Ken4lowEngine
@@ -466,7 +463,8 @@ namespace Ken4lowEngine
 		}
 
 #ifdef USE_IMGUI
-		if (ImGui_ImplWin32_WndProcHandler(hwnd, msg, wparam, lparam))
+		// ImGuiのWin32メッセージ処理はImGuiManager経由に集約する
+		if (ImGuiManager::GetInstance()->ProcessWin32Message(hwnd, msg, wparam, lparam))
 		{
 			return true;
 		}

--- a/Project/Engine/Platform/Windows/WinApp.h
+++ b/Project/Engine/Platform/Windows/WinApp.h
@@ -108,7 +108,7 @@ namespace Ken4lowEngine
 		/// ・WM_CLOSE：DestroyWindow を呼び出してウィンドウ破棄<br/>
 		/// ・WM_DESTROY：PostQuitMessage(0) を呼び出してアプリ終了を通知<br/>
 		/// ・それ以外：DefWindowProc に処理を委譲<br/>
-		/// ImGui 使用時は、先に ImGui_ImplWin32_WndProcHandler にメッセージを渡します。
+		/// ImGui 使用時は、先に ImGuiManager 経由でメッセージを渡します。
 		/// </summary>
 		/// <param name="hwnd">対象ウィンドウのハンドル。</param>
 		/// <param name="msg">メッセージ ID。</param>


### PR DESCRIPTION
### Motivation
- ImGui の初期化 / NewFrame / Render / 描画 / 終了処理を `ImGuiManager` に集約して責務を整理し、Scene や GameApplication 側に低レベル処理が散らばらないようにする。 
- Docking を有効化しつつ Multi-Viewport（別OSウィンドウ化）は今回の範囲外なので明示的に無効化する。 

### Description
- `ImGuiManager` に `DrawDockSpace()` と `ProcessWin32Message()` を追加し、`BeginFrame()` で `ImGui_Impl*` の NewFrame → `ImGui::NewFrame()` → `DrawDockSpace()` を毎フレーム呼ぶようにして DockSpaceOverViewport を常時用意する実装にした。 
- 初期化時に `io.ConfigFlags |= ImGuiConfigFlags_DockingEnable` を設定し `io.ConfigFlags &= ~ImGuiConfigFlags_ViewportsEnable` でマルチビューポートを無効化して仕様を固定した。 
- Win32 の WndProc 側の ImGui 依存を取り除き、`WinApp` は直接 `ImGui_ImplWin32_WndProcHandler` を呼ばず `ImGuiManager::ProcessWin32Message()` を経由してメッセージを渡すようにしたことで低レベル実装の依存を排除した。 
- 既存の描画順や見た目を崩さないため `DockSpaceOverViewport(..., ImGuiDockNodeFlags_PassthruCentralNode)` を使って中央ノードを透過し既存ウィンドウ表示に影響を与えないようにした。 
- DirectX の `D3D12_VIEWPORT` と ImGui の Viewport を混同しないように、`OcclusionDebugController` 内のローカル変数名を `imguiMainViewport` に変更した。 
- 変更ファイル（理由を含む）: `Project/Engine/DebugTools/ImGui/ImGuiManager.h`（API追加: DrawDockSpace / ProcessWin32Message）、`Project/Engine/DebugTools/ImGui/ImGuiManager.cpp`（初期化/NewFrame/EndFrame/Draw/Finalize の責務整理＋DockSpace描画＋Win32メッセージ集約）、`Project/Engine/Platform/Windows/WinApp.cpp`（WndProc から ImGui へのメッセージ経路を ImGuiManager 経由へ変更）、`Project/Engine/Platform/Windows/WinApp.h`（コメント修正）、`Project/ApplicationLayer/DebugTools/Occlusion/OcclusionDebugController.cpp`（Viewport 名の明示）。

### Testing
- `git diff --check` を実行して差分の静的問題は無いことを確認した（成功）。
- 変更箇所の検索で `ImGui_Impl*` / `ImGui::NewFrame` / `ImGui::Render` / `DockSpaceOverViewport` / `ViewportsEnable` / `DockingEnable` / `ImGui_ImplWin32_WndProcHandler` の使い所を確認した（成功）。
- Visual Studio/MSBuild による Debug/Release ビルドはこのコンテナに `msbuild` が無いため実行できなかった（未実行）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0131ab2710832d9a0fdf489171c4ec)