### PR TITLE
Make GameViewportRenderTarget follow Main Viewport size (dynamic resize, camera aspect & input)

### DIFF
--- a/Project/Engine/Core/Application/GameApplication.cpp
+++ b/Project/Engine/Core/Application/GameApplication.cpp
@@ -13,6 +13,7 @@
 #include <SceneManager.h>
 #include <Input.h>
 #include <GameTimer.h>
+#include <algorithm>
 
 #ifdef USE_IMGUI
 #include <ImGuiManager.h>
@@ -133,6 +134,17 @@ namespace Ken4lowEngine
 
 		/// ---------- ImGuiフレーム終了 ---------- ///
 		ImGuiManager::GetInstance()->EndFrame();
+#endif // USE_IMGUI
+
+#ifdef USE_IMGUI
+		const Vector2 mainViewportSize = EditorWindowManager::GetInstance()->GetMainViewportSize();
+		if (mainViewportSize.x > 0.0f && mainViewportSize.y > 0.0f)
+		{
+			// Scene描画前にMain Viewportの表示可能サイズへGameViewportRenderTargetを追従させる。
+			PostEffectManager::GetInstance()->RequestGameRenderTargetResize(
+				static_cast<uint32_t>(std::max(1.0f, mainViewportSize.x)),
+				static_cast<uint32_t>(std::max(1.0f, mainViewportSize.y)));
+		}
 #endif // USE_IMGUI
 
 		//--------------------------------------------

