### PR TITLE
Fix ImGui DX12 docking font initialization

### DIFF
--- a/Project/Engine/DebugTools/ImGui/ImGuiManager.cpp
+++ b/Project/Engine/DebugTools/ImGui/ImGuiManager.cpp
@@ -4,6 +4,7 @@
 #include "DirectXCommon.h"
 #include "SRVManager.h"
 
+#include <cassert>
 #include <stdexcept>
 
 #ifdef USE_IMGUI
@@ -35,14 +36,20 @@ namespace Ken4lowEngine
 	void ImGuiManager::Initialize(WinApp* winApp, DirectXCommon* dxCommon)
 	{
 #ifdef USE_IMGUI
-		// SRVの番号を取得
-		srvIndex_ = SRVManager::GetInstance()->Allocate();
-
-		if (srvIndex_ >= SRVManager::GetInstance()->GetkMaxSRVCount())
+		// 初期化順の不整合を起動時に明示的なエラーとして検出する
+		if (initialized_)
 		{
-			SRVManager::GetInstance()->Free(srvIndex_);
-			srvIndex_ = UINT32_MAX;
-			throw std::runtime_error("Failed to allocate SRV for ImGuiManager");
+			throw std::runtime_error("ImGuiManager is already initialized");
+		}
+		if (winApp == nullptr || dxCommon == nullptr || dxCommon->GetDevice() == nullptr || dxCommon->GetCommandManager() == nullptr || dxCommon->GetCommandManager()->GetCommandQueue() == nullptr)
+		{
+			throw std::runtime_error("Invalid arguments for ImGuiManager::Initialize");
+		}
+
+		auto* srvManager = SRVManager::GetInstance();
+		if (srvManager->GetDescriptorHeap() == nullptr)
+		{
+			throw std::runtime_error("SRV descriptor heap is not initialized for ImGuiManager");
 		}
 
 #pragma region ImGuiの初期化を行いDirectX12とWindowsAPIを使ってImGuiをセットアップする
@@ -60,16 +67,83 @@ namespace Ken4lowEngine
 		io.ConfigFlags &= ~ImGuiConfigFlags_ViewportsEnable;
 
 		ImGui::StyleColorsDark();					  // ImGuiスタイルの設定
-		ImGui_ImplWin32_Init(winApp->GetHwnd());	  // Win32バックエンドの初期化
-		ImGui_ImplDX12_Init(dxCommon->GetDevice(),	  // DirectX 12バックエンドの初期化
-			dxCommon->GetSwapChainDesc().BufferCount,
-			DXGI_FORMAT_R8G8B8A8_UNORM_SRGB,
-			SRVManager::GetInstance()->GetDescriptorHeap(),
-			SRVManager::GetInstance()->GetCPUDescriptorHandle(srvIndex_),
-			SRVManager::GetInstance()->GetGPUDescriptorHandle(srvIndex_));
+		const bool win32Initialized = ImGui_ImplWin32_Init(winApp->GetHwnd()); // Win32バックエンド初期化の失敗を起動時に検出する
+		assert(win32Initialized && "ImGui_ImplWin32_Init failed");
+		if (!win32Initialized)
+		{
+			ImGui::DestroyContext();
+			throw std::runtime_error("ImGui_ImplWin32_Init failed");
+		}
+
+		ImGui_ImplDX12_InitInfo dx12InitInfo{};
+		dx12InitInfo.Device = dxCommon->GetDevice();
+		dx12InitInfo.CommandQueue = dxCommon->GetCommandManager()->GetCommandQueue();
+		dx12InitInfo.NumFramesInFlight = static_cast<int>(dxCommon->GetSwapChainDesc().BufferCount);
+		dx12InitInfo.RTVFormat = DXGI_FORMAT_R8G8B8A8_UNORM_SRGB;
+		dx12InitInfo.SrvDescriptorHeap = srvManager->GetDescriptorHeap();
+		dx12InitInfo.SrvDescriptorAllocFn = AllocateImGuiSrvDescriptor;
+		dx12InitInfo.SrvDescriptorFreeFn = FreeImGuiSrvDescriptor;
+		dx12InitInfo.UserData = this;
+
+		const bool dx12Initialized = ImGui_ImplDX12_Init(&dx12InitInfo); // 1.92以降の動的フォントテクスチャ更新に対応したDX12初期化を行う
+		assert(dx12Initialized && "ImGui_ImplDX12_Init failed");
+		if (!dx12Initialized)
+		{
+			ImGui_ImplWin32_Shutdown();
+			ImGui::DestroyContext();
+			throw std::runtime_error("ImGui_ImplDX12_Init failed");
+		}
+
+		initialized_ = true;
 #pragma endregion
 #endif // USE_IMGUI
 	}
