### PR TITLE
Add World Outliner object listing and selection

### DIFF
--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
@@ -798,3 +798,23 @@ bool GamePlayScene::IsRetryFadeInFinished() const
 {
 	return fadeManager_ && fadeManager_->IsDropDone();
 }
+void GamePlayScene::CollectEditorObjects(std::vector<Ken4lowEngine::EditorObjectInfo>& outObjects) const
+{
+	const auto addObject = [&outObjects](uint64_t id, const char* displayName, const char* typeName)
+	{
+		outObjects.push_back({ id, displayName, typeName, "GamePlayScene" });
+	};
+
+	// OutlinerはPlay/Edit中の生成状態に依存しすぎないよう、主要サブシステムを安定IDで列挙する。
+	addObject(0x3000000000000001ull, "GamePlay Root", "Scene Root");
+	addObject(0x3000000000000002ull, "Player", world_ ? "Player" : "Player (pending)");
+	addObject(0x3000000000000003ull, "Main Camera", "Camera");
+	addObject(0x3000000000000004ull, "Light", "Directional Light");
+	addObject(0x3000000000000005ull, "Enemy Manager", world_ ? "Enemy Manager" : "Enemy Manager (pending)");
+	addObject(0x3000000000000006ull, "Bullet Manager", world_ ? "Bullet Manager" : "Bullet Manager (pending)");
+	addObject(0x3000000000000007ull, "Wave Manager", world_ ? "Wave Manager" : "Wave Manager (pending)");
+	addObject(0x3000000000000008ull, "Stage", stageContext_ ? "Stage" : "Stage (pending)");
+	addObject(0x3000000000000009ull, "HUD", world_ ? "HUD" : "HUD (pending)");
+	addObject(0x300000000000000aull, "Collision Manager", "Collision Manager");
+	addObject(0x300000000000000bull, "Fade Manager", fadeManager_ ? "Fade Manager" : "Fade Manager (pending)");
+}

--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.h
@@ -56,6 +56,9 @@ public: /// ---------- BaseScene override ---------- ///
 	// ImGui描画
 	void DrawImGui() override;
 
+	// World OutlinerへGamePlaySceneの主要オブジェクトを公開する。
+	void CollectEditorObjects(std::vector<Ken4lowEngine::EditorObjectInfo>& outObjects) const override;
+
 	// FPS操作が必要なGamePlaySceneだけF8入力キャプチャを許可する。
 	EditorInputPolicy GetEditorInputPolicy() const override { return EditorInputPolicy::FpsCapture; }
 

--- a/Project/ApplicationLayer/Scene/StageSelectScene/StageSelectScene.cpp
+++ b/Project/ApplicationLayer/Scene/StageSelectScene/StageSelectScene.cpp
@@ -726,3 +726,19 @@ void StageSelectScene::GoToGamePlay()
 		sceneManager_->ChangeScene("GamePlayScene");
 	}
 }
+
+void StageSelectScene::CollectEditorObjects(std::vector<Ken4lowEngine::EditorObjectInfo>& outObjects) const
+{
+	const auto addObject = [&outObjects](uint64_t id, const char* displayName, const char* typeName)
+	{
+		outObjects.push_back({ id, displayName, typeName, "StageSelectScene" });
+	};
+
+	// Outlinerはステージ選択画面の編集入口として、現在生成済みでなくても主要カテゴリを安定IDで列挙する。
+	addObject(0x2000000000000001ull, "StageSelect Root", "Scene Root");
+	addObject(0x2000000000000002ull, "Camera", "Camera");
+	addObject(0x2000000000000003ull, "Light", "Directional Light");
+	addObject(0x2000000000000004ull, "Stage Panels", activeSelector_ ? "Stage Selector" : "Stage Selector (pending)");
+	addObject(0x2000000000000005ull, "Stage Text Layout", isTextReady_ ? "Text Layout" : "Text Layout (pending)");
+	addObject(0x2000000000000006ull, "Fade Manager", "Fade Manager");
+}