--- a/Project/Engine/Editor/EditorWindowManager.cpp
+++ b/Project/Engine/Editor/EditorWindowManager.cpp
@@ -169,26 +169,11 @@ namespace Ken4lowEngine
 		{
 			const ImVec2 availableSize = ImGui::GetContentRegionAvail();
 			auto* postEffectManager = PostEffectManager::GetInstance();
-			const float targetWidth = static_cast<float>(postEffectManager->GetGameRenderTargetWidth());
-			const float targetHeight = static_cast<float>(postEffectManager->GetGameRenderTargetHeight());
-			const float targetAspect = targetWidth / targetHeight;
-			float imageWidth = availableSize.x;
-			float imageHeight = imageWidth / targetAspect;
-			if (imageHeight > availableSize.y)
-			{
-				imageHeight = availableSize.y;
-				imageWidth = imageHeight * targetAspect;
-			}
 
-			// Main Viewportの空き領域に引き伸ばさず、16:9を保った最大サイズで中央寄せする
-			const ImVec2 imageSize = ImVec2(std::max(0.0f, imageWidth), std::max(0.0f, imageHeight));
-			const ImVec2 cursorStart = ImGui::GetCursorPos();
+			// Main Viewportの表示可能領域をそのままゲーム描画サイズの基準として保存する。
+			const ImVec2 imageSize = ImVec2(std::max(0.0f, availableSize.x), std::max(0.0f, availableSize.y));
 			const ImVec2 screenStart = ImGui::GetCursorScreenPos();
-			const ImVec2 imageOffset = ImVec2(
-				std::max(0.0f, (availableSize.x - imageSize.x) * 0.5f),
-				std::max(0.0f, (availableSize.y - imageSize.y) * 0.5f));
-			ImGui::SetCursorPos(ImVec2(cursorStart.x + imageOffset.x, cursorStart.y + imageOffset.y));
-			mainViewportScreenPosition_ = { screenStart.x + imageOffset.x, screenStart.y + imageOffset.y };
+			mainViewportScreenPosition_ = { screenStart.x, screenStart.y };
 			mainViewportSize_ = { imageSize.x, imageSize.y };
 			// ImGui::Imageで描くゲーム画面のスクリーン矩形を入力変換用に保存する
 			mainViewportRect_.screenMin = mainViewportScreenPosition_;
@@ -199,7 +184,7 @@ namespace Ken4lowEngine
 			const D3D12_GPU_DESCRIPTOR_HANDLE gameSrv = postEffectManager->GetGameRenderTargetSrvHandleGPU();
 			if (gameSrv.ptr != 0 && imageSize.x > 1.0f && imageSize.y > 1.0f)
 			{
-				// SRVManagerで作成したGameRenderTargetのGPU SRVを16:9維持後の表示サイズで渡す
+				// SRVManagerで作成したGameRenderTargetのGPU SRVをMain Viewportの現在サイズで渡す
 				ImGui::Image(static_cast<ImTextureID>(gameSrv.ptr), imageSize, ImVec2(0.0f, 0.0f), ImVec2(1.0f, 1.0f));
 				mainViewportRect_.hovered = ImGui::IsItemHovered(); // 他ウィンドウに覆われたMain Viewportはゲームクリック扱いにしない
 			}
@@ -233,9 +218,6 @@ namespace Ken4lowEngine
 	bool EditorWindowManager::GetMousePositionInGameViewport(Vector2& outMouse) const
 	{
 #ifdef USE_IMGUI
-		constexpr float kGameBaseWidth = 1920.0f;
-		constexpr float kGameBaseHeight = 1080.0f;
-
 		outMouse = { 0.0f, 0.0f };
 		if (!mainViewportRect_.valid || !mainViewportRect_.hovered)
 		{
@@ -251,11 +233,20 @@ namespace Ken4lowEngine
 			return false;
 		}
 
-		// 16:9表示矩形内のローカル座標をゲーム内部の基準解像度へスケール変換する
+		const auto* postEffectManager = PostEffectManager::GetInstance();
+		const float renderTargetWidth = static_cast<float>(postEffectManager->GetGameRenderTargetWidth());
+		const float renderTargetHeight = static_cast<float>(postEffectManager->GetGameRenderTargetHeight());
+		if (renderTargetWidth <= 0.0f || renderTargetHeight <= 0.0f ||
+			mainViewportRect_.imageSize.x <= 0.0f || mainViewportRect_.imageSize.y <= 0.0f)
+		{
+			return false;
+		}
+
+		// 表示矩形内のローカル座標を現在のGameViewportRenderTargetピクセル座標へスケール変換する。
 		const Vector2 localMouse = { mouse.x - mainViewportRect_.screenMin.x, mouse.y - mainViewportRect_.screenMin.y };
 		outMouse = {
-			(localMouse.x / mainViewportRect_.imageSize.x) * kGameBaseWidth,
-			(localMouse.y / mainViewportRect_.imageSize.y) * kGameBaseHeight
+			(localMouse.x / mainViewportRect_.imageSize.x) * renderTargetWidth,
+			(localMouse.y / mainViewportRect_.imageSize.y) * renderTargetHeight
 		};
 		return true;
 #else

--- a/Project/Engine/Graphics/Camera/Core/Camera.cpp
+++ b/Project/Engine/Graphics/Camera/Core/Camera.cpp
@@ -58,6 +58,22 @@ namespace Ken4lowEngine
 	}
 
 	/// -------------------------------------------------------------
+	///						Aspect比設定
+	/// -------------------------------------------------------------
+	void Camera::SetAspectRatio(const float aspectRatio)
+	{
+		if (aspectRatio <= 0.0f)
+		{
+			return;
+		}
+
+		// RenderTargetのAspect変更を次フレーム待ちにせずProjectionへ即時反映する。
+		aspectRatio_ = aspectRatio;
+		projectionMatrix_ = Matrix4x4::MakePerspectiveFovMatrix(fovY_, aspectRatio_, nearClip_, farClip_);
+		viewProjectionMatrix_ = Matrix4x4::Multiply(viewMatrix_, projectionMatrix_);
+	}
+
+	/// -------------------------------------------------------------
 	///						ImGuiの描画
 	/// -------------------------------------------------------------
 	void Camera::DrawImGui()

--- a/Project/Engine/Graphics/Camera/Core/Camera.h
+++ b/Project/Engine/Graphics/Camera/Core/Camera.h
@@ -73,7 +73,7 @@ public: /// ---------- セッター ---------- ///
 	/// 通常は「画面幅 / 画面高さ」を指定します。
 	/// </summary>
 	/// <param name="aspectRatio">アスペクト比。</param>
-	void SetAspectRatio(const float aspectRatio) { aspectRatio_ = aspectRatio; }
+	void SetAspectRatio(const float aspectRatio);
 
 	/// <summary>
 	/// ニアクリップ距離を設定します。

--- a/Project/Engine/Graphics/Camera/DebugCamera/DebugCamera.cpp
+++ b/Project/Engine/Graphics/Camera/DebugCamera/DebugCamera.cpp
@@ -51,6 +51,22 @@ void DebugCamera::Finalize()
 }
 
 /// -------------------------------------------------------------
