### PR TITLE
Fix TitleScene freeze in Release and show cursor on GameScene UI states

### DIFF
--- a/Project/ApplicationLayer/Scene/GamePlayScene/Core/GamePlayFlow.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/Core/GamePlayFlow.cpp
@@ -8,6 +8,18 @@
 
 using namespace Ken4lowEngine;
 
+namespace
+{
+	void ApplyGameCursorMode(Ken4lowEngine::Input* input, bool fpsCapture)
+	{
+		if (!input) { return; }
+
+		// UI状態ではカーソルを表示し、通常プレイへ戻る時だけFPS用にロック/非表示へ戻す。
+		input->SetLockCursor(fpsCapture);
+		input->SetCursorVisible(!fpsCapture);
+	}
+}
+
 /// -------------------------------------------------------------
 ///				　			　初期化処理
 /// -------------------------------------------------------------
@@ -83,11 +95,7 @@ void GamePlayFlow::EnterPause(Ken4lowEngine::Input* input)
 	// ポーズメニューを開く
 	if (pauseMenu_)	pauseMenu_->Open();
 
-	if (input)
-	{
-		input->SetLockCursor(false);	// カーソルロック解除
-		input->SetCursorVisible(true);	// カーソル表示
-	}
+	ApplyGameCursorMode(input, false);
 }
 
 /// -------------------------------------------------------------
@@ -103,11 +111,7 @@ void GamePlayFlow::ExitPause(Ken4lowEngine::Input* input, bool lockCursorOnResum
 	// ポーズメニューを閉じる
 	if (pauseMenu_) pauseMenu_->Close();
 
-	if (input)
-	{
-		input->SetLockCursor(lockCursorOnResume);	  // カーソルロック
-		input->SetCursorVisible(!lockCursorOnResume); // カーソルはロックするなら非表示、ロックしないなら表示
-	}
+	ApplyGameCursorMode(input, lockCursorOnResume);
 }
 
 /// -------------------------------------------------------------
@@ -150,11 +154,7 @@ void GamePlayFlow::EnterGameClear(Ken4lowEngine::Input* input, const std::functi
 		resultMenu_->Open(ResultMenuMode::GameClear);
 	}
 
-	if (input)
-	{
-		input->SetLockCursor(false);	// カーソルロックを解除
-		input->SetCursorVisible(true);  // カーソルを表示
-	}
+	ApplyGameCursorMode(input, false);
 }
 
 /// -------------------------------------------------------------
@@ -172,11 +172,7 @@ void GamePlayFlow::EnterGameOver(Ken4lowEngine::Input* input)
 
 	if (resultMenu_) resultMenu_->Open(ResultMenuMode::GameOver);
 
-	if (input)
-	{
-		input->SetLockCursor(false);
-		input->SetCursorVisible(true);
-	}
+	ApplyGameCursorMode(input, false);
 }
 
 /// -------------------------------------------------------------
@@ -204,11 +200,7 @@ void GamePlayFlow::UpdatePaused(const PausedUpdateContext& ctx)
 		break;
 
 	case PauseMenuCommand::ToStageSelect:
-		if (ctx.input)
-		{
-			ctx.input->SetLockCursor(false);
-			ctx.input->SetCursorVisible(true);
-		}
+		ApplyGameCursorMode(ctx.input, false);
 		if (ctx.sceneManager)
 		{
 			ctx.sceneManager->ChangeScene("StageSelectScene");
@@ -216,11 +208,7 @@ void GamePlayFlow::UpdatePaused(const PausedUpdateContext& ctx)
 		break;
 
 	case PauseMenuCommand::ToTitle:
-		if (ctx.input)
-		{
-			ctx.input->SetLockCursor(false);
-			ctx.input->SetCursorVisible(true);
-		}
+		ApplyGameCursorMode(ctx.input, false);
 		if (ctx.sceneManager)
 		{
 			ctx.sceneManager->ChangeScene("TitleScene");

--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
@@ -23,6 +23,17 @@
 
 using namespace Ken4lowEngine;
 
+EditorInputPolicy GamePlayScene::GetEditorInputPolicy() const
+{
+	// UI操作が必要なポーズ/リザルト中はDebug Editor側にもカーソル表示モードを通知する。
+	if (flow_ && (flow_->IsPaused() || flow_->IsResultState()))
+	{
+		return EditorInputPolicy::UiMouse;
+	}
+
+	return EditorInputPolicy::FpsCapture;
+}
+
 /// -------------------------------------------------------------
 /// 初期化
 /// -------------------------------------------------------------

--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.h
@@ -60,7 +60,7 @@ public: /// ---------- BaseScene override ---------- ///
 	void CollectEditorObjects(std::vector<Ken4lowEngine::EditorObjectInfo>& outObjects) override;
 
 	// FPS操作が必要なGamePlaySceneだけF8入力キャプチャを許可する。
-	EditorInputPolicy GetEditorInputPolicy() const override { return EditorInputPolicy::FpsCapture; }
+	EditorInputPolicy GetEditorInputPolicy() const override;
 
 	// 段階ロード
 	void StartLoad() override;

--- a/Project/ApplicationLayer/Scene/TitleScene/State/TitleAttractState.cpp
+++ b/Project/ApplicationLayer/Scene/TitleScene/State/TitleAttractState.cpp
@@ -153,12 +153,12 @@ void TitleAttractState::Update(TitleScene* scene, float deltaTime)
 	}
 
 	// === 入力受付 ===
-	if (canAcceptInput && (
-		clickHintCommit //||
-		//input->TriggerKey(DIK_RETURN) ||          // Enter
-		//input->TriggerKey(DIK_SPACE) ||          // Space
-		//input->TriggerButton(XButtons.A)		// Aが押されたら
-		)) {
+	const bool titleAdvanceInput = clickHintCommit ||
+		input->TriggerKey(DIK_RETURN) ||
+		input->TriggerKey(DIK_SPACE) ||
+		input->TriggerButton(XButtons.A);
+	// ReleaseでもImGuiボタンに依存せず、キーボード/マウス/ゲームパッドでTitleSceneを進行できるようにする。
+	if (canAcceptInput && titleAdvanceInput) {
 
 		// カメラ姿勢スナップショット
 		Camera* cam = camera ? camera : scene->GetCamera();
@@ -176,7 +176,7 @@ void TitleAttractState::Update(TitleScene* scene, float deltaTime)
 		logoUI.exitLeft = logoUI.exitFade;          // Exitフェード開始
 	}
 
-	logoSprite->Update();
+	if (logoSprite) logoSprite->Update();
 
 	// カメラ補間が終わると、UpdateTransitionToLobby で state_ が LobbyIdle に変わる
 	if (state == State::TransitionToLobby)

--- a/Project/ApplicationLayer/Scene/TitleScene/State/TitleLobbyState.cpp
+++ b/Project/ApplicationLayer/Scene/TitleScene/State/TitleLobbyState.cpp
@@ -76,6 +76,13 @@ void TitleLobbyState::Update(TitleScene* scene, float deltaTime)
 		battleButtonUI.isPressing = false;
 	}
 
+	// ReleaseでもImGuiボタンに依存せず、キーボード/ゲームパッドでBattleボタンを決定できるようにする。
+	if (input->TriggerKey(DIK_RETURN) || input->TriggerKey(DIK_SPACE) || input->TriggerButton(XButtons.A))
+	{
+		SceneManager::GetInstance()->ChangeScene("StageSelectScene");
+		return;
+	}
+
 	// ----- 視覚効果 -----
 	const float pressTarget = (battleButtonUI.isPressing && mouseHeld) ? 1.0f : 0.0f;
 	const float hoverTarget = (!pressTarget && inBtn) ? 1.0f : 0.0f;

--- a/Project/ApplicationLayer/Scene/TitleScene/TitleScene.cpp
+++ b/Project/ApplicationLayer/Scene/TitleScene/TitleScene.cpp
@@ -37,6 +37,12 @@ void TitleScene::Initialize()
 
 	dxCommon_ = DirectXCommon::GetInstance();
 	input_ = Input::GetInstance();
+	if (input_)
+	{
+		// TitleSceneはReleaseでもDebug UIに依存しない操作画面なので、カーソルを通常表示へ戻す。
+		input_->SetLockCursor(false);
+		input_->SetCursorVisible(true);
+	}
 
 	skyBox_ = std::make_unique<SkyBox>();
 	skyBox_->Initialize("SkyBox/skybox.dds");
@@ -164,7 +170,7 @@ void TitleScene::Draw3DObjects()
 {
 #pragma region オブジェクト3Dの描画
 
-	skyBox_->Draw();
+	if (skyBox_) skyBox_->Draw();
 
 	if (terrain_) terrain_->Draw();
 
@@ -482,7 +488,7 @@ void TitleScene::UpdateDebug()
 		const bool next = !CameraManager::GetInstance()->IsUsingDebugCamera();
 
 		CameraManager::GetInstance()->SetUseDebugCamera(next);
-		skyBox_->SetDebugCamera(next);
+		if (skyBox_) skyBox_->SetDebugCamera(next);
 		Wireframe::GetInstance()->SetDebugCamera(next);
 		isDebugCamera_ = next;
 	}

--- a/Project/ApplicationLayer/SceneManagement/SceneManager/SceneManager.cpp
+++ b/Project/ApplicationLayer/SceneManagement/SceneManager/SceneManager.cpp
@@ -143,7 +143,12 @@ void SceneManager::Update()
 	{
 		if (!isTransitioning_ || sceneSwapped_)
 		{
-			if (K4E::EditorPlayController::GetInstance()->IsPlaying())
+			bool shouldUpdateGame = true;
+#ifdef USE_IMGUI
+			shouldUpdateGame = K4E::EditorPlayController::GetInstance()->IsPlaying();
+#endif // USE_IMGUI
+			// ReleaseではEditor/ImGuiのPlay状態に依存させず、TitleSceneを通常更新して暗転解除後も進行させる。
+			if (shouldUpdateGame)
 			{
 				scene_->Update();
 			}


### PR DESCRIPTION
### Motivation
- Release builds left TitleScene blocked because scene updates were gated on the editor/ImGui play state, causing dark/frozen title screen until editor UI was present. 
- GameScene did not consistently restore/show the OS cursor when entering UI-driven states (Pause / GameClear / GameOver), making UI interaction impossible in Debug.
- Cursor show/hide handling was scattered and used raw `SetLockCursor`/`SetCursorVisible` calls in multiple places causing potential double-call/count drift.

### Description
- SceneManager: allow scene `Update()` to run in Release independently from ImGui/editor Play state by using a `shouldUpdateGame` guard only when `USE_IMGUI` is enabled and adding a comment explaining the Release behavior change. (`Project/ApplicationLayer/SceneManagement/SceneManager/SceneManager.cpp`).
- TitleScene: ensure `Input` is available on Initialize and explicitly restore cursor state (`SetLockCursor(false)` / `SetCursorVisible(true)`) so TitleScene is operable in Release; harden skybox draw/update checks against null. (`Project/ApplicationLayer/Scene/TitleScene/TitleScene.cpp`).
- Title states: make title progression and lobby button activation not dependent on ImGui buttons by accepting keyboard (Enter/Space) and gamepad (A) input alongside the click hint/mouse; add small comment explaining the intent. (`Project/ApplicationLayer/Scene/TitleScene/State/TitleAttractState.cpp`, `Project/ApplicationLayer/Scene/TitleScene/State/TitleLobbyState.cpp`).
- GamePlayScene: change editor input policy so the scene reports `UiMouse` while in pause/result UI states and `FpsCapture` otherwise, allowing the EditorWindowManager to present the correct input mode for pause/result screens. (`Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.h`, `Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp`).
- GamePlayFlow: centralize cursor show/lock behavior into `ApplyGameCursorMode(input, fpsCapture)` and use it for Pause / ExitPause / GameClear / GameOver / pause menu actions to avoid duplicated logic and reduce risk of ShowCursor counter drift; add comment explaining function purpose. (`Project/ApplicationLayer/Scene/GamePlayScene/Core/GamePlayFlow.cpp`).

### Testing
- Ran `git diff --check` to confirm no whitespace or patch issues and reviewed diffs locally (succeeded). 
- Attempted to run a Release build with `msbuild Project/Ken4lowEngine.sln /p:Configuration=Release` but `msbuild` is not available in this Linux environment so a full build verification was not executed.
- Performed repository-level static inspections and greps to verify affected code paths (TitleScene init/update/draw, SceneManager transition/update, GamePlayFlow pause/result cursor handling, Title state input branches) were updated as intended.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0462c2b08c832dab09051c0898064e)