### PR TITLE
Organize ImGui Window menu visibility controls

### DIFF
--- a/Project/ApplicationLayer/Scene/GamePlayScene/DebugTools/GamePlayDebugTools.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/DebugTools/GamePlayDebugTools.cpp
@@ -20,6 +20,7 @@
 
 #ifdef USE_IMGUI
 #include <imgui.h>
+#include <Editor/EditorWindowManager.h>
 #endif
 
 bool GamePlayDebugTools::HandleFreezeToggle(K4E::Input* input, GamePlayFlow* flow)
@@ -115,12 +116,24 @@ void GamePlayDebugTools::DrawImGui(GamePlayWorld* world)
 	if (!world) { return; }
 
 	auto& characters = world->GetCharacters();
+	// WindowメニューのScene Debug/Rendering表示フラグをGamePlay系デバッグUIと共有する
+	auto& editorWindowState = K4E::EditorWindowManager::GetInstance()->GetWindowState();
 
-	K4E::LightManager::GetInstance()->DrawImGui();
-	characters.DrawImGui();
-	world->DrawImGui();
-	stageChunkDebugController_.DrawImGui(world->GetStage());
-	occlusionDebugController_.DrawImGui(world->GetStage());
+	K4E::LightManager::GetInstance()->DrawImGui(&editorWindowState.showLightEditor);
+	if (editorWindowState.showGameDebug)
+	{
+		if (ImGui::Begin("Game Debug", &editorWindowState.showGameDebug))
+		{
+			ImGui::Text("Debug Camera: %s", isDebugCamera_ ? "ON" : "OFF");
+			ImGui::Text("ImGui Freeze: %s", isImGuiFreeze_ ? "ON" : "OFF");
+		}
+		ImGui::End();
+
+		characters.DrawImGui();
+		world->DrawImGui();
+		stageChunkDebugController_.DrawImGui(world->GetStage());
+		occlusionDebugController_.DrawImGui(world->GetStage());
+	}
 
 	/// ---------- 武器マスターデータエディタ ---------- ///
 	static WeaponMasterDataDatabase weaponDB;
@@ -233,18 +246,22 @@ void GamePlayDebugTools::DrawImGui(GamePlayWorld* world)
 			return out;
 		};
 
-	weaponEditor.DrawImGui(weaponDB, hooks);
-
-	ImGui::Begin("Weapon Master Debug");
-	ImGui::Text("Last Applied ID: %d", lastAppliedWeaponID_);
-
-	if (ImGui::Button("Reload Weapon Editor DB"))
+	// WindowメニューのWeapon Master Debug表示フラグを武器デバッグUIの×ボタン状態と共有する
+	if (editorWindowState.showWeaponMasterDebug)
 	{
-		std::string err;
-		weaponDB = WeaponMasterDataDatabase{};
-		weaponDB.LoadFromDirectory(kRoot, &err);
+		weaponEditor.DrawImGui(weaponDB, hooks);
+
+		ImGui::Begin("Weapon Master Debug", &editorWindowState.showWeaponMasterDebug);
+		ImGui::Text("Last Applied ID: %d", lastAppliedWeaponID_);
+
+		if (ImGui::Button("Reload Weapon Editor DB"))
+		{
+			std::string err;
+			weaponDB = WeaponMasterDataDatabase{};
+			weaponDB.LoadFromDirectory(kRoot, &err);
+		}
+		ImGui::End();
 	}
-	ImGui::End();
 #else
 	(void)world;
 #endif

--- a/Project/ApplicationLayer/Scene/ShadowTestScene/ShadowTestScene.cpp
+++ b/Project/ApplicationLayer/Scene/ShadowTestScene/ShadowTestScene.cpp
@@ -5,6 +5,7 @@
 
 #ifdef USE_IMGUI
 #include <imgui.h>
+#include <Editor/EditorWindowManager.h>
 #endif
 
 using namespace Ken4lowEngine;
