### PR TITLE
Warm up Stage1 gameplay assets before camera handoff

### DIFF
--- a/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.cpp
+++ b/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.cpp
@@ -175,6 +175,30 @@ void CharacterWorld::Update(float dt)
 	}
 }
 
+void CharacterWorld::WarmupStartGameplayVisuals()
+{
+	if (player_)
+	{
+		player_->WarmupStartGameplayVisuals();
+	}
+
+	for (auto& e : enemies_)
+	{
+		if (e)
+		{
+			e->Update(0.0f);
+		}
+	}
+}
+
+void CharacterWorld::SetStartGameplayVisualsVisible(bool visible)
+{
+	if (player_)
+	{
+		player_->SetStartGameplayVisualsVisible(visible);
+	}
+}
+
 void CharacterWorld::Draw()
 {
 	if (player_) player_->Draw();

--- a/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.h
+++ b/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.h
@@ -41,6 +41,8 @@ public: /// ---------- メンバ関数 ---------- ///
 	void Finalize();
 
 	void Update(float dt);
+	void WarmupStartGameplayVisuals();
+	void SetStartGameplayVisualsVisible(bool visible);
 	void Draw();
 	void DrawImGui();
 	void DrawPlayerDebugImGui();

--- a/Project/ApplicationLayer/Character/Player/Component/PlayerWeaponVisualComponent.h
+++ b/Project/ApplicationLayer/Character/Player/Component/PlayerWeaponVisualComponent.h
@@ -27,6 +27,9 @@ public: /// ---------- メンバ関数 ---------- ///
 	// 更新
 	void Update(float deltaTime, bool isADS);
 
+	void SetVisible(bool visible) { visible_ = visible; }
+	bool IsVisible() const { return visible_; }
+
 	// 描画
 	void Draw();
 

--- a/Project/ApplicationLayer/Character/Player/Player.cpp
+++ b/Project/ApplicationLayer/Character/Player/Player.cpp
@@ -656,6 +656,20 @@ void Player::SyncViewToPlayer()
 	view_.SyncViewModeToFirstPersonFlag();
 }
 