+///					Aspect比設定
+/// -------------------------------------------------------------
+void DebugCamera::SetAspectRatio(float aspectRatio)
+{
+	if (aspectRatio <= 0.0f)
+	{
+		return;
+	}
+
+	// RenderTargetのAspect変更をDebugCameraのProjectionへ即時反映する。
+	aspectRatio_ = aspectRatio;
+	UpdateViewProjection();
+}
+
+
+/// -------------------------------------------------------------
 ///							　更新処理
 /// -------------------------------------------------------------
 void DebugCamera::Update()

--- a/Project/Engine/Graphics/Camera/DebugCamera/DebugCamera.h
+++ b/Project/Engine/Graphics/Camera/DebugCamera/DebugCamera.h
@@ -112,7 +112,7 @@ public: /// ---------- 設定 ---------- ///
 	/// 例：画面幅 / 画面高さ。
 	/// </summary>
 	/// <param name="aspectRatio">アスペクト比。</param>
-	void SetAspectRatio(float aspectRatio) { aspectRatio_ = aspectRatio; }
+	void SetAspectRatio(float aspectRatio);
 
 	/// <summary>
 	/// ニアクリップ面までの距離を設定します。

--- a/Project/Engine/Graphics/PostEffect/Effects/DissolveEffect/DissolveEffect.cpp
+++ b/Project/Engine/Graphics/PostEffect/Effects/DissolveEffect/DissolveEffect.cpp
@@ -4,6 +4,7 @@
 #include <ResourceManager.h>
 #include <UAVManager.h>
 #include <TextureManager.h>
+#include <PostEffectManager.h>
 
 #include <cassert>
 
@@ -105,9 +106,9 @@ namespace Ken4lowEngine
 		const uint32_t threadGroupSizeX = 8;
 		const uint32_t threadGroupSizeY = 8;
 
-		// Compute Dispatch範囲は固定GameViewportRenderTargetの1920x1080に合わせる
-		uint32_t width = 1920;
-		uint32_t height = 1080;
+		// Compute Dispatch範囲を現在のGameViewportRenderTargetサイズに合わせる。
+		uint32_t width = PostEffectManager::GetInstance()->GetGameRenderTargetWidth();
+		uint32_t height = PostEffectManager::GetInstance()->GetGameRenderTargetHeight();
 
 		uint32_t groupCountX = (width + threadGroupSizeX - 1) / threadGroupSizeX;
 		uint32_t groupCountY = (height + threadGroupSizeY - 1) / threadGroupSizeY;

--- a/Project/Engine/Graphics/PostEffect/Effects/GaussianFilterEffect/GaussianFilterEffect.cpp
+++ b/Project/Engine/Graphics/PostEffect/Effects/GaussianFilterEffect/GaussianFilterEffect.cpp
@@ -3,6 +3,7 @@
 #include <PostEffectPipelineBuilder.h>
 #include <ResourceManager.h>
 #include <UAVManager.h>
+#include <PostEffectManager.h>
 
 #ifdef USE_IMGUI
 #include <imgui.h>
@@ -83,9 +84,9 @@ namespace Ken4lowEngine
 		const uint32_t threadGroupSizeX = 8;
 		const uint32_t threadGroupSizeY = 8;
 
-		// Compute Dispatch範囲は固定GameViewportRenderTargetの1920x1080に合わせる
-		uint32_t width = 1920;
-		uint32_t height = 1080;
+		// Compute Dispatch範囲を現在のGameViewportRenderTargetサイズに合わせる。
+		uint32_t width = PostEffectManager::GetInstance()->GetGameRenderTargetWidth();
+		uint32_t height = PostEffectManager::GetInstance()->GetGameRenderTargetHeight();
 
 		uint32_t groupCountX = (width + threadGroupSizeX - 1) / threadGroupSizeX;
 		uint32_t groupCountY = (height + threadGroupSizeY - 1) / threadGroupSizeY;

--- a/Project/Engine/Graphics/PostEffect/Effects/GrayScaleEffect/GrayScaleEffect.cpp
+++ b/Project/Engine/Graphics/PostEffect/Effects/GrayScaleEffect/GrayScaleEffect.cpp
@@ -4,6 +4,7 @@
 #include <PostEffectShaderManifest.h>
 #include <ResourceManager.h>
 #include <UAVManager.h>
+#include <PostEffectManager.h>
 
 #include <cassert>
 
@@ -110,9 +111,9 @@ namespace Ken4lowEngine
 		const uint32_t threadGroupSizeX = 8;
 		const uint32_t threadGroupSizeY = 8;
 
