### PR TITLE
Editor: Add Transform editing in Details (World Outliner → Details)

### DIFF
--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
@@ -798,7 +798,7 @@ bool GamePlayScene::IsRetryFadeInFinished() const
 {
 	return fadeManager_ && fadeManager_->IsDropDone();
 }
-void GamePlayScene::CollectEditorObjects(std::vector<Ken4lowEngine::EditorObjectInfo>& outObjects) const
+void GamePlayScene::CollectEditorObjects(std::vector<Ken4lowEngine::EditorObjectInfo>& outObjects)
 {
 	const auto addObject = [&outObjects](uint64_t id, const char* displayName, const char* typeName)
 	{

--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.h
@@ -57,7 +57,7 @@ public: /// ---------- BaseScene override ---------- ///
 	void DrawImGui() override;
 
 	// World OutlinerへGamePlaySceneの主要オブジェクトを公開する。
-	void CollectEditorObjects(std::vector<Ken4lowEngine::EditorObjectInfo>& outObjects) const override;
+	void CollectEditorObjects(std::vector<Ken4lowEngine::EditorObjectInfo>& outObjects) override;
 
 	// FPS操作が必要なGamePlaySceneだけF8入力キャプチャを許可する。
 	EditorInputPolicy GetEditorInputPolicy() const override { return EditorInputPolicy::FpsCapture; }

--- a/Project/ApplicationLayer/Scene/StageSelectScene/StageSelectScene.cpp
+++ b/Project/ApplicationLayer/Scene/StageSelectScene/StageSelectScene.cpp
@@ -727,7 +727,7 @@ void StageSelectScene::GoToGamePlay()
 	}
 }
 
-void StageSelectScene::CollectEditorObjects(std::vector<Ken4lowEngine::EditorObjectInfo>& outObjects) const
+void StageSelectScene::CollectEditorObjects(std::vector<Ken4lowEngine::EditorObjectInfo>& outObjects)
 {
 	const auto addObject = [&outObjects](uint64_t id, const char* displayName, const char* typeName)
 	{

--- a/Project/ApplicationLayer/Scene/StageSelectScene/StageSelectScene.h
+++ b/Project/ApplicationLayer/Scene/StageSelectScene/StageSelectScene.h
@@ -125,7 +125,7 @@ public: /// ---------- メンバ関数 ---------- ///
 	void DrawImGui() override;
 
 	// World OutlinerへStageSelectSceneの主要オブジェクトを公開する。
-	void CollectEditorObjects(std::vector<Ken4lowEngine::EditorObjectInfo>& outObjects) const override;
+	void CollectEditorObjects(std::vector<Ken4lowEngine::EditorObjectInfo>& outObjects) override;
 
 	// 段階ロード
 	void StartLoad() override;

--- a/Project/ApplicationLayer/Scene/TitleScene/TitleScene.cpp
+++ b/Project/ApplicationLayer/Scene/TitleScene/TitleScene.cpp
@@ -15,6 +15,8 @@
 #include <LightManager.h>
 #include <GameTimer.h>
 
+#include <utility>
+
 #ifdef USE_IMGUI
 #include <Editor/EditorWindowManager.h>
 #endif // USE_IMGUI
@@ -485,18 +487,116 @@ void TitleScene::UpdateDebug()
 	}
 #endif // _DEBUG
 }
