### PR TITLE
Main Viewportのスプライト黒化を修正（BlendStateと最終合成の不透明化）

### DIFF
--- a/Project/Engine/Graphics/Pipeline/PipelineStatePresets.cpp
+++ b/Project/Engine/Graphics/Pipeline/PipelineStatePresets.cpp
@@ -10,8 +10,9 @@ namespace Ken4lowEngine::PipelineStatePresets
 		desc.RenderTarget[0].SrcBlend = D3D12_BLEND_SRC_ALPHA;
 		desc.RenderTarget[0].DestBlend = D3D12_BLEND_INV_SRC_ALPHA;
 		desc.RenderTarget[0].BlendOp = D3D12_BLEND_OP_ADD;
-		desc.RenderTarget[0].SrcBlendAlpha = D3D12_BLEND_ONE;
-		desc.RenderTarget[0].DestBlendAlpha = D3D12_BLEND_ZERO;
+		// Main ViewportをImGui::Imageで合成しても透けないようSprite描画ではRTのalphaを維持する。
+		desc.RenderTarget[0].SrcBlendAlpha = D3D12_BLEND_ZERO;
+		desc.RenderTarget[0].DestBlendAlpha = D3D12_BLEND_ONE;
 		desc.RenderTarget[0].BlendOpAlpha = D3D12_BLEND_OP_ADD;
 		desc.RenderTarget[0].RenderTargetWriteMask = D3D12_COLOR_WRITE_ENABLE_ALL;
 		return desc;

--- a/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.cpp
+++ b/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.cpp
@@ -161,6 +161,22 @@ namespace Ken4lowEngine
 		renderTarget.currentState_ = nextState;
 	}
 
