### PR TITLE
Fix bullet and GPU particle performance counters

### DIFF
--- a/Project/ApplicationLayer/Character/Bullet/BulletManager.cpp
+++ b/Project/ApplicationLayer/Character/Bullet/BulletManager.cpp
@@ -2,6 +2,8 @@
 #include "Bullet.h"
 #include "CollisionManager.h"
 
+#include <algorithm>
+
 using namespace Ken4lowEngine;
 
 void BulletManager::Initialize(CollisionManager* collisionManager)
@@ -41,18 +43,27 @@ void BulletManager::Update(float dt)
 {
 	for (auto& b : bullets_) b->Update(dt);
 
-	for (size_t i = 0; i < bullets_.size(); )
-	{
-		if (bullets_[i]->IsRemovable())
+	// 寿命切れ/衝突済みの弾はCollider解除後に管理対象から外し、Update/Draw負荷を残さない。
+	const auto removeBegin = std::remove_if(bullets_.begin(), bullets_.end(), [this](const std::unique_ptr<Bullet>& bullet)
 		{
-			if (collisionManager_) collisionManager_->RemoveCollider(bullets_[i].get());
-			bullets_.erase(bullets_.begin() + i);
-		}
-		else
+			if (!bullet || !bullet->IsRemovable())
+			{
+				return false;
+			}
+
+			if (collisionManager_) collisionManager_->RemoveCollider(bullet.get());
+			return true;
+		});
+
+	bullets_.erase(removeBegin, bullets_.end());
+}
+
+size_t BulletManager::GetActiveCount() const
+{
+	return static_cast<size_t>(std::count_if(bullets_.begin(), bullets_.end(), [](const std::unique_ptr<Bullet>& bullet)
 		{
-			++i;
-		}
-	}
+			return bullet && !bullet->IsDead() && !bullet->IsRemovable();
+		}));
 }
 
 void BulletManager::Draw()

--- a/Project/ApplicationLayer/Character/Bullet/BulletManager.h
+++ b/Project/ApplicationLayer/Character/Bullet/BulletManager.h
@@ -48,6 +48,7 @@ public: /// ---------- メンバ関数 ---------- ///
 public: /// ---------- アクセサ ---------- ///
 
 	size_t GetCount() const { return bullets_.size(); }
+	size_t GetActiveCount() const;
 
 private: /// ---------- メンバ変数 ---------- ///
 

