### PR TITLE
Smooth Stage1 intro camera handoff

### DIFF
--- a/Project/ApplicationLayer/Character/Player/Component/PlayerViewComponent.cpp
+++ b/Project/ApplicationLayer/Character/Player/Component/PlayerViewComponent.cpp
@@ -182,6 +182,11 @@ void PlayerViewComponent::SyncToPlayer()
 	fpsCamera_.SyncToPlayer();
 }
 
+void PlayerViewComponent::SetLookAngles(float pitchRad, float yawRad)
+{
+	fpsCamera_.SetLookAngles(pitchRad, yawRad);
+}
+
 void PlayerViewComponent::SyncViewModeToFirstPersonFlag()
 {
 	const bool fp = (fpsCamera_.GetViewMode() == K4E::FpsCamera::ViewMode::FirstPerson);

--- a/Project/ApplicationLayer/Character/Player/Component/PlayerViewComponent.h
+++ b/Project/ApplicationLayer/Character/Player/Component/PlayerViewComponent.h
@@ -47,6 +47,7 @@ public: /// ---------- メンバ関数 ---------- ///
 	void UpdateLook(float dt, const InputSnapshot& input);
 	void SyncToPlayer();
 	void SyncViewModeToFirstPersonFlag();
+	void SetLookAngles(float pitchRad, float yawRad);
 
 	void SetFirstPersonView(bool enabled);
 	bool IsFirstPersonView() const { return isFirstPersonView_; }

--- a/Project/ApplicationLayer/Character/Player/Player.cpp
+++ b/Project/ApplicationLayer/Character/Player/Player.cpp
@@ -645,6 +645,17 @@ void Player::SetSpawnOffset(const K4E::Vector3& offset)
 	}
 }
 
+void Player::SetViewLookAngles(float pitchRad, float yawRad)
+{
+	view_.SetLookAngles(pitchRad, yawRad);
+}
+
+void Player::SyncViewToPlayer()
+{
+	view_.SyncToPlayer();
+	view_.SyncViewModeToFirstPersonFlag();
+}
+
 void Player::ApplyEditedWeaponDataFromEditor(int32_t weaponID, const FWeaponMasterData& data)
 {
 	auto& db = weapon_.GetWeaponMasterDatabase();

--- a/Project/ApplicationLayer/Character/Player/Player.h
+++ b/Project/ApplicationLayer/Character/Player/Player.h
@@ -155,6 +155,8 @@ public: /// ---------- メンバ関数 ---------- ///
 
 	void SetSpawnPosition(const K4E::Vector3& worldPos);
 	void SetSpawnOffset(const K4E::Vector3& offset);
+	void SetViewLookAngles(float pitchRad, float yawRad);
+	void SyncViewToPlayer();
 
 	void SetStageWorldAABBs(const std::vector<K4E::AABB>* aabbs) { motor_.SetWorldAABBs(aabbs); }
 	void SetWorldCollisionSettings(const K4E::WorldCollisionSettings& s) { motor_.SetWorldCollisionSettings(s); }

--- a/Project/ApplicationLayer/Scene/GamePlayScene/Camera/GamePlayIntroDirector.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/Camera/GamePlayIntroDirector.cpp
@@ -386,17 +386,17 @@ void GamePlayIntroDirector::BeginGamePlayFromIntro(
 		return;
 	}
 
+	K4E::Vector3 introCameraRotation{};
+	if (const auto* camera = K4E::CameraManager::GetInstance()->GetMainCamera())
+	{
+		introCameraRotation = camera->GetRotate();
+	}
+
 	flow.StartPlaying();
 
 	introTimer_ = 0.0f;
 	currentSegment_ = 0;
 	segmentTimer_ = 0.0f;
-
-	if (K4E::Camera* camera = K4E::CameraManager::GetInstance()->GetMainCamera())
-	{
-		camera->SetRotate({ 0.0f, 0.0f, 0.0f });
-		camera->Update();
-	}
 
 	if (auto* player = world.GetCharacters().GetPlayer())
 	{
@@ -413,6 +413,14 @@ void GamePlayIntroDirector::BeginGamePlayFromIntro(
 	}
 
 	world.SyncAfterPlayerSpawn();
+
+	if (auto* player = world.GetCharacters().GetPlayer())
+	{
+		// 完了フレーム内でFPSカメラの初期向きを同期し、次フレーム待ちの停止感と向きの跳ねを防ぐ。
+		player->SetViewLookAngles(introCameraRotation.x, introCameraRotation.y);
+		player->SyncViewToPlayer();
+	}
+
 	world.StartWaves();
 
 	if (input)

--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
@@ -274,7 +274,7 @@ bool GamePlayScene::UpdateRetryTransition()
 /// -------------------------------------------------------------
 /// イントロ更新
 /// 
-/// イントロ中は通常ゲームプレイ更新を行わない。
+/// イントロ中は通常ゲームプレイ更新を止め、完了フレームだけ通常更新へ戻す。
 /// -------------------------------------------------------------
 bool GamePlayScene::UpdateIntro(float deltaTime)
 {
@@ -294,7 +294,8 @@ bool GamePlayScene::UpdateIntro(float deltaTime)
 			debugTools_ ? debugTools_->IsDebugCamera() : false);
 	}
 
-	return true;
+	// 完了フレーム内に通常更新へ進め、終点で1フレーム停止して見えるのを防ぐ。
+	return flow_ && flow_->IsIntro();
 }
 
 /// -------------------------------------------------------------

