### PR TITLE
Fix Main Viewport mouse coordinates and input routing

### DIFF
--- a/Project/Engine/Core/Application/Framework.cpp
+++ b/Project/Engine/Core/Application/Framework.cpp
@@ -102,7 +102,11 @@ namespace Ken4lowEngine
 		winApp_ = WinApp::GetInstance();
 
 		DisplaySettings ds{};
-		ds.mode = WindowMode::BorderlessFullscreen; // 初期ウィンドウモード
+#ifdef USE_IMGUI
+		ds.mode = WindowMode::Windowed; // DebugのImGui EditorではOSウィンドウ内にMain Viewportを表示する
+#else
+		ds.mode = WindowMode::BorderlessFullscreen; // Releaseでは従来通りゲーム全体をボーダーレス表示する
+#endif // USE_IMGUI
 		ds.monitorIndex = 0;
 
 		winApp_->CreateMainWindow(ds);

--- a/Project/Engine/Editor/EditorWindowManager.cpp
+++ b/Project/Engine/Editor/EditorWindowManager.cpp
@@ -159,6 +159,7 @@ namespace Ken4lowEngine
 		{
 			// Main Viewport非表示中はゲーム側へエディタマウス入力を渡さない
 			mainViewportRect_.valid = false;
+			mainViewportRect_.hovered = false;
 			Input::GetInstance()->SetEditorViewportMousePosition({ 0.0f, 0.0f }, false);
 			return;
 		}
@@ -195,25 +196,28 @@ namespace Ken4lowEngine
 			mainViewportRect_.imageSize = mainViewportSize_;
 			mainViewportRect_.valid = imageSize.x > 1.0f && imageSize.y > 1.0f;
 
-			Vector2 gameMouse = {};
-			const bool gameMouseValid = GetMousePositionInGameViewport(gameMouse);
-			Input::GetInstance()->SetEditorViewportMousePosition(gameMouse, gameMouseValid);
-
 			const D3D12_GPU_DESCRIPTOR_HANDLE gameSrv = postEffectManager->GetGameRenderTargetSrvHandleGPU();
 			if (gameSrv.ptr != 0 && imageSize.x > 1.0f && imageSize.y > 1.0f)
 			{
 				// SRVManagerで作成したGameRenderTargetのGPU SRVを16:9維持後の表示サイズで渡す
 				ImGui::Image(static_cast<ImTextureID>(gameSrv.ptr), imageSize, ImVec2(0.0f, 0.0f), ImVec2(1.0f, 1.0f));
+				mainViewportRect_.hovered = ImGui::IsItemHovered(); // 他ウィンドウに覆われたMain Viewportはゲームクリック扱いにしない
 			}
 			else
 			{
 				ImGui::TextUnformatted("GameRenderTarget SRV is not ready.");
+				mainViewportRect_.hovered = false;
 			}
+
+			Vector2 gameMouse = {};
+			const bool gameMouseValid = GetMousePositionInGameViewport(gameMouse);
+			Input::GetInstance()->SetEditorViewportMousePosition(gameMouse, gameMouseValid);
 		}
 		else
 		{
 			// Main Viewportウィンドウが折りたたまれた場合もゲーム側のマウス入力を無効化する
 			mainViewportRect_.valid = false;
+			mainViewportRect_.hovered = false;
 			Input::GetInstance()->SetEditorViewportMousePosition({ 0.0f, 0.0f }, false);
 		}
 		ImGui::End();
@@ -233,15 +237,9 @@ namespace Ken4lowEngine
 		constexpr float kGameBaseHeight = 1080.0f;
 
 		outMouse = { 0.0f, 0.0f };
-		if (!mainViewportRect_.valid)
+		if (!mainViewportRect_.valid || !mainViewportRect_.hovered)
 		{
-			return false;
-		}
-
-		const ImGuiIO& io = ImGui::GetIO();
-		if (io.WantCaptureMouse)
-		{
-			// ImGui操作中はゲーム側へマウス入力を渡さない
+			// Main Viewport外または他のImGuiウィンドウ操作中はゲーム側へマウス入力を渡さない
 			return false;
 		}
 

--- a/Project/Engine/Editor/EditorWindowManager.h
+++ b/Project/Engine/Editor/EditorWindowManager.h
@@ -44,6 +44,7 @@ namespace Ken4lowEngine
 		Vector2 screenMin = { 0.0f, 0.0f };
 		Vector2 screenMax = { 0.0f, 0.0f };
 		Vector2 imageSize = { 0.0f, 0.0f };