+
+#ifdef USE_IMGUI
+	/// -------------------------------------------------------------
+	///					ImGui用SRVディスクリプタ確保
+	/// -------------------------------------------------------------
+	void ImGuiManager::AllocateImGuiSrvDescriptor(ImGui_ImplDX12_InitInfo* info, D3D12_CPU_DESCRIPTOR_HANDLE* outCpuHandle, D3D12_GPU_DESCRIPTOR_HANDLE* outGpuHandle)
+	{
+		if (info == nullptr || info->UserData == nullptr || outCpuHandle == nullptr || outGpuHandle == nullptr)
+		{
+			throw std::runtime_error("Invalid ImGui DX12 SRV allocation request");
+		}
+
+		auto* self = static_cast<ImGuiManager*>(info->UserData);
+		auto* srvManager = SRVManager::GetInstance();
+		const uint32_t srvIndex = srvManager->Allocate();
+		*outCpuHandle = srvManager->GetCPUDescriptorHandle(srvIndex);
+		*outGpuHandle = srvManager->GetGPUDescriptorHandle(srvIndex);
+
+		// フォントを含むImGuiテクスチャ用SRVが有効なヒープ上に確保されたことを記録する
+		assert(outCpuHandle->ptr != 0 && outGpuHandle->ptr != 0);
+		self->imguiSrvHandleToIndex_[outCpuHandle->ptr] = srvIndex;
+	}
+
+	/// -------------------------------------------------------------
+	///					ImGui用SRVディスクリプタ解放
+	/// -------------------------------------------------------------
+	void ImGuiManager::FreeImGuiSrvDescriptor(ImGui_ImplDX12_InitInfo* info, D3D12_CPU_DESCRIPTOR_HANDLE cpuHandle, D3D12_GPU_DESCRIPTOR_HANDLE gpuHandle)
+	{
+		if (info == nullptr || info->UserData == nullptr || cpuHandle.ptr == 0 || gpuHandle.ptr == 0)
+		{
+			throw std::runtime_error("Invalid ImGui DX12 SRV free request");
+		}
+
+		auto* self = static_cast<ImGuiManager*>(info->UserData);
+		auto it = self->imguiSrvHandleToIndex_.find(cpuHandle.ptr);
+		if (it == self->imguiSrvHandleToIndex_.end())
+		{
+			throw std::runtime_error("Unknown ImGui DX12 SRV descriptor handle");
+		}
+
+		// ImGuiバックエンドから返却されたフォント/テクスチャ用SRVをSRVManagerへ戻す
+		SRVManager::GetInstance()->Free(it->second);
+		self->imguiSrvHandleToIndex_.erase(it);
+	}
+#endif // USE_IMGUI
+
 
 
 