-void TitleScene::CollectEditorObjects(std::vector<Ken4lowEngine::EditorObjectInfo>& outObjects) const
+void TitleScene::CollectEditorObjects(std::vector<Ken4lowEngine::EditorObjectInfo>& outObjects)
 {
 	const auto addObject = [&outObjects](uint64_t id, const char* displayName, const char* typeName)
 	{
 		outObjects.push_back({ id, displayName, typeName, "TitleScene" });
 	};
+	const auto addCameraObject = [&outObjects](uint64_t id, const char* displayName, const char* typeName, K4E::Camera* camera)
+	{
+		Ken4lowEngine::EditorObjectInfo object{ id, displayName, typeName, "TitleScene" };
+		if (camera)
+		{
+			object.canEditTransform = true;
+			object.readTransform = [camera](Ken4lowEngine::EditorTransform& transform)
+			{
+				if (!camera)
+				{
+					return false;
+				}
+				transform.position = camera->GetTranslate();
+				transform.rotation = camera->GetRotate();
+				transform.scale = camera->GetScale();
+				return true;
+			};
+			object.writeTransform = [camera](const Ken4lowEngine::EditorTransform& transform)
+			{
+				if (!camera)
+				{
+					return;
+				}
+				camera->SetTranslate(transform.position);
+				camera->SetRotate(transform.rotation);
+				camera->SetScale(transform.scale);
+				camera->Update();
+			};
+		}
+		outObjects.push_back(std::move(object));
+	};
+	const auto fillSpriteTransform = [](K4E::Sprite* sprite, Ken4lowEngine::EditorTransform& transform)
+	{
+		if (!sprite)
+		{
+			return false;
+		}
+		const K4E::Vector2& position = sprite->GetPosition();
+		const K4E::Vector2& size = sprite->GetSize();
+		transform.position = { position.x, position.y, 0.0f };
+		transform.rotation = { 0.0f, 0.0f, sprite->GetRotation() };
+		transform.scale = { size.x, size.y, 1.0f };
+		return true;
+	};
+	const auto applySpriteTransform = [](K4E::Sprite* sprite, const Ken4lowEngine::EditorTransform& transform)
+	{
+		if (!sprite)
+		{
+			return;
+		}
+		sprite->SetPosition({ transform.position.x, transform.position.y });
+		sprite->SetRotation(transform.rotation.z);
+		sprite->SetSize({ transform.scale.x, transform.scale.y });
+		sprite->Update();
+	};
+	const auto addLogoSpriteObject = [&outObjects, this, fillSpriteTransform, applySpriteTransform](uint64_t id, const char* displayName, const char* typeName)
+	{
+		K4E::Sprite* sprite = logoSprite_.get();
+		Ken4lowEngine::EditorObjectInfo object{ id, displayName, typeName, "TitleScene" };
+		if (sprite)
+		{
+			object.canEditTransform = true;
+			object.readTransform = [sprite, fillSpriteTransform](Ken4lowEngine::EditorTransform& transform)
+			{
+				return fillSpriteTransform(sprite, transform);
+			};
+			object.writeTransform = [this, sprite, applySpriteTransform](const Ken4lowEngine::EditorTransform& transform)
+			{
+				applySpriteTransform(sprite, transform);
+				logoUI_.baseSize = { transform.scale.x, transform.scale.y };
+			};
+		}
+		outObjects.push_back(std::move(object));
+	};
+	const auto addClickSpriteObject = [&outObjects, this, fillSpriteTransform, applySpriteTransform](uint64_t id, const char* displayName, const char* typeName)
+	{
+		K4E::Sprite* sprite = clickHintUI_.hintSprite.get();
+		Ken4lowEngine::EditorObjectInfo object{ id, displayName, typeName, "TitleScene" };
+		if (sprite)
+		{
+			object.canEditTransform = true;
+			object.readTransform = [sprite, fillSpriteTransform](Ken4lowEngine::EditorTransform& transform)
+			{
+				return fillSpriteTransform(sprite, transform);
+			};
+			object.writeTransform = [this, sprite, applySpriteTransform](const Ken4lowEngine::EditorTransform& transform)
+			{
+				applySpriteTransform(sprite, transform);
+				clickHintUI_.baseSize = { transform.scale.x, transform.scale.y };
+				if (logoSprite_)
+				{
+					const K4E::Vector2& logoPosition = logoSprite_->GetPosition();
+					clickHintUI_.offset = { transform.position.x - logoPosition.x, transform.position.y - logoPosition.y };
+				}
+			};
+		}
+		outObjects.push_back(std::move(object));
+	};
 
 	// Outlinerは編集対象の入口として、TitleSceneを構成する主要カテゴリだけを安定IDで列挙する。
 	addObject(0x1000000000000001ull, "Title Root", "Scene Root");
-	addObject(0x1000000000000002ull, "Camera", camera_ ? "Camera" : "Camera (pending)");
+	addCameraObject(0x1000000000000002ull, "Camera", camera_ ? "Camera" : "Camera (pending)", camera_);
 	addObject(0x1000000000000003ull, "Light", "Directional Light");
-	addObject(0x1000000000000004ull, "UI Root", "UI Root");
-	addObject(0x1000000000000005ull, "Click Text / Click Sprite", clickHintUI_.hintSprite ? "Sprite UI" : "Sprite UI (pending)");
+	addLogoSpriteObject(0x1000000000000004ull, "UI Root", logoSprite_ ? "Sprite UI" : "Sprite UI (pending)");
+	addClickSpriteObject(0x1000000000000005ull, "Click Text / Click Sprite", clickHintUI_.hintSprite ? "Sprite UI" : "Sprite UI (pending)");
 	addObject(0x1000000000000006ull, "Fade Manager", "Fade Manager");
 }