--- a/Project/ApplicationLayer/Scene/StageSelectScene/StageSelectScene.h
+++ b/Project/ApplicationLayer/Scene/StageSelectScene/StageSelectScene.h
@@ -124,6 +124,9 @@ public: /// ---------- メンバ関数 ---------- ///
 	// ImGui描画処理
 	void DrawImGui() override;
 
+	// World OutlinerへStageSelectSceneの主要オブジェクトを公開する。
+	void CollectEditorObjects(std::vector<Ken4lowEngine::EditorObjectInfo>& outObjects) const override;
+
 	// 段階ロード
 	void StartLoad() override;
 

--- a/Project/ApplicationLayer/Scene/TitleScene/TitleScene.cpp
+++ b/Project/ApplicationLayer/Scene/TitleScene/TitleScene.cpp
@@ -485,3 +485,18 @@ void TitleScene::UpdateDebug()
 	}
 #endif // _DEBUG
 }
+void TitleScene::CollectEditorObjects(std::vector<Ken4lowEngine::EditorObjectInfo>& outObjects) const
+{
+	const auto addObject = [&outObjects](uint64_t id, const char* displayName, const char* typeName)
+	{
+		outObjects.push_back({ id, displayName, typeName, "TitleScene" });
+	};
+
+	// Outlinerは編集対象の入口として、TitleSceneを構成する主要カテゴリだけを安定IDで列挙する。
+	addObject(0x1000000000000001ull, "Title Root", "Scene Root");
+	addObject(0x1000000000000002ull, "Camera", camera_ ? "Camera" : "Camera (pending)");
+	addObject(0x1000000000000003ull, "Light", "Directional Light");
+	addObject(0x1000000000000004ull, "UI Root", "UI Root");
+	addObject(0x1000000000000005ull, "Click Text / Click Sprite", clickHintUI_.hintSprite ? "Sprite UI" : "Sprite UI (pending)");
+	addObject(0x1000000000000006ull, "Fade Manager", "Fade Manager");
+}

--- a/Project/ApplicationLayer/Scene/TitleScene/TitleScene.h
+++ b/Project/ApplicationLayer/Scene/TitleScene/TitleScene.h
@@ -166,6 +166,9 @@ public: /// ---------- メンバ関数 ---------- ///
 	// ImGui描画処理
 	void DrawImGui() override;
 
+	// World OutlinerへTitleSceneの主要オブジェクトを公開する。
+	void CollectEditorObjects(std::vector<Ken4lowEngine::EditorObjectInfo>& outObjects) const override;
+
 	// 段階ロード
 	void StartLoad() override;
 

--- a/Project/ApplicationLayer/SceneManagement/BaseScene/BaseScene.h
+++ b/Project/ApplicationLayer/SceneManagement/BaseScene/BaseScene.h
@@ -1,5 +1,9 @@
 #pragma once
 
+#include <Editor/EditorObjectInfo.h>
+
+#include <vector>
+
 /// ---------- 前方宣言 ---------- ///
 class SceneManager;
 
@@ -46,6 +50,9 @@ public: /// ---------- 純粋仮想関数 ---------- ///
 
 	// UI主体のSceneはデフォルトでカーソル表示のMain Viewportクリック入力にする。
 	virtual EditorInputPolicy GetEditorInputPolicy() const { return EditorInputPolicy::UiMouse; }
+
+	// World Outliner用の安全な表示情報をScene側から収集する入口です。
+	virtual void CollectEditorObjects(std::vector<Ken4lowEngine::EditorObjectInfo>& /*outObjects*/) const {}
 
 	// シーンマネージャーをセット
 	virtual void SetSceneManager(SceneManager* sceneManager) { sceneManager_ = sceneManager; }

