### PR TITLE
Render game output inside ImGui Main Viewport

### DIFF
--- a/Project/Engine/Core/Application/GameApplication.cpp
+++ b/Project/Engine/Core/Application/GameApplication.cpp
@@ -159,14 +159,16 @@ namespace Ken4lowEngine
 		PostEffectManager::GetInstance()->EndDraw();
 
 		//--------------------------------------------
-		// 4. ポストエフェクト適用（3Dの最終結果をフルスクリーンクアッドに描画）
+		// 4. ポストエフェクト適用（3Dの最終結果をGameRenderTargetへ集約）
 		//--------------------------------------------
-		PostEffectManager::GetInstance()->RenderPostEffect(); // swapChainのバックバッファに描画
+		PostEffectManager::GetInstance()->RenderPostEffect(); // BackBufferではなくMain Viewport用GameRenderTargetへ描画
 
 		//--------------------------------------------
-		// 5. 2Dスプライト（UIなど）をその上に直接描画
+		// 5. 2Dスプライト（UIなど）をGameRenderTarget上に直接描画
 		//--------------------------------------------
+		PostEffectManager::GetInstance()->BeginGameRenderTargetOverlay(); // 2DをMain Viewportに含めるためGameRenderTargetをRTVへ戻す
 		SceneManager::GetInstance()->Draw2DSprites();
+		PostEffectManager::GetInstance()->EndGameRenderTargetOverlay(); // ImGui::Imageで読むためGameRenderTargetをSRVへ戻す
 
 #ifdef USE_IMGUI
 		//--------------------------------------------

--- a/Project/Engine/DebugTools/ImGui/ImGuiManager.cpp
+++ b/Project/Engine/DebugTools/ImGui/ImGuiManager.cpp
@@ -230,6 +230,8 @@ namespace Ken4lowEngine
 		ImGui::DockBuilderSetNodeSize(rootNode, viewport->Size);
 		ImGui::DockBuilderSplitNode(rootNode, ImGuiDir_Right, 0.28f, &rightNode, &rootNode);
 
+		// Main Viewportを中央Dockに固定名で配置してゲーム画面と各Dockウィンドウの重なりを避ける
+		ImGui::DockBuilderDockWindow("Main Viewport", rootNode);
 		ImGui::DockBuilderDockWindow("Details", rightNode);
 		ImGui::DockBuilderDockWindow("Post Effect Settings", rightNode);
 		ImGui::DockBuilderDockWindow("Light Editor", rightNode);

--- a/Project/Engine/Editor/EditorWindowManager.cpp
+++ b/Project/Engine/Editor/EditorWindowManager.cpp
@@ -1,6 +1,7 @@
 #include "EditorWindowManager.h"
 
 #include "ImGuiManager.h"
+#include "PostEffectManager.h"
 
 #ifdef USE_IMGUI
 #include <imgui.h>
@@ -86,15 +87,7 @@ namespace Ken4lowEngine
 				ImGui::EndMenu();
 			}
 
-			// LayoutはDockBuilderの初期配置をユーザー操作時だけ再適用する入口にする
-			if (ImGui::BeginMenu("Layout"))
-			{
-				if (ImGui::MenuItem("Reset Layout"))
-				{
-					ImGuiManager::GetInstance()->RequestResetDockLayout();
-				}
-				ImGui::EndMenu();
-			}
+			// Reset Layoutは誤操作でDock配置を崩しやすいため一旦メニューから外す
 			ImGui::EndMenu();
 		}
 
@@ -163,18 +156,34 @@ namespace Ken4lowEngine
 			return;
 		}
 
