### PR TITLE
Restore particles and post-effects in Release by routing SceneRenderTarget -> BackBuffer

### DIFF
--- a/Project/Engine/Core/Application/GameApplication.cpp
+++ b/Project/Engine/Core/Application/GameApplication.cpp
@@ -139,17 +139,9 @@ namespace Ken4lowEngine
 		(void)EditorWindowManager::GetInstance()->GetMainViewportSize();
 
 		//--------------------------------------------
-		// 1. オフスクリーンレンダリングの開始（3D用）
+		// 1. オフスクリーンレンダリング（3D + Particle）
 		//--------------------------------------------
-		PostEffectManager::GetInstance()->BeginDraw(); // RTV/DSVの設定・Clear
-
-		// Debug/Releaseで3D本編の描画順を揃え、最終ゲーム画面の差分を防ぐ。
-		DrawCurrentScene3DPass();
-
-		//--------------------------------------------
-		// 3. オフスクリーン描画終了（SRVへ切り替え）
-		//--------------------------------------------
-		PostEffectManager::GetInstance()->EndDraw();
+		DrawGameWorldToSceneTarget();
 
 		//--------------------------------------------
 		// 4. ポストエフェクト適用（3Dの最終結果をGameRenderTargetへ集約）
@@ -169,17 +161,17 @@ namespace Ken4lowEngine
 		//--------------------------------------------
 		ImGuiManager::GetInstance()->Draw();
 #else
-		// Release/GameではEditor用GameViewportRenderTargetを使わずBackBufferへ直接Sceneを描画する。
-		dxCommon_->PrepareBackBufferForGame();
+		// Release/Gameでも中間SceneRenderTargetを使い、ParticleとPostEffectの入力をDebugと揃える。
+		DrawGameWorldToSceneTarget();
 
-		// Release/GameでもDebug Main Viewportと同じ3D本編の描画順を通す。
-		DrawCurrentScene3DPass();
+		// PostEffect後の結果だけをBackBufferへ出し、HUD/UIを後段で重ねられる状態にする。
+		ApplyPostEffectToBackBuffer();
 
-		// GPU Particle等でRTVが切り替わった後、HUD/UI/Sprite/FontだけはBackBufferへ戻して重ねる。
+		// GPU Particle/PostEffectでRTVが切り替わった後、HUD/UI/Sprite/FontだけはBackBufferへ戻して重ねる。
 		dxCommon_->RebindBackBufferForGameOverlay();
 
-		// Release/GameのBackBuffer直接描画でもHUD/UI/Sprite/Fontを必ず重ねる。
-		DrawCurrentScene2DOverlay();
+		// HUD/UIはPostEffect後のBackBufferへ描画し、画面効果に巻き込まない。
+		DrawGameUIToBackBuffer();
 #endif // USE_IMGUI
 
 		// Draw計測終了
@@ -223,6 +215,26 @@ namespace Ken4lowEngine
 	{
 		// GamePlayScene::Draw2DSprites() 内で HUDManager/Reticle/Ammo/HP/Fade まで描画する。
 		SceneManager::GetInstance()->Draw2DSprites();
+	}
+
+	void GameApplication::DrawGameWorldToSceneTarget()
+	{
+		// Debug/ReleaseともSceneRenderTargetへ3D World + Particleを描画し、PostEffect入力を必ず作る。
+		PostEffectManager::GetInstance()->BeginDraw();
+		DrawCurrentScene3DPass();
+		PostEffectManager::GetInstance()->EndDraw();
+	}
+
+	void GameApplication::ApplyPostEffectToBackBuffer()
+	{
+		// SceneRenderTargetを入力にしたPostEffect結果をBackBufferへ出力する。
+		PostEffectManager::GetInstance()->RenderPostEffectToBackBuffer();
+	}
+
+	void GameApplication::DrawGameUIToBackBuffer()
+	{
+		// HUD/UI/Sprite/FontはPostEffect後のBackBufferへ直接描画する。
+		DrawCurrentScene2DOverlay();
 	}
 
 

--- a/Project/Engine/Core/Application/GameApplication.h
+++ b/Project/Engine/Core/Application/GameApplication.h
@@ -58,6 +58,11 @@ private:
 	// Debug/ReleaseでHUD/UI/Sprite/Fontを必ず重ねるための共通ルート。
 	void DrawCurrentScene2DOverlay();
 
+	// ReleaseでもSceneRenderTarget起点の描画順に揃えるためのフェーズ分割。
+	void DrawGameWorldToSceneTarget();
+	void ApplyPostEffectToBackBuffer();
+	void DrawGameUIToBackBuffer();
+
 public:
 	/// <summary>
 	/// ゲーム終了時の後始末処理。<br/>

--- a/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.cpp
+++ b/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.cpp
@@ -180,6 +180,29 @@ namespace Ken4lowEngine
 		commandList->DrawInstanced(3, 1, 0, 0);
 	}
 