+void Player::SetStartGameplayVisualsVisible(bool visible)
+{
+	weaponVisual_.SetVisible(visible);
+}
+
+void Player::WarmupStartGameplayVisuals()
+{
+	// カメラ切り替え時の一括初期化を避けるため、FPS腕表示と武器モデルを事前構築しておく。
+	view_.SetFirstPersonView(true);
+	weaponVisual_.SetVisible(false);
+	weaponVisual_.Update(0.0f, false);
+	SyncHurtboxes();
+}
+
 void Player::ApplyEditedWeaponDataFromEditor(int32_t weaponID, const FWeaponMasterData& data)
 {
 	auto& db = weapon_.GetWeaponMasterDatabase();

--- a/Project/ApplicationLayer/Character/Player/Player.h
+++ b/Project/ApplicationLayer/Character/Player/Player.h
@@ -166,6 +166,8 @@ public: /// ---------- メンバ関数 ---------- ///
 	void ApplyEditedWeaponDataFromEditor(int32_t weaponID, const FWeaponMasterData& data);
 
 	void ForceRefreshWeaponVisual() { weaponVisual_.ForceRefresh(); }
+	void SetStartGameplayVisualsVisible(bool visible);
+	void WarmupStartGameplayVisuals();
 
 	void SetOnHitSECallback(std::function<void()> cb) { audio_.onHit = std::move(cb); }
 	void SetOnFireSECallback(std::function<void()> cb) { audio_.onFire = std::move(cb); }

--- a/Project/ApplicationLayer/Scene/GamePlayScene/Camera/GamePlayIntroDirector.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/Camera/GamePlayIntroDirector.cpp
@@ -414,6 +414,9 @@ void GamePlayIntroDirector::BeginGamePlayFromIntro(
 
 	world.SyncAfterPlayerSpawn();
 
+	// カメラ切り替え時の一括初期化を避けるため、ここでは事前生成済みビジュアルの表示だけ戻す。
+	world.SetStartGameplayVisualsVisible(true);
+
 	if (auto* player = world.GetCharacters().GetPlayer())
 	{
 		// 完了フレーム内でFPSカメラの初期向きを同期し、次フレーム待ちの停止感と向きの跳ねを防ぐ。

--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
@@ -144,9 +144,17 @@ void GamePlayScene::SetupNewGame(bool skipIntro)
 
 	flow_->ResetForNewGame(startIntro);
 
-	if (!startIntro && world_)
+	if (world_)
 	{
-		world_->StartWaves();
+		if (startIntro)
+		{
+			world_->WarmupStartGameplayForIntro();
+		}
+		else
+		{
+			world_->SetStartGameplayVisualsVisible(true);
+			world_->StartWaves();
+		}
 	}
 }
 

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
@@ -396,10 +396,30 @@ void GamePlayWorld::SyncAfterPlayerSpawn()
 
 void GamePlayWorld::StartWaves()
 {
-	if (waveManager_)
+	if (waveManager_ && !waveManager_->HasStarted())
 	{
 		waveManager_->Start();
 	}
+}
+
+void GamePlayWorld::WarmupStartGameplayForIntro()
+{
+	// カメラ切り替え時の一括初期化を避けるため、イントロ中に敵・武器・腕表示を事前生成して非表示で温める。
+	SetStartGameplayVisualsVisible(false);
+
+	StartWaves();
+	if (waveManager_)
+	{
+		waveManager_->Update(characters_, 0.0f);
+	}
+
+	characters_.WarmupStartGameplayVisuals();
+	CollisionUpdate();
+}
+
+void GamePlayWorld::SetStartGameplayVisualsVisible(bool visible)
+{
+	characters_.SetStartGameplayVisualsVisible(visible);
 }
 
 bool GamePlayWorld::IsPlayerDead()

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.h
@@ -24,6 +24,8 @@ public: /// ---------- メンバ関数 ---------- ///
 	void Update(float deltaTime);
 
 	void UpdateIntroVisuals();
+	void WarmupStartGameplayForIntro();
+	void SetStartGameplayVisualsVisible(bool visible);
 
 	void Draw3D(bool hideCharactersDuringIntro);
 	void DrawShadow(bool hideCharactersDuringIntro);


### PR DESCRIPTION
### Motivation
- カメライントロ終了→プレイヤーカメラ切り替え時に敵・腕・武器・HUD 等の初回生成/初回ロード処理が集中してフレーム落ち（カクつき）しているため、切り替え瞬間に重い初期化を走らせないよう事前にウォームアップを行う。 

### Description
- イントロあり開始でイントロ中に事前準備を行うよう `GamePlayScene::SetupNewGame` に起動パスを追加し、イントロ時は `GamePlayWorld::WarmupStartGameplayForIntro()` を呼ぶようにした。  
- `GamePlayWorld` に `WarmupStartGameplayForIntro()` と `SetStartGameplayVisualsVisible(bool)` を追加し、Wave の開始を冪等化してイントロ中にゼロ時間更新でウォームアップを行うようにした（`StartWaves()` を一度だけ開始する判定も追加）。  
- 敵・プレイヤー周りをまとめる `CharacterWorld` に `WarmupStartGameplayVisuals()` と `SetStartGameplayVisualsVisible(bool)` を追加し、プレイヤーのウォームアップと各敵へ `Update(0.0f)` を回して初期状態／GPUリソース生成を先に走らせるようにした。  
- `Player` に `WarmupStartGameplayVisuals()` と `SetStartGameplayVisualsVisible(bool)` を追加し、イントロ中にFPS腕と武器ビジュアルを非表示で事前構築しておき、カメラ切替直前は表示フラグ切替のみで済ませる設計にした。  
- `PlayerWeaponVisualComponent` に可視化制御API（`SetVisible`/`IsVisible`）を追加し、切り替え瞬間の再構築を避けて `visible` フラグの切り替えだけで描画を復帰できるようにした。  
- イントロ→プレイヤー切替のハンドオフ箇所 `GamePlayIntroDirector::BeginGamePlayFromIntro` は、生成をここで再実行するのではなく事前生成済みの可視化だけを戻すように変更した。  
- 各変更箇所には「カメラ切り替え時の一括初期化を避けるため」等の意図が分かるコメントを追加している。  
- 変更ファイルの主な一覧: `GamePlayScene.cpp`, `GamePlayIntroDirector.cpp`, `GamePlayWorld.{h,cpp}`, `CharacterWorld.{h,cpp}`, `Player.{h,cpp}`, `PlayerWeaponVisualComponent.h`.

### Testing
- 自動チェックとして `git diff --check` を実行して差分に問題がないことを確認した（成功）。
- ソリューションビルド `dotnet msbuild Project/Ken4lowEngine.sln` を試行したが、実行環境に `dotnet` が存在しないためビルドは実行できなかった（環境依存）。
- 本変更はランタイムの初期化順を変えるため、実機/CI ビルド環境でのビルドおよび実動作（イントロあり/なしでのカメラ切替時のプロファイル）での動作確認を推奨する。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a045fb50c60832d9d90f1d152e93c03)