### PR TITLE
Fix Outliner↔Details selection sync, stable EditorObject IDs, and inspector hints

### DIFF
--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
@@ -912,15 +912,14 @@ void GamePlayScene::CollectEditorObjects(std::vector<Ken4lowEngine::EditorObject
 	};
 
 	// OutlinerはPlay/Edit中の生成状態に依存しすぎないよう、主要サブシステムを安定IDで列挙する。
-	addObject(0x3000000000000001ull, "GamePlay Root", "Scene Root");
-	addPlayerObject(0x3000000000000002ull, "Player", world_ ? "Player" : "Player (pending)");
-	addCameraObject(0x3000000000000003ull, "Main Camera", "Camera");
-	addLightObject(0x3000000000000004ull, "Light", "Directional Light");
-	addObject(0x3000000000000005ull, "Enemy Manager", world_ ? "Enemy Manager" : "Enemy Manager (pending)");
-	addObject(0x3000000000000006ull, "Bullet Manager", world_ ? "Bullet Manager" : "Bullet Manager (pending)");
-	addObject(0x3000000000000007ull, "Wave Manager", world_ ? "Wave Manager" : "Wave Manager (pending)");
-	addObject(0x3000000000000008ull, "Stage", stageContext_ ? "Stage" : "Stage (pending)");
-	addObject(0x3000000000000009ull, "HUD", world_ ? "HUD" : "HUD (pending)");
-	addObject(0x300000000000000aull, "Collision Manager", "Collision Manager");
-	addObject(0x300000000000000bull, "Fade Manager", fadeManager_ ? "Fade Manager" : "Fade Manager (pending)");
+	addObject(Ken4lowEngine::MakeStableEditorObjectId("GamePlayScene.Root"), "GamePlay Root", "Scene Root");
+	addPlayerObject(Ken4lowEngine::MakeStableEditorObjectId("GamePlayScene.Player"), "Player", world_ ? "Player" : "Player (pending)");
+	addCameraObject(Ken4lowEngine::MakeStableEditorObjectId("GamePlayScene.MainCamera"), "Main Camera", "Camera");
+	addLightObject(Ken4lowEngine::MakeStableEditorObjectId("GamePlayScene.DirectionalLight.0"), "Directional Light", "Directional Light");
+	addObject(Ken4lowEngine::MakeStableEditorObjectId("GamePlayScene.EnemyManager"), "Enemy Manager", world_ ? "Enemy Manager" : "Enemy Manager (pending)");
+	addObject(Ken4lowEngine::MakeStableEditorObjectId("GamePlayScene.BulletManager"), "Bullet Manager", world_ ? "Bullet Manager" : "Bullet Manager (pending)");
+	addObject(Ken4lowEngine::MakeStableEditorObjectId("GamePlayScene.WaveManager"), "Wave Manager", world_ ? "Wave Manager" : "Wave Manager (pending)");
+	addObject(Ken4lowEngine::MakeStableEditorObjectId("GamePlayScene.Stage"), "Stage", stageContext_ ? "Stage" : "Stage (pending)");
+	addObject(Ken4lowEngine::MakeStableEditorObjectId("GamePlayScene.HUD"), "HUD", world_ ? "HUD" : "HUD (pending)");
+	addObject(Ken4lowEngine::MakeStableEditorObjectId("GamePlayScene.CollisionManager"), "Collision Manager", "Collision Manager");
 }

--- a/Project/ApplicationLayer/Scene/StageSelectScene/StageSelectScene.cpp
+++ b/Project/ApplicationLayer/Scene/StageSelectScene/StageSelectScene.cpp
@@ -16,6 +16,7 @@
 #include "TextSpriteDrawer.h"
 
 #include <algorithm>
+#include <utility>
 
 #ifdef USE_IMGUI
 #include <imgui.h>
@@ -753,11 +754,15 @@ void StageSelectScene::CollectEditorObjects(std::vector<Ken4lowEngine::EditorObj
 	};
 
 	// Outlinerはステージ選択画面の編集入口として、現在生成済みでなくても主要カテゴリを安定IDで列挙する。