+	void PostEffectManager::CopyRenderTargetToBackBuffer(RenderTarget& srcRT, ID3D12GraphicsCommandList* commandList)
+	{
+		const uint32_t backBufferIndex = dxCommon_->GetSwapChain()->GetSwapChain()->GetCurrentBackBufferIndex();
+		auto backBuffer = dxCommon_->GetBackBuffer(backBufferIndex);
+		auto* swapChain = dxCommon_->GetSwapChain();
+
+		// ReleaseでもSceneRenderTarget入力のPostEffect結果をBackBufferへ明示的にコピーする。
+		SRVManager::GetInstance()->PreDraw();
+		TransitionTo(srcRT, commandList, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+		dxCommon_->ResourceTransition(backBuffer.Get(), swapChain->GetBackBufferState(backBufferIndex), D3D12_RESOURCE_STATE_RENDER_TARGET);
+		swapChain->SetBackBufferState(backBufferIndex, D3D12_RESOURCE_STATE_RENDER_TARGET);
+
+		D3D12_CPU_DESCRIPTOR_HANDLE backBufferRtv = dxCommon_->GetBackBufferRTV(backBufferIndex);
+		commandList->OMSetRenderTargets(1, &backBufferRtv, false, nullptr);
+		commandList->RSSetViewports(1, &dxCommon_->GetMainRenderTarget()->GetViewport());
+		commandList->RSSetScissorRects(1, &dxCommon_->GetMainRenderTarget()->GetScissorRect());
+		commandList->SetPipelineState(pipelineBuilder_->GetCopyPipelineState().Get());
+		commandList->SetGraphicsRootSignature(pipelineBuilder_->GetCopyRootSignature().Get());
+		SRVManager::GetInstance()->SetGraphicsRootDescriptorTable(0, srcRT.srvIndex);
+		commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+		commandList->DrawInstanced(3, 1, 0, 0);
+	}
+
 
 	/// -------------------------------------------------------------
 	///				　	ポストエフェクトの更新処理
@@ -429,6 +452,17 @@ namespace Ken4lowEngine
 		TransitionTo(gameRT, commandList, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
 
 	}
+
+	void PostEffectManager::RenderPostEffectToBackBuffer()
+	{
+		// Release/GameもDebugと同じSceneRenderTarget起点でPostEffectを通してからBackBufferへ出す。
+		RenderPostEffect();
+
+		auto commandList = dxCommon_->GetCommandManager()->GetCommandList();
+		auto& gameRT = renderTargets_[0];
+		CopyRenderTargetToBackBuffer(gameRT, commandList);
+	}
+
 
 	void PostEffectManager::BeginGameRenderTargetOverlay()
 	{

--- a/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.h
+++ b/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.h
@@ -104,6 +104,11 @@ public: /// ---------- メンバ関数 ---------- ///
 	void RenderPostEffect();
 
 	/// <summary>
+	/// Release/Game用にPostEffect結果をBackBufferへ出力します。
+	/// </summary>
+	void RenderPostEffectToBackBuffer();
+
+	/// <summary>
 	/// ポストエフェクト済みのゲーム画面へ2D描画を重ねるためのRTVをバインドします。
 	/// </summary>
 	void BeginGameRenderTargetOverlay();
@@ -184,6 +189,7 @@ private: /// ---------- メンバ関数 ---------- ///
 	/// 既存のコピー用PSOで入力RTを出力RTへ描画します。
 	/// </summary>
 	void CopyRenderTarget(RenderTarget& srcRT, RenderTarget& dstRT, ID3D12GraphicsCommandList* commandList);
+	void CopyRenderTargetToBackBuffer(RenderTarget& srcRT, ID3D12GraphicsCommandList* commandList);
 
 private: /// ---------- メンバ関数 ---------- ///
 


### PR DESCRIPTION
### Motivation
- Release builds drew the scene directly to the BackBuffer, skipping the `SceneRenderTarget` path that GPU/CPU particles and post-effects expect, which caused particles and post-effects to disappear while HUD/UI still rendered.
- Goal: render 3D world + particles into a stable scene render target, apply post-effects, then composite HUD/UI on top of the BackBuffer so Debug/Release rendering order stays consistent and HUD is not affected by post-effects.

### Description
- Unified the game draw flow so both Debug (Editor) and Release use a SceneRenderTarget for the game world and particle pass by introducing `DrawGameWorldToSceneTarget()`, `ApplyPostEffectToBackBuffer()` and `DrawGameUIToBackBuffer()` in `GameApplication` and routing the Release path through these phases instead of drawing directly to the BackBuffer (`Project/Engine/Core/Application/GameApplication.cpp`, `GameApplication.h`).
- Added `PostEffectManager::RenderPostEffectToBackBuffer()` and `PostEffectManager::CopyRenderTargetToBackBuffer()` to explicitly copy the final post-effect `GameRenderTarget` into the BackBuffer for Release, preserving the post-effect output while allowing HUD/UI to be drawn afterwards (`Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.h`, `PostEffectManager.cpp`).
- Kept existing `BeginDraw()`/`EndDraw()`/`RenderPostEffect()` logic for Debug/Editor (ImGui) flow; Release now runs the same post-effect pipeline then copies the result to the swap chain BackBuffer so post-effects are applied in Release as well.
- Files changed: `GameApplication.cpp`, `GameApplication.h`, `PostEffectManager.cpp`, `PostEffectManager.h`.

### Testing
- Ran `git diff --check` to ensure no trailing whitespace or obvious index errors; result: no issues (succeeded).
- Attempted a Release build with `msbuild Project/Ken4lowEngine.sln /p:Configuration=Release /p:Platform=x64` but `msbuild` was not available in this environment so a full compile/test could not be run here (tooling error: `msbuild: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a046fec07f4832dbfd7ad61eea0e581)