+	void PostEffectManager::CopyRenderTarget(RenderTarget& srcRT, RenderTarget& dstRT, ID3D12GraphicsCommandList* commandList)
+	{
+		assert(srcRT.resource.Get() != dstRT.resource.Get());
+
+		// 最終表示先のSRVを固定するため、既存のフルスクリーンコピーPSOでRT間コピーを行う。
+		SRVManager::GetInstance()->PreDraw();
+		TransitionTo(srcRT, commandList, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+		TransitionTo(dstRT, commandList, D3D12_RESOURCE_STATE_RENDER_TARGET);
+		commandList->OMSetRenderTargets(1, &dstRT.rtvHandle, false, nullptr);
+		commandList->SetPipelineState(pipelineBuilder_->GetCopyPipelineState().Get());
+		commandList->SetGraphicsRootSignature(pipelineBuilder_->GetCopyRootSignature().Get());
+		SRVManager::GetInstance()->SetGraphicsRootDescriptorTable(0, srcRT.srvIndex);
+		commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+		commandList->DrawInstanced(3, 1, 0, 0);
+	}
+
 
 	/// -------------------------------------------------------------
 	///				　	ポストエフェクトの更新処理
@@ -322,12 +338,14 @@ namespace Ken4lowEngine
 
 		uint32_t src = 0; // ソースのインデックス
 		uint32_t dst = 1; // デスティネーションのインデックス
+		bool appliedAnyEffect = false; // 最終alpha補正コピーが必要か判定するため適用有無を保持する
 
 		// ポストエフェクトの描画
 		for (const auto& [name, _] : effectOrder_)
 		{
 			if (!(effectEnabled_[name] || effectEnableFlags_[name])) continue;  // エフェクトが無効ならスキップ
 
+			appliedAnyEffect = true;
 			auto& inRT = renderTargets_[src]; // 入力レンダーテクスチャ
 			auto& outRT = renderTargets_[dst]; // 出力レンダーテクスチャ
 
@@ -373,19 +391,13 @@ namespace Ken4lowEngine
 
 		if (src != 0)
 		{
-			// 最終PostEffect出力とGameRenderTargetが別Resourceであることを確認してSRV/RTV同時使用を避ける。
-			assert(finalRT.resource.Get() != gameRT.resource.Get());
-
-			// BackBufferではなくGameRenderTargetへコピーしてDockウィンドウとの重なりを避ける
-			SRVManager::GetInstance()->PreDraw();
-			TransitionTo(finalRT, commandList, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
-			TransitionTo(gameRT, commandList, D3D12_RESOURCE_STATE_RENDER_TARGET);
-			commandList->OMSetRenderTargets(1, &gameRT.rtvHandle, false, nullptr);
-			commandList->SetPipelineState(pipelineBuilder_->GetCopyPipelineState().Get());
-			commandList->SetGraphicsRootSignature(pipelineBuilder_->GetCopyRootSignature().Get());
-			SRVManager::GetInstance()->SetGraphicsRootDescriptorTable(0, finalRT.srvIndex);
-			commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-			commandList->DrawInstanced(3, 1, 0, 0);
+			CopyRenderTarget(finalRT, gameRT, commandList);
+		}
+		else if (appliedAnyEffect && renderTargets_.size() >= 2)
+		{
+			// 偶数個のPostEffectでGameRenderTargetへ戻った場合もalpha=1のコピーPSOを通して最終合成を不透明化する。
+			CopyRenderTarget(gameRT, renderTargets_[1], commandList);
+			CopyRenderTarget(renderTargets_[1], gameRT, commandList);
 		}
 
 		// Main ViewportのImGui::Imageが読めるよう最終GameRenderTargetをSRV状態にしておく

--- a/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.h
+++ b/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.h
@@ -179,6 +179,11 @@ private: /// ---------- メンバ関数 ---------- ///
 	/// </summary>
 	void TransitionTo(RenderTarget& renderTarget, ID3D12GraphicsCommandList* commandList, D3D12_RESOURCE_STATES nextState);
 
+	/// <summary>
+	/// 既存のコピー用PSOで入力RTを出力RTへ描画します。
+	/// </summary>
+	void CopyRenderTarget(RenderTarget& srcRT, RenderTarget& dstRT, ID3D12GraphicsCommandList* commandList);
+
 private: /// ---------- メンバ関数 ---------- ///
 
 	/// <summary>

--- a/Project/Resources/Shaders/PostEffect/NormalEffect.PS.hlsl
+++ b/Project/Resources/Shaders/PostEffect/NormalEffect.PS.hlsl
@@ -12,5 +12,6 @@ PixelShaderOutput main(VertexShaderOutput input)
 {
     PixelShaderOutput output;
     output.color = gTexture.Sample(gSampler, input.texcoord);
+    output.color.a = 1.0f; // Main Viewport用の最終合成結果はImGui::Image上で透けないよう不透明にする
     return output;
 }


### PR DESCRIPTION
### Motivation
- Main Viewportで一部スプライトが黒く見える問題を、既存描画結果を維持しつつ最小修正で解消するための対応です。 
- 原因調査で BlendState によるレンダーターゲットの alpha 書き込みが ImGui::Image 描画時の再合成で黒化を招いていると判定しました。 
- 大規模な設計変更を避けつつ、PostEffect経路で最終合成の alpha が抜ける可能性にも対策を入れます。 
- 修正箇所には意図が分かる1行コメントを追加しています。 

### Description
- BlendState を変更し Sprite 用アルファ合成で RenderTarget の alpha を上書きしないように `MakeBlendAlpha()` の `SrcBlendAlpha/DestBlendAlpha` を変更しました（ファイル: `Project/Engine/Graphics/Pipeline/PipelineStatePresets.cpp`）。
- PostEffectManager に既存のコピー用 PSO を用いて RT 間を確実にフルスクリーン描画でコピーする `CopyRenderTarget` を追加し、ポストエフェクト適用後の最終出力を安定して GameRenderTarget に戻す処理を導入しました（ファイル: `Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.h` / `.cpp`）。
- 偶数個の PostEffect 適用などで最終出力が GameRenderTarget に戻らないケースに備え、適用有無フラグを追加して必要な場合は中間RTを挟んで不透明化コピーを行うロジックを追加しました（ファイル: `PostEffectManager.cpp`）。
- 最終合成に使うフルスクリーンピクセルシェーダーで出力 alpha を `1.0f` に固定して ImGui::Image 表示時に透けないようにしました（ファイル: `Project/Resources/Shaders/PostEffect/NormalEffect.PS.hlsl`）。
- Sprite 描画時の Pipeline/RootSignature の切り替えフローや GameRenderTarget のフォーマット/クリア色/描画順は変更せず維持しています（該当箇所を確認済み）。

### Testing
- `git diff --check` を実行して差分に問題がないことを確認しました（成功）。
- ソースツリー上で変更ファイルは次の通りです: `PipelineStatePresets.cpp`, `PostEffectManager.cpp`, `PostEffectManager.h`, `NormalEffect.PS.hlsl`（変更はコミット済み）。
- Visual Studio/MSBuild による Debug/Release ビルドはこの Linux 実行環境に `msbuild` が無いため実行できず未実行であることを確認しました（環境依存で失敗）。
- コンパイル/ランタイム確認は Windows 開発環境での Debug/Release ビルド実行と実機表示確認を推奨します（この PR の目的は最小侵襲での BlendState 修正と最終合成経路の安定化です）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a016cc4bd2c832d8b5b476340fe8bc1)