### PR TITLE
Make Light Editor dockable and add initial DockBuilder layout

### DIFF
--- a/Project/Engine/DebugTools/ImGui/ImGuiManager.cpp
+++ b/Project/Engine/DebugTools/ImGui/ImGuiManager.cpp
@@ -8,6 +8,9 @@
 #include <stdexcept>
 
 #ifdef USE_IMGUI
+// DockBuilder APIを使って初期Docking配置を組むため内部ヘッダーを参照する
+#include <imgui_internal.h>
+
 extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
 #endif // USE_IMGUI
 
@@ -175,10 +178,39 @@ namespace Ken4lowEngine
 	void ImGuiManager::DrawDockSpace()
 	{
 #ifdef USE_IMGUI
+		const ImGuiViewport* viewport = ImGui::GetMainViewport();
 		// 既存描画の見た目を変えないよう中央ノードは透過したDockSpaceを毎フレーム用意する
-		ImGui::DockSpaceOverViewport(0, ImGui::GetMainViewport(), ImGuiDockNodeFlags_PassthruCentralNode);
+		const ImGuiID dockspaceId = ImGui::DockSpaceOverViewport(0, viewport, ImGuiDockNodeFlags_PassthruCentralNode);
+
+		if (!dockLayoutInitialized_)
+		{
+			// 初回だけDetails/Post Effect Settings側へライト編集ウィンドウを配置できるDockBuilderレイアウトを作る
+			SetupDefaultDockLayout(dockspaceId, viewport);
+			dockLayoutInitialized_ = true;
+		}
 #endif // USE_IMGUI
 	}
+
+#ifdef USE_IMGUI
+	void ImGuiManager::SetupDefaultDockLayout(ImGuiID dockspaceId, const ImGuiViewport* viewport)
+	{
+		if (dockspaceId == 0 || viewport == nullptr)
+		{
+			return;
+		}
+
+		ImGuiID rootNode = dockspaceId;
+		ImGuiID rightNode = 0;
+		ImGui::DockBuilderRemoveNodeChildNodes(rootNode);
+		ImGui::DockBuilderSetNodeSize(rootNode, viewport->Size);
+		ImGui::DockBuilderSplitNode(rootNode, ImGuiDir_Right, 0.28f, &rightNode, &rootNode);
+
+		ImGui::DockBuilderDockWindow("Details", rightNode);
+		ImGui::DockBuilderDockWindow("Post Effect Settings", rightNode);
+		ImGui::DockBuilderDockWindow("Light Editor", rightNode);
+		ImGui::DockBuilderFinish(dockspaceId);
+	}
+#endif // USE_IMGUI
 
 
 	/// -------------------------------------------------------------

--- a/Project/Engine/DebugTools/ImGui/ImGuiManager.h
+++ b/Project/Engine/DebugTools/ImGui/ImGuiManager.h
@@ -98,12 +98,15 @@ namespace Ken4lowEngine
 		// ImGuiバックエンドが要求するSRVディスクリプタをSRVManager経由で確保する
 		static void AllocateImGuiSrvDescriptor(ImGui_ImplDX12_InitInfo* info, D3D12_CPU_DESCRIPTOR_HANDLE* outCpuHandle, D3D12_GPU_DESCRIPTOR_HANDLE* outGpuHandle);
 		static void FreeImGuiSrvDescriptor(ImGui_ImplDX12_InitInfo* info, D3D12_CPU_DESCRIPTOR_HANDLE cpuHandle, D3D12_GPU_DESCRIPTOR_HANDLE gpuHandle);
+		// DockBuilderで初期配置するウィンドウ名を一箇所に集約する
+		void SetupDefaultDockLayout(ImGuiID dockspaceId, const ImGuiViewport* viewport);
 #endif // USE_IMGUI
 
 		bool initialized_ = false;
 
 #ifdef USE_IMGUI
 		std::unordered_map<SIZE_T, uint32_t> imguiSrvHandleToIndex_;
+		bool dockLayoutInitialized_ = false; // 初期DockBuilder配置を毎フレーム上書きしないためのフラグ
 #endif // USE_IMGUI
 
 	private: /// ---------- コンストラクタ・デストラクタ ---------- ///