-	addObject(0x2000000000000001ull, "StageSelect Root", "Scene Root");
-	addCameraObject(0x2000000000000002ull, "Camera", "Camera");
-	addLightObject(0x2000000000000003ull, "Light", "Directional Light");
-	addObject(0x2000000000000004ull, "Stage Panels", activeSelector_ ? "Stage Selector" : "Stage Selector (pending)");
-	addObject(0x2000000000000005ull, "Stage Text Layout", isTextReady_ ? "Text Layout" : "Text Layout (pending)");
-	addObject(0x2000000000000006ull, "Fade Manager", "Fade Manager");
-	addSpriteObject(0x2000000000000007ull, "Background UI", bg_ ? "Sprite UI" : "Sprite UI (pending)");
+	addObject(Ken4lowEngine::MakeStableEditorObjectId("StageSelectScene.Root"), "StageSelect Root", "Scene Root");
+	addCameraObject(Ken4lowEngine::MakeStableEditorObjectId("StageSelectScene.Camera"), "Camera", "Camera");
+	addLightObject(Ken4lowEngine::MakeStableEditorObjectId("StageSelectScene.DirectionalLight.0"), "Directional Light", "Directional Light");
+	addObject(Ken4lowEngine::MakeStableEditorObjectId("StageSelectScene.StagePanels"), "Stage Panels", activeSelector_ ? "Stage Selector" : "Stage Selector (pending)");
+	{
+		Ken4lowEngine::EditorObjectInfo textLayout{ Ken4lowEngine::MakeStableEditorObjectId("StageSelectScene.StageTextLayout"), "Stage Text Layout", "StageSelect Text Layout", "StageSelectScene" };
+		// 専用StageSelect Text Layoutウィンドウと競合しないよう、Detailsには編集先の案内だけを持たせる。
+		textLayout.inspectorHint = "Use StageSelect Text Layout tab for detailed editing.";
+		outObjects.push_back(std::move(textLayout));
+	}
+	addSpriteObject(Ken4lowEngine::MakeStableEditorObjectId("StageSelectScene.BackgroundUI"), "Background UI", bg_ ? "Sprite UI" : "Sprite UI (pending)");
 }

--- a/Project/Engine/Editor/EditorObjectInfo.h
+++ b/Project/Engine/Editor/EditorObjectInfo.h
@@ -3,11 +3,24 @@
 #include <cstdint>
 #include <functional>
 #include <string>
+#include <string_view>
 
 #include "Vector3.h"
 
 namespace Ken4lowEngine
 {
+
+	inline uint64_t MakeStableEditorObjectId(std::string_view path)
+	{
+		uint64_t hash = 14695981039346656037ull;
+		for (const char c : path)
+		{
+			// 固定パス文字列からFNV-1aでIDを作り、フレームごとのアドレス変化へ依存しないようにする。
+			hash ^= static_cast<unsigned char>(c);
+			hash *= 1099511628211ull;
+		}
+		return hash;
+	}
 
 	/// <summary>
 	/// Detailsで表示・編集するための汎用Transformスナップショットです。
@@ -33,6 +46,7 @@ namespace Ken4lowEngine
 		std::string sceneName;
 		bool canEditTransform = false;
 		std::string transformUnavailableReason = "Transform editing is not available for this object.";
+		std::string inspectorHint;
 		ReadTransformFunc readTransform;
 		WriteTransformFunc writeTransform;
 

--- a/Project/Engine/Editor/EditorWindowManager.cpp
+++ b/Project/Engine/Editor/EditorWindowManager.cpp
@@ -474,11 +474,6 @@ namespace Ken4lowEngine
 	void EditorWindowManager::DrawWorldOutliner()
 	{
 #ifdef USE_IMGUI
-		if (!windowState_.showWorldOutliner)
-		{
-			return;
-		}
-
 		std::vector<EditorObjectInfo> objects;
 		BaseScene* scene = SceneManager::GetInstance()->GetCurrentScene();
 		if (scene)
@@ -504,6 +499,12 @@ namespace Ken4lowEngine
 				// Scene切り替えやロード状態変化で消えた選択はDetails表示前に破棄する。
 				selection_.Clear();
 			}
+		}
+
+		if (!windowState_.showWorldOutliner)
+		{
+			// Detailsだけ表示している場合も、現在Sceneの収集結果で古い選択を先に破棄する。
+			return;
 		}
 
 		if (ImGui::Begin("World Outliner", &windowState_.showWorldOutliner))
