### PR TITLE
Fix game viewport render target sizing

### DIFF
--- a/Project/Engine/Core/Application/GameApplication.cpp
+++ b/Project/Engine/Core/Application/GameApplication.cpp
@@ -92,7 +92,7 @@ namespace Ken4lowEngine
 		// Deaw計測開始
 		GameTimer::GetInstance()->BeginDraw();
 
-		// 描画開始（バックバッファのクリア）
+		// 描画開始（BackBufferはImGui直前までバインドせず、Scene描画をGameViewportRenderTargetに限定する）
 		dxCommon_->BeginDraw();
 
 		dxCommon_->BeginShadowMapPass(); // シャドウマップパス開始

--- a/Project/Engine/Editor/EditorWindowManager.cpp
+++ b/Project/Engine/Editor/EditorWindowManager.cpp
@@ -3,6 +3,8 @@
 #include "ImGuiManager.h"
 #include "PostEffectManager.h"
 
+#include <algorithm>
+
 #ifdef USE_IMGUI
 #include <imgui.h>
 #endif // USE_IMGUI
@@ -159,17 +161,35 @@ namespace Ken4lowEngine
 		// Main ViewportはGameRenderTargetをImGui::Imageで表示する固定名ウィンドウにする
 		if (ImGui::Begin("Main Viewport", &windowState_.showMainViewport, ImGuiWindowFlags_NoScrollbar))
 		{
-			const ImVec2 viewportSize = ImGui::GetContentRegionAvail();
-			const ImVec2 imageOrigin = ImGui::GetCursorScreenPos();
-			mainViewportScreenPosition_ = { imageOrigin.x, imageOrigin.y };
-			mainViewportSize_ = { viewportSize.x, viewportSize.y };
-
+			const ImVec2 availableSize = ImGui::GetContentRegionAvail();
 			auto* postEffectManager = PostEffectManager::GetInstance();
-			const D3D12_GPU_DESCRIPTOR_HANDLE gameSrv = postEffectManager->GetGameRenderTargetSrvHandleGPU();
-			if (gameSrv.ptr != 0 && viewportSize.x > 1.0f && viewportSize.y > 1.0f)
+			const float targetWidth = static_cast<float>(postEffectManager->GetGameRenderTargetWidth());
+			const float targetHeight = static_cast<float>(postEffectManager->GetGameRenderTargetHeight());
+			const float targetAspect = targetWidth / targetHeight;
+			float imageWidth = availableSize.x;
+			float imageHeight = imageWidth / targetAspect;
+			if (imageHeight > availableSize.y)
 			{
-				// SRVManagerで作成したGameRenderTargetのGPU SRVをImTextureIDとして渡す
-				ImGui::Image(static_cast<ImTextureID>(gameSrv.ptr), viewportSize, ImVec2(0.0f, 0.0f), ImVec2(1.0f, 1.0f));
+				imageHeight = availableSize.y;
+				imageWidth = imageHeight * targetAspect;
+			}
+
+			// Main Viewportの空き領域に引き伸ばさず、16:9を保った最大サイズで中央寄せする
+			const ImVec2 imageSize = ImVec2(std::max(0.0f, imageWidth), std::max(0.0f, imageHeight));
+			const ImVec2 cursorStart = ImGui::GetCursorPos();
+			const ImVec2 screenStart = ImGui::GetCursorScreenPos();
+			const ImVec2 imageOffset = ImVec2(
+				std::max(0.0f, (availableSize.x - imageSize.x) * 0.5f),
+				std::max(0.0f, (availableSize.y - imageSize.y) * 0.5f));
+			ImGui::SetCursorPos(ImVec2(cursorStart.x + imageOffset.x, cursorStart.y + imageOffset.y));
+			mainViewportScreenPosition_ = { screenStart.x + imageOffset.x, screenStart.y + imageOffset.y };
+			mainViewportSize_ = { imageSize.x, imageSize.y };
+
+			const D3D12_GPU_DESCRIPTOR_HANDLE gameSrv = postEffectManager->GetGameRenderTargetSrvHandleGPU();
+			if (gameSrv.ptr != 0 && imageSize.x > 1.0f && imageSize.y > 1.0f)
+			{
+				// SRVManagerで作成したGameRenderTargetのGPU SRVを16:9維持後の表示サイズで渡す
+				ImGui::Image(static_cast<ImTextureID>(gameSrv.ptr), imageSize, ImVec2(0.0f, 0.0f), ImVec2(1.0f, 1.0f));
 			}
 			else
 			{

--- a/Project/Engine/Graphics/Device/Facade/DirectXCommon.cpp
+++ b/Project/Engine/Graphics/Device/Facade/DirectXCommon.cpp
@@ -129,19 +129,8 @@ namespace Ken4lowEngine
 			return;
 		}
 
+		// Scene描画はGameViewportRenderTargetだけへ行うため、フレーム開始時はBackBufferをまだRTVへバインドしない。
 		backBufferIndex_ = swapChain_->GetSwapChain()->GetCurrentBackBufferIndex();
-		auto backBuffer = GetBackBuffer(backBufferIndex_);
-
-		// BackBufferの記録状態を元にRTVへ戻し、固定beforeによる状態ズレを避ける
-		const D3D12_RESOURCE_STATES beforeState = swapChain_->GetBackBufferState(backBufferIndex_);
-		ResourceTransition(
-			backBuffer.Get(),
-			beforeState,
-			D3D12_RESOURCE_STATE_RENDER_TARGET
-		);
-		swapChain_->SetBackBufferState(backBufferIndex_, D3D12_RESOURCE_STATE_RENDER_TARGET);
-
-		mainRenderTarget_->Begin(commandManager_->GetCommandList(), backBufferIndex_);
 	}
 
 	/// -------------------------------------------------------------