--- a/Project/Engine/Graphics/Lighting/LightManager.cpp
+++ b/Project/Engine/Graphics/Lighting/LightManager.cpp
@@ -268,100 +268,106 @@ namespace Ken4lowEngine
 	void LightManager::DrawImGui()
 	{
 #ifdef USE_IMGUI
-		if (ImGui::CollapsingHeader("Punctual Lights"))
+		// ライト調整UIを暗黙のDebugウィンドウではなくDocking可能な通常ウィンドウとして描画する
+		ImGui::SetNextWindowSize(ImVec2(360.0f, 480.0f), ImGuiCond_FirstUseEver);
+		if (ImGui::Begin("Light Editor"))
 		{
-
-			// 追加ボタン
-			if (ImGui::Button("+ Add Light"))
+			if (ImGui::CollapsingHeader("Punctual Lights"))
 			{
-				PunctualLightGPU L{};
-				L.lightType = 1;                 // 既定: Directional
-				L.color = { 1,1,1,1 };
-				L.intensity = 1.0f;
-				L.direction = { 0,-1,0 };          // 下向き
-				punctualLights_.push_back(L);
-			}
-			ImGui::SameLine();
-			if (ImGui::Button("Clear All"))
-			{
-				punctualLights_.clear();
-			}
 
-			// 一覧
-			for (size_t i = 0; i < punctualLights_.size(); ++i)
-			{
-				ImGui::PushID(static_cast<int>(i));
-				auto& L = punctualLights_[i];
-
-				ImGui::Separator();
-				ImGui::Text("Light #%zu", i);
-
-				// 種類
-				int type = static_cast<int>(L.lightType);
-				const char* types[] = { "None","Directional","Point","Spot" };
-				if (ImGui::Combo("Type", &type, types, IM_ARRAYSIZE(types)))
-					L.lightType = static_cast<uint32_t>(type);
-
-				// 共通
-				ImGui::ColorEdit4("Color", &L.color.x);
-				ImGui::SliderFloat("Intensity", &L.intensity, 0.0f, 20.0f);
-
-				// 種類別
-				if (L.lightType == 1)
+				// 追加ボタン
+				if (ImGui::Button("+ Add Light"))
 				{
-					Vector3 eulerDeg = DirectionToEulerDeg(L.direction);
+					PunctualLightGPU L{};
+					L.lightType = 1;                 // 既定: Directional
+					L.color = { 1,1,1,1 };
+					L.intensity = 1.0f;
+					L.direction = { 0,-1,0 };          // 下向き
+					punctualLights_.push_back(L);
+				}
+				ImGui::SameLine();
+				if (ImGui::Button("Clear All"))
+				{
+					punctualLights_.clear();
+				}
 
-					bool changed = false;
-					changed |= ImGui::DragFloat("Pitch (X)", &eulerDeg.x, 0.5f, -89.0f, 89.0f, "%.1f deg");
-					changed |= ImGui::DragFloat("Yaw (Y)", &eulerDeg.y, 0.5f, -180.0f, 180.0f, "%.1f deg");
+				// 一覧
+				for (size_t i = 0; i < punctualLights_.size(); ++i)
+				{
+					ImGui::PushID(static_cast<int>(i));
+					auto& L = punctualLights_[i];
 
-					// Roll は光の向き自体には効かないので表示だけにするか、隠す
-					ImGui::BeginDisabled();
-					ImGui::DragFloat("Roll (Z)", &eulerDeg.z, 0.5f, -180.0f, 180.0f, "%.1f deg");
-					ImGui::EndDisabled();
+					ImGui::Separator();
+					ImGui::Text("Light #%zu", i);
 
-					if (changed)
+					// 種類
+					int type = static_cast<int>(L.lightType);
+					const char* types[] = { "None","Directional","Point","Spot" };
+					if (ImGui::Combo("Type", &type, types, IM_ARRAYSIZE(types)))
+						L.lightType = static_cast<uint32_t>(type);
+
+					// 共通
+					ImGui::ColorEdit4("Color", &L.color.x);
+					ImGui::SliderFloat("Intensity", &L.intensity, 0.0f, 20.0f);
+
+					// 種類別
+					if (L.lightType == 1)
 					{
-						L.direction = EulerDegToDirection(eulerDeg);
+						Vector3 eulerDeg = DirectionToEulerDeg(L.direction);
+
+						bool changed = false;
+						changed |= ImGui::DragFloat("Pitch (X)", &eulerDeg.x, 0.5f, -89.0f, 89.0f, "%.1f deg");
+						changed |= ImGui::DragFloat("Yaw (Y)", &eulerDeg.y, 0.5f, -180.0f, 180.0f, "%.1f deg");
+
+						// Roll は光の向き自体には効かないので表示だけにするか、隠す
+						ImGui::BeginDisabled();
+						ImGui::DragFloat("Roll (Z)", &eulerDeg.z, 0.5f, -180.0f, 180.0f, "%.1f deg");
+						ImGui::EndDisabled();
+
+						if (changed)
+						{
+							L.direction = EulerDegToDirection(eulerDeg);
+						}
+
+						ImGui::Text("Dir = (%.3f, %.3f, %.3f)", L.direction.x, L.direction.y, L.direction.z);
+					}
+					else if (L.lightType == 2)
+					{
+						// Point
+						ImGui::SliderFloat3("Position", &L.position.x, -50.0f, 50.0f);
+						ImGui::SliderFloat("Radius", &L.radius, 0.0f, 200.0f);
+						ImGui::SliderFloat("Decay", &L.decay, 0.0f, 10.0f);
+					}
+					else if (L.lightType == 3)
+					{
+						// Spot
+						ImGui::SliderFloat3("Position", &L.position.x, -50.0f, 50.0f);
+						if (ImGui::SliderFloat3("Direction", &L.direction.x, -1.0f, 1.0f))
+						{
+							L.direction = Vector3::Normalize(L.direction);
+						}
+						ImGui::SliderFloat("Distance", &L.distance, 0.0f, 200.0f);
+						ImGui::SliderFloat("Decay", &L.decay, 0.0f, 10.0f);
+						ImGui::SliderFloat("cosInner", &L.cosFalloffStart, 0.0f, 1.0f);
+						ImGui::SliderFloat("cosOuter", &L.cosAngle, 0.0f, 1.0f);
+						if (L.cosFalloffStart < L.cosAngle) L.cosFalloffStart = L.cosAngle; // 内>=外
 					}
 
-					ImGui::Text("Dir = (%.3f, %.3f, %.3f)", L.direction.x, L.direction.y, L.direction.z);
-				}
-				else if (L.lightType == 2)
-				{
-					// Point
-					ImGui::SliderFloat3("Position", &L.position.x, -50.0f, 50.0f);
-					ImGui::SliderFloat("Radius", &L.radius, 0.0f, 200.0f);
-					ImGui::SliderFloat("Decay", &L.decay, 0.0f, 10.0f);
-				}
-				else if (L.lightType == 3)
-				{
-					// Spot
-					ImGui::SliderFloat3("Position", &L.position.x, -50.0f, 50.0f);
-					if (ImGui::SliderFloat3("Direction", &L.direction.x, -1.0f, 1.0f))
+					if (ImGui::Button("Remove"))
 					{
-						L.direction = Vector3::Normalize(L.direction);
+						punctualLights_.erase(punctualLights_.begin() + i);
+						ImGui::PopID();
+						--i; // 次の要素が詰まるのでインデックス調整
+						continue;
 					}
-					ImGui::SliderFloat("Distance", &L.distance, 0.0f, 200.0f);
-					ImGui::SliderFloat("Decay", &L.decay, 0.0f, 10.0f);
-					ImGui::SliderFloat("cosInner", &L.cosFalloffStart, 0.0f, 1.0f);
-					ImGui::SliderFloat("cosOuter", &L.cosAngle, 0.0f, 1.0f);
-					if (L.cosFalloffStart < L.cosAngle) L.cosFalloffStart = L.cosAngle; // 内>=外
-				}
-
-				if (ImGui::Button("Remove"))
-				{
-					punctualLights_.erase(punctualLights_.begin() + i);
 					ImGui::PopID();
-					--i; // 次の要素が詰まるのでインデックス調整
-					continue;
 				}
-				ImGui::PopID();
-			}
 
-			// 参考表示（GPUへは UpdatePunctualLight で同期）
-			ImGui::Text("Active Lights (type!=0): will be uploaded");
+				// 参考表示（GPUへは UpdatePunctualLight で同期）
+				ImGui::Text("Active Lights (type!=0): will be uploaded");
+			}
 		}
