### PR TITLE
Persist ImGui docking layout and apply default DockBuilder only on first run or reset

### DIFF
--- a/Project/Engine/DebugTools/ImGui/ImGuiManager.cpp
+++ b/Project/Engine/DebugTools/ImGui/ImGuiManager.cpp
@@ -5,6 +5,7 @@
 #include "SRVManager.h"
 
 #include <cassert>
+#include <fstream>
 #include <stdexcept>
 
 #ifdef USE_IMGUI
@@ -12,6 +13,22 @@
 #include <imgui_internal.h>
 
 extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg, WPARAM wParam, LPARAM lParam);
+
+namespace
+{
+	constexpr const char* kEditorLayoutIniFilename = "ken4low_editor_layout.ini";
+
+	bool FileExists(const char* path)
+	{
+		if (path == nullptr)
+		{
+			return false;
+		}
+
+		std::ifstream file(path, std::ios::binary);
+		return file.good();
+	}
+}
 #endif // USE_IMGUI
 
 
@@ -60,6 +77,12 @@ namespace Ken4lowEngine
 		ImGui::CreateContext();						  // ImGuiコンテキストの作成
 
 		ImGuiIO& io = ImGui::GetIO();				  // ImGuiIOへの参照を取得
+
+		// 手動Dockingレイアウトを次回起動時に復元するため、専用iniへ保存する
+		io.IniFilename = kEditorLayoutIniFilename;
+		shouldApplyDefaultDockLayout_ = !FileExists(io.IniFilename);
+		resetDockLayoutRequested_ = false;
+		dockLayoutInitialized_ = false;
 
 		// フォントの設定
 		io.Fonts->AddFontFromFileTTF("Resources/Fonts/NotoSansJP-VariableFont_wght.ttf", 18.0f, nullptr, io.Fonts->GetGlyphRangesJapanese()); // 日本語フォントの追加
@@ -182,11 +205,13 @@ namespace Ken4lowEngine
 		// 既存描画の見た目を変えないよう中央ノードは透過したDockSpaceを毎フレーム用意する
 		const ImGuiID dockspaceId = ImGui::DockSpaceOverViewport(0, viewport, ImGuiDockNodeFlags_PassthruCentralNode);
 
-		if (!dockLayoutInitialized_)
+		if (shouldApplyDefaultDockLayout_ || resetDockLayoutRequested_)
 		{
-			// 初回だけDetails/Post Effect Settings側へライト編集ウィンドウを配置できるDockBuilderレイアウトを作る
+			// 保存済みiniが無い初回起動、または明示リセット時だけDockBuilderで初期配置を作る
 			SetupDefaultDockLayout(dockspaceId, viewport);
 			dockLayoutInitialized_ = true;
+			shouldApplyDefaultDockLayout_ = false;
+			resetDockLayoutRequested_ = false;
 		}
 #endif // USE_IMGUI
 	}
@@ -211,6 +236,20 @@ namespace Ken4lowEngine
 		ImGui::DockBuilderFinish(dockspaceId);
 	}
 #endif // USE_IMGUI
+
+
+	/// -------------------------------------------------------------
+	///					Dockingレイアウトリセット要求
+	/// -------------------------------------------------------------
+	void ImGuiManager::RequestResetDockLayout()
+	{
+#ifdef USE_IMGUI
+		// Windowメニューからの操作で次フレームに初期DockBuilder配置を再適用する
+		resetDockLayoutRequested_ = true;
+		shouldApplyDefaultDockLayout_ = false;
+		dockLayoutInitialized_ = false;
+#endif // USE_IMGUI
+	}
 
 
 	/// -------------------------------------------------------------
@@ -275,6 +314,12 @@ namespace Ken4lowEngine
 			return;
 		}
 
+		// DestroyContext前にiniへ書き出して、終了直前のDockingレイアウトを確実に残す
+		if (ImGui::GetIO().IniFilename != nullptr)
+		{
+			ImGui::SaveIniSettingsToDisk(ImGui::GetIO().IniFilename);
+		}
+
 		// ImGuiバックエンドとコンテキストの終了処理をManagerに集約する
 		ImGui_ImplDX12_Shutdown();
 		// DX12バックエンドから返却されなかったSRVがあればFinalize時に回収する
@@ -286,6 +331,9 @@ namespace Ken4lowEngine
 		ImGui::DestroyContext();
 		imguiSrvHandleToIndex_.clear();
 		initialized_ = false;