@@ -79,6 +153,12 @@ namespace Ken4lowEngine
 	void ImGuiManager::BeginFrame()
 	{
 #ifdef USE_IMGUI
+		// DX12/Win32バックエンド初期化前のNewFrame呼び出しを防ぐ
+		if (!initialized_)
+		{
+			throw std::runtime_error("ImGuiManager::BeginFrame called before Initialize");
+		}
+
 		// ImGuiバックエンドとコンテキストのフレーム開始をManagerに集約する
 		ImGui_ImplDX12_NewFrame();
 		ImGui_ImplWin32_NewFrame();
@@ -158,17 +238,22 @@ namespace Ken4lowEngine
 	void ImGuiManager::Finalize()
 	{
 #ifdef USE_IMGUI
-		// SRVが有効であるかを確認
-		if (srvIndex_ != UINT32_MAX)
+		if (!initialized_)
 		{
-			SRVManager::GetInstance()->Free(srvIndex_);
-			srvIndex_ = UINT32_MAX; // 無効な状態にリセット
+			return;
 		}
 
 		// ImGuiバックエンドとコンテキストの終了処理をManagerに集約する
 		ImGui_ImplDX12_Shutdown();
+		// DX12バックエンドから返却されなかったSRVがあればFinalize時に回収する
+		for (const auto& srvEntry : imguiSrvHandleToIndex_)
+		{
+			SRVManager::GetInstance()->Free(srvEntry.second);
+		}
 		ImGui_ImplWin32_Shutdown();
 		ImGui::DestroyContext();
+		imguiSrvHandleToIndex_.clear();
+		initialized_ = false;
 #endif // USE_IMGUI
 	}
 

--- a/Project/Engine/DebugTools/ImGui/ImGuiManager.h
+++ b/Project/Engine/DebugTools/ImGui/ImGuiManager.h
@@ -7,6 +7,7 @@
 #include <cstdint>
 #include <functional>
 #include <string>
+#include <unordered_map>
 #include <vector>
 
 #ifdef USE_IMGUI
@@ -52,8 +53,8 @@ namespace Ken4lowEngine
 
 		/// <summary>
 		/// ImGui の初期化処理を行います。<br/>
-		/// ・SRVManager から ImGui 用フォントテクスチャ用の SRV インデックスを確保<br/>
 		/// ・ImGui コンテキストの作成<br/>
+		/// ・SRVManager を使う DX12 用 SRV 確保コールバックの登録<br/>
 		/// ・Win32 / DX12 バックエンドの初期化<br/>
 		/// を行い、ImGui を使える状態にします。
 		/// </summary>
@@ -101,7 +102,7 @@ namespace Ken4lowEngine
 
 		/// <summary>
 		/// ImGui の終了処理を行います。<br/>
-		/// ・確保していた SRV インデックスの解放<br/>
+		/// ・DX12 バックエンド経由で確保した SRV の解放<br/>
 		/// ・DX12 / Win32 バックエンドのシャットダウン<br/>
 		/// ・ImGui コンテキストの破棄<br/>
 		/// を行います。
@@ -123,11 +124,17 @@ namespace Ken4lowEngine
 
 	private: /// ---------- メンバ関数 ---------- ///
 
-		// SRVIndex確保
-		uint32_t srvIndex_ = UINT32_MAX;
+#ifdef USE_IMGUI
+		// ImGuiバックエンドが要求するSRVディスクリプタをSRVManager経由で確保する
+		static void AllocateImGuiSrvDescriptor(ImGui_ImplDX12_InitInfo* info, D3D12_CPU_DESCRIPTOR_HANDLE* outCpuHandle, D3D12_GPU_DESCRIPTOR_HANDLE* outGpuHandle);
+		static void FreeImGuiSrvDescriptor(ImGui_ImplDX12_InitInfo* info, D3D12_CPU_DESCRIPTOR_HANDLE cpuHandle, D3D12_GPU_DESCRIPTOR_HANDLE gpuHandle);
+#endif // USE_IMGUI
+
+		bool initialized_ = false;
 
 #ifdef USE_IMGUI
 		std::vector<DebugPanel> panels_;
+		std::unordered_map<SIZE_T, uint32_t> imguiSrvHandleToIndex_;
 #endif // USE_IMGUI
 
 		int selectedIndex_ = 0;


### PR DESCRIPTION
### Motivation
- Startup assert occurred from ImGui when docking was enabled: the font atlas was not built while the renderer backend did not advertise `ImGuiBackendFlags_RendererHasTextures`.
- Investigation showed the legacy DX12 init path cleared `RendererHasTextures`, breaking the docking-branch dynamic font/texture flow and triggering the assert in `imgui_draw.cpp`.

### Description
- Switched ImGui DX12 initialization in `ImGuiManager::Initialize()` to use `ImGui_ImplDX12_InitInfo` and pass `CommandQueue`, `SrvDescriptorHeap` and SRV allocate/free callbacks so the backend preserves `RendererHasTextures` for the docking branch.
- Added SRV allocation/free callbacks implemented via `SRVManager` and a map to track ImGui-owned SRV indices, and updated the header to declare the callbacks and the tracking map.
- Added runtime checks and asserts to detect failures from `ImGui_ImplWin32_Init()` and `ImGui_ImplDX12_Init()`, a guard that prevents `BeginFrame()` being called before `Initialize()`, and comments clarifying intent at key code locations.
- On finalize, free any SRVs still tracked and clear the tracking map to avoid leaking descriptors if the backend did not release them.

### Testing
- Ran static validation scripts that checked `ImGui_ImplDX12_InitInfo` usage, the `NewFrame()` call order, `ImGui::Render()` → `ImGui_ImplDX12_RenderDrawData()` ordering, docking/viewports flags, and SRV callback registration, and all checks passed.
- Ran `git diff --check` to ensure no whitespace/patch issues and fixed formatting where needed, and those checks passed.
- Attempted Visual Studio/MSBuild builds for Debug/Release but they were not executed in this environment because `msbuild` is not available, so full builds remain to be validated on Windows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01364ec49c832db24c9c56b967fb0b)