--- a/Project/Engine/Graphics/Camera/FPS/FpsCamera.cpp
+++ b/Project/Engine/Graphics/Camera/FPS/FpsCamera.cpp
@@ -372,6 +372,13 @@ namespace Ken4lowEngine
 		RebuildCachedEuler();
 	}
 
+	void FpsCamera::SetLookAngles(float pitchRad, float yawRad)
+	{
+		pitch_ = std::clamp(pitchRad, minPitch_, maxPitch_);
+		yaw_ = yawRad;
+		RebuildCachedEulerAfterExternalChange();
+	}
+
 	/// ----------------------------------------------
 	///				表示モードを切替
 	/// ----------------------------------------------

--- a/Project/Engine/Graphics/Camera/FPS/FpsCamera.h
+++ b/Project/Engine/Graphics/Camera/FPS/FpsCamera.h
@@ -95,6 +95,9 @@ namespace Ken4lowEngine
 		// cachedEuler_ を即座に再構築する。
 		void RebuildCachedEulerAfterExternalChange();
 
+		// イントロ終了直後など、外部カメラの向きをFPSカメラの初期向きへ同期する。
+		void SetLookAngles(float pitchRad, float yawRad);
+
 		/// <summary>
 		/// ViewMode を一つずつ切り替えます。<br/>
 		/// FirstPerson → ThirdBack → ThirdFront → FirstPerson → …<br/>


### PR DESCRIPTION
### Motivation
- Intro camera finishes then waits one frame before switching to the player camera, creating a perceptible pause and a visible orientation snap at the handoff. The change aims to remove that one-frame pause and make the transition visually smooth.

### Description
- Make `GamePlayScene::UpdateIntro` return `flow_->IsIntro()` so the frame where the intro finishes can immediately proceed to normal updates instead of stalling one extra frame (`GamePlayScene.cpp`).
- On intro end, capture the final intro camera rotation and apply it to the player/FPS camera before syncing the player view to avoid a jump; this is done in `GamePlayIntroDirector::BeginGamePlayFromIntro` by calling `player->SetViewLookAngles(...)` and `player->SyncViewToPlayer()` (`GamePlayIntroDirector.cpp`).
- Add `FpsCamera::SetLookAngles(float pitchRad, float yawRad)` to allow externally forcing FPS camera pitch/yaw and rebuilding cached euler values (`FpsCamera.h`/`FpsCamera.cpp`).
- Add thin forwarding methods `PlayerViewComponent::SetLookAngles`, `Player::SetViewLookAngles` and `Player::SyncViewToPlayer` to bridge intro director -> player camera sync without changing existing camera systems (`PlayerViewComponent.*`, `Player.*`).
- Small inline comments were added where the immediate handoff is performed to explain why the sync happens in the same frame.

### Testing
- Ran `git diff --check` to validate whitespace/merge problems and it reported no issues (passed). 
- Attempted to build with `msbuild Project/Ken4lowEngine.sln /p:Configuration=Debug /p:Platform=x64` but `msbuild` was not available in this environment so a full compile/test could not be executed here (build not run).
- No automated unit tests exist for this flow; changes were implemented conservatively to keep existing fade/load behavior intact and to only alter the handoff frame and camera-sync logic.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a045bd6d230832daffb88a1eae98d0b)