### PR TITLE
Editor: Map Main Viewport mouse coordinates to 1920x1080 game space

### DIFF
--- a/Project/Engine/Editor/EditorWindowManager.cpp
+++ b/Project/Engine/Editor/EditorWindowManager.cpp
@@ -2,6 +2,7 @@
 
 #include "ImGuiManager.h"
 #include "PostEffectManager.h"
+#include <Input.h>
 
 #include <algorithm>
 
@@ -155,6 +156,9 @@ namespace Ken4lowEngine
 #ifdef USE_IMGUI
 		if (!windowState_.showMainViewport)
 		{
+			// Main Viewport非表示中はゲーム側へエディタマウス入力を渡さない
+			mainViewportRect_.valid = false;
+			Input::GetInstance()->SetEditorViewportMousePosition({ 0.0f, 0.0f }, false);
 			return;
 		}
 
@@ -184,6 +188,15 @@ namespace Ken4lowEngine
 			ImGui::SetCursorPos(ImVec2(cursorStart.x + imageOffset.x, cursorStart.y + imageOffset.y));
 			mainViewportScreenPosition_ = { screenStart.x + imageOffset.x, screenStart.y + imageOffset.y };
 			mainViewportSize_ = { imageSize.x, imageSize.y };
+			// ImGui::Imageで描くゲーム画面のスクリーン矩形を入力変換用に保存する
+			mainViewportRect_.screenMin = mainViewportScreenPosition_;
+			mainViewportRect_.screenMax = { mainViewportScreenPosition_.x + imageSize.x, mainViewportScreenPosition_.y + imageSize.y };
+			mainViewportRect_.imageSize = mainViewportSize_;
+			mainViewportRect_.valid = imageSize.x > 1.0f && imageSize.y > 1.0f;
+
+			Vector2 gameMouse = {};
+			const bool gameMouseValid = GetMousePositionInGameViewport(gameMouse);
+			Input::GetInstance()->SetEditorViewportMousePosition(gameMouse, gameMouseValid);
 
 			const D3D12_GPU_DESCRIPTOR_HANDLE gameSrv = postEffectManager->GetGameRenderTargetSrvHandleGPU();
 			if (gameSrv.ptr != 0 && imageSize.x > 1.0f && imageSize.y > 1.0f)
@@ -196,6 +209,12 @@ namespace Ken4lowEngine
 				ImGui::TextUnformatted("GameRenderTarget SRV is not ready.");
 			}
 		}
+		else
+		{
+			// Main Viewportウィンドウが折りたたまれた場合もゲーム側のマウス入力を無効化する
+			mainViewportRect_.valid = false;
+			Input::GetInstance()->SetEditorViewportMousePosition({ 0.0f, 0.0f }, false);
+		}
 		ImGui::End();
 #endif // USE_IMGUI
 	}
@@ -204,6 +223,46 @@ namespace Ken4lowEngine
 	{
 		// 入力系はこの入口でスクリーン座標からMain Viewportローカル座標へ変換する
 		return { screenPosition.x - mainViewportScreenPosition_.x, screenPosition.y - mainViewportScreenPosition_.y };
+	}
+
+	bool EditorWindowManager::GetMousePositionInGameViewport(Vector2& outMouse) const
+	{
+#ifdef USE_IMGUI
+		constexpr float kGameBaseWidth = 1920.0f;
+		constexpr float kGameBaseHeight = 1080.0f;
+
+		outMouse = { 0.0f, 0.0f };
+		if (!mainViewportRect_.valid)
+		{
+			return false;
+		}
+
+		const ImGuiIO& io = ImGui::GetIO();
+		if (io.WantCaptureMouse)
+		{
+			// ImGui操作中はゲーム側へマウス入力を渡さない
+			return false;
+		}
+
+		const ImVec2 mouseScreen = ImGui::GetMousePos();
+		const Vector2 mouse = { mouseScreen.x, mouseScreen.y };
+		if (mouse.x < mainViewportRect_.screenMin.x || mouse.y < mainViewportRect_.screenMin.y ||
+			mouse.x > mainViewportRect_.screenMax.x || mouse.y > mainViewportRect_.screenMax.y)
+		{
+			return false;
+		}
+
+		// 16:9表示矩形内のローカル座標をゲーム内部の基準解像度へスケール変換する
+		const Vector2 localMouse = { mouse.x - mainViewportRect_.screenMin.x, mouse.y - mainViewportRect_.screenMin.y };
+		outMouse = {
+			(localMouse.x / mainViewportRect_.imageSize.x) * kGameBaseWidth,
+			(localMouse.y / mainViewportRect_.imageSize.y) * kGameBaseHeight
+		};
+		return true;
+#else
+		outMouse = { 0.0f, 0.0f };
+		return false;
+#endif // USE_IMGUI
 	}
 
 	void EditorWindowManager::DrawWorldOutliner()

