### PR TITLE
Fix render-target resource state tracking and name unnamed D3D12 resources

### DIFF
--- a/Project/Engine/Graphics/Device/Facade/DirectXCommon.cpp
+++ b/Project/Engine/Graphics/Device/Facade/DirectXCommon.cpp
@@ -132,12 +132,14 @@ namespace Ken4lowEngine
 		backBufferIndex_ = swapChain_->GetSwapChain()->GetCurrentBackBufferIndex();
 		auto backBuffer = GetBackBuffer(backBufferIndex_);
 
-		// Present -> RenderTarget
+		// BackBufferの記録状態を元にRTVへ戻し、固定beforeによる状態ズレを避ける
+		const D3D12_RESOURCE_STATES beforeState = swapChain_->GetBackBufferState(backBufferIndex_);
 		ResourceTransition(
 			backBuffer.Get(),
-			D3D12_RESOURCE_STATE_PRESENT,
+			beforeState,
 			D3D12_RESOURCE_STATE_RENDER_TARGET
 		);
+		swapChain_->SetBackBufferState(backBufferIndex_, D3D12_RESOURCE_STATE_RENDER_TARGET);
 
 		mainRenderTarget_->Begin(commandManager_->GetCommandList(), backBufferIndex_);
 	}
@@ -157,12 +159,14 @@ namespace Ken4lowEngine
 
 		mainRenderTarget_->End(commandManager_->GetCommandList());
 
-		// RenderTarget -> Present
+		// BackBufferの記録状態を元にPresentへ戻し、メインRTの状態管理を一箇所に寄せる
+		const D3D12_RESOURCE_STATES beforeState = swapChain_->GetBackBufferState(backBufferIndex_);
 		ResourceTransition(
 			backBuffer.Get(),
-			D3D12_RESOURCE_STATE_RENDER_TARGET,
+			beforeState,
 			D3D12_RESOURCE_STATE_PRESENT
 		);
+		swapChain_->SetBackBufferState(backBufferIndex_, D3D12_RESOURCE_STATE_PRESENT);
 
 		// コマンド実行と GPU 完了待ち
 		commandManager_->ExecuteAndWait();

--- a/Project/Engine/Graphics/Device/SwapChain/DX12SwapChain.cpp
+++ b/Project/Engine/Graphics/Device/SwapChain/DX12SwapChain.cpp
@@ -2,6 +2,7 @@
 #include "WinApp.h"
 
 #include <cassert>
+#include <cwchar>
 
 namespace Ken4lowEngine
 {
@@ -29,16 +30,9 @@ void DX12SwapChain::Initialize(WinApp* winApp, IDXGIFactory7* dxgiFactory, ID3D1
 	hr = dxgiFactory->CreateSwapChainForHwnd(commandQueue, winApp->GetHwnd(), &swapChainDesc, nullptr, nullptr, reinterpret_cast<IDXGISwapChain1**>(swapChain.GetAddressOf()));
 	assert(SUCCEEDED(hr));
 
-	//SwapChainからResourceを引っ張ってくる
-	hr = swapChain->GetBuffer(0, IID_PPV_ARGS(&swapChainResources[0]));
-	swapChainResources[0]->SetName(L"BackBuffer : 0");
-	//うまく取得できなければ起動できない
-	assert(SUCCEEDED(hr));
-
-	// 2つ目のバッファも同様に取得
-	hr = swapChain->GetBuffer(1, IID_PPV_ARGS(&swapChainResources[1]));
-	swapChainResources[1]->SetName(L"BackBuffer : 1");
-	assert(SUCCEEDED(hr));
+	// SwapChainからResourceを引っ張り、BackBuffer名と状態を一元管理する
+	CacheBackBuffer(0);
+	CacheBackBuffer(1);
 }
 
 void DX12SwapChain::Resize(uint32_t width, uint32_t height)
@@ -56,15 +50,28 @@ void DX12SwapChain::Resize(uint32_t width, uint32_t height)
 	);
 	assert(SUCCEEDED(hr));
 
