### PR TITLE
Organize Window menu, add window toggles, safe Rebuild Default Layout and Game Focus entry

### DIFF
--- a/Project/ApplicationLayer/Scene/GamePlayScene/DebugTools/GamePlayDebugTools.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/DebugTools/GamePlayDebugTools.cpp
@@ -149,6 +149,11 @@ void GamePlayDebugTools::DrawImGui(GamePlayWorld* world)
 
 		characters.DrawImGui();
 		world->DrawImGui();
+	}
+
+	if (editorWindowState.showCullingDebug)
+	{
+		// WindowメニューのCulling Debug表示フラグでStageChunk/Occlusion系の周辺デバッグUIをまとめる。
 		stageChunkDebugController_.DrawImGui(world->GetStage());
 		occlusionDebugController_.DrawImGui(world->GetStage());
 	}

--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
@@ -6,6 +6,7 @@
 #include <GameTimer.h>
 #include <PostEffectManager.h>
 #include <Player.h>
+#include <Editor/EditorWindowManager.h>
 
 #ifdef _DEBUG
 #include <DebugCamera.h>
@@ -594,8 +595,10 @@ void GamePlayScene::DrawImGui()
 		debugTools_->DrawImGui(world_.get());
 	}
 
-	if (frustumCullingDebug_)
+	auto& editorWindowState = K4E::EditorWindowManager::GetInstance()->GetWindowState();
+	if (frustumCullingDebug_ && editorWindowState.showCullingDebug)
 	{
+		// WindowメニューのCulling Debug表示フラグでFrustum Culling Debugも表示切替する。
 		frustumCullingDebug_->DrawImGui();
 	}
 

--- a/Project/ApplicationLayer/SceneManagement/FadeManager/FadeManager.cpp
+++ b/Project/ApplicationLayer/SceneManagement/FadeManager/FadeManager.cpp
@@ -760,14 +760,14 @@ void FadeManager::Draw2DSprites()
 void FadeManager::DrawImGui()
 {
 #ifdef USE_IMGUI
-	// WindowメニューのFadeManager - Tile Fade表示フラグを×ボタン状態と共有する
+	// WindowメニューのFadeManager表示フラグを×ボタン状態と共有する
 	auto& editorWindowState = K4E::EditorWindowManager::GetInstance()->GetWindowState();
-	if (!editorWindowState.showTileFadeDebug)
+	if (!editorWindowState.showFadeManager)
 	{
 		return;
 	}
 
-	ImGui::Begin("FadeManager - Tile Fade", &editorWindowState.showTileFadeDebug);
+	ImGui::Begin("FadeManager", &editorWindowState.showFadeManager);
 
 	const char* st =
 		(state_ == State::None) ? "演出していない待機状態" :

--- a/Project/Engine/Editor/EditorWindowManager.cpp
+++ b/Project/Engine/Editor/EditorWindowManager.cpp
@@ -95,22 +95,22 @@ namespace Ken4lowEngine
 			// Commonは常時使うエディタ基本パネルをまとめて表示切替できるようにする
 			if (ImGui::BeginMenu("Common"))
 			{
-				ImGui::MenuItem("Toolbar", nullptr, &windowState_.showToolbar);
 				ImGui::MenuItem("Main Viewport", nullptr, &windowState_.showMainViewport);
-				ImGui::MenuItem("Content Browser", nullptr, &windowState_.showContentBrowser);
 				ImGui::MenuItem("World Outliner", nullptr, &windowState_.showWorldOutliner);
 				ImGui::MenuItem("Details", nullptr, &windowState_.showDetails);
+				ImGui::MenuItem("Content Browser", nullptr, &windowState_.showContentBrowser);
 				ImGui::MenuItem("Output Log", nullptr, &windowState_.showOutputLog);
+				ImGui::MenuItem("Toolbar", nullptr, &windowState_.showToolbar);
 				ImGui::EndMenu();
 			}
 
 			// Renderingは描画・画面・ライト調整系ウィンドウをまとめて表示切替できるようにする
 			if (ImGui::BeginMenu("Rendering"))
 			{
-				ImGui::MenuItem("Parameters", nullptr, &windowState_.showParameters);
-				ImGui::MenuItem("Display", nullptr, &windowState_.showDisplay);
-				ImGui::MenuItem("Post Effect Settings", nullptr, &windowState_.showPostEffectSettings);
 				ImGui::MenuItem("Light Editor", nullptr, &windowState_.showLightEditor);
+				ImGui::MenuItem("Post Effect Settings", nullptr, &windowState_.showPostEffectSettings);
+				ImGui::MenuItem("Display", nullptr, &windowState_.showDisplay);
+				ImGui::MenuItem("Parameters", nullptr, &windowState_.showParameters);
 				ImGui::EndMenu();
 			}
 
@@ -120,12 +120,41 @@ namespace Ken4lowEngine
 				ImGui::MenuItem("Title Debug", nullptr, &windowState_.showTitleDebug);
 				ImGui::MenuItem("Stage Select Debug", nullptr, &windowState_.showStageSelectDebug);
 				ImGui::MenuItem("Game Debug", nullptr, &windowState_.showGameDebug);
-				ImGui::MenuItem("Weapon Master Debug", nullptr, &windowState_.showWeaponMasterDebug);
-				ImGui::MenuItem("FadeManager - Tile Fade", nullptr, &windowState_.showTileFadeDebug);
+				ImGui::MenuItem("Culling Debug", nullptr, &windowState_.showCullingDebug);
+				ImGui::MenuItem("FadeManager", nullptr, &windowState_.showFadeManager);
 				ImGui::EndMenu();
 			}
 
