### PR TITLE
Add editor input capture toggle (F8) and toolbar status

### DIFF
--- a/Project/Engine/Editor/EditorInputCaptureController.cpp
+++ b/Project/Engine/Editor/EditorInputCaptureController.cpp
@@ -1,0 +1,71 @@
+#include "EditorInputCaptureController.h"
+
+namespace Ken4lowEngine
+{
+
+	EditorInputCaptureController* EditorInputCaptureController::GetInstance()
+	{
+		static EditorInputCaptureController instance;
+		return &instance;
+	}
+
+	void EditorInputCaptureController::ToggleInputCapture()
+	{
+		// F8はEscと独立したゲーム入力キャプチャ専用トグルにする。
+		if (IsGameCaptured())
+		{
+			ReleaseGameInput();
+			return;
+		}
+
+		CaptureGameInput();
+	}
+
+	void EditorInputCaptureController::CaptureGameInput()
+	{
+		// Main Viewport上でのみゲーム操作を受け付ける状態へ切り替える。
+		inputMode_ = EditorInputMode::GameCaptured;
+	}
+
+	void EditorInputCaptureController::ReleaseGameInput()
+	{
+		// Editor/ImGui操作を優先し、ゲーム側へのマウス入力を止める。
+		inputMode_ = EditorInputMode::GameReleased;
+	}
+
+	void EditorInputCaptureController::ForceReleaseToEditor()
+	{
+		// Shift+F8はどの状態からでもEditor操作へ戻す安全な入口にする。
+		inputMode_ = EditorInputMode::Editor;
+	}
+
+	bool EditorInputCaptureController::IsGameCaptured() const
+	{
+		return inputMode_ == EditorInputMode::GameCaptured;
+	}
+
+	bool EditorInputCaptureController::IsGameReleased() const
+	{
+		return inputMode_ == EditorInputMode::GameReleased;
+	}
+
+	bool EditorInputCaptureController::IsEditorInputMode() const
+	{
+		return inputMode_ == EditorInputMode::Editor;
+	}
+
+	const char* EditorInputCaptureController::GetInputStatusText() const
+	{
+		switch (inputMode_)
+		{
+		case EditorInputMode::GameCaptured:
+			return "Input: Game Captured";
+		case EditorInputMode::GameReleased:
+			return "Input: Editor Released";
+		case EditorInputMode::Editor:
+		default:
+			return "Input: Editor";
+		}
+	}
+
+} // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorInputCaptureController.h
+++ b/Project/Engine/Editor/EditorInputCaptureController.h
@@ -1,0 +1,42 @@
+#pragma once
+
+namespace Ken4lowEngine
+{
+
+	enum class EditorInputMode
+	{
+		Editor,
+		GameCaptured,
+		GameReleased,
+	};
+
+	/// <summary>
+	/// EditorとMain Viewport上のゲーム入力キャプチャ状態を管理します。
+	/// </summary>
+	class EditorInputCaptureController
+	{
+	public:
+		static EditorInputCaptureController* GetInstance();
+
+		void ToggleInputCapture();
+		void CaptureGameInput();
+		void ReleaseGameInput();
+		void ForceReleaseToEditor();
+
+		bool IsGameCaptured() const;
+		bool IsGameReleased() const;
+		bool IsEditorInputMode() const;
+
+		EditorInputMode GetInputMode() const { return inputMode_; }
+		const char* GetInputStatusText() const;
+
+	private:
+		EditorInputCaptureController() = default;
+		~EditorInputCaptureController() = default;
+		EditorInputCaptureController(const EditorInputCaptureController&) = delete;
+		EditorInputCaptureController& operator=(const EditorInputCaptureController&) = delete;
+
+		EditorInputMode inputMode_ = EditorInputMode::GameReleased; // 起動直後はEditor操作を優先して誤クリックを防ぐ
+	};
+
+} // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorWindowManager.cpp
+++ b/Project/Engine/Editor/EditorWindowManager.cpp
@@ -1,6 +1,7 @@
 #define NOMINMAX
 #include "EditorWindowManager.h"
 
+#include "EditorInputCaptureController.h"
 #include "ImGuiManager.h"
 #include "PostEffectManager.h"
 #include "GameViewportConstants.h"