--- a/Project/ApplicationLayer/Scene/TitleScene/TitleScene.h
+++ b/Project/ApplicationLayer/Scene/TitleScene/TitleScene.h
@@ -167,7 +167,7 @@ public: /// ---------- メンバ関数 ---------- ///
 	void DrawImGui() override;
 
 	// World OutlinerへTitleSceneの主要オブジェクトを公開する。
-	void CollectEditorObjects(std::vector<Ken4lowEngine::EditorObjectInfo>& outObjects) const override;
+	void CollectEditorObjects(std::vector<Ken4lowEngine::EditorObjectInfo>& outObjects) override;
 
 	// 段階ロード
 	void StartLoad() override;

--- a/Project/ApplicationLayer/SceneManagement/BaseScene/BaseScene.h
+++ b/Project/ApplicationLayer/SceneManagement/BaseScene/BaseScene.h
@@ -52,7 +52,7 @@ public: /// ---------- 純粋仮想関数 ---------- ///
 	virtual EditorInputPolicy GetEditorInputPolicy() const { return EditorInputPolicy::UiMouse; }
 
 	// World Outliner用の安全な表示情報をScene側から収集する入口です。
-	virtual void CollectEditorObjects(std::vector<Ken4lowEngine::EditorObjectInfo>& /*outObjects*/) const {}
+	virtual void CollectEditorObjects(std::vector<Ken4lowEngine::EditorObjectInfo>& /*outObjects*/) {}
 
 	// シーンマネージャーをセット
 	virtual void SetSceneManager(SceneManager* sceneManager) { sceneManager_ = sceneManager; }

--- a/Project/ApplicationLayer/SceneManagement/SceneManager/SceneManager.h
+++ b/Project/ApplicationLayer/SceneManagement/SceneManager/SceneManager.h
@@ -54,6 +54,7 @@ public: /// ---------- セッタ ---------- ///
 	bool IsTransitioning() const { return isTransitioning_ || (fadeManager_ && fadeManager_->IsBusy()); }
 
 	// Editor入力制御が現在Sceneのポリシーを参照できるようにする。
+	BaseScene* GetCurrentScene() { return scene_.get(); }
 	const BaseScene* GetCurrentScene() const { return scene_.get(); }
 
 private: /// ---------- メンバ関数 ---------- ///

--- a/Project/Engine/Editor/EditorObjectInfo.h
+++ b/Project/Engine/Editor/EditorObjectInfo.h
@@ -1,20 +1,54 @@
 #pragma once
 
 #include <cstdint>
+#include <functional>
 #include <string>
