### PR TITLE
Rework Outliner → Details inspectors; add Punctual Lights / Fade / StageSelect inspectors

### DIFF
--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
@@ -828,7 +828,9 @@ void GamePlayScene::CollectEditorObjects(std::vector<Ken4lowEngine::EditorObject
 	const auto addObject = [&outObjects](uint64_t id, const char* displayName, const char* typeName)
 	{
 		// Transform未対応の管理項目はDetailsで理由だけを表示し、編集入口を持たせない。
-		outObjects.push_back({ id, displayName, typeName, "GamePlayScene" });
+		Ken4lowEngine::EditorObjectInfo object{ id, displayName, typeName, "GamePlayScene" };
+		object.inspectorType = Ken4lowEngine::EditorInspectorType::ManagerInfo;
+		outObjects.push_back(std::move(object));
 	};
 	const auto addCameraObject = [&outObjects](uint64_t id, const char* displayName, const char* typeName)
 	{
@@ -838,12 +840,15 @@ void GamePlayScene::CollectEditorObjects(std::vector<Ken4lowEngine::EditorObject
 	const auto addLightObject = [&outObjects](uint64_t id, const char* displayName, const char* typeName)
 	{
 		// LightManagerの先頭ライトを安全なindex指定でDetails編集へ公開する。
-		outObjects.push_back(Ken4lowEngine::MakePunctualLightEditorObject(id, displayName, typeName, "GamePlayScene", 0));
+		Ken4lowEngine::EditorObjectInfo object{ id, displayName, typeName, "GamePlayScene" };
+		object.inspectorType = Ken4lowEngine::EditorInspectorType::PunctualLights;
+		outObjects.push_back(std::move(object));
 	};
 	const auto addPlayerObject = [&outObjects, this](uint64_t id, const char* displayName, const char* typeName)
 	{
 		Player* player = world_ ? world_->GetCharacters().GetPlayer() : nullptr;
 		Ken4lowEngine::EditorObjectInfo object{ id, displayName, typeName, "GamePlayScene" };
+		object.inspectorType = Ken4lowEngine::EditorInspectorType::Transform;
 		if (!player)
 		{
 			object.transformUnavailableReason = "Player is not created yet.";
@@ -915,11 +920,23 @@ void GamePlayScene::CollectEditorObjects(std::vector<Ken4lowEngine::EditorObject
 	addObject(Ken4lowEngine::MakeStableEditorObjectId("GamePlayScene.Root"), "GamePlay Root", "Scene Root");
 	addPlayerObject(Ken4lowEngine::MakeStableEditorObjectId("GamePlayScene.Player"), "Player", world_ ? "Player" : "Player (pending)");
 	addCameraObject(Ken4lowEngine::MakeStableEditorObjectId("GamePlayScene.MainCamera"), "Main Camera", "Camera");
-	addLightObject(Ken4lowEngine::MakeStableEditorObjectId("GamePlayScene.DirectionalLight.0"), "Directional Light", "Directional Light");
+	addLightObject(Ken4lowEngine::MakeStableEditorObjectId("GamePlayScene.PunctualLights"), "Punctual Lights", "Light Manager / Punctual Lights");
 	addObject(Ken4lowEngine::MakeStableEditorObjectId("GamePlayScene.EnemyManager"), "Enemy Manager", world_ ? "Enemy Manager" : "Enemy Manager (pending)");
 	addObject(Ken4lowEngine::MakeStableEditorObjectId("GamePlayScene.BulletManager"), "Bullet Manager", world_ ? "Bullet Manager" : "Bullet Manager (pending)");
 	addObject(Ken4lowEngine::MakeStableEditorObjectId("GamePlayScene.WaveManager"), "Wave Manager", world_ ? "Wave Manager" : "Wave Manager (pending)");
 	addObject(Ken4lowEngine::MakeStableEditorObjectId("GamePlayScene.Stage"), "Stage", stageContext_ ? "Stage" : "Stage (pending)");
 	addObject(Ken4lowEngine::MakeStableEditorObjectId("GamePlayScene.HUD"), "HUD", world_ ? "HUD" : "HUD (pending)");
 	addObject(Ken4lowEngine::MakeStableEditorObjectId("GamePlayScene.CollisionManager"), "Collision Manager", "Collision Manager");
+	{
+		Ken4lowEngine::EditorObjectInfo fadeObject{ Ken4lowEngine::MakeStableEditorObjectId("GamePlayScene.FadeManager"), "FadeManager", "Fade Manager", "GamePlayScene" };
+		fadeObject.inspectorType = Ken4lowEngine::EditorInspectorType::FadeManager;
+		fadeObject.drawInspector = [this]()
+		{
+			if (fadeManager_)
+			{
+				fadeManager_->DrawInspectorContent();
+			}
+		};
+		outObjects.push_back(std::move(fadeObject));
+	}
 }

--- a/Project/ApplicationLayer/Scene/StageSelectScene/StageSelectScene.cpp
+++ b/Project/ApplicationLayer/Scene/StageSelectScene/StageSelectScene.cpp
@@ -365,6 +365,54 @@ void StageSelectScene::Finalize()
 /// -------------------------------------------------------------
 ///				　			ImGui描画処理
 /// -------------------------------------------------------------
+void StageSelectScene::DrawStageSelectTextLayoutInspectorContent()
+{
+#ifdef USE_IMGUI
+	// Detailsと専用StageSelect Text Layoutウィンドウの表示差分をなくすため、調整UIを共有する。
+	ImGui::Text("Current Stage Index : %d", currentStageIndex_);
+
+	ImGui::SeparatorText("Global");
+	ImGui::DragFloat("Center X Offset", &textLayoutDebug_.centerXOffset, 1.0f, -400.0f, 400.0f);
+
+	ImGui::SeparatorText("Title");
+	ImGui::DragFloat("Title Y", &textLayoutDebug_.titleY, 1.0f, 0.0f, 300.0f);
+	ImGui::DragFloat("Title Scale", &textLayoutDebug_.titleScale, 0.01f, 0.2f, 3.0f);
+
+	ImGui::SeparatorText("Stage No");
+	ImGui::DragFloat("StageNo Y", &textLayoutDebug_.stageNoY, 1.0f, -1000.0f, 100.0f);
+	ImGui::DragFloat("StageNo Scale", &textLayoutDebug_.stageNoScale, 0.01f, 0.2f, 3.0f);
+
+	ImGui::SeparatorText("Stage Name");
+	ImGui::DragFloat("StageName Y", &textLayoutDebug_.stageNameY, 1.0f, -1000.0f, 100.0f);
+	ImGui::DragFloat("StageName Scale", &textLayoutDebug_.stageNameScale, 0.01f, 0.2f, 3.0f);
+
+	ImGui::SeparatorText("Category");
+	ImGui::DragFloat("Category Y", &textLayoutDebug_.categoryY, 1.0f, -1000.0f, 100.0f);
+	ImGui::DragFloat("Category Scale", &textLayoutDebug_.categoryScale, 0.01f, 0.2f, 3.0f);
+
+	ImGui::SeparatorText("Catch Copy");
+	ImGui::DragFloat("Catch Y", &textLayoutDebug_.catchY, 1.0f, -1000.0f, 100.0f);
+	ImGui::DragFloat("Catch Scale", &textLayoutDebug_.catchScale, 0.01f, 0.2f, 3.0f);
+
+	ImGui::SeparatorText("Description");
+	ImGui::DragFloat("Desc Y", &textLayoutDebug_.descY, 1.0f, -1000.0f, 100.0f);
+	ImGui::DragFloat("Desc Scale", &textLayoutDebug_.descScale, 0.01f, 0.2f, 3.0f);
+
+	ImGui::SeparatorText("Unlock");
+	ImGui::DragFloat("Unlock Y", &textLayoutDebug_.unlockY, 1.0f, -1000.0f, 100.0f);
+	ImGui::DragFloat("Unlock Scale", &textLayoutDebug_.unlockScale, 0.01f, 0.2f, 3.0f);
+
+	ImGui::SeparatorText("Guide");
+	ImGui::DragFloat("Guide Y", &textLayoutDebug_.guideY, 1.0f, -1000.0f, 100.0f);
+	ImGui::DragFloat("Guide Scale", &textLayoutDebug_.guideScale, 0.01f, 0.2f, 3.0f);
+
+	if (ImGui::Button("Reset Layout"))
+	{
+		textLayoutDebug_ = CreateDefaultTextLayoutDebug();
+	}
+#endif // USE_IMGUI
+}
+
 void StageSelectScene::DrawImGui()
 {
 #ifdef USE_IMGUI
@@ -374,98 +422,10 @@ void StageSelectScene::DrawImGui()
 
 	if (ImGui::Begin("StageSelect Text Layout", &editorWindowState.showStageSelectDebug))
 	{
-		ImGui::Text("Current Stage Index : %d", currentStageIndex_);
-
-		ImGui::SeparatorText("Global");
-		ImGui::DragFloat("Center X Offset", &textLayoutDebug_.centerXOffset, 1.0f, -400.0f, 400.0f);
-
-		ImGui::SeparatorText("Title");
-		ImGui::DragFloat("Title Y", &textLayoutDebug_.titleY, 1.0f, 0.0f, 300.0f);
-		ImGui::DragFloat("Title Scale", &textLayoutDebug_.titleScale, 0.01f, 0.2f, 3.0f);
-
-		ImGui::SeparatorText("Stage No");
-		ImGui::DragFloat("StageNo Y", &textLayoutDebug_.stageNoY, 1.0f, -1000.0f, 100.0f);
-		ImGui::DragFloat("StageNo Scale", &textLayoutDebug_.stageNoScale, 0.01f, 0.2f, 3.0f);
-
-		ImGui::SeparatorText("Stage Name");
-		ImGui::DragFloat("StageName Y", &textLayoutDebug_.stageNameY, 1.0f, -1000.0f, 100.0f);
-		ImGui::DragFloat("StageName Scale", &textLayoutDebug_.stageNameScale, 0.01f, 0.2f, 3.0f);
-
-		ImGui::SeparatorText("Category");
-		ImGui::DragFloat("Category Y", &textLayoutDebug_.categoryY, 1.0f, -1000.0f, 100.0f);
-		ImGui::DragFloat("Category Scale", &textLayoutDebug_.categoryScale, 0.01f, 0.2f, 3.0f);
-
-		ImGui::SeparatorText("Catch Copy");
-		ImGui::DragFloat("Catch Y", &textLayoutDebug_.catchY, 1.0f, -1000.0f, 100.0f);
-		ImGui::DragFloat("Catch Scale", &textLayoutDebug_.catchScale, 0.01f, 0.2f, 3.0f);
-
-		ImGui::SeparatorText("Description");
-		ImGui::DragFloat("Desc Y", &textLayoutDebug_.descY, 1.0f, -1000.0f, 100.0f);
-		ImGui::DragFloat("Desc Scale", &textLayoutDebug_.descScale, 0.01f, 0.2f, 3.0f);
-
-		ImGui::SeparatorText("Unlock");
-		ImGui::DragFloat("Unlock Y", &textLayoutDebug_.unlockY, 1.0f, -1000.0f, 100.0f);
-		ImGui::DragFloat("Unlock Scale", &textLayoutDebug_.unlockScale, 0.01f, 0.2f, 3.0f);
-
-		ImGui::SeparatorText("Guide");
-		ImGui::DragFloat("Guide Y", &textLayoutDebug_.guideY, 1.0f, -1000.0f, 100.0f);
-		ImGui::DragFloat("Guide Scale", &textLayoutDebug_.guideScale, 0.01f, 0.2f, 3.0f);
-
-		if (ImGui::Button("Reset Layout"))
-		{
-			textLayoutDebug_ = CreateDefaultTextLayoutDebug();
-		}
+		DrawStageSelectTextLayoutInspectorContent();
 	}
 	ImGui::End();
 #endif // USE_IMGUI
-
-}
-
-void StageSelectScene::StartLoad()
-{
-	loadStep_ = 0;
-	isLoadReady_ = false;
-	state_ = State::Loading;
-}
-
-void StageSelectScene::UpdateLoad()
-{
-	switch (loadStep_)
-	{
-	case 0:
-		// ステージ情報だけ先に作る
-		InitializeStages();
-		++loadStep_;
-		break;
-
-	case 1:
-		// セレクタのコンテキストだけ組む
-		InitializeSelectors();
-		++loadStep_;
-		break;
-
-	case 2:
-		// 背景と GridSelector の生成
-		InitializeBackground();
-		++loadStep_;
-		break;
-
-	case 3:
-		// 選択状態へ入る
-		ChangeState(std::make_unique<StageSelectSelectingState>());
-		state_ = State::Selecting;
-		isLoadReady_ = true;
-		++loadStep_;
-		break;
-
-	default:
-		break;
-	}
-}
-
-bool StageSelectScene::IsReadyToStartUncover() const
-{
-	return isLoadReady_;
 }
 
 /// -------------------------------------------------------------
@@ -735,7 +695,9 @@ void StageSelectScene::CollectEditorObjects(std::vector<Ken4lowEngine::EditorObj
 	const auto addObject = [&outObjects](uint64_t id, const char* displayName, const char* typeName)
 	{
 		// Transform未対応の管理項目はDetailsで理由だけを表示し、編集入口を持たせない。
-		outObjects.push_back({ id, displayName, typeName, "StageSelectScene" });
+		Ken4lowEngine::EditorObjectInfo object{ id, displayName, typeName, "StageSelectScene" };
+		object.inspectorType = Ken4lowEngine::EditorInspectorType::ManagerInfo;
+		outObjects.push_back(std::move(object));
 	};
 	const auto addCameraObject = [&outObjects](uint64_t id, const char* displayName, const char* typeName)
 	{
@@ -745,7 +707,9 @@ void StageSelectScene::CollectEditorObjects(std::vector<Ken4lowEngine::EditorObj
 	const auto addLightObject = [&outObjects](uint64_t id, const char* displayName, const char* typeName)
 	{
 		// LightManagerの先頭ライトを安全なindex指定でDetails編集へ公開する。
-		outObjects.push_back(Ken4lowEngine::MakePunctualLightEditorObject(id, displayName, typeName, "StageSelectScene", 0));
+		Ken4lowEngine::EditorObjectInfo object{ id, displayName, typeName, "StageSelectScene" };
+		object.inspectorType = Ken4lowEngine::EditorInspectorType::PunctualLights;
+		outObjects.push_back(std::move(object));
 	};
 	const auto addSpriteObject = [&outObjects, this](uint64_t id, const char* displayName, const char* typeName)
 	{
@@ -756,12 +720,16 @@ void StageSelectScene::CollectEditorObjects(std::vector<Ken4lowEngine::EditorObj
 	// Outlinerはステージ選択画面の編集入口として、現在生成済みでなくても主要カテゴリを安定IDで列挙する。
 	addObject(Ken4lowEngine::MakeStableEditorObjectId("StageSelectScene.Root"), "StageSelect Root", "Scene Root");
 	addCameraObject(Ken4lowEngine::MakeStableEditorObjectId("StageSelectScene.Camera"), "Camera", "Camera");
-	addLightObject(Ken4lowEngine::MakeStableEditorObjectId("StageSelectScene.DirectionalLight.0"), "Directional Light", "Directional Light");
+	addLightObject(Ken4lowEngine::MakeStableEditorObjectId("StageSelectScene.PunctualLights"), "Punctual Lights", "Light Manager / Punctual Lights");
 	addObject(Ken4lowEngine::MakeStableEditorObjectId("StageSelectScene.StagePanels"), "Stage Panels", activeSelector_ ? "Stage Selector" : "Stage Selector (pending)");
 	{
 		Ken4lowEngine::EditorObjectInfo textLayout{ Ken4lowEngine::MakeStableEditorObjectId("StageSelectScene.StageTextLayout"), "Stage Text Layout", "StageSelect Text Layout", "StageSelectScene" };
-		// 専用StageSelect Text Layoutウィンドウと競合しないよう、Detailsには編集先の案内だけを持たせる。
-		textLayout.inspectorHint = "Use StageSelect Text Layout tab for detailed editing.";
+		// Detailsからも専用StageSelect Text Layoutと同じ調整UIを開けるようにする。
+		textLayout.inspectorType = Ken4lowEngine::EditorInspectorType::StageSelectTextLayout;
+		textLayout.drawInspector = [this]()
+		{
+			DrawStageSelectTextLayoutInspectorContent();
+		};
 		outObjects.push_back(std::move(textLayout));
 	}
 	addSpriteObject(Ken4lowEngine::MakeStableEditorObjectId("StageSelectScene.BackgroundUI"), "Background UI", bg_ ? "Sprite UI" : "Sprite UI (pending)");

--- a/Project/ApplicationLayer/Scene/StageSelectScene/StageSelectScene.h
+++ b/Project/ApplicationLayer/Scene/StageSelectScene/StageSelectScene.h
@@ -127,6 +127,9 @@ public: /// ---------- メンバ関数 ---------- ///
 	// World OutlinerへStageSelectSceneの主要オブジェクトを公開する。
 	void CollectEditorObjects(std::vector<Ken4lowEngine::EditorObjectInfo>& outObjects) override;
 
+	// Details Inspectorと専用StageSelect Text Layoutウィンドウで同じ調整UIを共有する。
+	void DrawStageSelectTextLayoutInspectorContent();
+
 	// 段階ロード
 	void StartLoad() override;
 

--- a/Project/ApplicationLayer/Scene/TitleScene/TitleScene.cpp
+++ b/Project/ApplicationLayer/Scene/TitleScene/TitleScene.cpp
@@ -493,16 +493,21 @@ void TitleScene::CollectEditorObjects(std::vector<Ken4lowEngine::EditorObjectInf
 	const auto addObject = [&outObjects](uint64_t id, const char* displayName, const char* typeName)
 	{
 		// Transform未対応の管理項目はDetailsで理由だけを表示し、編集入口を持たせない。
-		outObjects.push_back({ id, displayName, typeName, "TitleScene" });
+		Ken4lowEngine::EditorObjectInfo object{ id, displayName, typeName, "TitleScene" };
+		object.inspectorType = Ken4lowEngine::EditorInspectorType::ManagerInfo;
+		outObjects.push_back(std::move(object));
 	};
 	const auto addLightObject = [&outObjects](uint64_t id, const char* displayName, const char* typeName)
 	{
 		// LightManagerの先頭ライトを安全なindex指定でDetails編集へ公開する。
-		outObjects.push_back(Ken4lowEngine::MakePunctualLightEditorObject(id, displayName, typeName, "TitleScene", 0));
+		Ken4lowEngine::EditorObjectInfo object{ id, displayName, typeName, "TitleScene" };
+		object.inspectorType = Ken4lowEngine::EditorInspectorType::PunctualLights;
+		outObjects.push_back(std::move(object));
 	};
 	const auto addCameraObject = [&outObjects](uint64_t id, const char* displayName, const char* typeName, K4E::Camera* camera)
 	{
 		Ken4lowEngine::EditorObjectInfo object{ id, displayName, typeName, "TitleScene" };
+		object.inspectorType = Ken4lowEngine::EditorInspectorType::Transform;
 		if (camera)
 		{
 			object.canEditTransform = true;
@@ -559,6 +564,7 @@ void TitleScene::CollectEditorObjects(std::vector<Ken4lowEngine::EditorObjectInf
 	{
 		K4E::Sprite* sprite = logoSprite_.get();
 		Ken4lowEngine::EditorObjectInfo object{ id, displayName, typeName, "TitleScene" };
+		object.inspectorType = Ken4lowEngine::EditorInspectorType::Transform;
 		if (sprite)
 		{
 			object.canEditTransform = true;
@@ -578,6 +584,7 @@ void TitleScene::CollectEditorObjects(std::vector<Ken4lowEngine::EditorObjectInf
 	{
 		K4E::Sprite* sprite = clickHintUI_.hintSprite.get();
 		Ken4lowEngine::EditorObjectInfo object{ id, displayName, typeName, "TitleScene" };
+		object.inspectorType = Ken4lowEngine::EditorInspectorType::Transform;
 		if (sprite)
 		{
 			object.canEditTransform = true;
@@ -600,10 +607,21 @@ void TitleScene::CollectEditorObjects(std::vector<Ken4lowEngine::EditorObjectInf
 	};
 
 	// Outlinerは編集対象の入口として、TitleSceneを構成する主要カテゴリだけを安定IDで列挙する。
-	addObject(0x1000000000000001ull, "Title Root", "Scene Root");
-	addCameraObject(0x1000000000000002ull, "Camera", camera_ ? "Camera" : "Camera (pending)", camera_);
-	addLightObject(0x1000000000000003ull, "Light", "Directional Light");
-	addLogoSpriteObject(0x1000000000000004ull, "UI Root", logoSprite_ ? "Sprite UI" : "Sprite UI (pending)");
-	addClickSpriteObject(0x1000000000000005ull, "Click Text / Click Sprite", clickHintUI_.hintSprite ? "Sprite UI" : "Sprite UI (pending)");
-	addObject(0x1000000000000006ull, "Fade Manager", "Fade Manager");
+	addObject(Ken4lowEngine::MakeStableEditorObjectId("TitleScene.Root"), "Title Root", "Scene Root");
+	addCameraObject(Ken4lowEngine::MakeStableEditorObjectId("TitleScene.Camera"), "Camera", camera_ ? "Camera" : "Camera (pending)", camera_);
+	addLightObject(Ken4lowEngine::MakeStableEditorObjectId("TitleScene.PunctualLights"), "Punctual Lights", "Light Manager / Punctual Lights");
+	addLogoSpriteObject(Ken4lowEngine::MakeStableEditorObjectId("TitleScene.UIRoot"), "UI Root", logoSprite_ ? "Sprite UI" : "Sprite UI (pending)");
+	addClickSpriteObject(Ken4lowEngine::MakeStableEditorObjectId("TitleScene.ClickText"), "Click Text / Click Sprite", clickHintUI_.hintSprite ? "Sprite UI" : "Sprite UI (pending)");
+	{
+		Ken4lowEngine::EditorObjectInfo fadeObject{ Ken4lowEngine::MakeStableEditorObjectId("TitleScene.FadeManager"), "FadeManager", "Fade Manager", "TitleScene" };
+		fadeObject.inspectorType = Ken4lowEngine::EditorInspectorType::FadeManager;
+		fadeObject.drawInspector = []()
+		{
+			if (FadeManager* fadeManager = SceneManager::GetInstance()->GetFadeManager())
+			{
+				fadeManager->DrawInspectorContent();
+			}
+		};
+		outObjects.push_back(std::move(fadeObject));
+	}
 }

--- a/Project/ApplicationLayer/SceneManagement/FadeManager/FadeManager.cpp
+++ b/Project/ApplicationLayer/SceneManagement/FadeManager/FadeManager.cpp
@@ -757,18 +757,10 @@ void FadeManager::Draw2DSprites()
 // ------------------------------
 // ImGui
 // ------------------------------
-void FadeManager::DrawImGui()
+void FadeManager::DrawInspectorContent()
 {
 #ifdef USE_IMGUI
-	// WindowメニューのFadeManager表示フラグを×ボタン状態と共有する
-	auto& editorWindowState = K4E::EditorWindowManager::GetInstance()->GetWindowState();
-	if (!editorWindowState.showFadeManager)
-	{
-		return;
-	}
-
-	ImGui::Begin("FadeManager", &editorWindowState.showFadeManager);
-
+	// Detailsと専用FadeManagerウィンドウの表示差分をなくすため、内部状態UIを共有する。
 	const char* st =
 		(state_ == State::None) ? "演出していない待機状態" :
 		(state_ == State::TileCover) ? "タイルが配置されて画面を覆う段階" :
@@ -776,7 +768,10 @@ void FadeManager::DrawImGui()
 		(state_ == State::Crack) ? "ひび割れアニメーション中" :
 		(state_ == State::TileUncover) ? "タイルを解除して画面が戻る段階" : "Unknown";
 
-	ImGui::Text("State: %s", st);
+	ImGui::Text("Current State: %s", st);
+	ImGui::Text("Fade Busy: %s", IsBusy() ? "Yes" : "No");
+	ImGui::Text("Timer: %.3f", stateTime_);
+	ImGui::Text("Cover Duration: %.3f / Crack Duration: %.3f / Drop Delay: %.3f", coverTileAnimTime_, crackTileAnimTime_, dropStartDelay_);
 	ImGui::Text("ひび割れ: %s", crackDone_ ? "完了" : "途中");
 	ImGui::Text("落下演出: %s", dropDone_ ? "落下完了" : "落下中");
 
@@ -869,6 +864,25 @@ void FadeManager::DrawImGui()
 		RebuildTiles(screenW_, screenH_);
 	}
 
+#else
+	// ImGui無効なら何もしない
+#endif
+}
+
+void FadeManager::DrawImGui()
+{
+#ifdef USE_IMGUI
+	// WindowメニューのFadeManager表示フラグを×ボタン状態と共有する
+	auto& editorWindowState = K4E::EditorWindowManager::GetInstance()->GetWindowState();
+	if (!editorWindowState.showFadeManager)
+	{
+		return;
+	}
+
+	if (ImGui::Begin("FadeManager", &editorWindowState.showFadeManager))
+	{
+		DrawInspectorContent();
+	}
 	ImGui::End();
 #else
 	// ImGui無効なら何もしない

--- a/Project/ApplicationLayer/SceneManagement/FadeManager/FadeManager.h
+++ b/Project/ApplicationLayer/SceneManagement/FadeManager/FadeManager.h
@@ -94,6 +94,9 @@ public: /// ---------- メンバ関数 ---------- ///
 	// ImGuiデバッグ
 	void DrawImGui();
 
+	// Details Inspectorと専用FadeManagerウィンドウで同じDebug UIを共有する。
+	void DrawInspectorContent();
+
 	// 破棄
 	void Finalize();
 

--- a/Project/ApplicationLayer/SceneManagement/SceneManager/SceneManager.h
+++ b/Project/ApplicationLayer/SceneManagement/SceneManager/SceneManager.h
@@ -57,6 +57,10 @@ public: /// ---------- セッタ ---------- ///
 	BaseScene* GetCurrentScene() { return scene_.get(); }
 	const BaseScene* GetCurrentScene() const { return scene_.get(); }
 
+	// Details InspectorはSceneManager所有のFadeManagerを毎フレーム取り直して古い参照を避ける。
+	FadeManager* GetFadeManager() { return fadeManager_.get(); }
+	const FadeManager* GetFadeManager() const { return fadeManager_.get(); }
+
 private: /// ---------- メンバ関数 ---------- ///
 
 	// 次シーン適用（Finalize→差し替え→Initialize）

--- a/Project/Engine/Editor/EditorObjectInfo.h
+++ b/Project/Engine/Editor/EditorObjectInfo.h
@@ -32,6 +32,16 @@ namespace Ken4lowEngine
 		Vector3 scale = { 1.0f, 1.0f, 1.0f };
 	};
 
+	enum class EditorInspectorType
+	{
+		None,
+		Transform,
+		PunctualLights,
+		FadeManager,
+		StageSelectTextLayout,
+		ManagerInfo,
+	};
+
 	/// <summary>
 	/// World OutlinerとDetailsへ安全に渡すための軽量なエディタ表示用オブジェクト情報です。
 	/// </summary>
@@ -39,6 +49,7 @@ namespace Ken4lowEngine
 	{
 		using ReadTransformFunc = std::function<bool(EditorTransform&)>;
 		using WriteTransformFunc = std::function<void(const EditorTransform&)>;
+		using DrawInspectorFunc = std::function<void()>;
 
 		uint64_t id = 0;
 		std::string displayName;
@@ -46,8 +57,10 @@ namespace Ken4lowEngine
 		std::string sceneName;
 		bool canEditTransform = false;
 		std::string transformUnavailableReason = "Transform editing is not available for this object.";
+		EditorInspectorType inspectorType = EditorInspectorType::None;
 		std::string inspectorHint;
 		ReadTransformFunc readTransform;
+		DrawInspectorFunc drawInspector;
 		WriteTransformFunc writeTransform;
 
 		// Detailsは毎フレーム再収集された入口だけを使い、古いraw pointerへ直接触れないようにする。

--- a/Project/Engine/Editor/EditorTransformAccess.h
+++ b/Project/Engine/Editor/EditorTransformAccess.h
@@ -17,6 +17,7 @@ namespace Ken4lowEngine
 	inline EditorObjectInfo MakeCameraEditorObject(uint64_t id, std::string displayName, std::string typeName, std::string sceneName, Camera* camera)
 	{
 		EditorObjectInfo object{ id, std::move(displayName), std::move(typeName), std::move(sceneName) };
+		object.inspectorType = EditorInspectorType::Transform;
 		if (!camera)
 		{
 			object.transformUnavailableReason = "Camera is not created yet.";
@@ -53,6 +54,7 @@ namespace Ken4lowEngine
 	inline EditorObjectInfo MakeSpriteEditorObject(uint64_t id, std::string displayName, std::string typeName, std::string sceneName, Sprite* sprite)
 	{
 		EditorObjectInfo object{ id, std::move(displayName), std::move(typeName), std::move(sceneName) };
+		object.inspectorType = EditorInspectorType::Transform;
 		if (!sprite)
 		{
 			object.transformUnavailableReason = "Sprite is not created yet.";
@@ -92,6 +94,7 @@ namespace Ken4lowEngine
 	{
 		EditorObjectInfo object{ id, std::move(displayName), std::move(typeName), std::move(sceneName) };
 		object.canEditTransform = lightIndex < LightManager::GetInstance()->GetPunctualLights().size();
+		object.inspectorType = EditorInspectorType::Transform;
 		object.transformUnavailableReason = "Light is not created yet.";
 		object.readTransform = [lightIndex](EditorTransform& transform)
 		{

--- a/Project/Engine/Editor/EditorWindowManager.cpp
+++ b/Project/Engine/Editor/EditorWindowManager.cpp
@@ -6,6 +6,7 @@
 #include "PostEffectManager.h"
 #include "GameViewportConstants.h"
 #include <Input.h>
+#include <LightManager.h>
 #include <SceneManager.h>
 
 #include <algorithm>
@@ -552,35 +553,76 @@ namespace Ken4lowEngine
 			else
 			{
 				const EditorObjectInfo& selected = selection_.GetSelected();
-				// Detailsは識別情報と編集可能なTransformだけを表示し、未対応オブジェクトは安全に弾く。
+				// DetailsはTransform専用ではなく、Outliner選択に対応するInspector種別で必ず表示内容を切り替える。
 				ImGui::Text("Selected Name: %s", selected.displayName.c_str());
 				ImGui::Text("Type: %s", selected.typeName.c_str());
 				ImGui::Text("Scene: %s", selected.sceneName.c_str());
 				ImGui::Text("ID: %llu", static_cast<unsigned long long>(selected.id));
-				ImGui::Text("Transform Editable: %s", selected.canEditTransform ? "Yes" : "No");
 				if (!selected.inspectorHint.empty())
 				{
-					// 専用Debugウィンドウを持つ項目でも、Detailsへ編集先の案内を表示する。
 					ImGui::Text("Inspector: %s", selected.inspectorHint.c_str());
 				}
 				ImGui::Separator();
 
-				EditorTransform transform{};
-				if (selected.TryReadTransform(transform))
+				switch (selected.inspectorType)
 				{
-					bool changed = false;
-					changed |= ImGui::DragFloat3("Position", &transform.position.x, 0.1f);
-					changed |= ImGui::DragFloat3("Rotation", &transform.rotation.x, 0.01f);
-					changed |= ImGui::DragFloat3("Scale", &transform.scale.x, 0.1f);
-					if (changed)
+				case EditorInspectorType::Transform:
+				{
+					EditorTransform transform{};
+					if (selected.TryReadTransform(transform))
 					{
-						// ImGuiで編集した値はScene側が用意した書き戻し入口から即時反映する。
-						selected.WriteTransform(transform);
+						bool changed = false;
+						changed |= ImGui::DragFloat3("Position", &transform.position.x, 0.1f);
+						changed |= ImGui::DragFloat3("Rotation", &transform.rotation.x, 0.01f);
+						changed |= ImGui::DragFloat3("Scale", &transform.scale.x, 0.1f);
+						if (changed)
+						{
+							// ImGuiで編集した値はScene側が用意した書き戻し入口から即時反映する。
+							selected.WriteTransform(transform);
+						}
 					}
+					else
+					{
+						ImGui::Text("%s", selected.transformUnavailableReason.c_str());
+					}
+					break;
 				}
-				else
-				{
-					ImGui::Text("%s", selected.transformUnavailableReason.c_str());
+				case EditorInspectorType::PunctualLights:
+					ImGui::TextUnformatted("Type: Light Manager / Punctual Lights");
+					LightManager::GetInstance()->DrawPunctualLightsInspector();
+					break;
+				case EditorInspectorType::FadeManager:
+					if (selected.drawInspector)
+					{
+						selected.drawInspector();
+					}
+					else
+					{
+						ImGui::TextUnformatted("FadeManager Inspector is unavailable.");
+					}
+					break;
+				case EditorInspectorType::StageSelectTextLayout:
+					if (selected.drawInspector)
+					{
+						selected.drawInspector();
+					}
+					else
+					{
+						ImGui::TextUnformatted("StageSelect Text Layout Inspector is unavailable.");
+					}
+					break;
+				case EditorInspectorType::ManagerInfo:
+					ImGui::TextUnformatted("This manager has no Transform.");
+					ImGui::TextUnformatted("Use the dedicated Debug window for detailed editing when available.");
+					break;
+				case EditorInspectorType::None:
+				default:
+					ImGui::TextUnformatted("この項目はDetails Inspector未実装です。");
+					if (!selected.transformUnavailableReason.empty())
+					{
+						ImGui::Text("%s", selected.transformUnavailableReason.c_str());
+					}
+					break;
 				}
 			}
 		}

--- a/Project/Engine/Graphics/Lighting/LightManager.cpp
+++ b/Project/Engine/Graphics/Lighting/LightManager.cpp
@@ -265,6 +265,111 @@ namespace Ken4lowEngine
 	/// -------------------------------------------------------------
 	///				　		　	ImGui
 	/// -------------------------------------------------------------
+	void LightManager::DrawPunctualLightsInspector()
+	{
+#ifdef USE_IMGUI
+		// Detailsと専用Light Editorの内容差分をなくすため、Punctual Lights本体の描画をここへ集約する。
+		ImGui::Text("Light Count: %zu", punctualLights_.size());
+		if (!punctualLights_.empty())
+		{
+			const auto& first = punctualLights_.front();
+			const char* summaryTypes[] = { "None", "Directional", "Point", "Spot" };
+			const uint32_t typeIndex = (first.lightType < static_cast<uint32_t>(IM_ARRAYSIZE(summaryTypes))) ? first.lightType : 0;
+			Vector3 eulerDeg = DirectionToEulerDeg(first.direction);
+			ImGui::Text("Light #0 Type: %s", summaryTypes[typeIndex]);
+			ImGui::Text("Light #0 Color: (%.3f, %.3f, %.3f, %.3f)", first.color.x, first.color.y, first.color.z, first.color.w);
+			ImGui::Text("Light #0 Intensity: %.3f", first.intensity);
+			ImGui::Text("Light #0 Pitch / Yaw / Roll: %.1f / %.1f / %.1f", eulerDeg.x, eulerDeg.y, eulerDeg.z);
+			ImGui::Text("Light #0 Direction: (%.3f, %.3f, %.3f)", first.direction.x, first.direction.y, first.direction.z);
+		}
+		ImGui::Separator();
+
+		if (ImGui::Button("+ Add Light"))
+		{
+			PunctualLightGPU L{};
+			L.lightType = 1;
+			L.color = { 1,1,1,1 };
+			L.intensity = 1.0f;
+			L.direction = { 0,-1,0 };
+			punctualLights_.push_back(L);
+		}
+		ImGui::SameLine();
+		if (ImGui::Button("Clear All"))
+		{
+			punctualLights_.clear();
+		}
+
+		for (size_t i = 0; i < punctualLights_.size(); ++i)
+		{
+			ImGui::PushID(static_cast<int>(i));
+			auto& L = punctualLights_[i];
+
+			ImGui::Separator();
+			ImGui::Text("Light #%zu", i);
+
+			int type = static_cast<int>(L.lightType);
+			const char* types[] = { "None","Directional","Point","Spot" };
+			if (ImGui::Combo("Type", &type, types, IM_ARRAYSIZE(types)))
+			{
+				L.lightType = static_cast<uint32_t>(type);
+			}
+
+			ImGui::ColorEdit4("Color", &L.color.x);
+			ImGui::SliderFloat("Intensity", &L.intensity, 0.0f, 20.0f);
+
+			if (L.lightType == 1)
+			{
+				Vector3 eulerDeg = DirectionToEulerDeg(L.direction);
+
+				bool changed = false;
+				changed |= ImGui::DragFloat("Pitch (X)", &eulerDeg.x, 0.5f, -89.0f, 89.0f, "%.1f deg");
+				changed |= ImGui::DragFloat("Yaw (Y)", &eulerDeg.y, 0.5f, -180.0f, 180.0f, "%.1f deg");
+
+				ImGui::BeginDisabled();
+				ImGui::DragFloat("Roll (Z)", &eulerDeg.z, 0.5f, -180.0f, 180.0f, "%.1f deg");
+				ImGui::EndDisabled();
+
+				if (changed)
+				{
+					L.direction = EulerDegToDirection(eulerDeg);
+				}
+
+				ImGui::Text("Dir = (%.3f, %.3f, %.3f)", L.direction.x, L.direction.y, L.direction.z);
+			}
+			else if (L.lightType == 2)
+			{
+				ImGui::SliderFloat3("Position", &L.position.x, -50.0f, 50.0f);
+				ImGui::SliderFloat("Radius", &L.radius, 0.0f, 200.0f);
+				ImGui::SliderFloat("Decay", &L.decay, 0.0f, 10.0f);
+			}
+			else if (L.lightType == 3)
+			{
+				ImGui::SliderFloat3("Position", &L.position.x, -50.0f, 50.0f);
+				if (ImGui::SliderFloat3("Direction", &L.direction.x, -1.0f, 1.0f))
+				{
+					L.direction = Vector3::Normalize(L.direction);
+				}
+				ImGui::SliderFloat("Distance", &L.distance, 0.0f, 200.0f);
+				ImGui::SliderFloat("Decay", &L.decay, 0.0f, 10.0f);
+				ImGui::SliderFloat("cosInner", &L.cosFalloffStart, 0.0f, 1.0f);
+				ImGui::SliderFloat("cosOuter", &L.cosAngle, 0.0f, 1.0f);
+				if (L.cosFalloffStart < L.cosAngle) L.cosFalloffStart = L.cosAngle;
+			}
+
+			if (ImGui::Button("Remove"))
+			{
+				punctualLights_.erase(punctualLights_.begin() + i);
+				ImGui::PopID();
+				--i;
+				continue;
+			}
+			ImGui::PopID();
+		}
+
+		ImGui::Text("Active Lights (type!=0): will be uploaded");
+#endif // USE_IMGUI
+	}
+
 	void LightManager::DrawImGui(bool* pOpen)
 	{
 #ifdef USE_IMGUI
@@ -280,97 +385,7 @@ namespace Ken4lowEngine
 		{
 			if (ImGui::CollapsingHeader("Punctual Lights"))
 			{
-
-				// 追加ボタン
-				if (ImGui::Button("+ Add Light"))
-				{
-					PunctualLightGPU L{};
-					L.lightType = 1;                 // 既定: Directional
-					L.color = { 1,1,1,1 };
-					L.intensity = 1.0f;
-					L.direction = { 0,-1,0 };          // 下向き
-					punctualLights_.push_back(L);
-				}
-				ImGui::SameLine();
-				if (ImGui::Button("Clear All"))
-				{
-					punctualLights_.clear();
-				}
-
-				// 一覧
-				for (size_t i = 0; i < punctualLights_.size(); ++i)
-				{
-					ImGui::PushID(static_cast<int>(i));
-					auto& L = punctualLights_[i];
-
-					ImGui::Separator();
-					ImGui::Text("Light #%zu", i);
-
-					// 種類
-					int type = static_cast<int>(L.lightType);
-					const char* types[] = { "None","Directional","Point","Spot" };
-					if (ImGui::Combo("Type", &type, types, IM_ARRAYSIZE(types)))
-						L.lightType = static_cast<uint32_t>(type);
-
-					// 共通
-					ImGui::ColorEdit4("Color", &L.color.x);
-					ImGui::SliderFloat("Intensity", &L.intensity, 0.0f, 20.0f);
-
-					// 種類別
-					if (L.lightType == 1)
-					{
-						Vector3 eulerDeg = DirectionToEulerDeg(L.direction);
-
-						bool changed = false;
-						changed |= ImGui::DragFloat("Pitch (X)", &eulerDeg.x, 0.5f, -89.0f, 89.0f, "%.1f deg");
-						changed |= ImGui::DragFloat("Yaw (Y)", &eulerDeg.y, 0.5f, -180.0f, 180.0f, "%.1f deg");
-
-						// Roll は光の向き自体には効かないので表示だけにするか、隠す
-						ImGui::BeginDisabled();
-						ImGui::DragFloat("Roll (Z)", &eulerDeg.z, 0.5f, -180.0f, 180.0f, "%.1f deg");
-						ImGui::EndDisabled();
-
-						if (changed)
-						{
-							L.direction = EulerDegToDirection(eulerDeg);
-						}
-
-						ImGui::Text("Dir = (%.3f, %.3f, %.3f)", L.direction.x, L.direction.y, L.direction.z);
-					}
-					else if (L.lightType == 2)
-					{
-						// Point
-						ImGui::SliderFloat3("Position", &L.position.x, -50.0f, 50.0f);
-						ImGui::SliderFloat("Radius", &L.radius, 0.0f, 200.0f);
-						ImGui::SliderFloat("Decay", &L.decay, 0.0f, 10.0f);
-					}
-					else if (L.lightType == 3)
-					{
-						// Spot
-						ImGui::SliderFloat3("Position", &L.position.x, -50.0f, 50.0f);
-						if (ImGui::SliderFloat3("Direction", &L.direction.x, -1.0f, 1.0f))
-						{
-							L.direction = Vector3::Normalize(L.direction);
-						}
-						ImGui::SliderFloat("Distance", &L.distance, 0.0f, 200.0f);
-						ImGui::SliderFloat("Decay", &L.decay, 0.0f, 10.0f);
-						ImGui::SliderFloat("cosInner", &L.cosFalloffStart, 0.0f, 1.0f);
-						ImGui::SliderFloat("cosOuter", &L.cosAngle, 0.0f, 1.0f);
-						if (L.cosFalloffStart < L.cosAngle) L.cosFalloffStart = L.cosAngle; // 内>=外
-					}
-
-					if (ImGui::Button("Remove"))
-					{
-						punctualLights_.erase(punctualLights_.begin() + i);
-						ImGui::PopID();
-						--i; // 次の要素が詰まるのでインデックス調整
-						continue;
-					}
-					ImGui::PopID();
-				}
-
-				// 参考表示（GPUへは UpdatePunctualLight で同期）
-				ImGui::Text("Active Lights (type!=0): will be uploaded");
+				DrawPunctualLightsInspector();
 			}
 		}
 		ImGui::End();
@@ -380,7 +395,7 @@ namespace Ken4lowEngine
 	}
 
 	/// -------------------------------------------------------------
-	///				　	ライト情報をシェーダーにバインド
+	///					ライト情報をシェーダーにバインド
 	/// -------------------------------------------------------------
 	void LightManager::BindPunctualLights(uint32_t rootIndexCB_b2, uint32_t rootIndexSRV_t2)
 	{

--- a/Project/Engine/Graphics/Lighting/LightManager.h
+++ b/Project/Engine/Graphics/Lighting/LightManager.h
@@ -87,6 +87,9 @@ namespace Ken4lowEngine
 		/// </summary>
 		void DrawImGui(bool* pOpen = nullptr);
 
+		// Details Inspectorと専用Light Editorで同じPunctual Lights編集UIを共有する。
+		void DrawPunctualLightsInspector();
+
 		/// <summary>
 		/// パンクチュアルライト情報をシェーダにバインドします。<br/>
 		/// 内部で UpdatePunctualLight() を呼び出して GPU バッファと SRV を更新し、<br/>


### PR DESCRIPTION
### Motivation
- Details only displayed `Transform` data and ignored other editor-specific editors (Light, FadeManager, Stage Text Layout), causing Outliner selections to not be reflected in Details. 
- Outliner entries used unstable/flaky identifiers and inconsistent display names (e.g. `Directional Light`) which made stable Details mapping and future hierarchy extensions harder.

### Description
- Added `EditorInspectorType` and a `drawInspector` callback to `EditorObjectInfo` so Details can switch by inspector kind rather than only transform availability (added to `Project/Engine/Editor/EditorObjectInfo.h`).
- Switched Details rendering in `EditorWindowManager::DrawDetails()` to branch on `inspectorType` and handle `Transform`, `PunctualLights`, `FadeManager`, `StageSelectTextLayout`, `ManagerInfo`, and fallback `None` inspectors (modified `Project/Engine/Editor/EditorWindowManager.cpp`).
- Exposed shared inspector drawing functions and reused existing specialized UIs in Details: implemented `LightManager::DrawPunctualLightsInspector()` and reused it from the Light Editor; extracted `FadeManager::DrawInspectorContent()` and called it both from its window and Details; factored StageSelect UI into `DrawStageSelectTextLayoutInspectorContent()` and reused it (changes in `Project/Engine/Graphics/Lighting/*`, `Project/ApplicationLayer/SceneManagement/FadeManager/*`, and `Project/ApplicationLayer/Scene/StageSelectScene/*`).
- Updated scene `CollectEditorObjects` implementations to provide stable IDs and appropriate `inspectorType` entries, renamed Outliner entries from `Directional Light` -> `Punctual Lights`, and added `FadeManager` / `StageSelect Text Layout` inspector hooks (changes in `TitleScene`, `StageSelectScene`, `GamePlayScene`).
- Set transform-capable editor objects (Camera, Sprite, Player, per-light transform access) to `EditorInspectorType::Transform` via `EditorTransformAccess` and ensured `TryReadTransform`/`WriteTransform` callbacks remain the write path; made `SceneManager` expose `GetFadeManager()` for safe Details access.

### Testing
- Ran `git diff --check` to validate whitespace and basic diff checks which completed with no reported issues.
- Attempted to build with `msbuild Project/Ken4lowEngine.sln` for both Debug and Release but the build tool was not available in this container, so full compilation could not be verified here.  
- Local code searches and small-run validations (`rg`/`sed`/scripted edits) were used to confirm new symbols (`EditorInspectorType`, `DrawPunctualLightsInspector`, `DrawInspectorContent`, `DrawStageSelectTextLayoutInspectorContent`) are referenced consistently across files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01d5891680832dac8c9f7cae5d3be1)