--- a/Project/Engine/Editor/EditorWindowManager.h
+++ b/Project/Engine/Editor/EditorWindowManager.h
@@ -37,6 +37,17 @@ namespace Ken4lowEngine
 	};
 
 	/// <summary>
+	/// Main Viewport内で実際にゲーム画面を表示している矩形を保持します。
+	/// </summary>
+	struct EditorViewportRect
+	{
+		Vector2 screenMin = { 0.0f, 0.0f };
+		Vector2 screenMax = { 0.0f, 0.0f };
+		Vector2 imageSize = { 0.0f, 0.0f };
+		bool valid = false;
+	};
+
+	/// <summary>
 	/// UE5風エディタUIのメニュー、ツールバー、各パネルをまとめて描画します。
 	/// </summary>
 	class EditorWindowManager
@@ -58,6 +69,12 @@ namespace Ken4lowEngine
 		/// </summary>
 		Vector2 ConvertScreenToMainViewportPosition(const Vector2& screenPosition) const;
 
+		/// <summary>
+		/// ImGuiのMain Viewport内マウス座標をゲーム基準解像度へ変換します。
+		/// </summary>
+		bool GetMousePositionInGameViewport(Vector2& outMouse) const;
+
+		const EditorViewportRect& GetMainViewportRect() const { return mainViewportRect_; }
 		const Vector2& GetMainViewportScreenPosition() const { return mainViewportScreenPosition_; }
 		const Vector2& GetMainViewportSize() const { return mainViewportSize_; }
 
@@ -71,6 +88,7 @@ namespace Ken4lowEngine
 		EditorWindowManager& operator=(const EditorWindowManager&) = delete;
 
 		EditorWindowState windowState_{};
+		EditorViewportRect mainViewportRect_{}; // Main Viewport内で実際にゲーム画面を表示している矩形
 		Vector2 mainViewportScreenPosition_ = { 0.0f, 0.0f }; // マウス座標をMain Viewport基準へ変換するための左上座標
 		Vector2 mainViewportSize_ = { 0.0f, 0.0f }; // Main Viewport内でGameRenderTargetを表示しているサイズ
 	};