+
+#include "Vector3.h"
 
 namespace Ken4lowEngine
 {
+
+	/// <summary>
+	/// Detailsで表示・編集するための汎用Transformスナップショットです。
+	/// </summary>
+	struct EditorTransform
+	{
+		Vector3 position = { 0.0f, 0.0f, 0.0f };
+		Vector3 rotation = { 0.0f, 0.0f, 0.0f };
+		Vector3 scale = { 1.0f, 1.0f, 1.0f };
+	};
 
 	/// <summary>
 	/// World OutlinerとDetailsへ安全に渡すための軽量なエディタ表示用オブジェクト情報です。
 	/// </summary>
 	struct EditorObjectInfo
 	{
+		using ReadTransformFunc = std::function<bool(EditorTransform&)>;
+		using WriteTransformFunc = std::function<void(const EditorTransform&)>;
+
 		uint64_t id = 0;
 		std::string displayName;
 		std::string typeName;
 		std::string sceneName;
+		bool canEditTransform = false;
+		ReadTransformFunc readTransform;
+		WriteTransformFunc writeTransform;
+
+		// Detailsは毎フレーム再収集された入口だけを使い、古いraw pointerへ直接触れないようにする。
+		bool TryReadTransform(EditorTransform& outTransform) const
+		{
+			return canEditTransform && readTransform && readTransform(outTransform);
+		}
+
+		// Transform反映はScene側が用意した安全な書き戻し関数へ集約する。
+		void WriteTransform(const EditorTransform& transform) const
+		{
+			if (canEditTransform && writeTransform)
+			{
+				writeTransform(transform);
+			}
+		}
 	};
 
 } // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorSelection.cpp
+++ b/Project/Engine/Editor/EditorSelection.cpp
@@ -10,6 +10,13 @@ namespace Ken4lowEngine
 		hasSelection_ = true;
 	}
 
