### PR TITLE
Keep GameViewportRenderTarget 1920x1080; preserve 16:9 display and map editor input to fixed resolution

### DIFF
--- a/Project/ApplicationLayer/DebugTools/FrustumCulling/FrustumCullingDebugController.cpp
+++ b/Project/ApplicationLayer/DebugTools/FrustumCulling/FrustumCullingDebugController.cpp
@@ -5,6 +5,7 @@
 #include "CameraManager.h"
 #include "Engine/Graphics/Culling/FrustumDebugRenderer.h"
 #include "Object3DCommon.h"
+#include "PostEffectManager.h"
 #include "WinApp.h"
 
 #ifdef _DEBUG
@@ -184,7 +185,7 @@ void FrustumCullingDebugController::CopyDebugCameraToMainCamera()
 	mainCamera->SetFovY(debugCamera->GetFovY());
 	mainCamera->SetNearClip(debugCamera->GetNearClip());
 	mainCamera->SetFarClip(debugCamera->GetFarClip());
-	mainCamera->SetAspectRatio(debugCamera->GetAspectRatio());
+	mainCamera->SetAspectRatio(GetCurrentWindowAspectRatio()); // Debug反映時も固定内部解像度の16:9を維持する。
 	mainCamera->Update();
 #endif
 }
@@ -258,6 +259,7 @@ void FrustumCullingDebugController::GetCullingCameraClipDistances(float& nearDis
 
 float FrustumCullingDebugController::GetCurrentWindowAspectRatio() const
 {
-	const float height = static_cast<float>(std::max(K4E::WinApp::GetInstance()->GetClientHeight(), 1u));
-	return static_cast<float>(K4E::WinApp::GetInstance()->GetClientWidth()) / height;
+	const auto* postEffectManager = K4E::PostEffectManager::GetInstance();
+	const float height = static_cast<float>(std::max(postEffectManager->GetGameRenderTargetHeight(), 1u));
+	return static_cast<float>(postEffectManager->GetGameRenderTargetWidth()) / height; // Camera AspectはMain Viewport表示サイズではなく固定内部解像度16:9にする。
 }

--- a/Project/ApplicationLayer/Scene/TitleScene/State/TitleAttractState.cpp
+++ b/Project/ApplicationLayer/Scene/TitleScene/State/TitleAttractState.cpp
@@ -4,6 +4,7 @@
 #include <Camera.h>
 #include "Input.h"
 #include <LinearInterpolation.h>
+#include <PostEffectManager.h>
 #include "TitleTransitionToLobby.h"
 
 using namespace Ken4lowEngine;
@@ -106,7 +107,7 @@ void TitleAttractState::Update(TitleScene* scene, float deltaTime)
 			(pulse + clickHintUI.scaleHover * clickHintUI.hoverAnim) -
 			(clickHintUI.scalePress * clickHintUI.pressAnim);
 		Vector2 posNow = { basePos.x, basePos.y + wobble + clickHintUI.offsetPressY * clickHintUI.pressAnim };
-		posNow.y = std::min(posNow.y, 720.0f - 60.0f); // 画面下クランプ（1280x720基準）
+		posNow.y = std::min(posNow.y, static_cast<float>(PostEffectManager::GetInstance()->GetGameRenderTargetHeight()) - 60.0f); // クリック判定も固定内部解像度1920x1080基準でクランプする。
 
 		const Vector2 sizeNow = { clickHintUI.baseSize.x * scaleNow, clickHintUI.baseSize.y * scaleNow };
 		const float minX = posNow.x - sizeNow.x * 0.5f; // アンカー(0.5,0.0)

--- a/Project/ApplicationLayer/Scene/TitleScene/TitleScene.cpp
+++ b/Project/ApplicationLayer/Scene/TitleScene/TitleScene.cpp
@@ -360,7 +360,7 @@ void TitleScene::InitializeLogoUI()
 	logoUI_.baseSize = logoSprite_->GetSize();
 	logoUI_.baseSize *= 0.7f; // 元画像が大きい場合は適宜縮小
 	logoSprite_->SetAnchorPoint({ 0.5f, 0.5f });
-	logoSprite_->SetPosition({ dxCommon_->GetClientWidth() * 0.5f, dxCommon_->GetClientHeight() * 0.25f });
+	logoSprite_->SetPosition({ PostEffectManager::GetInstance()->GetGameRenderTargetWidth() * 0.5f, PostEffectManager::GetInstance()->GetGameRenderTargetHeight() * 0.25f }); // Title UIは固定内部解像度1920x1080基準にする。
 }
 
 /// -------------------------------------------------------------