-	// 再取得
-	hr = swapChain->GetBuffer(0, IID_PPV_ARGS(&swapChainResources[0]));
-	assert(SUCCEEDED(hr));
-	hr = swapChain->GetBuffer(1, IID_PPV_ARGS(&swapChainResources[1]));
-	assert(SUCCEEDED(hr));
+	// 再取得時もBackBuffer0/1の名前を付け直してUnnamed Resourceを避ける
+	CacheBackBuffer(0);
+	CacheBackBuffer(1);
 
 	// descも更新しておくと便利
 	swapChainDesc.Width = width;
 	swapChainDesc.Height = height;
+}
+
+
+void DX12SwapChain::CacheBackBuffer(uint32_t index)
+{
+	HRESULT hr = swapChain->GetBuffer(index, IID_PPV_ARGS(&swapChainResources[index]));
+	assert(SUCCEEDED(hr));
+
+	wchar_t name[32]{};
+	swprintf_s(name, L"BackBuffer%u", index);
+	// DebugLayerのResource名にBackBuffer番号を出し、RTV状態違反の対象を特定しやすくする。
+	swapChainResources[index]->SetName(name);
+
+	// SwapChainの取得直後はPRESENT(COMMON)として扱い、DirectXCommonのBarrier beforeと一致させる。
+	backBufferStates[index] = D3D12_RESOURCE_STATE_PRESENT;
 }
 
 } // namespace Ken4lowEngine

--- a/Project/Engine/Graphics/Device/SwapChain/DX12SwapChain.h
+++ b/Project/Engine/Graphics/Device/SwapChain/DX12SwapChain.h
@@ -46,6 +46,10 @@ public: /// ---------- メンバ関数 ---------- ///
 
 	void Resize(uint32_t width, uint32_t height);
 
+private:
+	/// バックバッファ名と初期ステートを揃えてDebugLayerで特定しやすくする。
+	void CacheBackBuffer(uint32_t index);
+
 public: /// ---------- ゲッター ---------- ///
 
 	/// <summary>

--- a/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.cpp
+++ b/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.cpp
@@ -53,6 +53,9 @@ namespace Ken4lowEngine
 		pipelineBuilder_->BuildCopyPipeline(); // コピー用パイプラインのビルド
 
 		renderTargets_.resize(2); // ポストエフェクトのping-pongと最終GameRenderTargetに使う
+		// RT0はScene/GameViewport、RT1はPostEffect出力として名前を固定し、DebugLayerで対象を特定する。
+		renderTargets_[0].debugName = L"SceneRenderTarget_GameViewportRenderTarget";
+		renderTargets_[1].debugName = L"PostEffectRenderTarget";
 
 		// 初期GameRenderTargetはMain Viewport表示用に1280x720固定で確保する
 		renderTargetWidth_ = kInitialGameRenderTargetWidth_;
@@ -244,11 +247,14 @@ namespace Ken4lowEngine
 		SetViewportAndScissorRect(width, height);
 
 		// RTを作り直して、同じdescriptor indexに上書き