--- a/Project/ApplicationLayer/Colliders/CollisionManager.cpp
+++ b/Project/ApplicationLayer/Colliders/CollisionManager.cpp
@@ -195,6 +195,10 @@ void CollisionManager::CheckAllCollisions()
 /// -------------------------------------------------------------
 void CollisionManager::AddCollider(K4E::Collider* other)
 {
+	if (!other) return;
+	if (std::find(all_.begin(), all_.end(), other) != all_.end()) return;
+
+	// 同一Colliderの二重登録を防ぎ、弾発射後にCollision負荷が増え続けないようにする。
 	all_.push_back(other);
 	const uint32_t id = other->GetTypeID();
 	if (id < kMaxTypes) buckets_[id].push_back(other);

--- a/Project/ApplicationLayer/Colliders/CollisionManager.h
+++ b/Project/ApplicationLayer/Colliders/CollisionManager.h
@@ -58,6 +58,13 @@ public: /// ---------- メンバ関数 ---------- ///
     // Detailsの簡易表示用に現在登録中のCollider総数だけを公開する。
     size_t GetColliderCount() const { return all_.size(); }
 
+    // Debug表示用にタイプ別Collider数を公開する。
+    size_t GetColliderCountByType(uint32_t typeId) const
+    {
+        if (typeId >= kMaxTypes) return 0;
+        return buckets_[typeId].size();
+    }
+
 private: /// ---------- メンバ関数 ---------- ///
 
     // コライダー2つの衝突判定（衝突したら両者へ接触を登録）

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
@@ -10,7 +10,11 @@
 #include "Wireframe.h"
 #include "Player.h"
 #include "EnemyBase.h"
+#include "GpuParticleManager.h"
+#include "ParticleManager.h"
+#include "CollisionTypeIdDef.h"
 
+#include <chrono>
 #include <cmath>
 
 #ifdef USE_IMGUI
@@ -175,10 +179,16 @@ void GamePlayWorld::Update(float deltaTime)
 
 	if (bulletManager_)
 	{
+		const auto begin = std::chrono::steady_clock::now();
 		bulletManager_->Update(deltaTime);
+		lastBulletUpdateMs_ = std::chrono::duration<float, std::milli>(std::chrono::steady_clock::now() - begin).count();
 	}
 
-	CollisionUpdate();
+	{
+		const auto begin = std::chrono::steady_clock::now();
+		CollisionUpdate();
+		lastCollisionUpdateMs_ = std::chrono::duration<float, std::milli>(std::chrono::steady_clock::now() - begin).count();
+	}
 
 	if (skyBox_)
 	{
@@ -360,6 +370,42 @@ void GamePlayWorld::DrawGameDebugImGui()
 	ImGui::Text("Defense Target Destroyed: %s", defenseTargetDestroyed_ ? "true" : "false");
 	ImGui::Text("Player Dead: %s", IsPlayerDead() ? "true" : "false");
 	ImGui::Text("Enemies: %d", characters_.GetEnemyCount());
+
+	const float fps = ImGui::GetIO().Framerate;
+	const auto* particleManager = K4E::ParticleManager::GetInstance();
+	const auto* gpuParticleManager = K4E::GpuParticleManager::GetInstance();
+
+	const size_t activeBulletCount = bulletManager_ ? bulletManager_->GetActiveCount() : 0;
+	const size_t totalBulletCount = bulletManager_ ? bulletManager_->GetCount() : 0;
+	const size_t activeParticleCount = particleManager ? particleManager->GetActiveParticleCount() : 0;
+	const size_t totalParticleCount = particleManager ? particleManager->GetTotalParticleCount() : 0;
+	const uint32_t gpuParticleActiveCount = gpuParticleManager ? gpuParticleManager->GetEstimatedActiveParticleCount() : 0;
+	const size_t particleEmitterCount = gpuParticleManager ? gpuParticleManager->GetEmitterCount() : 0;
+	const size_t activeParticleEmitterCount = gpuParticleManager ? gpuParticleManager->GetActiveEmitterCount() : 0;
+	const size_t colliderCount = collisionManager_ ? collisionManager_->GetColliderCount() : 0;
+	const size_t bulletColliderCount = collisionManager_
+		? collisionManager_->GetColliderCountByType(static_cast<uint32_t>(CollisionTypeIdDef::kBullet))
+		: 0;
+	const size_t enemyBulletColliderCount = collisionManager_
+		? collisionManager_->GetColliderCountByType(static_cast<uint32_t>(CollisionTypeIdDef::kEnemyBullet)) +
+		collisionManager_->GetColliderCountByType(static_cast<uint32_t>(CollisionTypeIdDef::kBossBullet))
+		: 0;
+	const uint32_t drawCallCount = gpuParticleManager ? gpuParticleManager->GetLastDrawCallCount() : 0;
+
+	ImGui::SeparatorText("Performance Counters");
+	ImGui::Text("FPS: %.1f", fps);
+	ImGui::Text("Active Bullet Count: %zu", activeBulletCount);
+	ImGui::Text("Total Bullet Count: %zu", totalBulletCount);
+	ImGui::Text("Active Particle Count: %zu", activeParticleCount);
+	ImGui::Text("Total Particle Count: %zu", totalParticleCount);
+	ImGui::Text("GPU Particle Active Count (estimated): %u", gpuParticleActiveCount);
+	ImGui::Text("Particle Emitter Count: %zu (active: %zu)", particleEmitterCount, activeParticleEmitterCount);
+	ImGui::Text("CollisionManager Collider Count: %zu", colliderCount);
+	ImGui::Text("Bullet Collider Count: %zu (enemy/boss: %zu)", bulletColliderCount, enemyBulletColliderCount);
+	ImGui::Text("Draw Call Count (GPU Particle): %u", drawCallCount);
+	ImGui::SeparatorText("Simple Profile");
+	ImGui::Text("BulletManager::Update: %.3f ms", lastBulletUpdateMs_);
+	ImGui::Text("CollisionManager::CheckAllCollisions: %.3f ms", lastCollisionUpdateMs_);
 #endif
 }
 

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.h
@@ -116,4 +116,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	bool reachedGoal_ = false;
 	bool bossDefeated_ = false;
 	bool defenseTargetDestroyed_ = false;
+
+	float lastBulletUpdateMs_ = 0.0f;
+	float lastCollisionUpdateMs_ = 0.0f;
 };