+		ImGui::End();
 #endif // USE_IMGUI
 	}
 


### PR DESCRIPTION
### Motivation
- The light adjustment UI was drawn implicitly on ImGui's fallback "Debug" window which prevented proper docking and needed to be a regular dockable window.
- Provide a predictable initial docking placement so users can dock the light UI next to `Details` / `Post Effect Settings` without changing the light UI internals.
- Keep multi-viewport disabled (`ImGuiConfigFlags_ViewportsEnable` remains off) and avoid changing the existing light controls logic.

### Description
- Wrap existing light controls in a normal ImGui window by adding `ImGui::SetNextWindowSize(..., ImGuiCond_FirstUseEver);` and `ImGui::Begin("Light Editor")` / `ImGui::End()`, renaming the outer window to `"Light Editor"` while preserving all internal widgets and behavior in `Project/Engine/Graphics/Lighting/LightManager.cpp`.
- Add a one-time `DockBuilder` setup (`SetupDefaultDockLayout`) that, on first frame, docks `"Light Editor"` together with `"Details"` and `"Post Effect Settings"` on the right side of the main dockspace in `Project/Engine/DebugTools/ImGui/ImGuiManager.cpp` and declare the helper in `ImGuiManager.h`.
- Use `imgui_internal.h` only to call `DockBuilder*` APIs for the initial layout and guard the operation with a `dockLayoutInitialized_` flag so the layout is not re-applied each frame.
- Add short, intent-explaining one-line comments at the modified locations and keep `ImGuiConfigFlags_ViewportsEnable` explicitly disabled as required.

### Testing
- Ran `git diff --check` and ensured no whitespace/patch issues (succeeded).
- Ran repository assertions via a short `python3` check that verifies presence of `ImGui::Begin("Light Editor")`, `ImGuiCond_FirstUseEver`, absence of `ImGuiWindowFlags_NoDocking`, and that `DockBuilderDockWindow("Light Editor")` is present (succeeded).
- Formatted modified files with `clang-format -i` to keep style consistent (succeeded).
- Attempted to run `msbuild` for Debug and Release builds but `msbuild` is not available in this Linux environment so full builds were not executed here (not run).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01404a9868832d96940cc605272695)