@@ -168,8 +157,8 @@ namespace Ken4lowEngine
 		);
 		swapChain_->SetBackBufferState(backBufferIndex_, D3D12_RESOURCE_STATE_RENDER_TARGET);
 
-		D3D12_CPU_DESCRIPTOR_HANDLE rtvHandle = mainRenderTarget_->GetRtvHandleCPU(backBufferIndex_);
-		commandManager_->GetCommandList()->OMSetRenderTargets(1, &rtvHandle, false, nullptr);
+		// BackBufferにはSceneを描かず、ImGui描画直前にだけRTV/Viewport/Scissorを設定してクリアする。
+		mainRenderTarget_->Begin(commandManager_->GetCommandList(), backBufferIndex_);
 	}
 
 

--- a/Project/Engine/Graphics/PostEffect/Effects/DissolveEffect/DissolveEffect.cpp
+++ b/Project/Engine/Graphics/PostEffect/Effects/DissolveEffect/DissolveEffect.cpp
@@ -105,9 +105,9 @@ namespace Ken4lowEngine
 		const uint32_t threadGroupSizeX = 8;
 		const uint32_t threadGroupSizeY = 8;
 
-		// レンダーターゲットの解像度（仮に 1280x720）
-		uint32_t width = dxCommon_->GetClientWidth(); // ウィンドウの幅
-		uint32_t height = dxCommon_->GetClientHeight(); // ウィンドウの高さ
+		// Compute Dispatch範囲は固定GameViewportRenderTargetの1920x1080に合わせる
+		uint32_t width = 1920;
+		uint32_t height = 1080;
 
 		uint32_t groupCountX = (width + threadGroupSizeX - 1) / threadGroupSizeX;
 		uint32_t groupCountY = (height + threadGroupSizeY - 1) / threadGroupSizeY;

--- a/Project/Engine/Graphics/PostEffect/Effects/GaussianFilterEffect/GaussianFilterEffect.cpp
+++ b/Project/Engine/Graphics/PostEffect/Effects/GaussianFilterEffect/GaussianFilterEffect.cpp
@@ -83,9 +83,9 @@ namespace Ken4lowEngine
 		const uint32_t threadGroupSizeX = 8;
 		const uint32_t threadGroupSizeY = 8;
 
-		// レンダーターゲットの解像度（仮に 1280x720）
-		uint32_t width = dxCommon_->GetClientWidth(); // ウィンドウの幅
-		uint32_t height = dxCommon_->GetClientHeight(); // ウィンドウの高さ
+		// Compute Dispatch範囲は固定GameViewportRenderTargetの1920x1080に合わせる
+		uint32_t width = 1920;
+		uint32_t height = 1080;
 
 		uint32_t groupCountX = (width + threadGroupSizeX - 1) / threadGroupSizeX;
 		uint32_t groupCountY = (height + threadGroupSizeY - 1) / threadGroupSizeY;