--- a/Project/Engine/Graphics/Renderer/GpuParticle/Emitter/GpuParticleEmitter.cpp
+++ b/Project/Engine/Graphics/Renderer/GpuParticle/Emitter/GpuParticleEmitter.cpp
@@ -1,10 +1,37 @@
 #include "GpuParticleEmitter.h"
 
+#include <algorithm>
+
 namespace Ken4lowEngine
 {
+namespace
+{
+	float EstimateGpuParticleLifeTimeSec(GpuParticleType type)
+	{
+		switch (type)
+		{
+		case GpuParticleType::Blood: return 0.80f;
+		case GpuParticleType::Dust: return 1.20f;
+		case GpuParticleType::Debris: return 1.00f;
+		case GpuParticleType::Smoke: return 3.00f;
+		case GpuParticleType::Ambient: return 7.00f;
+		case GpuParticleType::Spark: return 0.22f;
+		case GpuParticleType::Shockwave: return 0.50f;
+		case GpuParticleType::Heal: return 1.40f;
+		case GpuParticleType::Trail: return 0.22f;
+		case GpuParticleType::DeathBurstCore: return 0.28f;
+		case GpuParticleType::PlayerDamageBlood: return 0.55f;
+		case GpuParticleType::MuzzleFlash: return 0.085f;
+		case GpuParticleType::BulletTracer: return 0.30f;
+		case GpuParticleType::Default:
+		default:
+			return 1.00f;
+		}
+	}
+}
 
 /// -------------------------------------------------------------
-///				　　　	コンストラクタ
+///					　　　コンストラクタ
 /// -------------------------------------------------------------
 GpuParticleEmitter::GpuParticleEmitter(const std::string& name, const EmitterInfo& info)
 	: name_(name), info_(info)
@@ -12,15 +39,46 @@ GpuParticleEmitter::GpuParticleEmitter(const std::string& name, const EmitterInf
 }
 
 /// -------------------------------------------------------------
-///				　　　	射出要求
+///					　　　射出要求
 /// -------------------------------------------------------------
 void GpuParticleEmitter::RequestEmit(uint32_t count)
 {
 	pendingBurstCount_ += count;
 }
 
+void GpuParticleEmitter::UpdateActivity(float deltaTime)
+{
+	for (auto& batch : activeBatches_)
+	{
+		batch.remainingSec -= deltaTime;
+	}
+
+	while (!activeBatches_.empty() && activeBatches_.front().remainingSec <= 0.0f)
+	{
+		estimatedActiveParticleCount_ -= std::min(estimatedActiveParticleCount_, activeBatches_.front().count);
+		activeBatches_.pop_front();
+	}
+}
+
+float GpuParticleEmitter::EstimateParticleLifeTimeSec() const
+{
+	// HLSL の lifeMax と合わせ、寿命後は Draw 対象から外して常時フル描画を避ける。
+	return EstimateGpuParticleLifeTimeSec(static_cast<GpuParticleType>(GetEffectiveType())) + 0.10f;
+}
+
+void GpuParticleEmitter::RegisterActiveBatch(uint32_t count)
+{
+	if (count == 0)
+	{
+		return;
+	}
+
+	activeBatches_.push_back({ EstimateParticleLifeTimeSec(), count });
+	estimatedActiveParticleCount_ += count;
+}
+
 /// -------------------------------------------------------------
-///				　　	定期発射の更新
+///				　　定期発射の更新
 /// -------------------------------------------------------------
 bool GpuParticleEmitter::BuildCB(GpuEmitterCBData& out, float deltaTime)
 {
@@ -67,6 +125,9 @@ bool GpuParticleEmitter::BuildCB(GpuEmitterCBData& out, float deltaTime)
 	out.emit = 1;
 	out.count = pendingBurstCount_;
 	out.frequencyTime = 0.0f; // 使わないなら0固定でOK
+
+	// 生存数をCPU側でも概算追跡し、寿命終了後の不要な全エミッター描画を止める。
+	RegisterActiveBatch(pendingBurstCount_);
 
 	// 消費（このフレーム分を確定）
 	pendingBurstCount_ = 0;

--- a/Project/Engine/Graphics/Renderer/GpuParticle/Emitter/GpuParticleEmitter.h
+++ b/Project/Engine/Graphics/Renderer/GpuParticle/Emitter/GpuParticleEmitter.h
@@ -1,5 +1,6 @@
 #pragma once
 #include <string>
+#include <deque>
 #include <Vector3.h>
 #include <Vector4.h>
 
@@ -61,6 +62,9 @@ public: /// ---------- メンバ関数 ---------- ///
 	/// <param name="count">このフレームに追加で発生させたいパーティクル数</param>
 	void RequestEmit(uint32_t count);
 
+	/// 発生済み粒子が残っている間だけ描画するための軽量更新。
+	void UpdateActivity(float deltaTime);
+
 	/// <summary>
 	/// 定期発射（ループ）とバースト発生をまとめて処理し、<br/>
 	/// GPU に渡すエミッター用 CB データを構築します。<br/>
@@ -111,6 +115,10 @@ public: /// ---------- ゲッター ---------- ///
 	// 位置もUIで見たい
 	const Vector3 GetPosition() const { return position_; }
 
+	/// GPU readback を避けるため、発生要求数と寿命から推定した生存数を返す。
+	uint32_t GetEstimatedActiveParticleCount() const { return estimatedActiveParticleCount_; }
+	bool HasActiveParticles() const { return estimatedActiveParticleCount_ > 0 || pendingBurstCount_ > 0; }
+
 private: /// ---------- プライベート関数 ---------- ///
 
 	static constexpr uint32_t ToU32(BillboardMode m) { return static_cast<uint32_t>(m); }
@@ -150,6 +158,18 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	// このフレームに放出予定の累積数
 	uint32_t pendingBurstCount_ = 0;
+
+	struct ActiveBatch
+	{
+		float remainingSec = 0.0f;
+		uint32_t count = 0;
+	};
+
+	float EstimateParticleLifeTimeSec() const;
+	void RegisterActiveBatch(uint32_t count);
+
+	std::deque<ActiveBatch> activeBatches_;
+	uint32_t estimatedActiveParticleCount_ = 0;
 };
 
 

--- a/Project/Engine/Graphics/Renderer/GpuParticle/Manager/GpuParticleManager.cpp
+++ b/Project/Engine/Graphics/Renderer/GpuParticle/Manager/GpuParticleManager.cpp
@@ -20,6 +20,8 @@
 #include <imgui.h>
 #endif // USE_IMGUI
 #include <cstdint>
+#include <string>
+#include <unordered_set>
 
 namespace Ken4lowEngine
 {
@@ -99,6 +101,8 @@ namespace Ken4lowEngine
 
 		for (auto& [name, emitter] : emitters_)
 		{
+			emitter->UpdateActivity(deltaTime);
+
 			// slotの場所に書く
 			auto* cb = gpuParticleBuffers_->GetEmitterCBData(slot);
 
@@ -119,19 +123,33 @@ namespace Ken4lowEngine
 		const UINT instanceCount = GpuParticleBuffers::GetMaxParticles();
 
 		uint32_t drawSlot = 0;
+		lastDrawCallCount_ = 0;
+		std::unordered_set<std::string> drawnKeys;
 
 		for (auto& [name, emitter] : emitters_)
 		{
+			(void)name;
+			if (!emitter->HasActiveParticles())
+			{
+				continue;
+			}
+
 			const auto& info = emitter->GetInfo();
+			const uint32_t drawType = emitter->GetDrawType();
+			const std::string drawKey = info.textureFilePath + "#" + std::to_string(drawType);
+			if (!drawnKeys.insert(drawKey).second)
+			{
+				continue;
+			}
 
 			gpuParticleRenderer_->SetTextureFilePath(info.textureFilePath);
 
 			// emitter->GetDrawType() を使う（drawType=0ならtype）
-			gpuParticleRenderer_->SetDrawType(emitter->GetDrawType(), drawSlot);
+			gpuParticleRenderer_->SetDrawType(drawType, drawSlot);
 
-			// 通常のパーティクルとして描画
+			// 同じ描画タイプは1回だけ描画し、寿命切れ後のフルインスタンスDrawも抑える。
 			gpuParticleRenderer_->Draw(instanceCount, drawSlot);
-
+			++lastDrawCallCount_;
 			++drawSlot;
 		}
 	}
@@ -791,6 +809,34 @@ namespace Ken4lowEngine
 	/// -------------------------------------------------------------
 	///				　　　		名前指定でバースト
 	/// -------------------------------------------------------------
+	size_t GpuParticleManager::GetActiveEmitterCount() const
+	{
+		size_t count = 0;
+		for (const auto& [name, emitter] : emitters_)
+		{
+			(void)name;
+			if (emitter && emitter->HasActiveParticles())
+			{
+				++count;
+			}
+		}
+		return count;
+	}
+
+	uint32_t GpuParticleManager::GetEstimatedActiveParticleCount() const
+	{
+		uint32_t count = 0;
+		for (const auto& [name, emitter] : emitters_)
+		{
+			(void)name;
+			if (emitter)
+			{
+				count += emitter->GetEstimatedActiveParticleCount();
+			}
+		}
+		return count;
+	}
+
 	void GpuParticleManager::BurstEmitter(const std::string& name, uint32_t count)
 	{
 		// 指定された名前のエミッターを取得

--- a/Project/Engine/Graphics/Renderer/GpuParticle/Manager/GpuParticleManager.h
+++ b/Project/Engine/Graphics/Renderer/GpuParticle/Manager/GpuParticleManager.h
@@ -12,6 +12,7 @@
 #include "GpuParticleEmitterAsset.h"
 
 #include <unordered_map>
+#include <cstddef>
 #include <memory>
 #include <ModelData.h>
 
@@ -346,6 +347,18 @@ namespace Ken4lowEngine
 		/// <param name="enabled">有効にする場合は true。</param>
 		void SetDebugCameraEnabled(bool enabled) { gpuParticleBuffers_->SetDebugCameraEnabled(enabled); }
 
+		/// デバッグ表示用：登録済みエミッター数を返す。
+		size_t GetEmitterCount() const { return emitters_.size(); }
+
+		/// デバッグ表示用：寿命推定上まだ描画対象のエミッター数を返す。
+		size_t GetActiveEmitterCount() const;
+
+		/// デバッグ表示用：GPU readback なしの推定生存パーティクル数を返す。
+		uint32_t GetEstimatedActiveParticleCount() const;
+
+		/// デバッグ表示用：直近フレームの GPU Particle draw call 数を返す。
+		uint32_t GetLastDrawCallCount() const { return lastDrawCallCount_; }
+
 	public:
 
 		bool RemoveEmitter(const std::string& name);
@@ -430,6 +443,8 @@ namespace Ken4lowEngine
 		/// 名前をキーにしたエミッター管理テーブルです。
 		/// </summary>
 		std::unordered_map<std::string, std::unique_ptr<GpuParticleEmitter>> emitters_;
+
+		uint32_t lastDrawCallCount_ = 0;
 
 	private: /// ---------- メッシュデータ ---------- ///
 

--- a/Project/Engine/Graphics/Renderer/Particle/Manager/ParticleManager.h
+++ b/Project/Engine/Graphics/Renderer/Particle/Manager/ParticleManager.h
@@ -8,6 +8,7 @@
 #include "ParticleFactory.h"
 
 #include <unordered_map>
+#include <cstddef>
 #include <list>
 #include <random>
 #include <numbers>
@@ -173,6 +174,21 @@ public: /// ---------- メンバ関数 ---------- ///
 	/// ※ 値コピーなので、更新は反映されません。
 	/// </summary>
 	std::unordered_map<std::string, ParticleManager::ParticleGroup> GetParticleGroups() { return particleGroups; }
+
+	/// Debug表示用：CPUパーティクルの現在数をコピーなしで集計する。
+	size_t GetTotalParticleCount() const
+	{
+		size_t count = 0;
+		for (const auto& [name, group] : particleGroups)
+		{
+			(void)name;
+			count += group.particles.size();
+		}
+		return count;
+	}
+
+	/// Debug表示用：現在の実装では list 内の粒子が active 対象。
+	size_t GetActiveParticleCount() const { return GetTotalParticleCount(); }
 
 	/// <summary>
 	/// パーティクルに関する ImGui デバッグ UI の描画処理。<br/>


### PR DESCRIPTION
### Motivation
- 発射やパーティクル発生後に FPS が低下し、そのまま回復しない問題を調査した結果、寿命切れの扱いや GPU パーティクルの不要な描画が継続していることが判明したため、その原因特定用のカウント表示追加と寿命管理／描画最適化を行いました。

### Description
- GamePlayScene のデバッグ領域に `FPS`、`Active/Total Bullet Count`、`Active/Total CPU Particle Count`、`GPU Particle Active Count (推定)`、`Particle Emitter Count` / `Active Emitter Count`、`CollisionManager Collider Count`、`Bullet Collider Count`、`GPU Particle Draw Call Count`、および `BulletManager::Update` / `CollisionManager::CheckAllCollisions` の簡易 ms を追加しました（`GamePlayWorld.cpp`）。
- `BulletManager` を `remove_if` ベースで整理して寿命切れ・削除対象の弾を一括除去し、削除前に必ず `CollisionManager::RemoveCollider` を呼ぶようにして `GetActiveCount()` を追加しました（`BulletManager.*`）。
- `CollisionManager::AddCollider` に二重登録ガードを追加し、タイプ別カウント取得 API を追加してコライダー登録漏れや増殖を防止しました（`CollisionManager.*`）。
- GPU パーティクル側は `GpuParticleEmitter` に CPU 側の「発生バッチ／推定生存数」ロジックを導入して `UpdateActivity` と `RegisterActiveBatch` を追加し、寿命推定により寿命切れ後は描画対象から外すようにして `GpuParticleManager::Draw` 側でアクティブでないエミッターをスキップ、さらに同一 `texture+drawType` の描画をデデュープして余分なインスタンス描画と Draw Call を削減しました（`GpuParticleEmitter.*`, `GpuParticleManager.*`）。
- CPU 側パーティクルではデバッグ用にコピーを作らずに現在の粒子数を集計する `GetTotalParticleCount()` 等を追加しました（`ParticleManager.h`）。
- 変更の主なファイル: `GamePlayWorld.*`, `BulletManager.*`, `BulletManager.h`, `CollisionManager.*`, `ParticleManager.h`, `GpuParticleEmitter.*`, `GpuParticleEmitter.h`, `GpuParticleManager.*`, `GpuParticleManager.h`。

### Testing
- 自動チェックとして `git diff --check` を実行して問題ないことを確認しました（成功）。
- `GpuParticleEmitter.cpp` に対して `clang++ -fsyntax-only` による構文チェックを行い該当ファイルは構文エラーなしで通過しました（成功）。
- より広範な構文チェック（`GpuParticleManager.cpp` など）は試行しましたが、実行環境に Windows / DirectX ヘッダ（例: `d3d12.h`）が存在しないためシステム全体のビルド／構文チェックは実行できませんでした（環境制約のため未実施）。
- 実機（Windows / Visual Studio）での動作確認と FPS 回復の検証は、DirectX 環境での起動確認が必要です（未実施）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0473944710832d9a44f0a5b5614d5a)