-		// Main Viewportは既存の中央表示用プレースホルダーとしてWindowメニューの表示状態と同期する
-		if (ImGui::Begin("Main Viewport", &windowState_.showMainViewport))
+		// Main ViewportはGameRenderTargetをImGui::Imageで表示する固定名ウィンドウにする
+		if (ImGui::Begin("Main Viewport", &windowState_.showMainViewport, ImGuiWindowFlags_NoScrollbar))
 		{
 			const ImVec2 viewportSize = ImGui::GetContentRegionAvail();
-			ImGui::TextUnformatted("Main Viewport");
-			ImGui::Separator();
-			ImGui::Text("RenderTarget preview will be displayed here.");
-			ImGui::Text("Available Size: %.0f x %.0f", viewportSize.x, viewportSize.y);
-			ImGui::Dummy(ImVec2(viewportSize.x, viewportSize.y > 80.0f ? viewportSize.y - 80.0f : 0.0f));
+			const ImVec2 imageOrigin = ImGui::GetCursorScreenPos();
+			mainViewportScreenPosition_ = { imageOrigin.x, imageOrigin.y };
+			mainViewportSize_ = { viewportSize.x, viewportSize.y };
+
+			auto* postEffectManager = PostEffectManager::GetInstance();
+			const D3D12_GPU_DESCRIPTOR_HANDLE gameSrv = postEffectManager->GetGameRenderTargetSrvHandleGPU();
+			if (gameSrv.ptr != 0 && viewportSize.x > 1.0f && viewportSize.y > 1.0f)
+			{
+				// SRVManagerで作成したGameRenderTargetのGPU SRVをImTextureIDとして渡す
+				ImGui::Image(static_cast<ImTextureID>(gameSrv.ptr), viewportSize, ImVec2(0.0f, 0.0f), ImVec2(1.0f, 1.0f));
+			}
+			else
+			{
+				ImGui::TextUnformatted("GameRenderTarget SRV is not ready.");
+			}
 		}
 		ImGui::End();
 #endif // USE_IMGUI
+	}
+
+	Vector2 EditorWindowManager::ConvertScreenToMainViewportPosition(const Vector2& screenPosition) const
+	{
+		// 入力系はこの入口でスクリーン座標からMain Viewportローカル座標へ変換する
+		return { screenPosition.x - mainViewportScreenPosition_.x, screenPosition.y - mainViewportScreenPosition_.y };
 	}
 
 	void EditorWindowManager::DrawWorldOutliner()

--- a/Project/Engine/Editor/EditorWindowManager.h
+++ b/Project/Engine/Editor/EditorWindowManager.h
@@ -1,4 +1,5 @@
 #pragma once
+#include "Vector2.h"
 
 namespace Ken4lowEngine
 {
@@ -52,6 +53,14 @@ namespace Ken4lowEngine
 		void DrawContentBrowser();
 		void DrawOutputLog();
 
+		/// <summary>
+		/// スクリーン座標をMain Viewport左上基準へ変換する入口です。
+		/// </summary>
+		Vector2 ConvertScreenToMainViewportPosition(const Vector2& screenPosition) const;
+
+		const Vector2& GetMainViewportScreenPosition() const { return mainViewportScreenPosition_; }
+		const Vector2& GetMainViewportSize() const { return mainViewportSize_; }
+
 		EditorWindowState& GetWindowState() { return windowState_; }
 		const EditorWindowState& GetWindowState() const { return windowState_; }
 
@@ -62,6 +71,8 @@ namespace Ken4lowEngine
 		EditorWindowManager& operator=(const EditorWindowManager&) = delete;
 
 		EditorWindowState windowState_{};
+		Vector2 mainViewportScreenPosition_ = { 0.0f, 0.0f }; // マウス座標をMain Viewport基準へ変換するための左上座標
+		Vector2 mainViewportSize_ = { 0.0f, 0.0f }; // Main Viewport内でGameRenderTargetを表示しているサイズ
 	};
 
 } // namespace Ken4lowEngine

--- a/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.cpp
+++ b/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.cpp
@@ -63,13 +63,17 @@ namespace Ken4lowEngine
 		pipelineBuilder_->Initialize(dxCommon); // パイプラインビルダーの初期化
 		pipelineBuilder_->BuildCopyPipeline(); // コピー用パイプラインのビルド
 