-			// Reset Layoutは誤操作でDock配置を崩しやすいため一旦メニューから外す
+			// Layout操作はDock再構築と簡易Focusレイアウト入口を明示的に分ける。
+			if (ImGui::BeginMenu("Layout"))
+			{
+				if (ImGui::MenuItem("Rebuild Default Layout"))
+				{
+					// Rebuild Default Layoutは誤操作を避けるためPopupでOK確認してから実行する。
+					openRebuildDefaultLayoutPopup_ = true;
+				}
+				if (ImGui::MenuItem("Game Focus Layout"))
+				{
+					// Game Focus LayoutはDock再配置せず周辺ウィンドウだけ一時的に非表示にする。
+					windowState_.showMainViewport = true;
+					windowState_.showToolbar = false;
+					windowState_.showWorldOutliner = false;
+					windowState_.showDetails = false;
+					windowState_.showContentBrowser = false;
+					windowState_.showOutputLog = false;
+					windowState_.showLightEditor = false;
+					windowState_.showPostEffectSettings = false;
+					windowState_.showDisplay = false;
+					windowState_.showParameters = false;
+					windowState_.showTitleDebug = false;
+					windowState_.showStageSelectDebug = false;
+					windowState_.showGameDebug = false;
+					windowState_.showCullingDebug = false;
+					windowState_.showFadeManager = false;
+				}
+				ImGui::EndMenu();
+			}
+
 			ImGui::EndMenu();
 		}
 
@@ -162,6 +191,33 @@ namespace Ken4lowEngine
 		}
 
 		ImGui::EndMainMenuBar();