@@ -556,6 +557,12 @@ namespace Ken4lowEngine
 				ImGui::Text("Type: %s", selected.typeName.c_str());
 				ImGui::Text("Scene: %s", selected.sceneName.c_str());
 				ImGui::Text("ID: %llu", static_cast<unsigned long long>(selected.id));
+				ImGui::Text("Transform Editable: %s", selected.canEditTransform ? "Yes" : "No");
+				if (!selected.inspectorHint.empty())
+				{
+					// 専用Debugウィンドウを持つ項目でも、Detailsへ編集先の案内を表示する。
+					ImGui::Text("Inspector: %s", selected.inspectorHint.c_str());
+				}
 				ImGui::Separator();
 
 				EditorTransform transform{};


### PR DESCRIPTION
### Motivation
- World Outlinerの選択がDetailsに反映されず、Scene切替や専用Debugウィンドウの項目で古い選択を掴み続ける問題を解消するため。 
- Outliner項目IDが毎フレームや一時ポインタに依存して不安定だったため、安定IDにして選択同期を確実にするため。 
- 専用編集タブを持つ項目（例: StageSelect Text Layout）でもDetailsに最低限の案内を出して操作をわかりやすくするため。

### Description
- `EditorObjectInfo` に `MakeStableEditorObjectId(std::string_view)` を追加し、固定パス文字列からFNV-1aで `uint64_t` の安定IDを生成するようにした (`Project/Engine/Editor/EditorObjectInfo.h`).
- `EditorObjectInfo` に `inspectorHint` フィールドを追加し、Detailsに専用Editorの案内を表示できるようにした (`Project/Engine/Editor/EditorObjectInfo.h`).
- `EditorWindowManager::DrawWorldOutliner()` で毎フレーム `CollectEditorObjects()` の結果と現在選択を突き合わせ、存在すれば `RefreshSelected()`、存在しなければ `Clear()` してDetailsが古い参照を保持しないようにした (`Project/Engine/Editor/EditorWindowManager.cpp`).
- `DrawDetails()` は `EditorSelection` のみを参照して表示し、常に `Selected Name` / `Type` / `Scene` / `ID` / `Transform Editable` を出力し、`inspectorHint` があれば `Inspector: ...` を表示するようにした (`Project/Engine/Editor/EditorWindowManager.cpp`).
- 各Sceneの `CollectEditorObjects()` を固定文字列IDへ差し替え、Light表示を `Directional Light` に統一し、`Fade Manager` をOutliner列挙から外した（`StageSelectScene` / `GamePlayScene` の収集処理を変更） (`Project/ApplicationLayer/Scene/StageSelectScene/StageSelectScene.cpp`, `Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp`).
- `StageSelectScene` の `Stage Text Layout` 項目は `inspectorHint` を渡し、専用ウィンドウ（`StageSelect Text Layout`）利用を明示するようにした (`Project/ApplicationLayer/Scene/StageSelectScene/StageSelectScene.cpp`).

### Testing
- コード差分チェックとして `git diff --check` を実行し問題なしを確認した（自動差分チェックは成功）。
- 変更箇所の存在確認とパターン検査として `rg` による検索（`Fade Manager` がOutlinerから消えていること、`Directional Light`、`StageSelectScene.StageTextLayout`、`GamePlayScene.Player` 等の出力）を実行し期待どおりの変更を検出できた（成功）。
- ビルドコマンド `msbuild Project/Ken4lowEngine.sln /p:Configuration=Debug /p:Platform=x64` と `Release` を試行したが、この実行環境に `msbuild` が存在しないため実行不可でありビルドは未検証（ツール不在）。
- 変更ファイル: `Project/Engine/Editor/EditorObjectInfo.h`, `Project/Engine/Editor/EditorWindowManager.cpp`, `Project/ApplicationLayer/Scene/StageSelectScene/StageSelectScene.cpp`, `Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01d220c77c832db70e1f2cecffa5e6)