@@ -24,6 +25,14 @@ namespace Ken4lowEngine
 	void EditorWindowManager::Draw()
 	{
 #ifdef USE_IMGUI
+		auto* input = Input::GetInstance();
+		const bool shiftPressed = input->PushRawKey(DIK_LSHIFT) || input->PushRawKey(DIK_RSHIFT);
+		if (input->TriggerRawKey(DIK_F8))
+		{
+			// Escの既存挙動を避け、F8だけを入力キャプチャ切り替えに使う。
+			shiftPressed ? EditorInputCaptureController::GetInstance()->ForceReleaseToEditor() : EditorInputCaptureController::GetInstance()->ToggleInputCapture();
+		}
+
 		// UE5風エディタUIの描画順をManagerに集約する
 		DrawMenuBar();
 		if (windowState_.showToolbar)
@@ -135,6 +144,8 @@ namespace Ken4lowEngine
 	void EditorWindowManager::DrawToolbar()
 	{
 #ifdef USE_IMGUI
+		auto* inputCapture = EditorInputCaptureController::GetInstance();
+
 		// ツールバーは将来のPlay/Build/保存などの操作を集約する固定パネルにする
 		ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
 		if (ImGui::Begin("Toolbar", &windowState_.showToolbar, flags))
@@ -148,6 +159,16 @@ namespace Ken4lowEngine
 			ImGui::Button("Stop");
 			ImGui::SameLine();
 			ImGui::Button("Build");
+			ImGui::SameLine();
+			ImGui::TextUnformatted("|");
+			ImGui::SameLine();
+			ImGui::TextUnformatted(inputCapture->GetInputStatusText());
+			ImGui::SameLine();
+			if (ImGui::Button(inputCapture->IsGameCaptured() ? "Release Input" : "Capture Input"))
+			{
+				// ToolbarボタンからもF8と同じキャプチャ切り替えを実行できるようにする。
+				inputCapture->ToggleInputCapture();
+			}
 		}
 		ImGui::End();
 #endif // USE_IMGUI
@@ -161,6 +182,7 @@ namespace Ken4lowEngine
 			// Main Viewport非表示中はゲーム側へエディタマウス入力を渡さない
 			mainViewportRect_.valid = false;
 			mainViewportRect_.isHovered = false;
+			Input::GetInstance()->SetGameInputEnabled(false);
 			Input::GetInstance()->SetEditorViewportMousePosition({ 0.0f, 0.0f }, false);
 			return;
 		}
@@ -215,7 +237,9 @@ namespace Ken4lowEngine
 			{
 				// InvisibleButtonでMain Viewport全体をアイテム登録してhover判定と境界更新を担わせる。
 				ImGui::InvisibleButton("MainViewportImageArea", availableSize);
-				const bool imguiBlocking = ImGui::IsAnyItemActive() && !ImGui::IsItemActive();
+				const ImGuiIO& io = ImGui::GetIO();
+				const bool mouseCapturedByOther = io.WantCaptureMouse && !ImGui::IsItemHovered();
+				const bool imguiBlocking = (ImGui::IsAnyItemActive() && !ImGui::IsItemActive()) || mouseCapturedByOther || io.WantCaptureKeyboard;
 				mainViewportRect_.isHovered = ImGui::IsItemHovered() && !imguiBlocking; // 他ウィンドウ操作中はゲームクリック扱いにしない
 			}
 			else
@@ -225,6 +249,8 @@ namespace Ken4lowEngine
 
 			Vector2 gameMouse = {};
 			const bool gameMouseValid = GetMousePositionInGameViewport(gameMouse);
+			const bool gameInputEnabled = EditorInputCaptureController::GetInstance()->IsGameCaptured() && gameMouseValid;
+			Input::GetInstance()->SetGameInputEnabled(gameInputEnabled);
 			Input::GetInstance()->SetEditorViewportMousePosition(gameMouse, gameMouseValid);
 		}
 		else
@@ -232,6 +258,7 @@ namespace Ken4lowEngine
 			// Main Viewportウィンドウが折りたたまれた場合もゲーム側のマウス入力を無効化する
 			mainViewportRect_.valid = false;
 			mainViewportRect_.isHovered = false;
+			Input::GetInstance()->SetGameInputEnabled(false);
 			Input::GetInstance()->SetEditorViewportMousePosition({ 0.0f, 0.0f }, false);
 		}
 		ImGui::End();