--- a/Project/Engine/Graphics/PostEffect/Effects/GrayScaleEffect/GrayScaleEffect.cpp
+++ b/Project/Engine/Graphics/PostEffect/Effects/GrayScaleEffect/GrayScaleEffect.cpp
@@ -110,8 +110,9 @@ namespace Ken4lowEngine
 		const uint32_t threadGroupSizeX = 8;
 		const uint32_t threadGroupSizeY = 8;
 
-		const uint32_t width = dxCommon_->GetClientWidth();
-		const uint32_t height = dxCommon_->GetClientHeight();
+		// Compute Dispatch範囲は固定GameViewportRenderTargetの1920x1080に合わせる
+		const uint32_t width = 1920;
+		const uint32_t height = 1080;
 
 		const uint32_t groupCountX = (width + threadGroupSizeX - 1) / threadGroupSizeX;
 		const uint32_t groupCountY = (height + threadGroupSizeY - 1) / threadGroupSizeY;

--- a/Project/Engine/Graphics/PostEffect/Effects/LuminanceOutlineEffect/LuminanceOutlineEffect.cpp
+++ b/Project/Engine/Graphics/PostEffect/Effects/LuminanceOutlineEffect/LuminanceOutlineEffect.cpp
@@ -83,9 +83,9 @@ namespace Ken4lowEngine
 		const uint32_t threadGroupSizeX = 8;
 		const uint32_t threadGroupSizeY = 8;
 
-		// レンダーターゲットの解像度（仮に 1280x720）
-		uint32_t width = dxCommon_->GetClientWidth(); // ウィンドウの幅
-		uint32_t height = dxCommon_->GetClientHeight(); // ウィンドウの高さ
+		// Compute Dispatch範囲は固定GameViewportRenderTargetの1920x1080に合わせる
+		uint32_t width = 1920;
+		uint32_t height = 1080;
 
 		uint32_t groupCountX = (width + threadGroupSizeX - 1) / threadGroupSizeX;
 		uint32_t groupCountY = (height + threadGroupSizeY - 1) / threadGroupSizeY;

--- a/Project/Engine/Graphics/PostEffect/Effects/PixelateEffect/PixelateEffect.cpp
+++ b/Project/Engine/Graphics/PostEffect/Effects/PixelateEffect/PixelateEffect.cpp
@@ -73,8 +73,9 @@ namespace Ken4lowEngine
 		const uint32_t threadGroupSizeX = 8;
 		const uint32_t threadGroupSizeY = 8;
 
-		uint32_t width = dxCommon_->GetClientWidth(); // ウィンドウの幅
-		uint32_t height = dxCommon_->GetClientHeight(); // ウィンドウの高さ
+		// Compute Dispatch範囲は固定GameViewportRenderTargetの1920x1080に合わせる
+		uint32_t width = 1920;
+		uint32_t height = 1080;
 
 		uint32_t groupCountX = (width + threadGroupSizeX - 1) / threadGroupSizeX;
 		uint32_t groupCountY = (height + threadGroupSizeY - 1) / threadGroupSizeY;