@@ -373,7 +373,7 @@ void TitleScene::InitializeBattleButtonUI()
 	battleButtonUI_.btnSprite->Initialize("UI/Common/btn_battle.dds");
 	battleButtonUI_.btnSprite->SetAnchorPoint(battleButtonUI_.anchor);
 
-	battleButtonUI_.position = { dxCommon_->GetClientWidth() * 0.5f, dxCommon_->GetClientHeight() * 0.75f }; // 画面中央下
+	battleButtonUI_.position = { PostEffectManager::GetInstance()->GetGameRenderTargetWidth() * 0.5f, PostEffectManager::GetInstance()->GetGameRenderTargetHeight() * 0.75f }; // Title UIは固定内部解像度1920x1080基準にする。
 
 	battleButtonUI_.btnSprite->SetPosition(battleButtonUI_.position);
 	battleButtonUI_.btnSprite->SetSize(battleButtonUI_.size);
@@ -402,7 +402,7 @@ void TitleScene::InitializeClickHintUI()
 	clickHintUI_.hintSprite->Initialize("UI/Common/ui_click_hint.dds");
 	clickHintUI_.hintSprite->SetAnchorPoint({ 0.5f, 0.0f });      // 中央上
 	// ここは今の 1/10 スケール指定のままでOK
-	clickHintUI_.hintSprite->SetPosition({ dxCommon_->GetClientWidth() * 0.5f + clickHintUI_.offset.x, dxCommon_->GetClientHeight() * 0.25f + clickHintUI_.offset.y });
+	clickHintUI_.hintSprite->SetPosition({ PostEffectManager::GetInstance()->GetGameRenderTargetWidth() * 0.5f + clickHintUI_.offset.x, PostEffectManager::GetInstance()->GetGameRenderTargetHeight() * 0.25f + clickHintUI_.offset.y }); // Title UIは固定内部解像度1920x1080基準にする。
 	clickHintUI_.hintSprite->SetSize({ 153.6f, 102.4f });       // 元画像が1536x1024pxなので1/10スケール
 	clickHintUI_.baseSize = clickHintUI_.hintSprite->GetSize(); // 基準サイズを保存
 }

--- a/Project/Engine/Core/Application/Framework.cpp
+++ b/Project/Engine/Core/Application/Framework.cpp
@@ -77,7 +77,7 @@ namespace Ken4lowEngine
 			if (winApp_->ConsumeResize(newWidth, newHeight))
 			{
 				dxCommon_->Resize(newWidth, newHeight);
-				PostEffectManager::GetInstance()->Resize(newWidth, newHeight);
+				// アプリ全体のウィンドウリサイズではGameViewportRenderTargetの1920x1080固定を維持する。
 			}
 
 			// 毎フレーム更新

--- a/Project/Engine/Core/Application/GameApplication.cpp
+++ b/Project/Engine/Core/Application/GameApplication.cpp
@@ -13,7 +13,6 @@
 #include <SceneManager.h>
 #include <Input.h>
 #include <GameTimer.h>
-#include <algorithm>
 
 #ifdef USE_IMGUI
 #include <ImGuiManager.h>
@@ -137,14 +136,8 @@ namespace Ken4lowEngine
 #endif // USE_IMGUI
 
 #ifdef USE_IMGUI
-		const Vector2 mainViewportSize = EditorWindowManager::GetInstance()->GetMainViewportSize();
-		if (mainViewportSize.x > 0.0f && mainViewportSize.y > 0.0f)
-		{
-			// Scene描画前にMain Viewportの表示可能サイズへGameViewportRenderTargetを追従させる。
-			PostEffectManager::GetInstance()->RequestGameRenderTargetResize(
-				static_cast<uint32_t>(std::max(1.0f, mainViewportSize.x)),
-				static_cast<uint32_t>(std::max(1.0f, mainViewportSize.y)));
-		}
+		// Debug/Editor時もゲーム内部解像度は固定し、Main Viewport側の表示だけを拡縮する。
+		(void)EditorWindowManager::GetInstance()->GetMainViewportSize();
 #endif // USE_IMGUI
 
 		//--------------------------------------------