--- a/Project/Engine/Editor/EditorObjectInfo.h
+++ b/Project/Engine/Editor/EditorObjectInfo.h
@@ -1,0 +1,20 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+
+namespace Ken4lowEngine
+{
+
+	/// <summary>
+	/// World OutlinerとDetailsへ安全に渡すための軽量なエディタ表示用オブジェクト情報です。
+	/// </summary>
+	struct EditorObjectInfo
+	{
+		uint64_t id = 0;
+		std::string displayName;
+		std::string typeName;
+		std::string sceneName;
+	};
+
+} // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorSelection.cpp
+++ b/Project/Engine/Editor/EditorSelection.cpp
@@ -1,0 +1,30 @@
+#include "EditorSelection.h"
+
+namespace Ken4lowEngine
+{
+
+	void EditorSelection::Select(const EditorObjectInfo& objectInfo)
+	{
+		// 選択はコピーした軽量情報だけを保持し、Scene側オブジェクト寿命に依存しないようにする。
+		selected_ = objectInfo;
+		hasSelection_ = true;
+	}
+
+	void EditorSelection::Clear()
+	{
+		// Scene切り替え時の古い選択を安全に破棄できる入口にする。
+		selected_ = {};
+		hasSelection_ = false;
+	}
+
+	bool EditorSelection::HasSelection() const
+	{
+		return hasSelection_;
+	}
+
+	const EditorObjectInfo& EditorSelection::GetSelected() const
+	{
+		return selected_;
+	}
+
+} // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorSelection.h
+++ b/Project/Engine/Editor/EditorSelection.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include "EditorObjectInfo.h"
+
+namespace Ken4lowEngine
+{
+
+	/// <summary>
+	/// World Outlinerで選択したオブジェクト情報をDetailsへ橋渡しします。
+	/// </summary>
+	class EditorSelection
+	{
+	public:
+		void Select(const EditorObjectInfo& objectInfo);
+		void Clear();
+		bool HasSelection() const;
+		const EditorObjectInfo& GetSelected() const;
+
+	private:
+		bool hasSelection_ = false;
+		EditorObjectInfo selected_{};
+	};
+
+} // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorWindowManager.cpp
+++ b/Project/Engine/Editor/EditorWindowManager.cpp
@@ -9,6 +9,7 @@
 #include <SceneManager.h>
 
 #include <algorithm>
+#include <vector>
 
 #ifdef USE_IMGUI
 #include <imgui.h>
@@ -470,15 +471,49 @@ namespace Ken4lowEngine
 			return;
 		}
 
-		// World Outlinerは後で実オブジェクト一覧へ差し替えるため仮ノードだけ表示する
+		std::vector<EditorObjectInfo> objects;
+		const BaseScene* scene = SceneManager::GetInstance()->GetCurrentScene();
+		if (scene)
+		{
+			// Scene側から軽量情報だけを収集し、Outlinerが実オブジェクト寿命へ依存しないようにする。
+			scene->CollectEditorObjects(objects);
+		}
+
+		if (selection_.HasSelection())
+		{
+			const EditorObjectInfo& selected = selection_.GetSelected();
+			const bool stillExists = std::any_of(objects.begin(), objects.end(), [&selected](const EditorObjectInfo& object)
+				{
+					return object.id == selected.id && object.sceneName == selected.sceneName;
+				});
+			if (!stillExists)
+			{
+				// Scene切り替えやロード状態変化で消えた選択はDetails表示前に破棄する。
+				selection_.Clear();
+			}
+		}
+
 		if (ImGui::Begin("World Outliner", &windowState_.showWorldOutliner))
 		{
-			if (ImGui::TreeNodeEx("Current Scene", ImGuiTreeNodeFlags_DefaultOpen))
+			const char* sceneLabel = objects.empty() ? "Current Scene" : objects.front().sceneName.c_str();
+			if (ImGui::TreeNodeEx(sceneLabel, ImGuiTreeNodeFlags_DefaultOpen))
 			{
-				ImGui::Selectable("Player (placeholder)");
-				ImGui::Selectable("Main Camera (placeholder)");
-				ImGui::Selectable("Directional Light (placeholder)");
-				ImGui::Selectable("Stage Root (placeholder)");
+				if (objects.empty())
+				{
+					ImGui::TextUnformatted("No editor objects.");
+				}
+				for (const EditorObjectInfo& object : objects)
+				{
+					const bool selected = selection_.HasSelection() &&
+						selection_.GetSelected().id == object.id &&
+						selection_.GetSelected().sceneName == object.sceneName;
+					const std::string label = object.displayName + "##" + object.sceneName + std::to_string(object.id);
+					if (ImGui::Selectable(label.c_str(), selected))
+					{
+						// クリックしたOutliner項目の軽量情報を選択状態として保存する。
+						selection_.Select(object);
+					}
+				}
 				ImGui::TreePop();
 			}
 		}