-		for (auto& rt : renderTargets_)
+		for (uint32_t i = 0; i < static_cast<uint32_t>(renderTargets_.size()); ++i)
 		{
+			auto& rt = renderTargets_[i];
 			rt.resource.Reset();
 			rt.resource = CreateRenderTextureResource(width, height,
 				DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, kRenderTextureClearColor_);
+			// Resize後もRenderTarget名を張り直し、Unnamed Resourceの再発を防ぐ。
+			rt.resource->SetName(rt.debugName);
 
 			RTVManager::GetInstance()->CreateRTVForTexture2D(rt.rtvIndex, rt.resource.Get());
 			rt.rtvHandle = RTVManager::GetInstance()->GetCPUDescriptorHandle(rt.rtvIndex);
@@ -268,6 +274,8 @@ namespace Ken4lowEngine
 		// depth作り直し
 		depthResource_.Reset();
 		depthResource_ = CreateDepthBufferResource(width, height);
+		// PostEffect用深度もResize後に名前を付け直してDebugLayerで追跡可能にする。
+		depthResource_->SetName(L"PostEffectManager DepthBuffer");
 		DSVManager::GetInstance()->CreateDSVForTexture2D(depthDsvIndex_, depthResource_.Get());
 		dsvHandle = DSVManager::GetInstance()->GetCPUDescriptorHandle(depthDsvIndex_);
 
@@ -316,6 +324,9 @@ namespace Ken4lowEngine
 			auto& inRT = renderTargets_[src]; // 入力レンダーテクスチャ
 			auto& outRT = renderTargets_[dst]; // 出力レンダーテクスチャ
 
+			// 入力SRVと出力RTV/UAVが同一Resourceにならないことを保証して自己参照描画を防ぐ。
+			assert(inRT.resource.Get() != outRT.resource.Get());
+
 			if (name == "GrayScaleEffect" || name == "RandomEffect" || name == "DissolveEffect" || name == "VignetteEffect" || name == "GaussianFilterEffect" || name == "RadialBlurEffect" || name == "LuminanceOutlineEffect" || name == "SmoothingEffect" || name == "PixelateEffect" || name == "PlayerHealthPostEffect")
 			{
 				TransitionTo(inRT, commandList, D3D12_RESOURCE_STATE_NON_PIXEL_SHADER_RESOURCE);
@@ -355,6 +366,9 @@ namespace Ken4lowEngine
 
 		if (src != 0)
 		{
+			// 最終PostEffect出力とGameRenderTargetが別Resourceであることを確認してSRV/RTV同時使用を避ける。
+			assert(finalRT.resource.Get() != gameRT.resource.Get());
+
 			// BackBufferではなくGameRenderTargetへコピーしてDockウィンドウとの重なりを避ける
 			SRVManager::GetInstance()->PreDraw();
 			TransitionTo(finalRT, commandList, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
@@ -591,7 +605,9 @@ namespace Ken4lowEngine
 
 			// レンダーテクスチャリソースの生成
 			rt.resource = CreateRenderTextureResource(renderTargetWidth_, renderTargetHeight_, DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, kRenderTextureClearColor_);
-			rt.resource->SetName((L"PostEffectManager RenderTarget " + std::to_wstring(i)).c_str());
+			// Scene/Game/PostEffectの役割名を付け、D3D12 DebugLayerのUnnamed Resourceをなくす。
+			rt.resource->SetName(rt.debugName);
+			rt.currentState_ = D3D12_RESOURCE_STATE_COMMON;
 
 			// RTVの生成
 			rt.rtvIndex = RTVManager::GetInstance()->Allocate();

--- a/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.h
+++ b/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.h
@@ -45,6 +45,7 @@ public: /// ---------- テンプレート ---------- ///
 	{
 		ComPtr<ID3D12Resource> resource = nullptr;				   // レンダーテクスチャリソース
 		D3D12_CPU_DESCRIPTOR_HANDLE rtvHandle = {};				   // RTVハンドル
+		const wchar_t* debugName = L"PostEffectRenderTarget";		   // DebugLayerでUnnamed Resourceにしないための名前
 		D3D12_RESOURCE_STATES currentState_ = D3D12_RESOURCE_STATE_COMMON; // 実リソースの現在状態を保持して固定beforeのBarrierを避ける
 		uint32_t rtvIndex = UINT32_MAX;							   // RTVインデックス
 		uint32_t srvIndex = UINT32_MAX;							   // SRVインデックス

--- a/Project/Engine/Graphics/RenderTarget/Main/MainRenderTarget.cpp
+++ b/Project/Engine/Graphics/RenderTarget/Main/MainRenderTarget.cpp
@@ -3,6 +3,8 @@
 #include "RTVManager.h"
 #include "DSVManager.h"
 
+#include <cwchar>
+
 namespace Ken4lowEngine
 {
 
@@ -57,6 +59,8 @@ namespace Ken4lowEngine
 			settings_.depthFormat,
 			clearValue
 		);
+		// MainRenderTargetの深度も名前を付け、DSV関連のDebugLayer出力から識別できるようにする。
+		depthStencilResource_->SetName(L"MainRenderTargetDepth");
 	}
 
 	/// -------------------------------------------------------------
@@ -104,6 +108,10 @@ namespace Ken4lowEngine
 		for (uint32_t i = 0; i < bufferCount; ++i)
 		{
 			auto backBuffer = dxCommon_->GetBackBuffer(i);
+			wchar_t name[32]{};
+			swprintf_s(name, L"BackBuffer%u", i);
+			// MainRenderTarget側で取得したComPtrにもBackBuffer名を再設定し、RTVエラーをUnnamedにしない。
+			backBuffer->SetName(name);
 			rtvManager->CreateRTVForTexture2D(backBufferRtvIndices_[i], backBuffer.Get());
 		}
 	}

--- a/Project/Engine/Graphics/RenderTarget/Shadow/ShadowMapRenderTarget.cpp
+++ b/Project/Engine/Graphics/RenderTarget/Shadow/ShadowMapRenderTarget.cpp
@@ -38,6 +38,8 @@ namespace Ken4lowEngine
 			settings_.width,
 			settings_.height
 		);
+		// ShadowMapRenderTargetにも名前を付け、深度RTのDebugLayer出力を特定しやすくする。
+		shadowMapResource_->SetName(L"ShadowMapRenderTarget");
 
 		// 新規生成直後は depth write 状態
 		resourceState_ = D3D12_RESOURCE_STATE_DEPTH_WRITE;
@@ -127,6 +129,7 @@ namespace Ken4lowEngine
 
 		if (resourceState_ != D3D12_RESOURCE_STATE_DEPTH_WRITE)
 		{
+			// ShadowMapを描画先として使う直前にDepthWriteへ戻し、SRV状態のまま描かない。
 			dxCommon_->ResourceTransition(
 				shadowMapResource_.Get(),
 				resourceState_,
@@ -164,6 +167,7 @@ namespace Ken4lowEngine
 
 		if (resourceState_ != D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE)
 		{
+			// ShadowMapを通常描画で読む前にPixelShaderResourceへ遷移する。
 			dxCommon_->ResourceTransition(
 				shadowMapResource_.Get(),
 				resourceState_,


### PR DESCRIPTION
### Motivation
- Intermittent D3D12 errors showed resources being used as `RENDER_TARGET` while left in `PIXEL_SHADER_RESOURCE` and some resources appeared as `Unnamed Resource` in the DebugLayer, making root-cause hard to find. 
- The post-effect pipeline and ImGui usage share several render targets and swapchain backbuffers, so correct and consistent resource-state tracking and clear resource naming were needed to prevent state mismatches. 
- Make minimal, localized fixes to add names, centralize state tracking, and ensure transitions without large design changes or breaking existing rendering.

### Description
- Added stable debug names via `SetName()` for swapchain backbuffers, main depth, shadow depth, post-effect render targets and depth, and ensured names are reapplied on `Resize()` so the DebugLayer never reports them as `Unnamed Resource` (changes in `DX12SwapChain`, `MainRenderTarget`, `ShadowMapRenderTarget`, `PostEffectManager`).
- Introduced `debugName` in `PostEffectManager::RenderTarget` and set `currentState_ = D3D12_RESOURCE_STATE_COMMON` after creation/resize to keep `currentState_` consistent with the `CreateCommittedResource` initial state, and reapply resource names during allocation/resize (changes in `PostEffectManager.h` / `PostEffectManager.cpp`).
- Prevented self-referential post-effect usage by asserting that an effect's input SRV resource and output RTV/UAV resource are not the same, and added an assertion that final output and game render target are distinct before copying (changes in `PostEffectManager.cpp`).
- Centralized backbuffer state tracking in `DX12SwapChain` with `CacheBackBuffer()` and `backBufferStates[]`, and changed `DirectXCommon::BeginDraw()` / `EndDraw()` to transition backbuffer resources using the recorded state rather than assuming fixed `PRESENT`/`RENDER_TARGET` before-states (changes in `DX12SwapChain.*` and `DirectXCommon.cpp`).
- Small clarifying comments added around ShadowMap transitions and other Transition usages; kept `PostEffectManager::TransitionTo()` behavior but tightened naming and state initialization so barriers align with tracked `currentState_`.

### Testing
- Ran `git diff --check` to validate whitespace/patch issues and it completed with no reported conflicts. (succeeded)
- Performed repository searches with `rg` to verify `SetName()` occurrences and that state-transition calls (`TransitionTo`, `ResourceTransition`) remain present and updated, confirming the intended insertion points; the expected matches were found. (succeeded)
- Inspected diffs (`git diff --stat`) and reviewed modified files to ensure the changes are localized to `DX12SwapChain`, `DirectXCommon`, `MainRenderTarget`, `ShadowMapRenderTarget`, and `PostEffectManager`; automated checks completed in this environment. (succeeded)
- Note: Visual Studio / D3D12 runtime tests and DebugLayer logging were not executed here because Windows/MSBuild/D3D12 are not available in this Linux container, so runtime verification on target Windows hardware is still recommended. (not run)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01559b71c0832d96663ae7111914cb)