--- a/Project/Engine/System/Input/Input.cpp
+++ b/Project/Engine/System/Input/Input.cpp
@@ -220,6 +220,12 @@ namespace Ken4lowEngine
 	/// -------------------------------------------------------------
 	bool Input::PushMouse(int button) const
 	{
+		if (editorViewportMouseOverrideEnabled_ && !editorViewportMousePositionValid_)
+		{
+			// Main Viewport外またはImGui操作中のマウス押下はゲーム入力へ渡さない
+			return false;
+		}
+
 		if (mouseState_.rgbButtons[button])
 		{
 			return true;
@@ -234,6 +240,12 @@ namespace Ken4lowEngine
 	/// -------------------------------------------------------------
 	bool Input::TriggerMouse(int button) const
 	{
+		if (editorViewportMouseOverrideEnabled_ && !editorViewportMousePositionValid_)
+		{
+			// Main Viewport外またはImGui操作中のマウストリガーはゲーム入力へ渡さない
+			return false;
+		}
+
 		if (mouseState_.rgbButtons[button] && !prevMouseState_.rgbButtons[button])
 		{
 			return true;
@@ -248,6 +260,12 @@ namespace Ken4lowEngine
 	/// -------------------------------------------------------------
 	bool Input::ReleaseMouse(int button) const
 	{
+		if (editorViewportMouseOverrideEnabled_ && !editorViewportMousePositionValid_)
+		{
+			// Main Viewport外またはImGui操作中のマウスリリースはゲーム入力へ渡さない
+			return false;
+		}
+
 		if (!mouseState_.rgbButtons[button] && prevMouseState_.rgbButtons[button])
 		{
 			return true;
@@ -294,7 +312,21 @@ namespace Ken4lowEngine
 	/// -------------------------------------------------------------
 	Vector2 Input::GetMousePosition()
 	{
+		if (editorViewportMouseOverrideEnabled_)
+		{
+			// 既存のゲーム側呼び出しはMain Viewport基準の座標を優先して受け取る
+			return editorViewportMousePositionValid_ ? editorViewportMousePosition_ : Vector2(-1.0f, -1.0f);
+		}
+
 		return Vector2(float(mousePosition_.x), float(mousePosition_.y));
+	}
+
+	void Input::SetEditorViewportMousePosition(const Vector2& position, bool valid)
+	{
+		// EditorWindowManagerで変換済みの座標と有効状態をInput側へ集約する
+		editorViewportMousePosition_ = position;
+		editorViewportMousePositionValid_ = valid;
+		editorViewportMouseOverrideEnabled_ = true;
 	}
 
 

--- a/Project/Engine/System/Input/Input.h
+++ b/Project/Engine/System/Input/Input.h
@@ -141,6 +141,11 @@ namespace Ken4lowEngine
 		/// <returns></returns>
 		Vector2 GetMousePosition();
 
+		/// <summary>
+		/// エディタMain Viewport基準へ変換済みのマウス座標を設定します。
+		/// </summary>
+		void SetEditorViewportMousePosition(const Vector2& position, bool valid);
+
 		// マウスのX座標を取得
 		int GetMouseMoveX() const { return mouseState_.lX; }
 
@@ -271,6 +276,9 @@ namespace Ken4lowEngine
 		DIMOUSESTATE mouseState_;				  // マウスの状態
 		DIMOUSESTATE prevMouseState_;			  // 前フレームのマウスの状態
 		POINT mousePosition_ = {};				  // マウスの座標
+		Vector2 editorViewportMousePosition_ = { 0.0f, 0.0f }; // Main Viewport基準へ変換済みのマウス座標
+		bool editorViewportMousePositionValid_ = false;	  // Main Viewport内かつImGui未操作中だけtrueにする
+		bool editorViewportMouseOverrideEnabled_ = false; // エディタ経由のマウス座標をゲーム入力へ反映するかどうか
 		bool lockCursor_ = false;				  // マウスカーソルをロックするかどうか
 		bool cursorVisible_ = true;				  // マウスカーソルの表示状態
 


### PR DESCRIPTION
### Motivation
- Align mouse hit-tests with the ImGui `Main Viewport` image by converting ImGui screen coordinates into the game's fixed internal resolution (1920x1080). 
- Ensure editor UI (ImGui) captures or hides input appropriately so the game only receives mouse events when the cursor is actually over the displayed game image. 
- Preserve existing game code that calls `Input::GetMousePosition()` while providing a safe override path from the editor. 

### Description
- Added `EditorViewportRect` to store `screenMin` / `screenMax` / `imageSize` / `valid` and a `mainViewportRect_` field to `EditorWindowManager` to remember the actual displayed image rectangle. 
- In `EditorWindowManager::DrawMainViewport()` the displayed 16:9 `ImGui::Image` size is computed and its screen rectangle is saved, and `GetMousePositionInGameViewport(Vector2&)` is used to compute game-space mouse and call `Input::SetEditorViewportMousePosition(...)`. 
- Implemented `GetMousePositionInGameViewport` which returns `false` when the viewport is invalid, the mouse is outside the image, or `ImGuiIO::WantCaptureMouse` is `true`, and otherwise maps local image coordinates to fixed game coordinates using `gameX = (localX / imageSize.x) * 1920.0f` and `gameY = (localY / imageSize.y) * 1080.0f`. 
- Added `Input::SetEditorViewportMousePosition(const Vector2&, bool)` plus backing members (`editorViewportMousePosition_`, `editorViewportMousePositionValid_`, `editorViewportMouseOverrideEnabled_`) and updated `Input::GetMousePosition()` to prefer the editor-converted coordinate when override is enabled; mouse button queries (`PushMouse`/`TriggerMouse`/`ReleaseMouse`) now block input when the editor override is enabled but invalid. 
- Added short, explanatory one-line comments at key change sites and ensured behavior disables game input when the Main Viewport is hidden or folded. 

### Testing
- Ran `git diff --check` to validate whitespace/patch issues and it reported no issues. 
- Attempted to build with `msbuild Project/Ken4lowEngine.sln /p:Configuration=Debug` and `Release`, but `msbuild` was not available in this environment so full Debug/Release builds could not be executed here. 
- Verified the repository contains the four modified files (`EditorWindowManager.h/.cpp` and `Input.h/.cpp`) and committed the changes locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01695ff7d4832d90e1187453d58f6e)