-		// Compute Dispatch範囲は固定GameViewportRenderTargetの1920x1080に合わせる
-		const uint32_t width = 1920;
-		const uint32_t height = 1080;
+		// Compute Dispatch範囲を現在のGameViewportRenderTargetサイズに合わせる。
+		const uint32_t width = PostEffectManager::GetInstance()->GetGameRenderTargetWidth();
+		const uint32_t height = PostEffectManager::GetInstance()->GetGameRenderTargetHeight();
 
 		const uint32_t groupCountX = (width + threadGroupSizeX - 1) / threadGroupSizeX;
 		const uint32_t groupCountY = (height + threadGroupSizeY - 1) / threadGroupSizeY;

--- a/Project/Engine/Graphics/PostEffect/Effects/LuminanceOutlineEffect/LuminanceOutlineEffect.cpp
+++ b/Project/Engine/Graphics/PostEffect/Effects/LuminanceOutlineEffect/LuminanceOutlineEffect.cpp
@@ -4,6 +4,7 @@
 #include <ResourceManager.h>
 #include <UAVManager.h>
 #include <WinApp.h>
+#include <PostEffectManager.h>
 
 #ifdef USE_IMGUI
 #include <imgui.h>
@@ -83,9 +84,9 @@ namespace Ken4lowEngine
 		const uint32_t threadGroupSizeX = 8;
 		const uint32_t threadGroupSizeY = 8;
 
-		// Compute Dispatch範囲は固定GameViewportRenderTargetの1920x1080に合わせる
-		uint32_t width = 1920;
-		uint32_t height = 1080;
+		// Compute Dispatch範囲を現在のGameViewportRenderTargetサイズに合わせる。
+		uint32_t width = PostEffectManager::GetInstance()->GetGameRenderTargetWidth();
+		uint32_t height = PostEffectManager::GetInstance()->GetGameRenderTargetHeight();
 
 		uint32_t groupCountX = (width + threadGroupSizeX - 1) / threadGroupSizeX;
 		uint32_t groupCountY = (height + threadGroupSizeY - 1) / threadGroupSizeY;

--- a/Project/Engine/Graphics/PostEffect/Effects/PixelateEffect/PixelateEffect.cpp
+++ b/Project/Engine/Graphics/PostEffect/Effects/PixelateEffect/PixelateEffect.cpp
@@ -4,6 +4,7 @@
 #include <ResourceManager.h>
 #include <UAVManager.h>
 #include <WinApp.h>
+#include <PostEffectManager.h>
 
 #ifdef USE_IMGUI
 #include <imgui.h>
@@ -73,9 +74,9 @@ namespace Ken4lowEngine
 		const uint32_t threadGroupSizeX = 8;
 		const uint32_t threadGroupSizeY = 8;
 
-		// Compute Dispatch範囲は固定GameViewportRenderTargetの1920x1080に合わせる
-		uint32_t width = 1920;
-		uint32_t height = 1080;
+		// Compute Dispatch範囲を現在のGameViewportRenderTargetサイズに合わせる。
+		uint32_t width = PostEffectManager::GetInstance()->GetGameRenderTargetWidth();
+		uint32_t height = PostEffectManager::GetInstance()->GetGameRenderTargetHeight();
 
 		uint32_t groupCountX = (width + threadGroupSizeX - 1) / threadGroupSizeX;
 		uint32_t groupCountY = (height + threadGroupSizeY - 1) / threadGroupSizeY;

--- a/Project/Engine/Graphics/PostEffect/Effects/PlayerHealthPostEffect/PlayerHealthPostEffect.cpp
+++ b/Project/Engine/Graphics/PostEffect/Effects/PlayerHealthPostEffect/PlayerHealthPostEffect.cpp
@@ -3,6 +3,7 @@
 #include <PostEffectPipelineBuilder.h>
 #include <ResourceManager.h>
 #include <UAVManager.h>
+#include <PostEffectManager.h>
 
 #ifdef USE_IMGUI
 #include <imgui.h>