+	void EditorSelection::RefreshSelected(const EditorObjectInfo& objectInfo)
+	{
+		// 選択IDを維持したまま、毎フレーム再収集された編集入口へ差し替える。
+		selected_ = objectInfo;
+		hasSelection_ = true;
+	}
+
 	void EditorSelection::Clear()
 	{
 		// Scene切り替え時の古い選択を安全に破棄できる入口にする。

--- a/Project/Engine/Editor/EditorSelection.h
+++ b/Project/Engine/Editor/EditorSelection.h
@@ -13,6 +13,7 @@ namespace Ken4lowEngine
 	public:
 		void Select(const EditorObjectInfo& objectInfo);
 		void Clear();
+		void RefreshSelected(const EditorObjectInfo& objectInfo);
 		bool HasSelection() const;
 		const EditorObjectInfo& GetSelected() const;
 

--- a/Project/Engine/Editor/EditorWindowManager.cpp
+++ b/Project/Engine/Editor/EditorWindowManager.cpp
@@ -22,7 +22,7 @@ namespace Ken4lowEngine
 	{
 		EditorInputPolicy GetCurrentEditorInputPolicy()
 		{
-			const BaseScene* scene = SceneManager::GetInstance()->GetCurrentScene();
+			BaseScene* scene = SceneManager::GetInstance()->GetCurrentScene();
 			// Scene未設定時はUI Mouse扱いにしてEditor操作を妨げない。
 			return scene ? scene->GetEditorInputPolicy() : EditorInputPolicy::UiMouse;
 		}
@@ -472,7 +472,7 @@ namespace Ken4lowEngine
 		}
 
 		std::vector<EditorObjectInfo> objects;
-		const BaseScene* scene = SceneManager::GetInstance()->GetCurrentScene();
+		BaseScene* scene = SceneManager::GetInstance()->GetCurrentScene();
 		if (scene)
 		{
 			// Scene側から軽量情報だけを収集し、Outlinerが実オブジェクト寿命へ依存しないようにする。
@@ -482,11 +482,16 @@ namespace Ken4lowEngine
 		if (selection_.HasSelection())
 		{
 			const EditorObjectInfo& selected = selection_.GetSelected();
-			const bool stillExists = std::any_of(objects.begin(), objects.end(), [&selected](const EditorObjectInfo& object)
+			auto selectedObject = std::find_if(objects.begin(), objects.end(), [&selected](const EditorObjectInfo& object)
 				{
 					return object.id == selected.id && object.sceneName == selected.sceneName;
 				});
-			if (!stillExists)
+			if (selectedObject != objects.end())
+			{
+				// Detailsが古いSceneオブジェクト入口を掴み続けないよう、現在フレームの情報へ更新する。
+				selection_.RefreshSelected(*selectedObject);
+			}
+			else
 			{
 				// Scene切り替えやロード状態変化で消えた選択はDetails表示前に破棄する。
 				selection_.Clear();
@@ -538,13 +543,30 @@ namespace Ken4lowEngine
 			else
 			{
 				const EditorObjectInfo& selected = selection_.GetSelected();
-				// DetailsはTransform編集の前段階として、選択中オブジェクトの識別情報だけを表示する。
+				// Detailsは識別情報と編集可能なTransformだけを表示し、未対応オブジェクトは安全に弾く。
 				ImGui::Text("Selected Name: %s", selected.displayName.c_str());
 				ImGui::Text("Type: %s", selected.typeName.c_str());
 				ImGui::Text("Scene: %s", selected.sceneName.c_str());
 				ImGui::Text("ID: %llu", static_cast<unsigned long long>(selected.id));
 				ImGui::Separator();
-				ImGui::TextUnformatted("Transform editing is not implemented yet.");
+
+				EditorTransform transform{};
+				if (selected.TryReadTransform(transform))
+				{
+					bool changed = false;
+					changed |= ImGui::DragFloat3("Position", &transform.position.x, 0.1f);
+					changed |= ImGui::DragFloat3("Rotation", &transform.rotation.x, 0.01f);
+					changed |= ImGui::DragFloat3("Scale", &transform.scale.x, 0.1f);
+					if (changed)
+					{
+						// ImGuiで編集した値はScene側が用意した書き戻し入口から即時反映する。
+						selected.WriteTransform(transform);
+					}
+				}
+				else
+				{
+					ImGui::TextUnformatted("Transform editing is not available for this object.");
+				}
 			}
 		}
 		ImGui::End();


### PR DESCRIPTION
### Motivation
- Provide a safe, incremental way to view and edit Position/Rotation/Scale from the Details panel for Outliner-selected objects that actually expose a Transform, while avoiding dangling raw pointers and crashes on scene switches. 

### Description
- Add an `EditorTransform` snapshot and transform read/write function hooks to `EditorObjectInfo` so Details can query and apply transforms via `TryReadTransform()` / `WriteTransform()` without touching scene internals. 
- Make `BaseScene::CollectEditorObjects()` non-`const` and add a non-`const` `SceneManager::GetCurrentScene()` overload so scenes can supply editable entry points; update `TitleScene` to publish camera and sprite edit entry points (camera, UI/logo sprite, click hint sprite) with safe read/write lambdas. 
- Refresh selection each frame via `EditorSelection::RefreshSelected()` and change World Outliner logic to replace stale selection entries with the current-frame `EditorObjectInfo` or `Clear()` the selection if the object disappeared, and implement Details UI using ImGui `DragFloat3` for `Position`/`Rotation`/`Scale` that calls the scene-provided write hook when changed. 
- Key modified files: `Project/Engine/Editor/EditorObjectInfo.h`, `Project/Engine/Editor/EditorSelection.*`, `Project/Engine/Editor/EditorWindowManager.cpp`, `Project/ApplicationLayer/SceneManagement/BaseScene/BaseScene.h`, `Project/ApplicationLayer/SceneManagement/SceneManager/SceneManager.h`, `Project/ApplicationLayer/Scene/TitleScene/TitleScene.*`, plus small adjustments in `GamePlayScene` and `StageSelectScene` signatures to match the non-`const` API. 

### Testing
- Ran repository checks such as `git diff --check` which reported no whitespace errors and passed. 
- Performed automated symbol/content sanity checks using `rg`/Python scripts (presence of `TryReadTransform`, `DragFloat3("Position"`, `addCameraObject`, `addClickSpriteObject`, `RefreshSelected`) and those checks passed. 
- Verified Outliner/Details code paths were updated and grep confirmed the old "Transform editing is not implemented yet" text was removed. 
- Attempted to run a full Debug/Release build but Visual Studio/MSBuild/.NET SDK were not available in this environment so binary builds were not executed; therefore runtime testing was not performed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01c2ff3fe8832d9aba5e7d9d662da8)