### PR TITLE
Fix Main Viewport ImGui draw bounds

### DIFF
--- a/Project/Engine/Editor/EditorWindowManager.cpp
+++ b/Project/Engine/Editor/EditorWindowManager.cpp
@@ -164,7 +164,7 @@ namespace Ken4lowEngine
 			return;
 		}
 
-		// Main ViewportはGameRenderTargetをImGui::Imageで表示する固定名ウィンドウにする
+		// Main ViewportはGameRenderTargetをDrawListで表示する固定名ウィンドウにする
 		if (ImGui::Begin("Main Viewport", &windowState_.showMainViewport, ImGuiWindowFlags_NoScrollbar))
 		{
 			const ImVec2 availableSize = ImGui::GetContentRegionAvail();
@@ -185,34 +185,42 @@ namespace Ken4lowEngine
 				}
 			}
 
-			const ImVec2 cursorStart = ImGui::GetCursorPos();
+			const ImVec2 contentScreenMin = ImGui::GetCursorScreenPos();
 			const ImVec2 imageOffset = ImVec2(
 				std::max(0.0f, (availableSize.x - imageSize.x) * 0.5f),
 				std::max(0.0f, (availableSize.y - imageSize.y) * 0.5f));
-			ImGui::SetCursorPos(ImVec2(cursorStart.x + imageOffset.x, cursorStart.y + imageOffset.y));
-			const ImVec2 screenStart = ImGui::GetCursorScreenPos();
-			mainViewportScreenPosition_ = { screenStart.x, screenStart.y };
+			const ImVec2 imageScreenMin = ImVec2(contentScreenMin.x + imageOffset.x, contentScreenMin.y + imageOffset.y);
+			const ImVec2 imageScreenMax = ImVec2(imageScreenMin.x + imageSize.x, imageScreenMin.y + imageSize.y);
+			mainViewportScreenPosition_ = { imageScreenMin.x, imageScreenMin.y };
 			mainViewportSize_ = { imageSize.x, imageSize.y };
-			// 入力は中央表示されたImGui::Imageの矩形だけを1920x1080へ逆変換する。
+			// 入力はAddImageで描画した中央表示矩形だけを1920x1080へ逆変換する。
 			mainViewportRect_.screenMin = mainViewportScreenPosition_;
-			mainViewportRect_.screenMax = { mainViewportScreenPosition_.x + imageSize.x, mainViewportScreenPosition_.y + imageSize.y };
+			mainViewportRect_.screenMax = { imageScreenMax.x, imageScreenMax.y };
 			mainViewportRect_.imageSize = mainViewportSize_;
 			mainViewportRect_.valid = imageSize.x > 1.0f && imageSize.y > 1.0f;
 
 			const D3D12_GPU_DESCRIPTOR_HANDLE gameSrv = postEffectManager->GetGameRenderTargetSrvHandleGPU();
 			if (gameSrv.ptr != 0 && imageSize.x > 1.0f && imageSize.y > 1.0f)
 			{
-				// SRVManagerで作成した固定GameRenderTargetのGPU SRVを16:9維持サイズで渡す。
-				ImGui::Image(static_cast<ImTextureID>(gameSrv.ptr), imageSize, ImVec2(0.0f, 0.0f), ImVec2(1.0f, 1.0f));
+				// SetCursorPosを使わずDrawListへ直接描画してImGuiの境界更新assertを避ける。
+				ImGui::GetWindowDrawList()->AddImage(static_cast<ImTextureID>(gameSrv.ptr), imageScreenMin, imageScreenMax, ImVec2(0.0f, 0.0f), ImVec2(1.0f, 1.0f));
+			}
+			else if (gameSrv.ptr == 0 && availableSize.x > 1.0f && availableSize.y > 1.0f)
+			{
+				ImGui::GetWindowDrawList()->AddText(contentScreenMin, ImGui::GetColorU32(ImGuiCol_Text), "GameRenderTarget SRV is not ready.");
+			}
+
+			if (availableSize.x > 1.0f && availableSize.y > 1.0f)
+			{
+				// InvisibleButtonでMain Viewport全体をアイテム登録してhover判定と境界更新を担わせる。
+				ImGui::InvisibleButton("MainViewportImageArea", availableSize);
 				const bool imguiBlocking = ImGui::IsAnyItemActive() && !ImGui::IsItemActive();
 				mainViewportRect_.hovered = ImGui::IsItemHovered() && !imguiBlocking; // 他ウィンドウ操作中はゲームクリック扱いにしない
 			}
 			else
 			{
-				ImGui::TextUnformatted("GameRenderTarget SRV is not ready.");
 				mainViewportRect_.hovered = false;
 			}
-			ImGui::SetCursorPos(ImVec2(cursorStart.x, cursorStart.y + availableSize.y));
 
 			Vector2 gameMouse = {};
 			const bool gameMouseValid = GetMousePositionInGameViewport(gameMouse);


### PR DESCRIPTION
### Motivation
- Prevent ImGui assert caused by using `SetCursorPos()`/`SetCursorScreenPos()` to extend window boundaries when drawing the game RenderTarget into the Main Viewport. 
- Keep the 16:9 centered display and preserve the existing game-mouse-to-1920x1080 conversion and downstream TitleScene click behaviour. 

### Description
- Replaced `ImGui::SetCursorPos()` + `ImGui::Image()` approach with `ImGui::GetWindowDrawList()->AddImage()` to draw the game `RenderTarget` directly into the Main Viewport window without moving the ImGui cursor. 
- Compute the centered 16:9 `imageScreenMin`/`imageScreenMax` rectangle and align `mainViewportScreenPosition_`, `mainViewportSize_`, and `mainViewportRect_.screenMin/screenMax/imageSize` to that rectangle. 
- Register an item for the Main Viewport with `ImGui::InvisibleButton("MainViewportImageArea", availableSize)` and use its hover state (`ImGui::IsItemHovered()`) for game hover/click detection instead of relying on cursor positioning. 
- Guard drawing with size checks (width/height > 1) and add inline comments explaining the intent to avoid the ImGui boundary-update assert and to indicate why `AddImage()` + `InvisibleButton()` are used. 

### Testing
- Ran a static runtime check script verifying `DrawMainViewport()` no longer uses `ImGui::SetCursorPos`/`ImGui::SetCursorScreenPos`/`ImGui::Image` and does use `ImGui::GetWindowDrawList()->AddImage` and `ImGui::InvisibleButton`, and the check succeeded. 
- Executed `git diff --check` and `git diff` validations which reported a clean diff and no whitespace/error issues. 
- Attempted to build Debug/Release in this Linux container but automated builds failed due to environment limitations (`cmake` cache not configured and `msbuild` not available); no in-container Debug/Release binary verification was performed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a017b709c18832db4af3a55e334ce1c)