### PR TITLE
Fix build issues for fixed 1920x1080 viewport (PauseMenu & GamePlayWorld)

### DIFF
--- a/Project/ApplicationLayer/Scene/GamePlayScene/UI/PauseMenu.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/UI/PauseMenu.cpp
@@ -278,11 +278,9 @@ void PauseMenu::RebuildLayout()
 
 void PauseMenu::RefreshScreenSizeIfNeeded()
 {
-	// Main Viewportの表示サイズ変更ではゲーム内部UI座標を変えない。
+	// 固定内部解像度は正値定数なので、定数条件チェックでC4127を出さない。
 	const float w = static_cast<float>(K4E::GameViewportConstants::Width);
 	const float h = static_cast<float>(K4E::GameViewportConstants::Height);
-
-	if (w <= 0.0f || h <= 0.0f) { return; }
 
 	if (w != screenWidth_ || h != screenHeight_)
 	{

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
@@ -3,6 +3,7 @@
 #include "GamePlayWorld.h"
 
 #include "GamePlayStageContext.h"
+#include "GameViewportConstants.h"
 
 #include "LightManager.h"
 #include "SkyBoxManager.h"
@@ -185,13 +186,16 @@ void GamePlayWorld::Update(float deltaTime)
 		if (auto* camera = player->GetCamera())
 		{
 			const std::vector<EnemyBase*> enemyList = characters_.GetEnemyRawList();
+			// 敵HPバー投影は固定内部解像度1920x1080を基準にする。
+			const float width = static_cast<float>(K4E::GameViewportConstants::Width);
+			const float height = static_cast<float>(K4E::GameViewportConstants::Height);
 
 			enemyHpBarManager_.Update(
 				enemyList,
 				camera->GetViewMatrix(),
 				camera->GetProjectionMatrix(),
-				static_cast<float>(width),
-				static_cast<float>(height),
+				width,
+				height,
 				deltaTime
 			);
 		}


### PR DESCRIPTION
### Motivation
- Fix compile errors introduced when using the fixed internal viewport constants (keep `GameViewportConstants` fixed at 1920x1080) with minimal, localized changes. 
- Preserve all `DebugScene` GPU particle / emitter code unchanged and avoid any design changes beyond what is necessary to build.

### Description
- Modified files: `Project/ApplicationLayer/Scene/GamePlayScene/UI/PauseMenu.cpp` and `Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp`. 
- In `PauseMenu.cpp` removed the `if (w <= 0.0f || h <= 0.0f)` guard in `PauseMenu::RefreshScreenSizeIfNeeded()` and added a one-line intent comment to avoid `C4127` when `GameViewportConstants::Width/Height` are compile-time positive constants. 
- In `GamePlayWorld.cpp` added `#include "GameViewportConstants.h"` and defined local `const float width` and `const float height` (from `K4E::GameViewportConstants`) before calling `enemyHpBarManager_.Update(...)`, with a one-line comment that the enemy HP bar projection uses the fixed 1920x1080 internal resolution. 
- Confirmed that `DebugScene.cpp` / `DebugScene.h` were not modified and no GPU particle / `FindEmitter` / `DebugParticlePreset` changes were introduced. 

### Testing
- Ran `git diff --check` which reported no whitespace/merge errors and passed. 
- Attempted to run the automated build commands `msbuild Project/Ken4lowEngine.sln /p:Platform=x64 /p:Configuration=Debug` and `msbuild ... /p:Configuration=Release`, but `msbuild` is not available in this execution environment so those builds were not executed. 
- Changes were committed locally (`Fix fixed viewport build errors`) and no other automated test failures were observed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0183372788832da0af09406af44021)