+		dockLayoutInitialized_ = false;
+		shouldApplyDefaultDockLayout_ = false;
+		resetDockLayoutRequested_ = false;
 #endif // USE_IMGUI
 	}
 

--- a/Project/Engine/DebugTools/ImGui/ImGuiManager.h
+++ b/Project/Engine/DebugTools/ImGui/ImGuiManager.h
@@ -78,6 +78,11 @@ namespace Ken4lowEngine
 		void Draw();
 
 		/// <summary>
+		/// 次フレームでDockBuilderの初期レイアウトを再適用します。
+		/// </summary>
+		void RequestResetDockLayout();
+
+		/// <summary>
 		/// Win32 メッセージを ImGui に渡します。<br/>
 		/// WinApp が ImGui バックエンドへ直接依存しないようにするための窓口です。
 		/// </summary>
@@ -107,6 +112,8 @@ namespace Ken4lowEngine
 #ifdef USE_IMGUI
 		std::unordered_map<SIZE_T, uint32_t> imguiSrvHandleToIndex_;
 		bool dockLayoutInitialized_ = false; // 初期DockBuilder配置を毎フレーム上書きしないためのフラグ
+		bool shouldApplyDefaultDockLayout_ = false; // 保存済みiniが無い場合だけ初期DockBuilder配置を適用するフラグ
+		bool resetDockLayoutRequested_ = false; // WindowメニューからのReset Layout要求を次フレームへ渡すフラグ
 #endif // USE_IMGUI
 
 	private: /// ---------- コンストラクタ・デストラクタ ---------- ///

--- a/Project/Engine/Editor/EditorWindowManager.cpp
+++ b/Project/Engine/Editor/EditorWindowManager.cpp
@@ -1,5 +1,7 @@
 #include "EditorWindowManager.h"
 
+#include "ImGuiManager.h"
+
 #ifdef USE_IMGUI
 #include <imgui.h>
 #endif // USE_IMGUI
@@ -58,6 +60,12 @@ namespace Ken4lowEngine
 			ImGui::MenuItem("Output Log", nullptr, &windowState_.showOutputLog);
 			ImGui::Separator();
 			ImGui::MenuItem("Toolbar", nullptr, &windowState_.showToolbar);
+			ImGui::Separator();
+			// ユーザーが崩れたDocking配置を明示的に初期状態へ戻せる入口にする
+			if (ImGui::MenuItem("Reset Layout"))
+			{
+				ImGuiManager::GetInstance()->RequestResetDockLayout();
+			}
 			ImGui::EndMenu();
 		}
 


### PR DESCRIPTION
### Motivation
- Users' manual ImGui Docking layouts were lost on restart because the editor did not set `ImGuiIO::IniFilename` and the DockBuilder default layout could overwrite saved settings on each run. 
- Ensure editor docking state is persisted to a dedicated ini and that default DockBuilder layout is only applied when appropriate. 
- Provide a user-accessible way to reset the layout from the UI.

### Description
- Set `io.IniFilename = "ken4low_editor_layout.ini"` in `ImGuiManager::Initialize()` and track whether an ini already exists to prefer saved layouts at startup. 
- Apply `SetupDefaultDockLayout()` only when no saved ini exists or when a reset was requested, using `shouldApplyDefaultDockLayout_` and `resetDockLayoutRequested_` flags. 
- Add `RequestResetDockLayout()` API and a `Window -> Reset Layout` menu item to trigger reapplication of the initial DockBuilder layout. 
- Explicitly call `ImGui::SaveIniSettingsToDisk()` before `ImGui::DestroyContext()` to ensure the current layout is written to disk, and add a small `FileExists()` helper and related state cleanup comments.
- Added short, intent-revealing comments at change points.
- Files changed: `Project/Engine/DebugTools/ImGui/ImGuiManager.cpp`, `Project/Engine/DebugTools/ImGui/ImGuiManager.h`, `Project/Engine/Editor/EditorWindowManager.cpp`.

### Testing
- Searched code usage and verified related symbols with `rg` and source inspection (succeeded). 
- Verified no project windows use `ImGuiWindowFlags_NoSavedSettings` within project sources via `rg` (only found in Externals), so windows remain savable (succeeded). 
- Searched for `ken4low_editor_layout.ini` and `IniFilename` occurrences with `find`/`rg` to confirm modifications and behavior (succeeded). 
- Ran `git diff --check` and basic repo status checks and committed changes (succeeded). 
- Attempted to build with `msbuild` for Debug/Release but `msbuild` is not available in this Linux container, so full builds could not be run here (not executed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a014488d444832d81c47ffae77e3d6a)