### PR TITLE
Unify GamePlay HUD overlay rendering

### DIFF
--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
@@ -510,6 +510,7 @@ void GamePlayScene::Draw2DSprites()
 
 	if (world_)
 	{
+		// ReleaseのBackBuffer直接描画でもHUDManager/Reticle/Ammo/HPをここで描画する。
 		world_->DrawHUD(ShouldHideCharactersDuringIntro());
 	}
 

--- a/Project/Engine/Core/Application/GameApplication.cpp
+++ b/Project/Engine/Core/Application/GameApplication.cpp
@@ -143,18 +143,8 @@ namespace Ken4lowEngine
 		//--------------------------------------------
 		PostEffectManager::GetInstance()->BeginDraw(); // RTV/DSVの設定・Clear
 
-		// --- 2. 3Dオブジェクトの描画 ---
-		Object3DCommon::GetInstance()->BeginObject3DPass();
-		SceneManager::GetInstance()->Draw3DObjects();
-
-		// --- デバッグ描画（3D用） ---
-		Wireframe::GetInstance()->Draw();
-
-		// --- Gpuパーティクル ---
-		GpuParticleManager::GetInstance()->Draw();
-
-		// --- パーティクル（UIエフェクトなどあれば） ---
-		ParticleManager::GetInstance()->Draw();
+		// Debug/Releaseで3D本編の描画順を揃え、最終ゲーム画面の差分を防ぐ。
+		DrawCurrentScene3DPass();
 
 		//--------------------------------------------
 		// 3. オフスクリーン描画終了（SRVへ切り替え）
@@ -170,7 +160,8 @@ namespace Ken4lowEngine
 		// 5. 2Dスプライト（UIなど）をGameRenderTarget上に直接描画
 		//--------------------------------------------
 		PostEffectManager::GetInstance()->BeginGameRenderTargetOverlay(); // 2DをMain Viewportに含めるためGameRenderTargetをRTVへ戻す
-		SceneManager::GetInstance()->Draw2DSprites();
+		// Debug/ReleaseでGamePlaySceneのHUD/UI/Sprite/Font描画を必ず同じ入口から呼ぶ。
+		DrawCurrentScene2DOverlay();
 		PostEffectManager::GetInstance()->EndGameRenderTargetOverlay(); // ImGui::Imageで読むためGameRenderTargetをSRVへ戻す
 
 		//--------------------------------------------
@@ -181,21 +172,11 @@ namespace Ken4lowEngine
 		// Release/GameではEditor用GameViewportRenderTargetを使わずBackBufferへ直接Sceneを描画する。
 		dxCommon_->PrepareBackBufferForGame();
 
-		// --- 1. 3Dオブジェクトの描画 ---
-		Object3DCommon::GetInstance()->BeginObject3DPass();
-		SceneManager::GetInstance()->Draw3DObjects();
+		// Release/GameでもDebug Main Viewportと同じ3D本編の描画順を通す。
+		DrawCurrentScene3DPass();
 
-		// --- デバッグ描画（3D用） ---
-		Wireframe::GetInstance()->Draw();
-
-		// --- Gpuパーティクル ---
-		GpuParticleManager::GetInstance()->Draw();
-
-		// --- パーティクル（UIエフェクトなどあれば） ---
-		ParticleManager::GetInstance()->Draw();
-
-		// --- 2Dスプライト（UIなど） ---
-		SceneManager::GetInstance()->Draw2DSprites();
+		// Release/GameのBackBuffer直接描画でもHUD/UI/Sprite/Fontを必ず重ねる。
+		DrawCurrentScene2DOverlay();
 #endif // USE_IMGUI
 
 		// Draw計測終了
@@ -217,6 +198,30 @@ namespace Ken4lowEngine
 		// フレーム終了
 		GameTimer::GetInstance()->EndFrame();
 	}
+
+	/// -------------------------------------------------------------
+	///						ゲーム本編3D描画の共通処理
+	/// -------------------------------------------------------------
+	void GameApplication::DrawCurrentScene3DPass()
+	{
+		// Scene 3D -> Debug Wireframe -> GPU Particle -> Particleの順をDebug/Releaseで固定する。
+		Object3DCommon::GetInstance()->BeginObject3DPass();
+		SceneManager::GetInstance()->Draw3DObjects();
+
+		Wireframe::GetInstance()->Draw();
+		GpuParticleManager::GetInstance()->Draw();
+		ParticleManager::GetInstance()->Draw();
+	}
+
+	/// -------------------------------------------------------------
+	///						HUD/UI/Sprite描画の共通処理
+	/// -------------------------------------------------------------
+	void GameApplication::DrawCurrentScene2DOverlay()
+	{
+		// GamePlayScene::Draw2DSprites() 内で HUDManager/Reticle/Ammo/HP/Fade まで描画する。
+		SceneManager::GetInstance()->Draw2DSprites();
+	}
+
 
 
 	/// -------------------------------------------------------------

--- a/Project/Engine/Core/Application/GameApplication.h
+++ b/Project/Engine/Core/Application/GameApplication.h
@@ -51,6 +51,14 @@ public: /// ---------- メンバ関数 ---------- ///
 	/// </summary>
 	void Draw() override;
 
+private:
+	// Debug/Releaseでゲーム本編の3D描画順を揃えるための共通ルート。
+	void DrawCurrentScene3DPass();
+
+	// Debug/ReleaseでHUD/UI/Sprite/Fontを必ず重ねるための共通ルート。
+	void DrawCurrentScene2DOverlay();
+
+public:
 	/// <summary>
 	/// ゲーム終了時の後始末処理。<br/>
 	/// まず Framework::Finalize() を呼び出して、WinApp / DirectXCommon など


### PR DESCRIPTION
### Motivation
- Ensure Release builds render the same final screen as Debug Editor by making HUD/UI/Sprite/Font drawing always executed in the Release backbuffer path.

### Description
- Added two shared drawing entrypoints to `GameApplication`: `DrawCurrentScene3DPass()` for the 3D pass and `DrawCurrentScene2DOverlay()` for HUD/UI/sprite overlay, and invoked them from both Debug/Editor (GameViewportRenderTarget) and Release (BackBuffer) paths.
- Replaced duplicated 3D and 2D draw code in `GameApplication::Draw()` with calls to the new shared functions to guarantee consistent ordering between Debug and Release.
- Added a clarifying comment in `GamePlayScene::Draw2DSprites()` to mark it as the required entry point for HUD/Reticle/Ammo/HP drawing in Release.
- Modified files: `Project/Engine/Core/Application/GameApplication.cpp`, `Project/Engine/Core/Application/GameApplication.h`, `Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp`.

### Testing
- Ran `git diff --check` to validate whitespace and simple diff issues and it succeeded.
- Attempted to run a full Debug/Release build but Visual Studio/MSBuild/MSVC toolchain is not available in this environment, so compilation and runtime verification could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0468fd073c832d9fd4fb954fe67b5d)