+
+		if (openRebuildDefaultLayoutPopup_)
+		{
+			// PopupをMainMenuBar終了後に開き、MenuItem押下だけでDockBuilderを走らせない。
+			ImGui::OpenPopup("Rebuild Default Layout?");
+			openRebuildDefaultLayoutPopup_ = false;
+		}
+
+		if (ImGui::BeginPopupModal("Rebuild Default Layout?", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+		{
+			ImGui::TextUnformatted("Rebuild the editor docking layout to the default placement?");
+			ImGui::TextUnformatted("Current dock positions will be overwritten when you press OK.");
+			ImGui::Separator();
+			if (ImGui::Button("OK", ImVec2(120.0f, 0.0f)))
+			{
+				// OK時だけDockBuilderによる初期配置再構築を次フレームへ要求する。
+				ImGuiManager::GetInstance()->RequestResetDockLayout();
+				ImGui::CloseCurrentPopup();
+			}
+			ImGui::SameLine();
+			if (ImGui::Button("Cancel", ImVec2(120.0f, 0.0f)))
+			{
+				// CancelではDockBuilder要求を発行せず現在の保存済みDocking配置を維持する。
+				ImGui::CloseCurrentPopup();
+			}
+			ImGui::EndPopup();
+		}
 #endif // USE_IMGUI
 	}
 

--- a/Project/Engine/Editor/EditorWindowManager.h
+++ b/Project/Engine/Editor/EditorWindowManager.h
@@ -27,8 +27,9 @@ namespace Ken4lowEngine
 		bool showTitleDebug = true;
 		bool showStageSelectDebug = true;
 		bool showGameDebug = true;
+		bool showCullingDebug = true;
+		bool showFadeManager = true;
 		bool showWeaponMasterDebug = true;
-		bool showTileFadeDebug = true;
 
 		bool debugShowCollider = false;
 		bool debugShowEnemyInfo = false;
@@ -103,6 +104,7 @@ namespace Ken4lowEngine
 		Vector2 mainViewportScreenPosition_ = { 0.0f, 0.0f }; // マウス座標をMain Viewport基準へ変換するための左上座標
 		Vector2 mainViewportSize_ = { 0.0f, 0.0f }; // Main Viewport内でGameRenderTargetを表示しているサイズ
 		EditorInputDebugInfo inputDebugInfo_{}; // Toolbarへゲーム入力ゲートの状態を可視化する
+		bool openRebuildDefaultLayoutPopup_ = false; // Rebuild Default Layoutを即時実行せず確認Popupへ遅延する。
 	};
 
 } // namespace Ken4lowEngine


### PR DESCRIPTION
### Motivation

- 整理された Window メニューでエディタパネルの表示/非表示を切り替えやすくし、レイアウトリセットの誤操作を防止するための安全なフローを追加しました。 
- シーン依存のデバッグ（Culling / FadeManager 等）をメニューから制御できるようにして、既存の描画や入力・Main Viewportの挙動は変えないようにする狙いです。

### Description

- `Window` メニューを `Common` / `Rendering` / `Scene Debug` / `Layout` に再編成し、要求された項目をそれぞれ追加しました（例: `Main Viewport`, `World Outliner`, `Details`, `Content Browser`, `Output Log`, `Toolbar`, `Light Editor`, `Post Effect Settings`, `Display`, `Parameters`, `Title Debug`, `Stage Select Debug`, `Game Debug`, `Culling Debug`, `FadeManager`, `Rebuild Default Layout`, `Game Focus Layout`）。
- `EditorWindowState` に `showCullingDebug` と `showFadeManager` を追加してメニューのチェック状態と各ウィンドウの表示を同期するようにしました（`EditorWindowManager.h` / `EditorWindowManager.cpp`）。
- `Rebuild Default Layout` はメニュー押下で即実行せず確認 `Popup` を表示し、`OK` 押下時のみ `ImGuiManager::RequestResetDockLayout()` を呼んで次フレームに `DockBuilder` を再適用するように変更しました（確認フロー用の `openRebuildDefaultLayoutPopup_` フラグを追加）。
- `Game Focus Layout` は入口実装として、DockBuilder を走らせず周辺ウィンドウを一時的に非表示にして `Main Viewport` を見やすくする振る舞いを実装しました（将来の専用レイアウト再構築は未実装）。
- シーン側連携として `Culling Debug` のフラグで StageChunk / Occlusion UI をまとめて制御するように `GamePlayDebugTools` と `GamePlayScene` を更新し、`FadeManager - Tile Fade` を `FadeManager` 名に統一してメニューフラグを同期しました。
- 変更ファイル: `Project/Engine/Editor/EditorWindowManager.h`, `Project/Engine/Editor/EditorWindowManager.cpp`, `Project/ApplicationLayer/SceneManagement/FadeManager/FadeManager.cpp`, `Project/ApplicationLayer/Scene/GamePlayScene/DebugTools/GamePlayDebugTools.cpp`, `Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp`.

### Testing

- `git diff --check` を実行してソースの差分に問題がないことを確認しました (成功)。
- `msbuild Project/Ken4lowEngine.sln /p:Configuration=Debug /p:Platform=x64` と `msbuild ... Release` を試みましたが、実行環境に `msbuild` が無いためビルドは実行できませんでした（`/bin/bash: line 1: msbuild: command not found`）。
- 変更はローカルで `git add` / `git commit` によってコミット済みで、ソース内の参照とフラグの結線は静的に確認済み。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01b7191268832d8257bab65a835177)