@@ -248,9 +275,16 @@ namespace Ken4lowEngine
 	{
 #ifdef USE_IMGUI
 		outMouse = { 0.0f, 0.0f };
-		if (!mainViewportRect_.valid || !mainViewportRect_.isHovered)
+		if (!EditorInputCaptureController::GetInstance()->IsGameCaptured())
 		{
-			// Main Viewport外または他のImGuiウィンドウ操作中はゲーム側へマウス入力を渡さない
+			// GameReleased/Editor状態ではゲーム側へマウス入力を渡さない。
+			return false;
+		}
+
+		const ImGuiIO& io = ImGui::GetIO();
+		if (!mainViewportRect_.valid || !mainViewportRect_.isHovered || io.WantCaptureKeyboard)
+		{
+			// Main Viewport外またはImGui操作中はゲーム側へマウス入力を渡さない。
 			return false;
 		}
 

--- a/Project/Engine/System/Input/Input.cpp
+++ b/Project/Engine/System/Input/Input.cpp
@@ -188,7 +188,13 @@ namespace Ken4lowEngine
 	/// -------------------------------------------------------------
 	bool Input::PushKey(BYTE keyNumber) const
 	{
-		return key[keyNumber] != 0;
+		if (!CanUseGameKeyboardInput(keyNumber))
+		{
+			// Editor操作中でもEscだけは既存Scene処理へ通して終了確認/Pauseを壊さない。
+			return false;
+		}
+
+		return PushRawKey(keyNumber);
 	}
 
 
@@ -197,6 +203,24 @@ namespace Ken4lowEngine
 	/// -------------------------------------------------------------
 	bool Input::TriggerKey(BYTE keyNumber) const
 	{
+		if (!CanUseGameKeyboardInput(keyNumber))
+		{
+			// Editor操作中でもEscだけは既存Scene処理へ通して終了確認/Pauseを壊さない。
+			return false;
+		}
+
+		return TriggerRawKey(keyNumber);
+	}
+
+	bool Input::PushRawKey(BYTE keyNumber) const
+	{
+		// Editor専用ショートカットはゲーム入力抑制状態に影響されず取得する。
+		return key[keyNumber] != 0;
+	}
+
+	bool Input::TriggerRawKey(BYTE keyNumber) const
+	{
+		// Editor専用ショートカットはゲーム入力抑制状態に影響されず取得する。
 		return key[keyNumber] != 0 && keyPre[keyNumber] == 0;
 	}
 
@@ -220,9 +244,9 @@ namespace Ken4lowEngine
 	/// -------------------------------------------------------------
 	bool Input::PushMouse(int button) const
 	{
-		if (editorViewportMouseOverrideEnabled_ && !editorViewportMousePositionValid_)
+		if (!CanUseGameMouseInput())
 		{
-			// Main Viewport外またはImGui操作中のマウス押下はゲーム入力へ渡さない
+			// Editor側でゲーム入力が無効な間はマウス押下をゲームへ渡さない。
 			return false;
 		}
 
@@ -240,9 +264,9 @@ namespace Ken4lowEngine
 	/// -------------------------------------------------------------
 	bool Input::TriggerMouse(int button) const
 	{
-		if (editorViewportMouseOverrideEnabled_ && !editorViewportMousePositionValid_)
+		if (!CanUseGameMouseInput())
 		{
-			// Main Viewport外またはImGui操作中のマウストリガーはゲーム入力へ渡さない
+			// Editor側でゲーム入力が無効な間はマウストリガーをゲームへ渡さない。
 			return false;
 		}
 
@@ -260,9 +284,9 @@ namespace Ken4lowEngine
 	/// -------------------------------------------------------------
 	bool Input::ReleaseMouse(int button) const
 	{
-		if (editorViewportMouseOverrideEnabled_ && !editorViewportMousePositionValid_)
+		if (!CanUseGameMouseInput())
 		{
-			// Main Viewport外またはImGui操作中のマウスリリースはゲーム入力へ渡さない
+			// Editor側でゲーム入力が無効な間はマウスリリースをゲームへ渡さない。
 			return false;
 		}
 
@@ -320,8 +344,8 @@ namespace Ken4lowEngine
 	{
 		if (editorViewportMouseOverrideEnabled_)
 		{
-			// Editor座標が有効な時だけ現在のGameViewportRenderTarget基準の座標を返す
-			return editorViewportMousePositionValid_ ? editorViewportMousePosition_ : Vector2(-1.0f, -1.0f);
+			// Editor座標と入力許可が有効な時だけGameViewportRenderTarget基準の座標を返す。
+			return CanUseGameMouseInput() ? editorViewportMousePosition_ : Vector2(-1.0f, -1.0f);
 		}
 
 		return Vector2(float(mousePosition_.x), float(mousePosition_.y));
@@ -335,6 +359,41 @@ namespace Ken4lowEngine
 		editorViewportMouseOverrideEnabled_ = true;
 	}
 
+	void Input::SetGameInputEnabled(bool enabled)
+	{
+		// Editorのキャプチャ状態をInputへ渡し、ゲーム側マウス入力の入口を一元化する。
+		gameInputEnabled_ = enabled;
+	}
+
+	int Input::GetMouseMoveX() const
+	{
+		// Main Viewport外やEditor操作中はゲーム側へマウス移動量を渡さない。
+		return CanUseGameMouseInput() ? mouseState_.lX : 0;
+	}
+
+	int Input::GetMouseMoveY() const
+	{
+		// Main Viewport外やEditor操作中はゲーム側へマウス移動量を渡さない。
+		return CanUseGameMouseInput() ? mouseState_.lY : 0;
+	}
+
+	int Input::GetMouseWheel() const
+	{
+		// Main Viewport外やEditor操作中はゲーム側へホイール入力を渡さない。
+		return CanUseGameMouseInput() ? mouseState_.lZ : 0;
+	}
+
+	bool Input::CanUseGameKeyboardInput(BYTE keyNumber) const
+	{
+		// Escは既存Sceneの終了確認/戻る/Pause処理を守るためEditor抑制中でも通す。
+		return keyNumber == DIK_ESCAPE || gameInputEnabled_;
+	}
+
+	bool Input::CanUseGameMouseInput() const
+	{
+		// Editor経由ではキャプチャ許可とMain Viewport有効判定の両方を満たす時だけゲーム入力にする。
+		return gameInputEnabled_ && (!editorViewportMouseOverrideEnabled_ || editorViewportMousePositionValid_);
+	}
 
 	void Input::SetLockCursor(bool lock)
 	{

--- a/Project/Engine/System/Input/Input.h
+++ b/Project/Engine/System/Input/Input.h
@@ -94,6 +94,12 @@ namespace Ken4lowEngine
 		/// <returns></returns>
 		bool TriggerKey(BYTE keyNumber) const;
 
+		/// <summary>
+		/// Editorショートカット用にゲーム入力抑制を通さずキー押下を取得します。
+		/// </summary>
+		bool PushRawKey(BYTE keyNumber) const;
+		bool TriggerRawKey(BYTE keyNumber) const;
+
 	public: /// ---------- マウスのメンバ関数 ---------- ///
 
 		/// <summary>
@@ -151,14 +157,20 @@ namespace Ken4lowEngine
 		/// </summary>
 		void SetEditorViewportMousePosition(const Vector2& position, bool valid);
 
+		/// <summary>
+		/// Editor側からゲーム入力を許可するか設定します。
+		/// </summary>
+		void SetGameInputEnabled(bool enabled);
+		bool IsGameInputEnabled() const { return gameInputEnabled_; }
+
 		// マウスのX座標を取得
-		int GetMouseMoveX() const { return mouseState_.lX; }
+		int GetMouseMoveX() const;
 
 		// マウスのY座標を取得
-		int GetMouseMoveY() const { return mouseState_.lY; }
+		int GetMouseMoveY() const;
 
 		// マウスのホイールの値を取得
-		int GetMouseWheel() const { return mouseState_.lZ; }
+		int GetMouseWheel() const;
 
 		// ドラッグ状態を取得
 		bool IsDragging(int button) const { return PushMouse(button); }
@@ -265,6 +277,9 @@ namespace Ken4lowEngine
 
 	private: /// ---------- メンバ変数 ---------- ///
 
+		bool CanUseGameKeyboardInput(BYTE keyNumber) const;
+		bool CanUseGameMouseInput() const;
+
 		// WindowsAPI
 		WinApp* winApp_ = nullptr;
 
@@ -284,6 +299,7 @@ namespace Ken4lowEngine
 		Vector2 editorViewportMousePosition_ = { 0.0f, 0.0f }; // Main Viewport基準へ変換済みのマウス座標
 		bool editorViewportMousePositionValid_ = false;	  // Main Viewport内かつImGui未操作中だけtrueにする
 		bool editorViewportMouseOverrideEnabled_ = false; // エディタ経由のマウス座標をゲーム入力へ反映するかどうか
+		bool gameInputEnabled_ = true; // Editorからゲーム入力を一括で許可/抑制するためのフラグ
 		bool lockCursor_ = false;				  // マウスカーソルをロックするかどうか
 		bool cursorVisible_ = true;				  // マウスカーソルの表示状態
 

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -318,6 +318,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="Engine\Core\Transform\WorldTransform.cpp" />
     <ClCompile Include="Engine\Core\Transform\WorldTransformEx.cpp" />
     <ClCompile Include="Engine\DebugTools\ImGui\ImGuiManager.cpp" />
+    <ClCompile Include="Engine\Editor\EditorInputCaptureController.cpp" />
     <ClCompile Include="Engine\Editor\EditorWindowManager.cpp" />
     <ClCompile Include="Engine\DebugTools\LeakCheck\D3DResourceLeakChecker.cpp" />
     <ClCompile Include="Engine\Graphics\Camera\Core\Camera.cpp" />
@@ -945,6 +946,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="Engine\Core\Transform\WorldTransform.h" />
     <ClInclude Include="Engine\Core\Transform\WorldTransformEx.h" />
     <ClInclude Include="Engine\DebugTools\ImGui\ImGuiManager.h" />
+    <ClInclude Include="Engine\Editor\EditorInputCaptureController.h" />
     <ClInclude Include="Engine\Editor\EditorWindowManager.h" />
     <ClInclude Include="Engine\DebugTools\LeakCheck\D3DResourceLeakChecker.h" />
     <ClInclude Include="Engine\Graphics\Camera\Core\Camera.h" />

--- a/Project/Ken4lowEngine.vcxproj.filters
+++ b/Project/Ken4lowEngine.vcxproj.filters
@@ -469,6 +469,9 @@
     <ClCompile Include="Engine\DebugTools\ImGui\ImGuiManager.cpp">
       <Filter>Engine\DebugTools\ImGui</Filter>
     </ClCompile>
+    <ClCompile Include="Engine\Editor\EditorInputCaptureController.cpp">
+      <Filter>Engine\Editor</Filter>
+    </ClCompile>
     <ClCompile Include="Engine\Editor\EditorWindowManager.cpp">
       <Filter>Engine\Editor</Filter>
     </ClCompile>
@@ -1274,6 +1277,9 @@
     </ClInclude>
     <ClInclude Include="Engine\DebugTools\ImGui\ImGuiManager.h">
       <Filter>Engine\DebugTools\ImGui</Filter>
+    </ClInclude>
+    <ClInclude Include="Engine\Editor\EditorInputCaptureController.h">
+      <Filter>Engine\Editor</Filter>
     </ClInclude>
     <ClInclude Include="Engine\Editor\EditorWindowManager.h">
       <Filter>Engine\Editor</Filter>


### PR DESCRIPTION
### Motivation
- Allow switching input focus between Editor/ImGui and the game viewport so developers can interact with the editor and play the game inside the same window. 
- Use `F8` to toggle game input capture and `Shift+F8` to force return to Editor mode while explicitly avoiding use of `Esc` so existing scene behavior remains unchanged. 
- Show the current input state in the toolbar and suppress game input when the mouse is outside the Main Viewport or when ImGui is capturing input.

### Description
- Added `EditorInputMode` and a singleton `EditorInputCaptureController` (`Project/Engine/Editor/EditorInputCaptureController.h` / `.cpp`) with `ToggleInputCapture()`, `CaptureGameInput()`, `ReleaseGameInput()`, `ForceReleaseToEditor()`, and status text via `GetInputStatusText()`.
- Updated `EditorWindowManager` (`Project/Engine/Editor/EditorWindowManager.cpp`) to read editor raw shortcuts, handle `F8` and `Shift+F8`, display `inputCapture->GetInputStatusText()` in the toolbar with a `Capture Input`/`Release Input` button, and gate game input by Main Viewport hover + `ImGuiIO::WantCaptureMouse/WantCaptureKeyboard` checks.
- Extended `Input` (`Project/Engine/System/Input/Input.h` / `.cpp`) with raw key access (`PushRawKey`/`TriggerRawKey`), `SetGameInputEnabled()`, guarded mouse movement getters (`GetMouseMoveX`/`GetMouseMoveY`/`GetMouseWheel`) and `CanUseGameMouseInput()`/`CanUseGameKeyboardInput()` logic that suppresses game input when appropriate while preserving `Esc` passthrough for existing scene behavior.
- Registered new source/header in the Visual Studio project files (`Project/Ken4lowEngine.vcxproj` and `.filters`) so the editor controller is built with the project.

### Testing
- Parsed `Project/Ken4lowEngine.vcxproj` and `Project/Ken4lowEngine.vcxproj.filters` with `python3` and `xml.etree.ElementTree` to verify XML is well-formed, and the check succeeded. 
- Ran `git diff --check` to ensure there are no whitespace/merge errors prior to commit, and the check passed. 
- Attempted to run `msbuild Project/Ken4lowEngine.sln /p:Configuration=Debug /p:Platform=x64` and `/p:Configuration=Release` but `msbuild` is not present in this environment, so full Debug/Release builds were not executed here (requires Windows/MSBuild environment for verification).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a018a938b60832d91f651b8b4915980)