@@ -131,7 +132,7 @@ void ShadowTestScene::Finalize()
 void ShadowTestScene::DrawImGui()
 {
 #ifdef USE_IMGUI
-	LightManager::GetInstance()->DrawImGui();
+	LightManager::GetInstance()->DrawImGui(&EditorWindowManager::GetInstance()->GetWindowState().showLightEditor);
 
 	box_->DrawImGui();
 	floor_->DrawImGui();

--- a/Project/ApplicationLayer/Scene/StageSelectScene/StageSelectScene.cpp
+++ b/Project/ApplicationLayer/Scene/StageSelectScene/StageSelectScene.cpp
@@ -16,6 +16,7 @@
 
 #ifdef USE_IMGUI
 #include <imgui.h>
+#include <Editor/EditorWindowManager.h>
 #endif // USE_IMGUI
 
 namespace K4E = ::Ken4lowEngine;
@@ -344,9 +345,11 @@ void StageSelectScene::Finalize()
 void StageSelectScene::DrawImGui()
 {
 #ifdef USE_IMGUI
-	if (!textLayoutDebug_.enableImGui) { return; }
+	// WindowメニューのStage Select Debug表示フラグを×ボタン状態と共有する
+	auto& editorWindowState = K4E::EditorWindowManager::GetInstance()->GetWindowState();
+	if (!textLayoutDebug_.enableImGui || !editorWindowState.showStageSelectDebug) { return; }
 
-	if (ImGui::Begin("StageSelect Text Layout"))
+	if (ImGui::Begin("StageSelect Text Layout", &editorWindowState.showStageSelectDebug))
 	{
 		ImGui::Text("Current Stage Index : %d", currentStageIndex_);
 

--- a/Project/ApplicationLayer/Scene/TitleScene/TitleScene.cpp
+++ b/Project/ApplicationLayer/Scene/TitleScene/TitleScene.cpp
@@ -14,6 +14,10 @@
 #include <LightManager.h>
 #include <GameTimer.h>
 
+#ifdef USE_IMGUI
+#include <Editor/EditorWindowManager.h>
+#endif // USE_IMGUI
+
 #include "TitleLoadState.h"
 #include "TitleAttractState.h"
 #include "TitleLobbyState.h"
@@ -240,19 +244,24 @@ void TitleScene::Finalize()
 void TitleScene::DrawImGui()
 {
 #ifdef USE_IMGUI
-	ImGui::Begin("Title Debug");
-	const char* stateNames =
-		state_ == State::TitleAttract ? "TitleAttract" :
-		state_ == State::TransitionToLobby ? "TransitionToLobby" :
-		state_ == State::LobbyIdle ? "LobbyIdle" :
-		state_ == State::Loading ? "Loading" : "";
-	ImGui::Text("State: %s", stateNames);
-	ImGui::Text("Idle: %.1fs / Return: %.0fs", timers_.idle, timers_.returnSeconds);
-	ImGui::End();
+	// WindowメニューのTitle Debug表示フラグを×ボタン状態と共有する
+	auto& editorWindowState = EditorWindowManager::GetInstance()->GetWindowState();
+	if (editorWindowState.showTitleDebug)
+	{
+		ImGui::Begin("Title Debug", &editorWindowState.showTitleDebug);
+		const char* stateNames =
+			state_ == State::TitleAttract ? "TitleAttract" :
+			state_ == State::TransitionToLobby ? "TransitionToLobby" :
+			state_ == State::LobbyIdle ? "LobbyIdle" :
+			state_ == State::Loading ? "Loading" : "";
+		ImGui::Text("State: %s", stateNames);
+		ImGui::Text("Idle: %.1fs / Return: %.0fs", timers_.idle, timers_.returnSeconds);
+		ImGui::End();
+	}
 
+	// WindowメニューのLight Editor表示フラグをTitleシーン側のライトUIにも共有する
+	LightManager::GetInstance()->DrawImGui(&editorWindowState.showLightEditor);
 #endif // USE_IMGUI
-
-	LightManager::GetInstance()->DrawImGui();
 }
 
 void TitleScene::StartLoad()

--- a/Project/ApplicationLayer/SceneManagement/FadeManager/FadeManager.cpp
+++ b/Project/ApplicationLayer/SceneManagement/FadeManager/FadeManager.cpp
@@ -9,6 +9,7 @@
 
 #ifdef USE_IMGUI
 #include <imgui.h>
+#include <Editor/EditorWindowManager.h>
 
 namespace K4E = ::Ken4lowEngine;
 
@@ -760,7 +761,14 @@ void FadeManager::Draw2DSprites()
 void FadeManager::DrawImGui()
 {
 #ifdef USE_IMGUI
-	ImGui::Begin("FadeManager - Tile Fade");
+	// WindowメニューのFadeManager - Tile Fade表示フラグを×ボタン状態と共有する
+	auto& editorWindowState = K4E::EditorWindowManager::GetInstance()->GetWindowState();
+	if (!editorWindowState.showTileFadeDebug)
+	{
+		return;
+	}
+
+	ImGui::Begin("FadeManager - Tile Fade", &editorWindowState.showTileFadeDebug);
 
 	const char* st =
 		(state_ == State::None) ? "演出していない待機状態" :

--- a/Project/Engine/Core/Application/GameApplication.cpp
+++ b/Project/Engine/Core/Application/GameApplication.cpp
@@ -107,13 +107,15 @@ namespace Ken4lowEngine
 		ImGuiManager::GetInstance()->BeginFrame();
 
 		// UE5風エディタUI土台を既存のシーン別ImGuiの前に描画する
-		EditorWindowManager::GetInstance()->Draw();
+		auto* editorWindows = EditorWindowManager::GetInstance();
+		editorWindows->Draw();
+		auto& editorWindowState = editorWindows->GetWindowState();
 
-		// ウィンドウ表示用の画面設定の変更
-		winApp_->DrawDisplaySettingsImGui();
+		// WindowメニューのDisplay表示フラグをWinApp側の×ボタン状態と共有する
+		winApp_->DrawDisplaySettingsImGui(&editorWindowState.showDisplay);
 
-		// グローバル変数の更新
-		ParameterManager::GetInstance()->Update();
+		// WindowメニューのParameters表示フラグをParameterManager側の×ボタン状態と共有する
+		ParameterManager::GetInstance()->Update(&editorWindowState.showParameters);
 
 		//defaultCamera_->DrawImGui();
 
@@ -126,8 +128,8 @@ namespace Ken4lowEngine
 		// ParticleManagerのImGuiの描画処理
 		ParticleManager::GetInstance()->DrawImGui();
 
-		// PostEffectManagerのImGuiの描画処理
-		PostEffectManager::GetInstance()->ImGuiRender();
+		// WindowメニューのPost Effect Settings表示フラグをPostEffectManager側の×ボタン状態と共有する
+		PostEffectManager::GetInstance()->ImGuiRender(&editorWindowState.showPostEffectSettings);
 
 		/// ---------- ImGuiフレーム終了 ---------- ///
 		ImGuiManager::GetInstance()->EndFrame();

--- a/Project/Engine/Editor/EditorWindowManager.cpp
+++ b/Project/Engine/Editor/EditorWindowManager.cpp
@@ -53,18 +53,47 @@ namespace Ken4lowEngine
 
 		if (ImGui::BeginMenu("Window"))
 		{
-			ImGui::MenuItem("Main Viewport", nullptr, &windowState_.showMainViewport);
-			ImGui::MenuItem("World Outliner", nullptr, &windowState_.showWorldOutliner);
-			ImGui::MenuItem("Details", nullptr, &windowState_.showDetails);
-			ImGui::MenuItem("Content Browser", nullptr, &windowState_.showContentBrowser);
-			ImGui::MenuItem("Output Log", nullptr, &windowState_.showOutputLog);
-			ImGui::Separator();
-			ImGui::MenuItem("Toolbar", nullptr, &windowState_.showToolbar);
-			ImGui::Separator();
-			// ユーザーが崩れたDocking配置を明示的に初期状態へ戻せる入口にする
-			if (ImGui::MenuItem("Reset Layout"))
+			// Commonは常時使うエディタ基本パネルをまとめて表示切替できるようにする
+			if (ImGui::BeginMenu("Common"))
 			{
-				ImGuiManager::GetInstance()->RequestResetDockLayout();
+				ImGui::MenuItem("Toolbar", nullptr, &windowState_.showToolbar);
+				ImGui::MenuItem("Main Viewport", nullptr, &windowState_.showMainViewport);
+				ImGui::MenuItem("Content Browser", nullptr, &windowState_.showContentBrowser);
+				ImGui::MenuItem("World Outliner", nullptr, &windowState_.showWorldOutliner);
+				ImGui::MenuItem("Details", nullptr, &windowState_.showDetails);
+				ImGui::MenuItem("Output Log", nullptr, &windowState_.showOutputLog);
+				ImGui::EndMenu();
+			}
+
+			// Renderingは描画・画面・ライト調整系ウィンドウをまとめて表示切替できるようにする
+			if (ImGui::BeginMenu("Rendering"))
+			{
+				ImGui::MenuItem("Parameters", nullptr, &windowState_.showParameters);
+				ImGui::MenuItem("Display", nullptr, &windowState_.showDisplay);
+				ImGui::MenuItem("Post Effect Settings", nullptr, &windowState_.showPostEffectSettings);
+				ImGui::MenuItem("Light Editor", nullptr, &windowState_.showLightEditor);
+				ImGui::EndMenu();
+			}
+
+			// Scene Debugは現在のシーンに応じて描かれるデバッグウィンドウをまとめて表示切替できるようにする
+			if (ImGui::BeginMenu("Scene Debug"))
+			{
+				ImGui::MenuItem("Title Debug", nullptr, &windowState_.showTitleDebug);
+				ImGui::MenuItem("Stage Select Debug", nullptr, &windowState_.showStageSelectDebug);
+				ImGui::MenuItem("Game Debug", nullptr, &windowState_.showGameDebug);
+				ImGui::MenuItem("Weapon Master Debug", nullptr, &windowState_.showWeaponMasterDebug);
+				ImGui::MenuItem("FadeManager - Tile Fade", nullptr, &windowState_.showTileFadeDebug);
+				ImGui::EndMenu();
+			}
+
+			// LayoutはDockBuilderの初期配置をユーザー操作時だけ再適用する入口にする
+			if (ImGui::BeginMenu("Layout"))
+			{
+				if (ImGui::MenuItem("Reset Layout"))
+				{
+					ImGuiManager::GetInstance()->RequestResetDockLayout();
+				}
+				ImGui::EndMenu();
 			}
 			ImGui::EndMenu();
 		}
@@ -134,7 +163,7 @@ namespace Ken4lowEngine
 			return;
 		}
 
-		// Main Viewportは後でRenderTarget Previewを差し込むための表示領域だけ先に確保する
+		// Main Viewportは既存の中央表示用プレースホルダーとしてWindowメニューの表示状態と同期する
 		if (ImGui::Begin("Main Viewport", &windowState_.showMainViewport))
 		{
 			const ImVec2 viewportSize = ImGui::GetContentRegionAvail();

--- a/Project/Engine/Editor/EditorWindowManager.h
+++ b/Project/Engine/Editor/EditorWindowManager.h
@@ -8,12 +8,26 @@ namespace Ken4lowEngine
 	/// </summary>
 	struct EditorWindowState
 	{
+		// WindowメニューのCommonカテゴリで切り替える標準エディタウィンドウです。
 		bool showToolbar = true;
 		bool showMainViewport = true;
+		bool showContentBrowser = true;
 		bool showWorldOutliner = true;
 		bool showDetails = true;
-		bool showContentBrowser = true;
 		bool showOutputLog = true;
+
+		// WindowメニューのRenderingカテゴリで切り替える描画調整ウィンドウです。
+		bool showParameters = true;
+		bool showDisplay = true;
+		bool showPostEffectSettings = true;
+		bool showLightEditor = true;
+
+		// WindowメニューのScene Debugカテゴリで切り替えるシーン依存デバッグウィンドウです。
+		bool showTitleDebug = true;
+		bool showStageSelectDebug = true;
+		bool showGameDebug = true;
+		bool showWeaponMasterDebug = true;
+		bool showTileFadeDebug = true;
 
 		bool debugShowCollider = false;
 		bool debugShowEnemyInfo = false;

--- a/Project/Engine/Graphics/Lighting/LightManager.cpp
+++ b/Project/Engine/Graphics/Lighting/LightManager.cpp
@@ -265,12 +265,18 @@ namespace Ken4lowEngine
 	/// -------------------------------------------------------------
 	///				　		　	ImGui
 	/// -------------------------------------------------------------
-	void LightManager::DrawImGui()
+	void LightManager::DrawImGui(bool* pOpen)
 	{
 #ifdef USE_IMGUI
+		// WindowメニューのLight Editor表示フラグが閉じている間はライト編集UIを生成しない
+		if (pOpen != nullptr && !*pOpen)
+		{
+			return;
+		}
+
 		// ライト調整UIを暗黙のDebugウィンドウではなくDocking可能な通常ウィンドウとして描画する
 		ImGui::SetNextWindowSize(ImVec2(360.0f, 480.0f), ImGuiCond_FirstUseEver);
-		if (ImGui::Begin("Light Editor"))
+		if (ImGui::Begin("Light Editor", pOpen))
 		{
 			if (ImGui::CollapsingHeader("Punctual Lights"))
 			{
@@ -368,6 +374,8 @@ namespace Ken4lowEngine
 			}
 		}
 		ImGui::End();
+#else
+		(void)pOpen;
 #endif // USE_IMGUI
 	}
 

--- a/Project/Engine/Graphics/Lighting/LightManager.h
+++ b/Project/Engine/Graphics/Lighting/LightManager.h
@@ -85,7 +85,7 @@ namespace Ken4lowEngine
 		/// ・ライトごとの削除<br/>
 		/// などを行います。
 		/// </summary>
-		void DrawImGui();
+		void DrawImGui(bool* pOpen = nullptr);
 
 		/// <summary>
 		/// パンクチュアルライト情報をシェーダにバインドします。<br/>

--- a/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.cpp
+++ b/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.cpp
@@ -389,10 +389,16 @@ namespace Ken4lowEngine
 	/// -------------------------------------------------------------
 	///				　	　		ImGui描画
 	/// -------------------------------------------------------------
-	void PostEffectManager::ImGuiRender()
+	void PostEffectManager::ImGuiRender(bool* pOpen)
 	{
 #ifdef USE_IMGUI
-		ImGui::Begin("Post Effect Settings");
+		// WindowメニューのPost Effect Settings表示フラグが閉じている間は後処理UIを生成しない
+		if (pOpen != nullptr && !*pOpen)
+		{
+			return;
+		}
+
+		ImGui::Begin("Post Effect Settings", pOpen);
 
 		for (const auto& [name, category] : effectCategory_)
 		{
@@ -403,6 +409,8 @@ namespace Ken4lowEngine
 			}
 		}
 		ImGui::End();
+#else
+		(void)pOpen;
 #endif // USE_IMGUI
 	}
 

--- a/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.h
+++ b/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.h
@@ -104,7 +104,7 @@ public: /// ---------- メンバ関数 ---------- ///
 	/// <summary>
 	/// ImGui の描画をレンダリングします。
 	/// </summary>
-	void ImGuiRender();
+	void ImGuiRender(bool* pOpen = nullptr);
 
 	/// <summary>
 	/// 指定された名前のエフェクトを有効にします。内部の effectEnableFlags_ マップの該当エントリを true に設定します。

--- a/Project/Engine/Platform/Windows/WinApp.cpp
+++ b/Project/Engine/Platform/Windows/WinApp.cpp
@@ -348,9 +348,15 @@ namespace Ken4lowEngine
 			SWP_NOMOVE | SWP_NOSIZE | SWP_NOZORDER | SWP_NOOWNERZORDER | SWP_FRAMECHANGED);
 	}
 
-	void WinApp::DrawDisplaySettingsImGui()
+	void WinApp::DrawDisplaySettingsImGui(bool* pOpen)
 	{
 #ifdef USE_IMGUI
+		// WindowメニューのDisplay表示フラグが閉じている間は画面設定UIを生成しない
+		if (pOpen != nullptr && !*pOpen)
+		{
+			return;
+		}
+
 		WinApp* win = WinApp::GetInstance();
 
 		// UI編集中の値を保持する。
@@ -371,7 +377,7 @@ namespace Ken4lowEngine
 			initialized = true;
 		}
 
-		if (ImGui::Begin("Display"))
+		if (ImGui::Begin("Display", pOpen))
 		{
 			const char* modeItems[] = { "Windowed", "Borderless" };
 			int mode = (edit.mode == WindowMode::Windowed) ? 0 : 1;
@@ -421,6 +427,8 @@ namespace Ken4lowEngine
 			ImGui::Text("Client: %u x %u", win->GetClientWidth(), win->GetClientHeight());
 		}
 		ImGui::End();
+#else
+		(void)pOpen;
 #endif // USE_IMGUI
 	}
 

--- a/Project/Engine/Platform/Windows/WinApp.h
+++ b/Project/Engine/Platform/Windows/WinApp.h
@@ -61,7 +61,7 @@ namespace Ken4lowEngine
 		bool ApplyDisplaySettings(const DisplaySettings& settings);
 
 		// ImGuiで表示する設定UI
-		void DrawDisplaySettingsImGui();
+		void DrawDisplaySettingsImGui(bool* pOpen = nullptr);
 
 		// Alt+Enter トグル要求
 		void RequestToggleFullscreen();

--- a/Project/Engine/System/Parameters/ParameterManager.cpp
+++ b/Project/Engine/System/Parameters/ParameterManager.cpp
@@ -29,10 +29,16 @@ void ParameterManager::CreateGroup(const std::string& groupName)
 /// -------------------------------------------------------------
 ///			　				更新処理
 /// -------------------------------------------------------------
-void ParameterManager::Update()
+void ParameterManager::Update(bool* pOpen)
 {
 #ifdef USE_IMGUI
-	if (!ImGui::Begin("Parameters", nullptr, ImGuiWindowFlags_MenuBar))
+	// WindowメニューのParameters表示フラグが閉じている間は編集UIを生成しない
+	if (pOpen != nullptr && !*pOpen)
+	{
+		return;
+	}
+
+	if (!ImGui::Begin("Parameters", pOpen, ImGuiWindowFlags_MenuBar))
 	{
 		ImGui::End();
 		return;
@@ -116,6 +122,8 @@ void ParameterManager::Update()
 	ImGui::Columns(1);
 
 	ImGui::End();
+#else
+	(void)pOpen;
 #endif
 }
 

--- a/Project/Engine/System/Parameters/ParameterManager.h
+++ b/Project/Engine/System/Parameters/ParameterManager.h
@@ -50,7 +50,7 @@ public: /// ---------- メンバ関数 ---------- ///
 	/// <summary>
 	/// 更新処理
 	/// </summary>
-	void Update();
+	void Update(bool* pOpen = nullptr);
 
 	/// <summary>
 	/// ファイルに書き出し


### PR DESCRIPTION
### Motivation
- Provide a single Window menu to toggle editor/debug ImGui windows and keep the menu organized into Common / Rendering / Scene Debug / Layout sections.
- Ensure window-close (×) buttons update the same visibility state as the menu items so closing a window reflects in the Window menu.
- Expose major rendering/debug windows for menu control without changing existing Docking behavior or breaking scene ImGui drawing.
- Keep Multi-viewport disabled and preserve Docking support.

### Description
- Add and reorganize visibility flags in `EditorWindowState` and group them into Common, Rendering, Scene Debug and Layout categories, and keep `Main Viewport` as a controllable window. (changes include `Project/Engine/Editor/EditorWindowManager.h`).
- Rework the `Window` menu into `Common` / `Rendering` / `Scene Debug` / `Layout`, provide menu items bound to the new `EditorWindowState` flags, and keep `Reset Layout` as an explicit request only (changes in `Project/Engine/Editor/EditorWindowManager.cpp`).
- Make major UI modules accept/observe `bool* pOpen` or otherwise gate their ImGui generation from the menu flags so a window’s right-top × updates the shared visibility state; this includes `WinApp::DrawDisplaySettingsImGui`, `ParameterManager::Update`, `PostEffectManager::ImGuiRender`, `LightManager::DrawImGui`, and scene/debug UI callers which now forward `EditorWindowState` flags (changes across `Project/Engine/Core/Application/GameApplication.cpp`, `Project/Engine/Platform/Windows/WinApp.*`, `Project/Engine/System/Parameters/*`, `Project/Engine/Graphics/PostEffect/Manager/*`, `Project/Engine/Graphics/Lighting/*`, and various scene/debug files like `TitleScene`, `StageSelectScene`, `GamePlayDebugTools`, `FadeManager`, `ShadowTestScene`).
- Keep existing DockSpace/Docking logic and ImGui initialization untouched: `ImGuiConfigFlags_DockingEnable` remains set and `ImGuiConfigFlags_ViewportsEnable` remains disabled; `ImGuiManager::RequestResetDockLayout()` is used for the Reset Layout action rather than re-running DockBuilder every frame (changes in `Project/Engine/DebugTools/ImGui/ImGuiManager.*`).

### Testing
- Verified updated menu and window bindings via code inspection and text search: confirmed `ImGui::Begin(...)` calls for major windows now take the `p_open` pointer or are gated by the new flags (search checks succeeded).
- Ran a repository static check (`diff --check` / workspace checks) and found no whitespace/merge errors after changes (succeeded).
- Attempted to build with solution build tools (`msbuild`) in this environment but the tool is not available here, so a full compile/test could not be executed (failed due to missing tool).
- No automated unit tests exist for UI state; behavior was integrated by updating all callers to consume the shared `EditorWindowState` flags and by keeping `DrawImGui()` call ordering unchanged so scene ImGui rendering remains unaffected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a014969e8b4832d834fe2802eddab8a)