### PR TITLE
Separate editor input capture by scene policy (UiMouse / FpsCapture)

### DIFF
--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.h
@@ -53,6 +53,9 @@ public: /// ---------- BaseScene override ---------- ///
 	// ImGui描画
 	void DrawImGui() override;
 
+	// FPS操作が必要なGamePlaySceneだけF8入力キャプチャを許可する。
+	EditorInputPolicy GetEditorInputPolicy() const override { return EditorInputPolicy::FpsCapture; }
+
 	// 段階ロード
 	void StartLoad() override;
 

--- a/Project/ApplicationLayer/SceneManagement/BaseScene/BaseScene.h
+++ b/Project/ApplicationLayer/SceneManagement/BaseScene/BaseScene.h
@@ -7,6 +7,12 @@ class SceneManager;
 /// -------------------------------------------------------------
 ///					　	シーンの基底クラス
 /// -------------------------------------------------------------
+enum class EditorInputPolicy
+{
+	UiMouse,
+	FpsCapture,
+};
+
 class BaseScene
 {
 public: /// ---------- 純粋仮想関数 ---------- ///
@@ -34,6 +40,9 @@ public: /// ---------- 純粋仮想関数 ---------- ///
 
 	// ImGui描画処理
 	virtual void DrawImGui() = 0;
+
+	// UI主体のSceneはデフォルトでカーソル表示のMain Viewportクリック入力にする。
+	virtual EditorInputPolicy GetEditorInputPolicy() const { return EditorInputPolicy::UiMouse; }
 
 	// シーンマネージャーをセット
 	virtual void SetSceneManager(SceneManager* sceneManager) { sceneManager_ = sceneManager; }

--- a/Project/ApplicationLayer/SceneManagement/SceneManager/SceneManager.h
+++ b/Project/ApplicationLayer/SceneManagement/SceneManager/SceneManager.h
@@ -53,6 +53,9 @@ public: /// ---------- セッタ ---------- ///
 
 	bool IsTransitioning() const { return isTransitioning_ || (fadeManager_ && fadeManager_->IsBusy()); }
 
+	// Editor入力制御が現在Sceneのポリシーを参照できるようにする。
+	const BaseScene* GetCurrentScene() const { return scene_.get(); }
+
 private: /// ---------- メンバ関数 ---------- ///
 
 	// 次シーン適用（Finalize→差し替え→Initialize）

--- a/Project/Engine/Editor/EditorWindowManager.cpp
+++ b/Project/Engine/Editor/EditorWindowManager.cpp
@@ -6,6 +6,7 @@
 #include "PostEffectManager.h"
 #include "GameViewportConstants.h"
 #include <Input.h>
+#include <SceneManager.h>
 
 #include <algorithm>
 
@@ -15,6 +16,22 @@
 
 namespace Ken4lowEngine
 {
+
+	namespace
+	{
+		EditorInputPolicy GetCurrentEditorInputPolicy()
+		{
+			const BaseScene* scene = SceneManager::GetInstance()->GetCurrentScene();
+			// Scene未設定時はUI Mouse扱いにしてEditor操作を妨げない。
+			return scene ? scene->GetEditorInputPolicy() : EditorInputPolicy::UiMouse;
+		}
+
+		bool IsFpsCapturePolicy()
+		{
+			// F8キャプチャはFPS操作Sceneだけで有効にする。
+			return GetCurrentEditorInputPolicy() == EditorInputPolicy::FpsCapture;
+		}
+	}
 
 	EditorWindowManager* EditorWindowManager::GetInstance()
 	{
@@ -26,10 +43,10 @@ namespace Ken4lowEngine
 	{
 #ifdef USE_IMGUI
 		auto* input = Input::GetInstance();
-		if (input->TriggerRawKey(DIK_F8))
+		if (input->TriggerRawKey(DIK_F8) && IsFpsCapturePolicy())
 		{
 			const bool forceRelease = input->PushRawKey(DIK_LSHIFT) || input->PushRawKey(DIK_RSHIFT);
-			// F8は入力キャプチャ切替、Shift+F8はFPS操作中でもEditor操作へ戻す非常口にする。
+			// F8はFPS操作Sceneだけ入力キャプチャ切替、Shift+F8は非常口にする。
 			if (forceRelease)
 			{
 				EditorPlayController::GetInstance()->ForceReleaseToEditor();
@@ -153,7 +170,8 @@ namespace Ken4lowEngine
 #ifdef USE_IMGUI
 		auto* playController = EditorPlayController::GetInstance();
 
-		// ツールバーはPlay状態と入力キャプチャ状態を同じController経由で操作する。
+		const bool fpsCapturePolicy = IsFpsCapturePolicy();
+		// ツールバーは現在Sceneの入力ポリシーに合わせて表示と操作可否を分ける。
 		ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
 		if (ImGui::Begin("Toolbar", &windowState_.showToolbar, flags))
 		{
@@ -181,12 +199,20 @@ namespace Ken4lowEngine
 			ImGui::SameLine();
 			ImGui::TextUnformatted("|");
 			ImGui::SameLine();
-			ImGui::Text("%s  F8: %s", playController->GetInputStatusText(), playController->IsGameCaptured() ? "Release" : "Capture");
-			ImGui::SameLine();
-			if (ImGui::Button(playController->IsGameCaptured() ? "Release Input" : "Capture Input"))
+			if (fpsCapturePolicy)
 			{
-				// ToolbarボタンからもF8と同じキャプチャ切り替えを実行できるようにする。
-				playController->ToggleInputCapture();
+				ImGui::Text("%s  F8: %s", playController->IsGameCaptured() ? "Input: FPS Captured" : "Input: Editor Released", playController->IsGameCaptured() ? "Release" : "Capture");
+				ImGui::SameLine();
+				if (ImGui::Button(playController->IsGameCaptured() ? "Release Input" : "Capture Input"))
+				{
+					// ToolbarボタンもFPS操作SceneでだけF8と同じキャプチャ切り替えを実行する。
+					playController->ToggleInputCapture();
+				}
+			}
+			else
+			{
+				// UI Mouse Sceneではキャプチャ操作を出さず常にカーソルUI操作を示す。
+				ImGui::TextUnformatted("Input: UI Mouse Mode");
 			}
 			// Debug Freezeは入力キャプチャとは別状態としてToolbar上で確認できるようにする。
 			ImGui::TextUnformatted(playController->GetDebugFreezeStatusText());
@@ -276,7 +302,7 @@ namespace Ken4lowEngine
 					mouseScreen.x >= imageScreenMin.x && mouseScreen.y >= imageScreenMin.y &&
 					mouseScreen.x <= imageScreenMax.x && mouseScreen.y <= imageScreenMax.y;
 				const bool otherItemActive = ImGui::IsAnyItemActive() && !ImGui::IsItemActive();
-				// WantCaptureMouseではなくGameCapturedかつMain Viewport画像上かどうかだけでゲームクリックを許可する。
+				// WantCaptureMouseではなくSceneポリシーとMain Viewport画像上かどうかでゲームクリックを許可する。
 				mainViewportRect_.isHovered = ImGui::IsWindowHovered(ImGuiHoveredFlags_AllowWhenBlockedByActiveItem) && mouseInsideImage && !otherItemActive;
 			}
 			else
@@ -286,12 +312,14 @@ namespace Ken4lowEngine
 
 			Vector2 gameMouse = {};
 			const bool gameMouseValid = GetMousePositionInGameViewport(gameMouse);
-			const bool gameInputEnabled = EditorPlayController::GetInstance()->IsGameCaptured() && mainViewportRect_.isHovered;
+			const EditorInputPolicy inputPolicy = GetCurrentEditorInputPolicy();
+			const bool gameInputEnabled = (inputPolicy == EditorInputPolicy::UiMouse || EditorPlayController::GetInstance()->IsGameCaptured()) && mainViewportRect_.isHovered;
 			Input::GetInstance()->SetGameInputEnabled(gameInputEnabled);
 			Input::GetInstance()->SetEditorViewportMousePosition(gameMouse, gameMouseValid);
-			// GameReleased中やViewport外では中央固定を解除し、Editor/ImGui操作用にカーソルを表示する。
-			Input::GetInstance()->SetLockCursor(gameInputEnabled);
-			Input::GetInstance()->SetCursorVisible(!gameInputEnabled);
+			// UI Mouseは常にカーソル表示、FPS CaptureはGameCaptured中だけ中央固定にする。
+			const bool lockForFpsCapture = inputPolicy == EditorInputPolicy::FpsCapture && gameInputEnabled;
+			Input::GetInstance()->SetLockCursor(lockForFpsCapture);
+			Input::GetInstance()->SetCursorVisible(!lockForFpsCapture);
 			inputDebugInfo_.mainViewportHovered = mainViewportRect_.isHovered; // 入力許可条件のViewport hoverをToolbarに表示する。
 			inputDebugInfo_.imguiMouseClicked0 = ImGui::IsMouseClicked(ImGuiMouseButton_Left);
 			inputDebugInfo_.imguiMouseDown0 = ImGui::IsMouseDown(ImGuiMouseButton_Left);
@@ -325,9 +353,10 @@ namespace Ken4lowEngine
 	{
 #ifdef USE_IMGUI
 		outMouse = { 0.0f, 0.0f };
-		if (!EditorPlayController::GetInstance()->IsGameCaptured())
+		const EditorInputPolicy inputPolicy = GetCurrentEditorInputPolicy();
+		if (inputPolicy == EditorInputPolicy::FpsCapture && !EditorPlayController::GetInstance()->IsGameCaptured())
 		{
-			// GameReleased/Editor状態ではゲーム側へマウス入力を渡さない。
+			// FPS Capture SceneのGameReleased中はゲーム側へマウス入力を渡さない。
 			return false;
 		}
 


### PR DESCRIPTION
### Motivation
- Prevent F8/GameCaptured from breaking UI-focused scenes (Title/StageSelect) by making editor input capture policy scene-local.  
- Ensure gameplay (`GamePlayScene`) still supports FPS capture and F8 toggling without changing existing `Esc` behaviors or viewport coordinate math.

### Description
- Added `EditorInputPolicy` enum with `UiMouse` and `FpsCapture` and a virtual `GetEditorInputPolicy()` on `BaseScene` returning `UiMouse` by default.  
- Overrode `GetEditorInputPolicy()` in `GamePlayScene` to return `FpsCapture`.  
- Exposed the active scene via `SceneManager::GetCurrentScene()` so editor UI can query the scene policy.  
- Updated `EditorWindowManager` to: gate F8 handling to scenes whose policy is `FpsCapture`, change toolbar text / buttons per-policy, and adjust Main Viewport input/cursor rules so `UiMouse` scenes always show the cursor and allow viewport clicks while `FpsCapture` scenes lock cursor only when `GameCaptured`.  
- Preserved existing constraints: `Esc` behaviors unchanged, Main Viewport 1920x1080 coordinate conversion kept, and `ImGuiConfigFlags_ViewportsEnable` untouched; added clarifying one-line comments at change points.

### Testing
- Ran `git diff --check` to verify no whitespace/merge errors and it passed.  
- Attempted Debug/Release build with `msbuild` but the CI environment does not provide `msbuild` so builds were not executed here (command attempted: `msbuild Project/Ken4lowEngine.sln /p:Configuration=Debug /p:Platform=x64`).  
- Verified source-level changes and grep checks to ensure `EditorInputPolicy` usages, F8 gating, and toolbar strings were updated as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01b04ff418832d9af3e157f4a1b2fe)