--- a/Project/Engine/Editor/EditorWindowManager.cpp
+++ b/Project/Engine/Editor/EditorWindowManager.cpp
@@ -169,13 +169,31 @@ namespace Ken4lowEngine
 		{
 			const ImVec2 availableSize = ImGui::GetContentRegionAvail();
 			auto* postEffectManager = PostEffectManager::GetInstance();
+			const float renderTargetWidth = static_cast<float>(postEffectManager->GetGameRenderTargetWidth());
+			const float renderTargetHeight = static_cast<float>(postEffectManager->GetGameRenderTargetHeight());
 
-			// Main Viewportの表示可能領域をそのままゲーム描画サイズの基準として保存する。
-			const ImVec2 imageSize = ImVec2(std::max(0.0f, availableSize.x), std::max(0.0f, availableSize.y));
+			// Main Viewport内では固定解像度GameRenderTargetを16:9維持で最大表示する。
+			ImVec2 imageSize = ImVec2(0.0f, 0.0f);
+			if (availableSize.x > 1.0f && availableSize.y > 1.0f && renderTargetWidth > 0.0f && renderTargetHeight > 0.0f)
+			{
+				const float targetAspect = renderTargetWidth / renderTargetHeight;
+				imageSize = ImVec2(std::max(0.0f, availableSize.x), std::max(0.0f, availableSize.x / targetAspect));
+				if (imageSize.y > availableSize.y)
+				{
+					imageSize.y = std::max(0.0f, availableSize.y);
+					imageSize.x = std::max(0.0f, availableSize.y * targetAspect);
+				}
+			}
+
+			const ImVec2 cursorStart = ImGui::GetCursorPos();
+			const ImVec2 imageOffset = ImVec2(
+				std::max(0.0f, (availableSize.x - imageSize.x) * 0.5f),
+				std::max(0.0f, (availableSize.y - imageSize.y) * 0.5f));
+			ImGui::SetCursorPos(ImVec2(cursorStart.x + imageOffset.x, cursorStart.y + imageOffset.y));
 			const ImVec2 screenStart = ImGui::GetCursorScreenPos();
 			mainViewportScreenPosition_ = { screenStart.x, screenStart.y };
 			mainViewportSize_ = { imageSize.x, imageSize.y };
-			// ImGui::Imageで描くゲーム画面のスクリーン矩形を入力変換用に保存する
+			// 入力は中央表示されたImGui::Imageの矩形だけを1920x1080へ逆変換する。
 			mainViewportRect_.screenMin = mainViewportScreenPosition_;
 			mainViewportRect_.screenMax = { mainViewportScreenPosition_.x + imageSize.x, mainViewportScreenPosition_.y + imageSize.y };
 			mainViewportRect_.imageSize = mainViewportSize_;
@@ -184,15 +202,17 @@ namespace Ken4lowEngine
 			const D3D12_GPU_DESCRIPTOR_HANDLE gameSrv = postEffectManager->GetGameRenderTargetSrvHandleGPU();
 			if (gameSrv.ptr != 0 && imageSize.x > 1.0f && imageSize.y > 1.0f)
 			{
-				// SRVManagerで作成したGameRenderTargetのGPU SRVをMain Viewportの現在サイズで渡す
+				// SRVManagerで作成した固定GameRenderTargetのGPU SRVを16:9維持サイズで渡す。
 				ImGui::Image(static_cast<ImTextureID>(gameSrv.ptr), imageSize, ImVec2(0.0f, 0.0f), ImVec2(1.0f, 1.0f));
-				mainViewportRect_.hovered = ImGui::IsItemHovered(); // 他ウィンドウに覆われたMain Viewportはゲームクリック扱いにしない
+				const bool imguiBlocking = ImGui::IsAnyItemActive() && !ImGui::IsItemActive();
+				mainViewportRect_.hovered = ImGui::IsItemHovered() && !imguiBlocking; // 他ウィンドウ操作中はゲームクリック扱いにしない
 			}
 			else
 			{
 				ImGui::TextUnformatted("GameRenderTarget SRV is not ready.");
 				mainViewportRect_.hovered = false;
 			}
+			ImGui::SetCursorPos(ImVec2(cursorStart.x, cursorStart.y + availableSize.y));
 
 			Vector2 gameMouse = {};
 			const bool gameMouseValid = GetMousePositionInGameViewport(gameMouse);
@@ -242,7 +262,7 @@ namespace Ken4lowEngine
 			return false;
 		}
 