@@ -494,16 +529,23 @@ namespace Ken4lowEngine
 			return;
 		}
 
-		// Detailsは後で選択中オブジェクトの編集UIへ接続するため仮プロパティを表示する
 		if (ImGui::Begin("Details", &windowState_.showDetails))
 		{
-			ImGui::TextUnformatted("Selection: None");
-			ImGui::Separator();
-			ImGui::TextUnformatted("Transform");
-			float zero3[3] = { 0.0f, 0.0f, 0.0f };
-			ImGui::InputFloat3("Location", zero3, "%.2f", ImGuiInputTextFlags_ReadOnly);
-			ImGui::InputFloat3("Rotation", zero3, "%.2f", ImGuiInputTextFlags_ReadOnly);
-			ImGui::InputFloat3("Scale", zero3, "%.2f", ImGuiInputTextFlags_ReadOnly);
+			if (!selection_.HasSelection())
+			{
+				ImGui::TextUnformatted("No object selected.");
+			}
+			else
+			{
+				const EditorObjectInfo& selected = selection_.GetSelected();
+				// DetailsはTransform編集の前段階として、選択中オブジェクトの識別情報だけを表示する。
+				ImGui::Text("Selected Name: %s", selected.displayName.c_str());
+				ImGui::Text("Type: %s", selected.typeName.c_str());
+				ImGui::Text("Scene: %s", selected.sceneName.c_str());
+				ImGui::Text("ID: %llu", static_cast<unsigned long long>(selected.id));
+				ImGui::Separator();
+				ImGui::TextUnformatted("Transform editing is not implemented yet.");
+			}
 		}
 		ImGui::End();
 #endif // USE_IMGUI

--- a/Project/Engine/Editor/EditorWindowManager.h
+++ b/Project/Engine/Editor/EditorWindowManager.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "Vector2.h"
+#include "EditorSelection.h"
 
 namespace Ken4lowEngine
 {
@@ -104,6 +105,7 @@ namespace Ken4lowEngine
 		Vector2 mainViewportScreenPosition_ = { 0.0f, 0.0f }; // マウス座標をMain Viewport基準へ変換するための左上座標
 		Vector2 mainViewportSize_ = { 0.0f, 0.0f }; // Main Viewport内でGameRenderTargetを表示しているサイズ
 		EditorInputDebugInfo inputDebugInfo_{}; // Toolbarへゲーム入力ゲートの状態を可視化する
+		EditorSelection selection_{}; // World OutlinerとDetailsで共有する軽量な選択状態
 		bool openRebuildDefaultLayoutPopup_ = false; // Rebuild Default Layoutを即時実行せず確認Popupへ遅延する。
 	};
 

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -319,6 +319,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="Engine\Core\Transform\WorldTransformEx.cpp" />
     <ClCompile Include="Engine\DebugTools\ImGui\ImGuiManager.cpp" />
     <ClCompile Include="Engine\Editor\EditorPlayController.cpp" />
+    <ClCompile Include="Engine\Editor\EditorSelection.cpp" />
     <ClCompile Include="Engine\Editor\EditorWindowManager.cpp" />
     <ClCompile Include="Engine\DebugTools\LeakCheck\D3DResourceLeakChecker.cpp" />
     <ClCompile Include="Engine\Graphics\Camera\Core\Camera.cpp" />
@@ -946,7 +947,9 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="Engine\Core\Transform\WorldTransform.h" />
     <ClInclude Include="Engine\Core\Transform\WorldTransformEx.h" />
     <ClInclude Include="Engine\DebugTools\ImGui\ImGuiManager.h" />
+    <ClInclude Include="Engine\Editor\EditorObjectInfo.h" />
     <ClInclude Include="Engine\Editor\EditorPlayController.h" />