-		renderTargets_.resize(2); // レンダーターゲットの数を1に設定
+		renderTargets_.resize(2); // ポストエフェクトのping-pongと最終GameRenderTargetに使う
+
+		// 初期GameRenderTargetはMain Viewport表示用に1280x720固定で確保する
+		renderTargetWidth_ = kInitialGameRenderTargetWidth_;
+		renderTargetHeight_ = kInitialGameRenderTargetHeight_;
 
 		// RTVとSRVの確保
 		AllocateRTV_DSV_SRV_UAV();
 
 		// ビューポート矩形とシザリング矩形の設定
-		SetViewportAndScissorRect(dxCommon_->GetClientWidth(), dxCommon_->GetClientHeight());
+		SetViewportAndScissorRect(renderTargetWidth_, renderTargetHeight_);
 
 		// エフェクトの初期化と生成
 		std::unordered_map<std::string, EffectEntry> effectTable = {
@@ -220,6 +224,10 @@ namespace Ken4lowEngine
 	{
 		if (width == 0 || height == 0) return;
 
+		// GameRenderTargetの現在サイズを記録してMain Viewport側の座標変換に使えるようにする
+		renderTargetWidth_ = width;
+		renderTargetHeight_ = height;
+
 		SetViewportAndScissorRect(width, height);
 
 		// RTを作り直して、同じdescriptor indexに上書き
@@ -271,29 +279,11 @@ namespace Ken4lowEngine
 		// レンダーテクスチャが1枚しかない場合
 		if (renderTargets_.size() < 2)
 		{
-			auto& rt = renderTargets_[0]; // A
+			auto& rt = renderTargets_[0];
 
-			// バックバッファRTV
-			uint32_t backBufferIndex = dxCommon_->GetSwapChain()->GetSwapChain()->GetCurrentBackBufferIndex();
-			ComPtr<ID3D12Resource> backBuffer = dxCommon_->GetBackBuffer(backBufferIndex);
-			D3D12_CPU_DESCRIPTOR_HANDLE backBufferRTV = dxCommon_->GetBackBufferRTV(backBufferIndex);
-
-			// PRESENT → RENDER_TARGET へ遷移
-			dxCommon_->ResourceTransition(backBuffer.Get(), D3D12_RESOURCE_STATE_PRESENT, D3D12_RESOURCE_STATE_RENDER_TARGET);
-
-			commandList->OMSetRenderTargets(1, &backBufferRTV, false, &dsvHandle);
-
-			// PSO / ルートシグネチャ
-			commandList->SetPipelineState(pipelineBuilder_->GetCopyPipelineState().Get());
-			commandList->SetGraphicsRootSignature(pipelineBuilder_->GetCopyRootSignature().Get());
-			SRVManager::GetInstance()->SetGraphicsRootDescriptorTable(0, rt.srvIndex);
-			commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-			commandList->DrawInstanced(3, 1, 0, 0); // フルスクリーンクアッドを描画
-
-			// RENDER_TARGET → PRESENT へ遷移
-			dxCommon_->ResourceTransition(backBuffer.Get(), D3D12_RESOURCE_STATE_RENDER_TARGET, D3D12_RESOURCE_STATE_PRESENT);
-
-			return; // これで終了
+			// GameRenderTargetはBackBufferへコピーせずMain ViewportのImGui::Imageから直接参照する
+			Transition(rt, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+			return;
 		}
 
 		// 複数枚がある場合
@@ -346,24 +336,47 @@ namespace Ken4lowEngine
 			std::swap(src, dst);
 		}
 
-		// 最後の出力レンダーテクスチャをバックバッファに描画する
-		auto& finalRT = renderTargets_[src]; // 最後の出力レンダーテクスチャ
+		// 最後の出力を固定のGameRenderTarget(renderTargets_[0])へ戻してImGuiへ渡すSRVを安定させる
+		auto& finalRT = renderTargets_[src];
+		auto& gameRT = renderTargets_[0];
 
-		// SRVヒープに戻す（コピーパスはGraphics）
-		SRVManager::GetInstance()->PreDraw();
+		if (src != 0)
+		{
+			// BackBufferではなくGameRenderTargetへコピーしてDockウィンドウとの重なりを避ける
+			SRVManager::GetInstance()->PreDraw();
+			Transition(finalRT, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+			Transition(gameRT, D3D12_RESOURCE_STATE_RENDER_TARGET);
+			commandList->OMSetRenderTargets(1, &gameRT.rtvHandle, false, nullptr);
+			commandList->SetPipelineState(pipelineBuilder_->GetCopyPipelineState().Get());
+			commandList->SetGraphicsRootSignature(pipelineBuilder_->GetCopyRootSignature().Get());
+			SRVManager::GetInstance()->SetGraphicsRootDescriptorTable(0, finalRT.srvIndex);
+			commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+			commandList->DrawInstanced(3, 1, 0, 0);
+		}
 
-		// バックバッファの取得
-		uint32_t backBufferIndex = dxCommon_->GetSwapChain()->GetSwapChain()->GetCurrentBackBufferIndex();
-		D3D12_CPU_DESCRIPTOR_HANDLE backBufferRTV = dxCommon_->GetBackBufferRTV(backBufferIndex);
+		// Main ViewportのImGui::Imageが読めるよう最終GameRenderTargetをSRV状態にしておく
+		Transition(gameRT, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
 
-		commandList->OMSetRenderTargets(1, &backBufferRTV, false, &dsvHandle);
+	}
 
-		// コピー用 PSO / ルートシグネチャ
-		commandList->SetPipelineState(pipelineBuilder_->GetCopyPipelineState().Get());
-		commandList->SetGraphicsRootSignature(pipelineBuilder_->GetCopyRootSignature().Get());
-		SRVManager::GetInstance()->SetGraphicsRootDescriptorTable(0, finalRT.srvIndex);
-		commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-		commandList->DrawInstanced(3, 1, 0, 0);
+	void PostEffectManager::BeginGameRenderTargetOverlay()
+	{
+		auto commandList = dxCommon_->GetCommandManager()->GetCommandList();
+		auto& gameRT = renderTargets_[0];
+
+		// 2Dスプライトはポストエフェクト後のGameRenderTargetへ重ねる
+		Transition(gameRT, D3D12_RESOURCE_STATE_RENDER_TARGET);
+		commandList->OMSetRenderTargets(1, &gameRT.rtvHandle, false, nullptr);
+		commandList->RSSetViewports(1, &viewport);
+		commandList->RSSetScissorRects(1, &scissorRect);
+	}
+
+	void PostEffectManager::EndGameRenderTargetOverlay()
+	{
+		auto& gameRT = renderTargets_[0];
+
+		// ImGui::Imageがこの後SRVとして読むためGameRenderTargetを読み取り状態へ戻す
+		Transition(gameRT, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
 	}
 
 	void PostEffectManager::BindSceneRenderTarget()
@@ -424,6 +437,38 @@ namespace Ken4lowEngine
 			return nullptr;
 		}
 		return it->second.get();
+	}
+
+	/// -------------------------------------------------------------
+	///				　GameRenderTargetのSRV取得
+	/// -------------------------------------------------------------
+	uint32_t PostEffectManager::GetGameRenderTargetSrvIndex() const
+	{
+		// Main Viewportへ渡すSRVは固定のGameRenderTarget(renderTargets_[0])に集約する
+		return renderTargets_.empty() ? UINT32_MAX : renderTargets_[0].srvIndex;
+	}
+
+	D3D12_GPU_DESCRIPTOR_HANDLE PostEffectManager::GetGameRenderTargetSrvHandleGPU() const
+	{
+		const uint32_t srvIndex = GetGameRenderTargetSrvIndex();
+		if (srvIndex == UINT32_MAX)
+		{
+			return {};
+		}
+
+		// ImGui::ImageにはSRVManagerのGPUハンドルをImTextureIDとして渡す
+		return SRVManager::GetInstance()->GetGPUDescriptorHandle(srvIndex);
+	}
+
+	void PostEffectManager::RequestGameRenderTargetResize(uint32_t width, uint32_t height)
+	{
+		if (width == 0 || height == 0 || (width == renderTargetWidth_ && height == renderTargetHeight_))
+		{
+			return;
+		}
+
+		// Main Viewport実サイズ追従を後で有効化しやすいよう既存Resizeへ集約する
+		Resize(width, height);
 	}
 
 	/// -------------------------------------------------------------
@@ -531,7 +576,7 @@ namespace Ken4lowEngine
 			auto& rt = renderTargets_[i];
 
 			// レンダーテクスチャリソースの生成
-			rt.resource = CreateRenderTextureResource(dxCommon_->GetClientWidth(), dxCommon_->GetClientHeight(), DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, kRenderTextureClearColor_);
+			rt.resource = CreateRenderTextureResource(renderTargetWidth_, renderTargetHeight_, DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, kRenderTextureClearColor_);
 			rt.resource->SetName((L"PostEffectManager RenderTarget " + std::to_wstring(i)).c_str());
 
 			// RTVの生成
@@ -553,7 +598,7 @@ namespace Ken4lowEngine
 		}
 
 		// 深度バッファの生成
-		depthResource_ = CreateDepthBufferResource(WinApp::kClientWidth, WinApp::kClientHeight);
+		depthResource_ = CreateDepthBufferResource(renderTargetWidth_, renderTargetHeight_);
 		depthResource_->SetName(L"PostEffectManager DepthBuffer");
 
 		// SRVの確保（深度用）

--- a/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.h
+++ b/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.h
@@ -99,6 +99,16 @@ public: /// ---------- メンバ関数 ---------- ///
 	/// </summary>
 	void RenderPostEffect();
 
+	/// <summary>
+	/// ポストエフェクト済みのゲーム画面へ2D描画を重ねるためのRTVをバインドします。
+	/// </summary>
+	void BeginGameRenderTargetOverlay();
+
+	/// <summary>
+	/// Main Viewport の ImGui::Image から読めるようゲーム画面をSRV状態へ戻します。
+	/// </summary>
+	void EndGameRenderTargetOverlay();
+
 	void BindSceneRenderTarget();
 
 	/// <summary>
@@ -122,6 +132,24 @@ public: /// ---------- メンバ関数 ---------- ///
 	/// 指定された名前のポストエフェクト(IPostEffect)を取得します。見つからなければ nullptr を返します。
 	/// </summary>
 	IPostEffect* GetEffect(const std::string& effectName);
+
+	/// <summary>
+	/// Main Viewport に表示する GameRenderTarget の SRV index を取得します。
+	/// </summary>
+	uint32_t GetGameRenderTargetSrvIndex() const;
+
+	/// <summary>
+	/// ImGui::Image に渡す GameRenderTarget の GPU SRV ハンドルを取得します。
+	/// </summary>
+	D3D12_GPU_DESCRIPTOR_HANDLE GetGameRenderTargetSrvHandleGPU() const;
+
+	uint32_t GetGameRenderTargetWidth() const { return renderTargetWidth_; }
+	uint32_t GetGameRenderTargetHeight() const { return renderTargetHeight_; }
+
+	/// <summary>
+	/// Main Viewport の表示サイズに合わせてリサイズしたい場合の入口です。
+	/// </summary>
+	void RequestGameRenderTargetResize(uint32_t width, uint32_t height);
 
 private: /// ---------- メンバ関数 ---------- ///
 
@@ -177,6 +205,10 @@ private: /// ---------- メンバ変数 ---------- ///
 	// ポストエフェクトのカテゴリ分類（名前 → カテゴリ名）
 	std::unordered_map<std::string, std::string> effectCategory_;
 
+	// GameRenderTargetの初期サイズはエディタ中央表示用に16:9固定から開始する
+	static constexpr uint32_t kInitialGameRenderTargetWidth_ = 1280;
+	static constexpr uint32_t kInitialGameRenderTargetHeight_ = 720;
+
 	// レンダーテクスチャのクリアカラー
 	const Vector4 kRenderTextureClearColor_ = { 0.08f, 0.08f, 0.18f, 1.0f }; // 分かりやすいように一旦赤色にする
 
@@ -196,6 +228,8 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	static constexpr int kPostRTCount = 1; // ポストエフェクト用のレンダーテクスチャ数
 	std::vector<RenderTarget> renderTargets_; // レンダーテクスチャのリスト
+	uint32_t renderTargetWidth_ = kInitialGameRenderTargetWidth_; // Main Viewportへ表示するGameRenderTarget幅
+	uint32_t renderTargetHeight_ = kInitialGameRenderTargetHeight_; // Main Viewportへ表示するGameRenderTarget高さ
 
 	// 深度ステンシルビューのインデックス
 	uint32_t depthDsvIndex_ = UINT32_MAX;


### PR DESCRIPTION
### Motivation

- Prevent the game scene from being drawn directly to the swapchain BackBuffer so it does not appear on top of ImGui windows.  
- Render the game into a dedicated GameRenderTarget and present it inside the fixed "Main Viewport" ImGui window.  
- Keep existing scene rendering/post-effect behavior and ImGui docking (no multi-viewport), and provide an entry for future Main Viewport resizing and input coordinate translation.

### Description

- Route final post-effect output into a stable GameRenderTarget (initial 1280x720) instead of copying to the swapchain BackBuffer and expose its SRV/GPU-handle for ImGui display; added SVR getters and a resize request entry in `PostEffectManager`. (changed `Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.h/.cpp`)
- Change frame flow to: render 3D → post-effect into GameRenderTarget → overlay 2D sprites on GameRenderTarget via `BeginGameRenderTargetOverlay()`/`EndGameRenderTargetOverlay()` → leave BackBuffer for ImGui; updated `GameApplication.cpp` accordingly. (changed `Project/Engine/Core/Application/GameApplication.cpp`)
- Show the GameRenderTarget inside the fixed-named Main Viewport via `ImGui::Image` by passing the `D3D12_GPU_DESCRIPTOR_HANDLE` as `ImTextureID`; track Main Viewport screen position/size and add `ConvertScreenToMainViewportPosition()` to `EditorWindowManager` for later input mapping. (changed `Project/Engine/Editor/EditorWindowManager.cpp/.h`)
- Make DockBuilder place the Main Viewport at the central dock and remove the risky "Reset Layout" menu item to avoid accidental layout loss. (changed `Project/Engine/DebugTools/ImGui/ImGuiManager.cpp` and `Project/Engine/Editor/EditorWindowManager.cpp`)
- Implementation notes: reused existing PostEffect/RTV/DSV/SRV managers and `SRVManager` descriptor heap; added one-line intent comments where modifications apply and provided an explicit API (`RequestGameRenderTargetResize`) for future viewport-driven resize.

### Testing

- Ran repository static checks: `git diff --check` (no whitespace/errors reported) — succeeded.  
- Attempted Debug/Release build with `msbuild` in this environment but `msbuild` is not available inside the Linux container, so full native Windows builds were not executed here — build attempts failed due to missing toolchain.  
- Verified code compiles locally is pending; integration/CI builds on Windows are recommended to confirm linking and DX12 backend interactions (SRV handle usage with ImGui DX12 backend).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a014eda7940832d813441f06cf202a6)