-		// 表示矩形内のローカル座標を現在のGameViewportRenderTargetピクセル座標へスケール変換する。
+		// 表示矩形内のローカル座標を固定GameViewportRenderTarget(1920x1080)へスケール変換する。
 		const Vector2 localMouse = { mouse.x - mainViewportRect_.screenMin.x, mouse.y - mainViewportRect_.screenMin.y };
 		outMouse = {
 			(localMouse.x / mainViewportRect_.imageSize.x) * renderTargetWidth,

--- a/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.cpp
+++ b/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.cpp
@@ -59,15 +59,16 @@ namespace Ken4lowEngine
 		renderTargets_[0].debugName = L"SceneRenderTarget_GameViewportRenderTarget";
 		renderTargets_[1].debugName = L"PostEffectRenderTarget";
 
-		// 初期GameViewportRenderTargetは既存UI/Sprite互換の基準解像度から開始する。
+		// GameViewportRenderTargetはDebug/Editor時も既存UI/Sprite互換の1920x1080固定で開始する。
 		renderTargetWidth_ = kDefaultGameRenderTargetWidth_;
 		renderTargetHeight_ = kDefaultGameRenderTargetHeight_;
 
 		// RTVとSRVの確保
 		AllocateRTV_DSV_SRV_UAV();
 
-		// ビューポート矩形とシザリング矩形の設定
+		// ビューポート矩形とシザリング矩形は固定内部解像度1920x1080で初期化する。
 		SetViewportAndScissorRect(renderTargetWidth_, renderTargetHeight_);
+		UpdateCameraAspectRatio(renderTargetWidth_, renderTargetHeight_);
 
 		// エフェクトの初期化と生成
 		std::unordered_map<std::string, EffectEntry> effectTable = {
@@ -257,18 +258,16 @@ namespace Ken4lowEngine
 	/// -------------------------------------------------------------
 	void PostEffectManager::Resize(uint32_t width, uint32_t height)
 	{
-		if (width == 0 || height == 0)
-		{
-			// Main Viewportが折りたたまれている間は0サイズRenderTargetを作らない。
-			return;
-		}
+		// 可変解像度はUI/Input対応後に戻すため、外部リサイズ要求は1920x1080固定へ丸める。
+		width = kDefaultGameRenderTargetWidth_;
+		height = kDefaultGameRenderTargetHeight_;
 
 		if (renderTargetWidth_ == width && renderTargetHeight_ == height && depthResource_)
 		{
 			return;
 		}
 
-		// GameRenderTargetの現在サイズをMain Viewportの実ピクセルサイズとして記録する。
+		// GameRenderTargetの現在サイズはゲーム内部解像度として1920x1080固定で記録する。
 		renderTargetWidth_ = width;
 		renderTargetHeight_ = height;
 
@@ -318,23 +317,18 @@ namespace Ken4lowEngine
 	/// -------------------------------------------------------------
 	///				　	Camera Aspect比更新
 	/// -------------------------------------------------------------
-	void PostEffectManager::UpdateCameraAspectRatio(uint32_t width, uint32_t height)
+	void PostEffectManager::UpdateCameraAspectRatio(uint32_t, uint32_t)
 	{
-		if (height == 0)
-		{
-			return;
-		}
-
-		const float aspectRatio = static_cast<float>(width) / static_cast<float>(height);
+		const float aspectRatio = static_cast<float>(kDefaultGameRenderTargetWidth_) / static_cast<float>(kDefaultGameRenderTargetHeight_);
 		auto* cameraManager = CameraManager::GetInstance();
 		if (Camera* mainCamera = cameraManager->GetMainCamera())
 		{
-			// Main CameraのProjectionをGameViewportRenderTargetのAspect比へ追従させる。
+			// Main CameraのProjectionは固定内部解像度に合わせて16:9で維持する。
 			mainCamera->SetAspectRatio(aspectRatio);
 		}
 		if (DebugCamera* debugCamera = cameraManager->GetDebugCamera())
 		{
-			// Debug Camera使用時も同じ描画AspectでFrustumを更新する。
+			// Debug Camera使用時も固定内部解像度と同じ16:9でFrustumを更新する。
 			debugCamera->SetAspectRatio(aspectRatio);
 		}
 	}
@@ -539,10 +533,10 @@ namespace Ken4lowEngine
 		return SRVManager::GetInstance()->GetGPUDescriptorHandle(srvIndex);
 	}
 
-	void PostEffectManager::RequestGameRenderTargetResize(uint32_t width, uint32_t height)
+	void PostEffectManager::RequestGameRenderTargetResize(uint32_t, uint32_t)
 	{
-		// Main Viewportの表示可能サイズが変わった時だけGameViewportRenderTargetを作り直す。
-		Resize(width, height);
+		// Main Viewportサイズ変更ではGameViewportRenderTargetをリサイズしない。
+		Resize(kDefaultGameRenderTargetWidth_, kDefaultGameRenderTargetHeight_);
 	}
 
 	/// -------------------------------------------------------------
@@ -693,10 +687,10 @@ namespace Ken4lowEngine
 	/// -------------------------------------------------------------
 	void PostEffectManager::SetViewportAndScissorRect(uint32_t width, uint32_t height)
 	{
-		// Scene描画範囲をGameViewportRenderTargetの実ピクセルサイズと必ず一致させる
+		// Scene描画範囲は固定GameViewportRenderTargetの1920x1080に必ず一致させる
 		viewport = D3D12_VIEWPORT(0.0f, 0.0f, static_cast<float>(width), static_cast<float>(height), 0.0f, 1.0f);
 
-		// ScissorもGameViewportRenderTargetの実ピクセルサイズと必ず一致させる
+		// Scissorも固定GameViewportRenderTargetの1920x1080に必ず一致させる
 		scissorRect = { 0, 0, static_cast<LONG>(width), static_cast<LONG>(height) };
 	}
 

--- a/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.h
+++ b/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.h
@@ -150,7 +150,7 @@ public: /// ---------- メンバ関数 ---------- ///
 	uint32_t GetGameRenderTargetHeight() const { return renderTargetHeight_; }
 
 	/// <summary>
-	/// Main Viewport の表示サイズに合わせてリサイズしたい場合の入口です。
+	/// Main Viewport の表示サイズ変更を受けても固定内部解像度を維持する入口です。
 	/// </summary>
 	void RequestGameRenderTargetResize(uint32_t width, uint32_t height);
 
@@ -223,7 +223,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	// ポストエフェクトのカテゴリ分類（名前 → カテゴリ名）
 	std::unordered_map<std::string, std::string> effectCategory_;
 
-	// 初期GameViewportRenderTargetは既存UI/Sprite互換の1920x1080から開始する。
+	// GameViewportRenderTargetは既存UI/Sprite互換の1920x1080固定にする。
 	static constexpr uint32_t kDefaultGameRenderTargetWidth_ = 1920;
 	static constexpr uint32_t kDefaultGameRenderTargetHeight_ = 1080;
 

--- a/Project/Engine/Graphics/Renderer/Sprite/Sprite.cpp
+++ b/Project/Engine/Graphics/Renderer/Sprite/Sprite.cpp
@@ -3,6 +3,7 @@
 #include "DirectXCommon.h"
 #include "TextureManager.h"
 #include "ResourceManager.h"
+#include "PostEffectManager.h"
 
 namespace Ken4lowEngine
 {
@@ -99,9 +100,10 @@ void Sprite::Update()
 	// ワールド行列の計算
 	Matrix4x4 worldMatrixSprite = Matrix4x4::MakeAffineMatrix(worldTransform.scale_, worldTransform.rotate_, worldTransform.translate_);
 
-	// ビュー行列とプロジェクション行列の計算(スプライト用)
+	// スプライトUIは固定GameViewportRenderTarget(1920x1080)基準で射影する。
 	Matrix4x4 viewMatrixSprite = Matrix4x4::MakeIdentity();
-	Matrix4x4 projectionMatrixSprite = Matrix4x4::MakeOrthographicMatrix(0.0f, 0.0f, (float)dxCommon_->GetClientWidth(), (float)dxCommon_->GetClientHeight(), 0.0f, 100.0f);
+	const auto* postEffectManager = PostEffectManager::GetInstance();
+	Matrix4x4 projectionMatrixSprite = Matrix4x4::MakeOrthographicMatrix(0.0f, 0.0f, static_cast<float>(postEffectManager->GetGameRenderTargetWidth()), static_cast<float>(postEffectManager->GetGameRenderTargetHeight()), 0.0f, 100.0f);
 	Matrix4x4 worldViewProjectionMatrixSprite = Matrix4x4::Multiply(worldMatrixSprite, Matrix4x4::Multiply(viewMatrixSprite, projectionMatrixSprite));
 
 	// 座標変換行列を更新


### PR DESCRIPTION
### Motivation
- Revert the previous change that resized `GameViewportRenderTarget` to the Main Viewport size and restore a fixed internal game resolution to prevent broken aspect/UI/mouse mapping. 
- Ensure editor/Main Viewport only scales the displayed image while the game continues rendering at a stable 1920x1080 internal resolution.
- Prevent clicks outside the displayed game image or during ImGui interactions from reaching game input handling.
- Make Camera aspect, viewport/scissor and UI sprite projection consistent with the fixed internal resolution so TitleScene click logic works correctly.

### Description
- Keep the game render target fixed at `1920x1080` by using `kDefaultGameRenderTargetWidth_` / `kDefaultGameRenderTargetHeight_` and clamp external resize requests inside `PostEffectManager::Resize` and `RequestGameRenderTargetResize` so the render target is not recreated for Main Viewport/app window changes. 1-line intent comments were added at key locations. 
- Restore fixed `D3D12_VIEWPORT` / scissor sizes in `PostEffectManager::SetViewportAndScissorRect` and force camera aspect via `Camera::SetAspectRatio` using the fixed 16:9 internal aspect in `PostEffectManager::UpdateCameraAspectRatio`. 
- Render the Main Viewport `ImGui::Image` with preserved 16:9 aspect and center it (letterbox/pillarbox) in `EditorWindowManager::DrawMainViewport`, and compute the displayed image rectangle for input hit-testing. 
- Convert screen mouse to game coordinates in `EditorWindowManager::GetMousePositionInGameViewport` by mapping the local mouse inside the displayed image to the fixed `1920x1080` space (scale: `gameX = localX / imageWidth * 1920`, `gameY = localY / imageHeight * 1080`) and only pass input when inside that rectangle and when ImGui is not actively operating. 
- Make Sprite projection and TitleScene UI placement/clip logic use the fixed internal resolution by switching sprite projection to use `PostEffectManager::GetGameRenderTargetWidth/Height` and updating TitleScene UI positions and click hint clamp to the fixed resolution. 
- Make debug/frustum helpers use the fixed internal aspect (adjusted `FrustumCullingDebugController`) so debug cameras match the fixed 16:9 rendering.

### Testing
- Ran `git diff --check` and repository diffs; no whitespace/conflict markers were reported (succeeded). 
- Ran multiple `rg` searches to verify modified callsites: `RequestGameRenderTargetResize`, `SetViewportAndScissorRect`, `GetGameRenderTargetWidth/Height`, and `ImGui::Image` changes (succeeded and matched updated files). 
- Verified the new constants and `PostEffectManager` resize/viewport logic via source inspection (`PostEffectManager.h/.cpp`) and validated the editor mouse mapping and display rectangle changes via code inspection of `EditorWindowManager.cpp` (succeeded). 
- Attempted to run full solution builds (`msbuild`) in this environment but `msbuild` is not available in the container, so Debug/Release builds were not executed here (manual/local build required to verify binary). 

If you want, I can run or provide a short checklist for manual local validation (editor window resize, ImGui interactions, TitleScene button clicks) to guide QA when building on Windows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0178d03664832d8eb82ea22973f732)