--- a/Project/Engine/Graphics/PostEffect/Effects/PlayerHealthPostEffect/PlayerHealthPostEffect.cpp
+++ b/Project/Engine/Graphics/PostEffect/Effects/PlayerHealthPostEffect/PlayerHealthPostEffect.cpp
@@ -55,8 +55,9 @@ void PlayerHealthPostEffect::Apply(ID3D12GraphicsCommandList* commandList, uint3
 
 	const uint32_t threadGroupSizeX = 8;
 	const uint32_t threadGroupSizeY = 8;
-	const uint32_t width = dxCommon_->GetClientWidth();
-	const uint32_t height = dxCommon_->GetClientHeight();
+	// Compute Dispatch範囲は固定GameViewportRenderTargetの1920x1080に合わせる
+	const uint32_t width = 1920;
+	const uint32_t height = 1080;
 	const uint32_t groupCountX = (width + threadGroupSizeX - 1) / threadGroupSizeX;
 	const uint32_t groupCountY = (height + threadGroupSizeY - 1) / threadGroupSizeY;
 

--- a/Project/Engine/Graphics/PostEffect/Effects/RadialBlurEffect/RadialBlurEffect.cpp
+++ b/Project/Engine/Graphics/PostEffect/Effects/RadialBlurEffect/RadialBlurEffect.cpp
@@ -84,9 +84,9 @@ namespace Ken4lowEngine
 		const uint32_t threadGroupSizeX = 8;
 		const uint32_t threadGroupSizeY = 8;
 
-		// レンダーターゲットの解像度（仮に 1280x720）
-		uint32_t width = dxCommon_->GetClientWidth(); // ウィンドウの幅
-		uint32_t height = dxCommon_->GetClientHeight(); // ウィンドウの高さ
+		// Compute Dispatch範囲は固定GameViewportRenderTargetの1920x1080に合わせる
+		uint32_t width = 1920;
+		uint32_t height = 1080;
 
 		uint32_t groupCountX = (width + threadGroupSizeX - 1) / threadGroupSizeX;
 		uint32_t groupCountY = (height + threadGroupSizeY - 1) / threadGroupSizeY;

--- a/Project/Engine/Graphics/PostEffect/Effects/RandomEffect/RandomEffect.cpp
+++ b/Project/Engine/Graphics/PostEffect/Effects/RandomEffect/RandomEffect.cpp
@@ -34,7 +34,8 @@ namespace Ken4lowEngine
 		// ランダムエフェクトの設定
 		randomSetting_->time = 0.0f; // 時間
 		randomSetting_->useMultiply = false; // 乗算を使用するかどうか
-		randomSetting_->textureSize = Vector2(static_cast<float>(dxCommon_->GetClientWidth()), static_cast<float>(dxCommon_->GetClientHeight())); // テクスチャのサイズ
+		// ノイズ計算の基準サイズも固定GameViewportRenderTargetの1920x1080に合わせる
+		randomSetting_->textureSize = Vector2(1920.0f, 1080.0f);
 
 		// 名前の設定
 		constantBuffer_->SetName(L"RandomEffect_ConstantBuffer");
@@ -93,8 +94,9 @@ namespace Ken4lowEngine
 		const uint32_t threadGroupSizeY = 8;
 
 		// いまの画面サイズを使う
-		uint32_t width = dxCommon_->GetClientWidth();
-		uint32_t height = dxCommon_->GetClientHeight();
+		// Compute Dispatch範囲は固定GameViewportRenderTargetの1920x1080に合わせる
+		uint32_t width = 1920;
+		uint32_t height = 1080;
 
 		// （textureSize を残すなら毎回更新しておく）
 		randomSetting_->textureSize = Vector2((float)width, (float)height);

--- a/Project/Engine/Graphics/PostEffect/Effects/SmoothingEffect/SmoothingEffect.cpp
+++ b/Project/Engine/Graphics/PostEffect/Effects/SmoothingEffect/SmoothingEffect.cpp
@@ -77,9 +77,9 @@ namespace Ken4lowEngine
 		const uint32_t threadGroupSizeX = 8;
 		const uint32_t threadGroupSizeY = 8;
 
-		// レンダーターゲットの解像度（仮に 1280x720）
-		uint32_t width = dxCommon_->GetClientWidth(); // ウィンドウの幅
-		uint32_t height = dxCommon_->GetClientHeight(); // ウィンドウの高さ
+		// Compute Dispatch範囲は固定GameViewportRenderTargetの1920x1080に合わせる
+		uint32_t width = 1920;
+		uint32_t height = 1080;
 
 		// スレッドグループの数を計算
 		uint32_t groupCountX = (width + threadGroupSizeX - 1) / threadGroupSizeX;

--- a/Project/Engine/Graphics/PostEffect/Effects/VignetteEffect/VignetteEffect.cpp
+++ b/Project/Engine/Graphics/PostEffect/Effects/VignetteEffect/VignetteEffect.cpp
@@ -79,9 +79,9 @@ namespace Ken4lowEngine
 		const uint32_t threadGroupSizeX = 8;
 		const uint32_t threadGroupSizeY = 8;
 
-		// レンダーターゲットの解像度（仮に 1280x720）
-		uint32_t width = dxCommon_->GetClientWidth(); // ウィンドウの幅
-		uint32_t height = dxCommon_->GetClientHeight(); // ウィンドウの高さ
+		// Compute Dispatch範囲は固定GameViewportRenderTargetの1920x1080に合わせる
+		uint32_t width = 1920;
+		uint32_t height = 1080;
 
 		// スレッドグループの数を計算
 		uint32_t groupCountX = (width + threadGroupSizeX - 1) / threadGroupSizeX;

--- a/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.cpp
+++ b/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.cpp
@@ -57,9 +57,9 @@ namespace Ken4lowEngine
 		renderTargets_[0].debugName = L"SceneRenderTarget_GameViewportRenderTarget";
 		renderTargets_[1].debugName = L"PostEffectRenderTarget";
 
-		// 初期GameRenderTargetはMain Viewport表示用に1280x720固定で確保する
-		renderTargetWidth_ = kInitialGameRenderTargetWidth_;
-		renderTargetHeight_ = kInitialGameRenderTargetHeight_;
+		// GameViewportRenderTargetはSprite/UI/Fontの基準解像度に合わせて1920x1080固定で確保する
+		renderTargetWidth_ = kFixedGameRenderTargetWidth_;
+		renderTargetHeight_ = kFixedGameRenderTargetHeight_;
 
 		// RTVとSRVの確保
 		AllocateRTV_DSV_SRV_UAV();
@@ -239,20 +239,26 @@ namespace Ken4lowEngine
 	/// -------------------------------------------------------------
 	void PostEffectManager::Resize(uint32_t width, uint32_t height)
 	{
-		if (width == 0 || height == 0) return;
+		(void)width;
+		(void)height;
 
-		// GameRenderTargetの現在サイズを記録してMain Viewport側の座標変換に使えるようにする
-		renderTargetWidth_ = width;
-		renderTargetHeight_ = height;
+		// Main Viewport実サイズ追従はまだ行わず、GameViewportRenderTargetを1920x1080固定で維持する。
+		const uint32_t fixedWidth = kFixedGameRenderTargetWidth_;
+		const uint32_t fixedHeight = kFixedGameRenderTargetHeight_;
+		if (renderTargetWidth_ == fixedWidth && renderTargetHeight_ == fixedHeight && depthResource_) return;
 
-		SetViewportAndScissorRect(width, height);
+		// GameRenderTargetの現在サイズを固定基準解像度として記録する
+		renderTargetWidth_ = fixedWidth;
+		renderTargetHeight_ = fixedHeight;
+
+		SetViewportAndScissorRect(fixedWidth, fixedHeight);
 
 		// RTを作り直して、同じdescriptor indexに上書き
 		for (uint32_t i = 0; i < static_cast<uint32_t>(renderTargets_.size()); ++i)
 		{
 			auto& rt = renderTargets_[i];
 			rt.resource.Reset();
-			rt.resource = CreateRenderTextureResource(width, height,
+			rt.resource = CreateRenderTextureResource(fixedWidth, fixedHeight,
 				DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, kRenderTextureClearColor_);
 			// Resize後もRenderTarget名を張り直し、Unnamed Resourceの再発を防ぐ。
 			rt.resource->SetName(rt.debugName);
@@ -274,7 +280,7 @@ namespace Ken4lowEngine
 
 		// depth作り直し
 		depthResource_.Reset();
-		depthResource_ = CreateDepthBufferResource(width, height);
+		depthResource_ = CreateDepthBufferResource(fixedWidth, fixedHeight);
 		// PostEffect用深度もResize後に名前を付け直してDebugLayerで追跡可能にする。
 		depthResource_->SetName(L"PostEffectManager DepthBuffer");
 		DSVManager::GetInstance()->CreateDSVForTexture2D(depthDsvIndex_, depthResource_.Get());
@@ -492,13 +498,11 @@ namespace Ken4lowEngine
 
 	void PostEffectManager::RequestGameRenderTargetResize(uint32_t width, uint32_t height)
 	{
-		if (width == 0 || height == 0 || (width == renderTargetWidth_ && height == renderTargetHeight_))
-		{
-			return;
-		}
+		(void)width;
+		(void)height;
 
-		// Main Viewport実サイズ追従を後で有効化しやすいよう既存Resizeへ集約する
-		Resize(width, height);
+		// Main Viewport実サイズ追従は未実装のため、外部からのリサイズ要求でも1920x1080固定を保つ
+		Resize(kFixedGameRenderTargetWidth_, kFixedGameRenderTargetHeight_);
 	}
 
 	/// -------------------------------------------------------------
@@ -649,10 +653,10 @@ namespace Ken4lowEngine
 	/// -------------------------------------------------------------
 	void PostEffectManager::SetViewportAndScissorRect(uint32_t width, uint32_t height)
 	{
-		// ビューポート矩形の設定
+		// Scene描画範囲をGameViewportRenderTargetの実ピクセルサイズと必ず一致させる
 		viewport = D3D12_VIEWPORT(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height), 0.0f, 1.0f);
 
-		// シザリング矩形の設定
+		// ScissorもGameViewportRenderTargetの実ピクセルサイズと必ず一致させる
 		scissorRect = { 0, 0, static_cast<LONG>(width), static_cast<LONG>(height) };
 	}
 

--- a/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.h
+++ b/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.h
@@ -213,9 +213,9 @@ private: /// ---------- メンバ変数 ---------- ///
 	// ポストエフェクトのカテゴリ分類（名前 → カテゴリ名）
 	std::unordered_map<std::string, std::string> effectCategory_;
 
-	// GameRenderTargetの初期サイズはエディタ中央表示用に16:9固定から開始する
-	static constexpr uint32_t kInitialGameRenderTargetWidth_ = 1280;
-	static constexpr uint32_t kInitialGameRenderTargetHeight_ = 720;
+	// GameViewportRenderTargetはゲーム側の基準解像度に合わせて1920x1080固定にする
+	static constexpr uint32_t kFixedGameRenderTargetWidth_ = 1920;
+	static constexpr uint32_t kFixedGameRenderTargetHeight_ = 1080;
 
 	// レンダーテクスチャのクリアカラー
 	const Vector4 kRenderTextureClearColor_ = { 0.08f, 0.08f, 0.18f, 1.0f }; // 分かりやすいように一旦赤色にする
@@ -236,8 +236,8 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	static constexpr int kPostRTCount = 1; // ポストエフェクト用のレンダーテクスチャ数
 	std::vector<RenderTarget> renderTargets_; // レンダーテクスチャのリスト
-	uint32_t renderTargetWidth_ = kInitialGameRenderTargetWidth_; // Main Viewportへ表示するGameRenderTarget幅
-	uint32_t renderTargetHeight_ = kInitialGameRenderTargetHeight_; // Main Viewportへ表示するGameRenderTarget高さ
+	uint32_t renderTargetWidth_ = kFixedGameRenderTargetWidth_; // Main Viewportへ表示するGameRenderTarget幅
+	uint32_t renderTargetHeight_ = kFixedGameRenderTargetHeight_; // Main Viewportへ表示するGameRenderTarget高さ
 
 	// 深度ステンシルビューのインデックス
 	uint32_t depthDsvIndex_ = UINT32_MAX;


### PR DESCRIPTION
### Motivation
- The main viewport image was stretched and viewports/scissor rectangles did not match the game render target, causing visual distortion. 
- The renderer and post-effect compute dispatches used inconsistent sizes (editor/backbuffer vs game target), so the goal is to stabilize the GameViewportRenderTarget to a fixed 1920x1080 and make all related view/dispatch sizes consistent.

### Description
- Make GameViewportRenderTarget fixed at 1920x1080 by default and ignore external resize requests so the render target stays stable; update `PostEffectManager` to use `kFixedGameRenderTargetWidth_/Height_`. (files: `PostEffectManager.h`, `PostEffectManager.cpp`)
- Ensure scene D3D12 viewport and scissor rects are set to the render target pixel size via `SetViewportAndScissorRect(1920,1080)`. (file: `PostEffectManager.cpp`)
- Render only to the GameViewportRenderTarget for scene/post-effect and draw sprites/UI into that RT; keep BackBuffer free of scene rendering and bind/clear BackBuffer only immediately before ImGui drawing. (files: `GameApplication.cpp`, `DirectXCommon.cpp`)
- Change Main Viewport ImGui code to compute a 16:9-preserving display size from `GetContentRegionAvail()`, center the image, and call `ImGui::Image` with that size instead of using the available region directly. (file: `EditorWindowManager.cpp`)
- Align post-effect compute dispatch and related effects to the fixed 1920x1080 target (replace previous usage of `GetClientWidth()/GetClientHeight()` with fixed 1920x1080 in post-effect compute shaders where appropriate). (files: various `Engine/Graphics/PostEffect/Effects/*.cpp`)
- Add short inline comments at change sites explaining the intent to keep the GameViewportRenderTarget fixed and to preserve 16:9 in the UI. (multiple files)

### Testing
- Ran repository checks with `git diff --check` which reported no whitespace/merge issues and succeeded. 
- Performed grep-based validations (`rg`) to confirm the old 1280x720 initialization and uses of `GetClientWidth()/GetClientHeight()` were replaced and that `ImGui::Image` usage was updated; those searches matched the intended replacements. 
- Attempted to perform Visual Studio/MSBuild Debug and Release builds, but `msbuild` is not available in this Linux container so the native builds were not executed here (builds should be verified on Windows CI or locally). 
- Committed the changes after automated checks passed; no automated render/run tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0165a5ada8832d851ef5c322f6a76a)