### PR TITLE
Restore StageSelectScene load overrides

### DIFF
--- a/Project/ApplicationLayer/Scene/StageSelectScene/StageSelectScene.cpp
+++ b/Project/ApplicationLayer/Scene/StageSelectScene/StageSelectScene.cpp
@@ -428,6 +428,54 @@ void StageSelectScene::DrawImGui()
 #endif // USE_IMGUI
 }
 
+// Scene遷移用ロードはEditor更新と分離し、Cover完了後に段階ロードを開始する。
+void StageSelectScene::StartLoad()
+{
+	loadStep_ = 0;
+	isLoadReady_ = false;
+	state_ = State::Loading;
+}
+
+void StageSelectScene::UpdateLoad()
+{
+	switch (loadStep_)
+	{
+	case 0:
+		// ステージ情報だけ先に作る
+		InitializeStages();
+		++loadStep_;
+		break;
+
+	case 1:
+		// セレクタのコンテキストだけ組む
+		InitializeSelectors();
+		++loadStep_;
+		break;
+
+	case 2:
+		// 背景と GridSelector の生成
+		InitializeBackground();
+		++loadStep_;
+		break;
+
+	case 3:
+		// 選択状態へ入る
+		ChangeState(std::make_unique<StageSelectSelectingState>());
+		state_ = State::Selecting;
+		isLoadReady_ = true;
+		++loadStep_;
+		break;
+
+	default:
+		break;
+	}
+}
+
+bool StageSelectScene::IsReadyToStartUncover() const
+{
+	return isLoadReady_;
+}
+
 /// -------------------------------------------------------------
 ///				　		　ステージ情報初期化
 /// -------------------------------------------------------------

--- a/Project/ApplicationLayer/Scene/StageSelectScene/StageSelectScene.h
+++ b/Project/ApplicationLayer/Scene/StageSelectScene/StageSelectScene.h
@@ -130,7 +130,7 @@ public: /// ---------- メンバ関数 ---------- ///
 	// Details Inspectorと専用StageSelect Text Layoutウィンドウで同じ調整UIを共有する。
 	void DrawStageSelectTextLayoutInspectorContent();
 
-	// 段階ロード
+	// SceneManager/FadeManagerのCover後ロードとUncover開始判定を担う既存override。
 	void StartLoad() override;
 
 	void UpdateLoad() override;


### PR DESCRIPTION
### Motivation
- A recent Editor/Outliner refactor removed the `StageSelectScene` load implementations which broke the SceneManager/FadeManager transition path, so the scene's load lifecycle must be restored. 
- `StartLoad`/`UpdateLoad`/`IsReadyToStartUncover` are required to keep Cover/Uncover timing and Scene transitions (Title → StageSelect → GamePlay) unchanged. 
- The load lifecycle must remain separate from Editor-only flows like `UpdateEditor`/Outliner/Details to preserve Edit/Play separation.

### Description
- Restored the load override declarations in `Project/ApplicationLayer/Scene/StageSelectScene/StageSelectScene.h` and annotated them with a comment explaining they are for SceneManager/FadeManager transitions. 
- Restored the implementations in `Project/ApplicationLayer/Scene/StageSelectScene/StageSelectScene.cpp` for `StartLoad()`, `UpdateLoad()` (stepwise: `InitializeStages()` → `InitializeSelectors()` → `InitializeBackground()` → enter `StageSelectSelectingState`), and `IsReadyToStartUncover()` which returns the `isLoadReady_` flag. 
- Kept Editor-related APIs (`UpdateEditor` / Outliner / Details) separate and added a one-line comment in the cpp noting the purpose of the restored load functions. 
- Changed files: `Project/ApplicationLayer/Scene/StageSelectScene/StageSelectScene.h` and `Project/ApplicationLayer/Scene/StageSelectScene/StageSelectScene.cpp` (committed as `e22bd15 Restore StageSelectScene load overrides`).

### Testing
- Verified `BaseScene` still exposes the virtual hooks `StartLoad`/`UpdateLoad`/`IsReadyToStartUncover` with `rg`, and the check succeeded. 
- Verified `TitleScene` and `GamePlayScene` still declare and implement their load overrides with `rg`, and the check succeeded. 
- Ran `git diff --check` and repository grep checks used in validation, and they all succeeded. 
- Attempted full solution build via `msbuild` for Debug and Release, but `msbuild` is not available in this container so those builds were not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01d9ea141c832db1cccee6f3910b77)