@@ -55,9 +56,9 @@ void PlayerHealthPostEffect::Apply(ID3D12GraphicsCommandList* commandList, uint3
 
 	const uint32_t threadGroupSizeX = 8;
 	const uint32_t threadGroupSizeY = 8;
-	// Compute Dispatch範囲は固定GameViewportRenderTargetの1920x1080に合わせる
-	const uint32_t width = 1920;
-	const uint32_t height = 1080;
+	// Compute Dispatch範囲を現在のGameViewportRenderTargetサイズに合わせる。
+	const uint32_t width = PostEffectManager::GetInstance()->GetGameRenderTargetWidth();
+	const uint32_t height = PostEffectManager::GetInstance()->GetGameRenderTargetHeight();
 	const uint32_t groupCountX = (width + threadGroupSizeX - 1) / threadGroupSizeX;
 	const uint32_t groupCountY = (height + threadGroupSizeY - 1) / threadGroupSizeY;
 

--- a/Project/Engine/Graphics/PostEffect/Effects/RadialBlurEffect/RadialBlurEffect.cpp
+++ b/Project/Engine/Graphics/PostEffect/Effects/RadialBlurEffect/RadialBlurEffect.cpp
@@ -3,6 +3,7 @@
 #include <PostEffectPipelineBuilder.h>
 #include <ResourceManager.h>
 #include <UAVManager.h>
+#include <PostEffectManager.h>
 
 #ifdef USE_IMGUI
 #include <imgui.h>
@@ -84,9 +85,9 @@ namespace Ken4lowEngine
 		const uint32_t threadGroupSizeX = 8;
 		const uint32_t threadGroupSizeY = 8;
 
-		// Compute Dispatch範囲は固定GameViewportRenderTargetの1920x1080に合わせる
-		uint32_t width = 1920;
-		uint32_t height = 1080;
+		// Compute Dispatch範囲を現在のGameViewportRenderTargetサイズに合わせる。
+		uint32_t width = PostEffectManager::GetInstance()->GetGameRenderTargetWidth();
+		uint32_t height = PostEffectManager::GetInstance()->GetGameRenderTargetHeight();
 
 		uint32_t groupCountX = (width + threadGroupSizeX - 1) / threadGroupSizeX;
 		uint32_t groupCountY = (height + threadGroupSizeY - 1) / threadGroupSizeY;

--- a/Project/Engine/Graphics/PostEffect/Effects/RandomEffect/RandomEffect.cpp
+++ b/Project/Engine/Graphics/PostEffect/Effects/RandomEffect/RandomEffect.cpp
@@ -4,6 +4,7 @@
 #include <ResourceManager.h>
 #include <UAVManager.h>
 #include <GameTimer.h>
+#include <PostEffectManager.h>
 
 #ifdef USE_IMGUI
 #include <imgui.h>
@@ -34,8 +35,10 @@ namespace Ken4lowEngine
 		// ランダムエフェクトの設定
 		randomSetting_->time = 0.0f; // 時間
 		randomSetting_->useMultiply = false; // 乗算を使用するかどうか
-		// ノイズ計算の基準サイズも固定GameViewportRenderTargetの1920x1080に合わせる
-		randomSetting_->textureSize = Vector2(1920.0f, 1080.0f);
+		// ノイズ計算の基準サイズも現在のGameViewportRenderTargetサイズに合わせる。
+		randomSetting_->textureSize = Vector2(
+			static_cast<float>(PostEffectManager::GetInstance()->GetGameRenderTargetWidth()),
+			static_cast<float>(PostEffectManager::GetInstance()->GetGameRenderTargetHeight()));
 
 		// 名前の設定
 		constantBuffer_->SetName(L"RandomEffect_ConstantBuffer");
@@ -94,9 +97,9 @@ namespace Ken4lowEngine
 		const uint32_t threadGroupSizeY = 8;
 
 		// いまの画面サイズを使う
-		// Compute Dispatch範囲は固定GameViewportRenderTargetの1920x1080に合わせる
-		uint32_t width = 1920;
-		uint32_t height = 1080;
+		// Compute Dispatch範囲を現在のGameViewportRenderTargetサイズに合わせる。
+		uint32_t width = PostEffectManager::GetInstance()->GetGameRenderTargetWidth();
+		uint32_t height = PostEffectManager::GetInstance()->GetGameRenderTargetHeight();
 
 		// （textureSize を残すなら毎回更新しておく）
 		randomSetting_->textureSize = Vector2((float)width, (float)height);

--- a/Project/Engine/Graphics/PostEffect/Effects/SmoothingEffect/SmoothingEffect.cpp
+++ b/Project/Engine/Graphics/PostEffect/Effects/SmoothingEffect/SmoothingEffect.cpp
@@ -3,6 +3,7 @@
 #include <PostEffectPipelineBuilder.h>
 #include <ResourceManager.h>
 #include <UAVManager.h>
+#include <PostEffectManager.h>
 
 #ifdef USE_IMGUI
 #include <imgui.h>
@@ -77,9 +78,9 @@ namespace Ken4lowEngine
 		const uint32_t threadGroupSizeX = 8;
 		const uint32_t threadGroupSizeY = 8;
 
-		// Compute Dispatch範囲は固定GameViewportRenderTargetの1920x1080に合わせる
-		uint32_t width = 1920;
-		uint32_t height = 1080;
+		// Compute Dispatch範囲を現在のGameViewportRenderTargetサイズに合わせる。
+		uint32_t width = PostEffectManager::GetInstance()->GetGameRenderTargetWidth();
+		uint32_t height = PostEffectManager::GetInstance()->GetGameRenderTargetHeight();
 
 		// スレッドグループの数を計算
 		uint32_t groupCountX = (width + threadGroupSizeX - 1) / threadGroupSizeX;

--- a/Project/Engine/Graphics/PostEffect/Effects/VignetteEffect/VignetteEffect.cpp
+++ b/Project/Engine/Graphics/PostEffect/Effects/VignetteEffect/VignetteEffect.cpp
@@ -3,6 +3,7 @@
 #include <PostEffectPipelineBuilder.h>
 #include <ResourceManager.h>
 #include <UAVManager.h>
+#include <PostEffectManager.h>
 
 #ifdef USE_IMGUI
 #include <imgui.h>
@@ -79,9 +80,9 @@ namespace Ken4lowEngine
 		const uint32_t threadGroupSizeX = 8;
 		const uint32_t threadGroupSizeY = 8;
 
-		// Compute Dispatch範囲は固定GameViewportRenderTargetの1920x1080に合わせる
-		uint32_t width = 1920;
-		uint32_t height = 1080;
+		// Compute Dispatch範囲を現在のGameViewportRenderTargetサイズに合わせる。
+		uint32_t width = PostEffectManager::GetInstance()->GetGameRenderTargetWidth();
+		uint32_t height = PostEffectManager::GetInstance()->GetGameRenderTargetHeight();
 
 		// スレッドグループの数を計算
 		uint32_t groupCountX = (width + threadGroupSizeX - 1) / threadGroupSizeX;

--- a/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.cpp
+++ b/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.cpp
@@ -3,6 +3,8 @@
 #include "WinApp.h"
 #include "DirectXCommon.h"
 #include <CameraManager.h>
+#include <Camera.h>
+#include <DebugCamera.h>
 #include "SRVManager.h"
 #include <UAVManager.h>
 #include <DSVManager.h>
@@ -57,9 +59,9 @@ namespace Ken4lowEngine
 		renderTargets_[0].debugName = L"SceneRenderTarget_GameViewportRenderTarget";
 		renderTargets_[1].debugName = L"PostEffectRenderTarget";
 
-		// GameViewportRenderTargetはSprite/UI/Fontの基準解像度に合わせて1920x1080固定で確保する
-		renderTargetWidth_ = kFixedGameRenderTargetWidth_;
-		renderTargetHeight_ = kFixedGameRenderTargetHeight_;
+		// 初期GameViewportRenderTargetは既存UI/Sprite互換の基準解像度から開始する。
+		renderTargetWidth_ = kDefaultGameRenderTargetWidth_;
+		renderTargetHeight_ = kDefaultGameRenderTargetHeight_;
 
 		// RTVとSRVの確保
 		AllocateRTV_DSV_SRV_UAV();
@@ -255,26 +257,30 @@ namespace Ken4lowEngine
 	/// -------------------------------------------------------------
 	void PostEffectManager::Resize(uint32_t width, uint32_t height)
 	{
-		(void)width;
-		(void)height;
+		if (width == 0 || height == 0)
+		{
+			// Main Viewportが折りたたまれている間は0サイズRenderTargetを作らない。
+			return;
+		}
 
-		// Main Viewport実サイズ追従はまだ行わず、GameViewportRenderTargetを1920x1080固定で維持する。
-		const uint32_t fixedWidth = kFixedGameRenderTargetWidth_;
-		const uint32_t fixedHeight = kFixedGameRenderTargetHeight_;
-		if (renderTargetWidth_ == fixedWidth && renderTargetHeight_ == fixedHeight && depthResource_) return;
+		if (renderTargetWidth_ == width && renderTargetHeight_ == height && depthResource_)
+		{
+			return;
+		}
 
-		// GameRenderTargetの現在サイズを固定基準解像度として記録する
-		renderTargetWidth_ = fixedWidth;
-		renderTargetHeight_ = fixedHeight;
+		// GameRenderTargetの現在サイズをMain Viewportの実ピクセルサイズとして記録する。
+		renderTargetWidth_ = width;
+		renderTargetHeight_ = height;
 
-		SetViewportAndScissorRect(fixedWidth, fixedHeight);
+		SetViewportAndScissorRect(width, height);
+		UpdateCameraAspectRatio(width, height);
 
 		// RTを作り直して、同じdescriptor indexに上書き
 		for (uint32_t i = 0; i < static_cast<uint32_t>(renderTargets_.size()); ++i)
 		{
 			auto& rt = renderTargets_[i];
 			rt.resource.Reset();
-			rt.resource = CreateRenderTextureResource(fixedWidth, fixedHeight,
+			rt.resource = CreateRenderTextureResource(width, height,
 				DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, kRenderTextureClearColor_);
 			// Resize後もRenderTarget名を張り直し、Unnamed Resourceの再発を防ぐ。
 			rt.resource->SetName(rt.debugName);
@@ -296,7 +302,7 @@ namespace Ken4lowEngine
 
 		// depth作り直し
 		depthResource_.Reset();
-		depthResource_ = CreateDepthBufferResource(fixedWidth, fixedHeight);
+		depthResource_ = CreateDepthBufferResource(width, height);
 		// PostEffect用深度もResize後に名前を付け直してDebugLayerで追跡可能にする。
 		depthResource_->SetName(L"PostEffectManager DepthBuffer");
 		DSVManager::GetInstance()->CreateDSVForTexture2D(depthDsvIndex_, depthResource_.Get());
@@ -310,7 +316,32 @@ namespace Ken4lowEngine
 
 
 	/// -------------------------------------------------------------
-	///				　	ポストエフェクトの描画適用処理
+	///				　	Camera Aspect比更新
+	/// -------------------------------------------------------------
+	void PostEffectManager::UpdateCameraAspectRatio(uint32_t width, uint32_t height)
+	{
+		if (height == 0)
+		{
+			return;
+		}
+
+		const float aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+		auto* cameraManager = CameraManager::GetInstance();
+		if (Camera* mainCamera = cameraManager->GetMainCamera())
+		{
+			// Main CameraのProjectionをGameViewportRenderTargetのAspect比へ追従させる。
+			mainCamera->SetAspectRatio(aspectRatio);
+		}
+		if (DebugCamera* debugCamera = cameraManager->GetDebugCamera())
+		{
+			// Debug Camera使用時も同じ描画AspectでFrustumを更新する。
+			debugCamera->SetAspectRatio(aspectRatio);
+		}
+	}
+
+
+	/// -------------------------------------------------------------
+	///					　	ポストエフェクトの描画適用処理
 	/// -------------------------------------------------------------
 	void PostEffectManager::RenderPostEffect()
 	{
@@ -510,11 +541,8 @@ namespace Ken4lowEngine
 
 	void PostEffectManager::RequestGameRenderTargetResize(uint32_t width, uint32_t height)
 	{
-		(void)width;
-		(void)height;
-
-		// Main Viewport実サイズ追従は未実装のため、外部からのリサイズ要求でも1920x1080固定を保つ
-		Resize(kFixedGameRenderTargetWidth_, kFixedGameRenderTargetHeight_);
+		// Main Viewportの表示可能サイズが変わった時だけGameViewportRenderTargetを作り直す。
+		Resize(width, height);
 	}
 
 	/// -------------------------------------------------------------

--- a/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.h
+++ b/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.h
@@ -196,6 +196,11 @@ private: /// ---------- メンバ関数 ---------- ///
 	/// </summary>
 	void SetViewportAndScissorRect(uint32_t width, uint32_t height);
 
+	/// <summary>
+	/// GameViewportRenderTargetのAspect比をCameraへ反映します。
+	/// </summary>
+	void UpdateCameraAspectRatio(uint32_t width, uint32_t height);
+
 private: /// ---------- メンバ変数 ---------- ///
 
 	// DirectX共通クラス
@@ -218,9 +223,9 @@ private: /// ---------- メンバ変数 ---------- ///
 	// ポストエフェクトのカテゴリ分類（名前 → カテゴリ名）
 	std::unordered_map<std::string, std::string> effectCategory_;
 
-	// GameViewportRenderTargetはゲーム側の基準解像度に合わせて1920x1080固定にする
-	static constexpr uint32_t kFixedGameRenderTargetWidth_ = 1920;
-	static constexpr uint32_t kFixedGameRenderTargetHeight_ = 1080;
+	// 初期GameViewportRenderTargetは既存UI/Sprite互換の1920x1080から開始する。
+	static constexpr uint32_t kDefaultGameRenderTargetWidth_ = 1920;
+	static constexpr uint32_t kDefaultGameRenderTargetHeight_ = 1080;
 
 	// レンダーテクスチャのクリアカラー
 	const Vector4 kRenderTextureClearColor_ = { 0.08f, 0.08f, 0.18f, 1.0f }; // 分かりやすいように一旦赤色にする
@@ -241,8 +246,8 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	static constexpr int kPostRTCount = 1; // ポストエフェクト用のレンダーテクスチャ数
 	std::vector<RenderTarget> renderTargets_; // レンダーテクスチャのリスト
-	uint32_t renderTargetWidth_ = kFixedGameRenderTargetWidth_; // Main Viewportへ表示するGameRenderTarget幅
-	uint32_t renderTargetHeight_ = kFixedGameRenderTargetHeight_; // Main Viewportへ表示するGameRenderTarget高さ
+	uint32_t renderTargetWidth_ = kDefaultGameRenderTargetWidth_; // Main Viewportへ表示するGameRenderTarget幅
+	uint32_t renderTargetHeight_ = kDefaultGameRenderTargetHeight_; // Main Viewportへ表示するGameRenderTarget高さ
 
 	// 深度ステンシルビューのインデックス
 	uint32_t depthDsvIndex_ = UINT32_MAX;

--- a/Project/Engine/System/Input/Input.cpp
+++ b/Project/Engine/System/Input/Input.cpp
@@ -320,7 +320,7 @@ namespace Ken4lowEngine
 	{
 		if (editorViewportMouseOverrideEnabled_)
 		{
-			// Editor座標が有効な時だけゲーム内部1920x1080基準の座標を返す
+			// Editor座標が有効な時だけ現在のGameViewportRenderTarget基準の座標を返す
 			return editorViewportMousePositionValid_ ? editorViewportMousePosition_ : Vector2(-1.0f, -1.0f);
 		}
 


### PR DESCRIPTION
### Motivation
- Align the editor Main Viewport display size with the actual game render target so the scene renders at the viewport's pixel size instead of being stretched from a fixed 1920x1080 RT.  
- Ensure D3D12 viewport/scissor, camera projection aspect, compute dispatch sizes and editor mouse mapping all follow the dynamic RT size while keeping ImGui multi-viewport disabled and preserving existing layouts.  

### Description
- EditorWindowManager: store Main Viewport available content size and screen origin (`mainViewportSize_`, `mainViewportScreenPosition_`) and display `ImGui::Image` at that current size; update hit / hovered logic accordingly and convert mouse to Main Viewport-local coordinates.  
- Input: `GetCursorPosition()` now returns editor-converted coordinates described in the current GameViewportRenderTarget basis when editor override is enabled.  
- PostEffectManager: make `Resize(width,height)` create/replace RTV/SRV/UAV/depth resources only when the requested non-zero size changes, update `viewport`/`scissorRect`, set per-RT `currentState_` to initial state, and expose `RequestGameRenderTargetResize()` as the external entrypoint.  
- Camera: add `Camera::SetAspectRatio()` and `DebugCamera::SetAspectRatio()` which immediately update projection / view-projection so scene uses the new aspect right after RT resize.  
- Integration: call `PostEffectManager::RequestGameRenderTargetResize()` with the Editor Main Viewport size just before the scene draw pass so RT, viewport/scissor and camera aspect are up-to-date.  
- Post-effect compute shaders: replace hard-coded 1920x1080 dispatch sizes with `PostEffectManager::GetInstance()->GetGameRenderTargetWidth()/Height()` and update RandomEffect's `textureSize` accordingly.  
- Keep `ImGuiConfigFlags_ViewportsEnable` disabled (unchanged) and avoid recreating RTs on every frame; add guards for zero-size and same-size no-op.  

### Testing
- Ran static checks: `git diff --check` completed with no whitespace errors. (succeeded)  
- Searched project for leftover fixed-1920/1080 usages and related markers to confirm replacements with the dynamic RT API (used `rg`); verified compute dispatch and mouse-scaling sites were updated. (succeeded)  
- Verified `ImGuiConfigFlags_ViewportsEnable` remains disabled in ImGui initialization. (succeeded)  
- Attempted to build with `msbuild` for Debug/Release to exercise the full C++ build, but `msbuild` is not available in this Linux environment so automated build could not be run here. (not executed due to missing tool)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0171b5a1c8832d980097055cd28d17)