+    <ClInclude Include="Engine\Editor\EditorSelection.h" />
     <ClInclude Include="Engine\Editor\EditorWindowManager.h" />
     <ClInclude Include="Engine\DebugTools\LeakCheck\D3DResourceLeakChecker.h" />
     <ClInclude Include="Engine\Graphics\Camera\Core\Camera.h" />

--- a/Project/Ken4lowEngine.vcxproj.filters
+++ b/Project/Ken4lowEngine.vcxproj.filters
@@ -472,6 +472,9 @@
     <ClCompile Include="Engine\Editor\EditorPlayController.cpp">
       <Filter>Engine\Editor</Filter>
     </ClCompile>
+    <ClCompile Include="Engine\Editor\EditorSelection.cpp">
+      <Filter>Engine\Editor</Filter>
+    </ClCompile>
     <ClCompile Include="Engine\Editor\EditorWindowManager.cpp">
       <Filter>Engine\Editor</Filter>
     </ClCompile>
@@ -1278,7 +1281,13 @@
     <ClInclude Include="Engine\DebugTools\ImGui\ImGuiManager.h">
       <Filter>Engine\DebugTools\ImGui</Filter>
     </ClInclude>
+    <ClInclude Include="Engine\Editor\EditorObjectInfo.h">
+      <Filter>Engine\Editor</Filter>
+    </ClInclude>
     <ClInclude Include="Engine\Editor\EditorPlayController.h">
+      <Filter>Engine\Editor</Filter>
+    </ClInclude>
+    <ClInclude Include="Engine\Editor\EditorSelection.h">
       <Filter>Engine\Editor</Filter>
     </ClInclude>
     <ClInclude Include="Engine\Editor\EditorWindowManager.h">


### PR DESCRIPTION
### Motivation
- Provide a UE5-style World Outliner that shows major objects in the current Scene and a simple Details view, without touching real object lifetime or transform editing yet.
- Keep editor/play/update separation and input/viewport behavior unchanged while exposing a safe, lightweight selection API for future editing features.
- Make the Outliner robust to Scene switches and Play-state changes by using stable IDs and copied lightweight info instead of raw pointers.

### Description
- Added a lightweight display struct `EditorObjectInfo` (`Project/Engine/Editor/EditorObjectInfo.h`) and a selection holder `EditorSelection` with `Select`/`Clear`/`HasSelection`/`GetSelected` (`Project/Engine/Editor/EditorSelection.h` / `.cpp`).
- Added a Scene hook `virtual void CollectEditorObjects(std::vector<EditorObjectInfo>& outObjects) const` to `BaseScene` and implemented it in `TitleScene`, `StageSelectScene`, and `GamePlayScene` to return stable, major-object entries (IDs, display/type/scene names).
- Reworked `EditorWindowManager::DrawWorldOutliner()` to call the current Scene's `CollectEditorObjects(...)`, render items with `ImGui::Selectable`, save the clicked item into `EditorSelection`, and clear stale selections when a listed object no longer exists.
- Reworked `EditorWindowManager::DrawDetails()` to display selection metadata (`Selected Name`, `Type`, `Scene`, `ID`) or `"No object selected."` when none is selected, and added a `selection_` member to `EditorWindowManager` to share state between Outliner and Details.
- Updated project files to include the new editor sources so they are compiled by the solution (`Project/Ken4lowEngine.vcxproj` and `.filters`).

### Testing
- Ran `git diff --check` to ensure no whitespace/patch issues and it passed successfully.
- Parsed Visual Studio project files with Python `xml.etree.ElementTree` (`ET.parse`) to validate XML integrity and the parse succeeded.
- Performed a syntax-only compile check with `g++ -std=c++20 -fsyntax-only -IProject/Engine -IProject/Engine/Editor Project/Engine/Editor/EditorSelection.cpp` which succeeded.
- Attempts to run `msbuild` and `dotnet --info` in this Linux container failed because those tools are not available here, so a full Windows build was not executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01bf70ce80832db8eaf2a3bb08734f)