+		bool hovered = false; // Main Viewportのゲーム画像上だけをゲーム入力の対象にする
 		bool valid = false;
 	};
 

--- a/Project/Engine/System/Input/Input.cpp
+++ b/Project/Engine/System/Input/Input.cpp
@@ -312,9 +312,15 @@ namespace Ken4lowEngine
 	/// -------------------------------------------------------------
 	Vector2 Input::GetMousePosition()
 	{
+		// 既存のゲーム側呼び出しもGetCursorPositionと同じ補正済み座標を返す
+		return GetCursorPosition();
+	}
+
+	Vector2 Input::GetCursorPosition()
+	{
 		if (editorViewportMouseOverrideEnabled_)
 		{
-			// 既存のゲーム側呼び出しはMain Viewport基準の座標を優先して受け取る
+			// Editor座標が有効な時だけゲーム内部1920x1080基準の座標を返す
 			return editorViewportMousePositionValid_ ? editorViewportMousePosition_ : Vector2(-1.0f, -1.0f);
 		}
 

--- a/Project/Engine/System/Input/Input.h
+++ b/Project/Engine/System/Input/Input.h
@@ -142,6 +142,11 @@ namespace Ken4lowEngine
 		Vector2 GetMousePosition();
 
 		/// <summary>
+		/// ゲーム基準のカーソル座標を取得します。
+		/// </summary>
+		Vector2 GetCursorPosition();
+
+		/// <summary>
 		/// エディタMain Viewport基準へ変換済みのマウス座標を設定します。
 		/// </summary>
 		void SetEditorViewportMousePosition(const Vector2& position, bool valid);


### PR DESCRIPTION
### Motivation
- ImGui の Main Viewport 内に GameRenderTarget を描画する際、OS座標とゲーム内1920x1080基準がずれてクリックが伝播しない問題を解決するため。 
- Main Viewport 外や他の ImGui ウィンドウ操作中にゲーム側へクリックが渡るのを防ぐため。 

### Description
- Main Viewport の表示矩形を保持する `EditorViewportRect` に `hovered` フラグを追加し、`screenMin`/`screenMax`/`imageSize` を保存するようにした。 (変更: `Project/Engine/Editor/EditorWindowManager.h`, `Project/Engine/Editor/EditorWindowManager.cpp`) 
- `ImGui::Image` 描画直後に `ImGui::IsItemHovered()` を `mainViewportRect_.hovered` に記録し、Main Viewport 上かつ他ウィンドウ操作が無い場合のみ座標変換を許可するようにした。 (変更: `Project/Engine/Editor/EditorWindowManager.cpp`) 
- ImGuiスクリーン座標をゲーム内部解像度へ変換する入口 `EditorWindowManager::GetMousePositionInGameViewport(Vector2& outMouse)` を実装し、Main Viewport 外や非 hover 時は `false` を返すようにした。 変換式は: `local = mouseScreen - screenMin`、`x = (local.x / imageSize.x) * 1920`、`y = (local.y / imageSize.y) * 1080`。 (変更: `Project/Engine/Editor/EditorWindowManager.cpp`) 
- `Input` 側に `GetCursorPosition()` を追加し、既存の `GetMousePosition()` は `GetCursorPosition()` に委譲して補正済み座標を返すようにしたため既存ロジックを壊さない。エディタで変換済み座標は `Input::SetEditorViewportMousePosition(position, valid)` 経由で集約され、`PushMouse`/`TriggerMouse`/`ReleaseMouse` は `valid==false` のときゲームへ渡さない。 (変更: `Project/Engine/System/Input/Input.h`, `Project/Engine/System/Input/Input.cpp`) 
- デバッグ(エディタ)とリリースのウィンドウ方針を分岐し、`USE_IMGUI` 有効時は `Windowed`、無効時は従来通り `BorderlessFullscreen` を使うようにした。 (変更: `Project/Engine/Core/Application/Framework.cpp`) 
- 変更した主なファイル: `Framework.cpp`, `EditorWindowManager.h/.cpp`, `Input.h/.cpp`。

### Testing
- `git diff --check` を実行して差分整合性を確認済みでエラーは見つかりませんでした（成功）。
- ソースのビルドはコンテナに `msbuild` が無いため実行できませんでした（`msbuild: command not found` によりビルド未実施）。
- 変更はローカルでコミット済み (`Fix editor viewport mouse coordinates`)。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a016f75b0e4832d95498c30d3ff5aab)