### PR TITLE
Introduce StageObjectiveManager to centralize stage objective logic

### DIFF
--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
@@ -26,14 +26,6 @@ using namespace Ken4lowEngine;
 void GamePlayWorld::Initialize(GamePlayStageContext& stageContext)
 {
 	const auto stageAssets = stageContext.GetCurrentStageAssets();
-	stageRule_ = stageContext.GetCurrentStageRule();
-
-	activatedDeviceCount_ = 0;
-	defendElapsedSec_ = 0.0f;
-	stageElapsedSec_ = 0.0f;
-	reachedGoal_ = false;
-	bossDefeated_ = false;
-	defenseTargetDestroyed_ = false;
 
 	K4E::Vector3 dummy{};
 	if (!TryGetDirectionalLightFromManager(dummy))
@@ -89,6 +81,10 @@ void GamePlayWorld::Initialize(GamePlayStageContext& stageContext)
 
 	stageContext.LoadSpawnPointsFromLevel(stageAssets.jsonPath);
 
+	// ステージ目的の実行中状態は専用マネージャへ集約する。
+	stageObjectiveManager_ = std::make_unique<StageObjectiveManager>();
+	stageObjectiveManager_->Initialize(stageContext);
+
 	if (auto* player = characters_.GetPlayer())
 	{
 		player->SetSpawnOffset({ 0.0f, 0.0f, 0.0f });
@@ -114,7 +110,7 @@ void GamePlayWorld::Initialize(GamePlayStageContext& stageContext)
 
 	waveManager_ = std::make_unique<WaveManager>();
 
-	if (stageRule_.useWaveSystem)
+	if (stageObjectiveManager_ && stageObjectiveManager_->UsesWaveSystem())
 	{
 		stageContext.SetupWaves(waveManager_.get());
 	}
@@ -132,6 +128,7 @@ void GamePlayWorld::Initialize(GamePlayStageContext& stageContext)
 
 void GamePlayWorld::Finalize()
 {
+	stageObjectiveManager_.reset();
 	waveManager_.reset();
 	hudManager_.reset();
 
@@ -226,8 +223,9 @@ void GamePlayWorld::Update(float deltaTime)
 		hudManager_->Update(deltaTime);
 	}
 
-	if (waveManager_)
+	if (stageObjectiveManager_ && stageObjectiveManager_->UsesWaveSystem() && waveManager_)
 	{
+		// WaveManagerはウェーブ使用ステージだけで更新し、非ウェーブ目的と分離する。
 		waveManager_->Update(characters_, deltaTime);
 
 		const int currentWave = waveManager_->GetCurrentWaveNumber();
@@ -264,7 +262,10 @@ void GamePlayWorld::Update(float deltaTime)
 		prevAllWavesCleared_ = isAllWavesCleared;
 	}
 
-	UpdateStageObjective(deltaTime);
+	if (stageObjectiveManager_)
+	{
+		stageObjectiveManager_->Update(deltaTime);
+	}
 }
 
 void GamePlayWorld::UpdateIntroVisuals()
@@ -363,11 +364,18 @@ void GamePlayWorld::DrawGameDebugImGui()
 {
 #ifdef USE_IMGUI
 	// Game DebugにはGamePlayScene全体の簡易ステータスをまとめる。
-	ImGui::Text("Stage Time: %.2f sec", stageElapsedSec_);
-	ImGui::Text("Activated Devices: %d", activatedDeviceCount_);
-	ImGui::Text("Reached Goal: %s", reachedGoal_ ? "true" : "false");
-	ImGui::Text("Boss Defeated: %s", bossDefeated_ ? "true" : "false");
-	ImGui::Text("Defense Target Destroyed: %s", defenseTargetDestroyed_ ? "true" : "false");
+	// ステージ目的の進行状態はStageObjectiveManagerから参照して表示する。
+	if (stageObjectiveManager_)
+	{
+		ImGui::Text("Stage Time: %.2f sec", stageObjectiveManager_->GetStageElapsedSec());
+		ImGui::Text("Activated Devices: %d / %d", stageObjectiveManager_->GetActivatedDeviceCount(), stageObjectiveManager_->GetDevicePointCount());
+		ImGui::Text("Defense Targets: %d", stageObjectiveManager_->GetDefenseTargetPointCount());
+		ImGui::Text("Goal Points: %d", stageObjectiveManager_->GetGoalPointCount());
+		ImGui::Text("Boss Spawn Point: %s", stageObjectiveManager_->HasBossSpawnPoint() ? "true" : "false");
+		ImGui::Text("Reached Goal: %s", stageObjectiveManager_->HasReachedGoal() ? "true" : "false");
+		ImGui::Text("Boss Defeated: %s", stageObjectiveManager_->IsBossDefeated() ? "true" : "false");
+		ImGui::Text("Defense Target Destroyed: %s", stageObjectiveManager_->IsDefenseTargetDestroyed() ? "true" : "false");
+	}
 	ImGui::Text("Player Dead: %s", IsPlayerDead() ? "true" : "false");
 	ImGui::Text("Enemies: %d", characters_.GetEnemyCount());
 
@@ -442,7 +450,7 @@ void GamePlayWorld::SyncAfterPlayerSpawn()
 
 void GamePlayWorld::StartWaves()
 {
-	if (waveManager_ && !waveManager_->HasStarted())
+	if (stageObjectiveManager_ && stageObjectiveManager_->UsesWaveSystem() && waveManager_ && !waveManager_->HasStarted())
 	{
 		waveManager_->Start();
 	}
@@ -454,7 +462,7 @@ void GamePlayWorld::WarmupStartGameplayForIntro()
 	SetStartGameplayVisualsVisible(false);
 
 	StartWaves();
-	if (waveManager_)
+	if (stageObjectiveManager_ && stageObjectiveManager_->UsesWaveSystem() && waveManager_)
 	{
 		waveManager_->Update(characters_, 0.0f);
 	}
@@ -481,40 +489,12 @@ bool GamePlayWorld::IsAllWavesCleared() const
 
 bool GamePlayWorld::IsStageObjectiveCleared() const
 {
-	switch (stageRule_.objectiveType)
-	{
-	case GamePlayStageContext::StageObjectiveType::ClearAllWaves:
-		return IsAllWavesCleared();
-
-	case GamePlayStageContext::StageObjectiveType::ActivateDevices:
-		return activatedDeviceCount_ >= stageRule_.requiredDeviceCount;
-
-	case GamePlayStageContext::StageObjectiveType::DefendTarget:
-		return !defenseTargetDestroyed_ && defendElapsedSec_ >= stageRule_.defendTimeSec;
-
-	case GamePlayStageContext::StageObjectiveType::ReachGoal:
-		return reachedGoal_;
-
-	case GamePlayStageContext::StageObjectiveType::DefeatBoss:
-		return bossDefeated_;
-	}
-
-	return false;
+	return stageObjectiveManager_ && stageObjectiveManager_->IsStageObjectiveCleared(IsAllWavesCleared());
 }
 
 bool GamePlayWorld::IsStageObjectiveFailed() const
 {
-	switch (stageRule_.objectiveType)
-	{
-	case GamePlayStageContext::StageObjectiveType::DefendTarget:
-		return defenseTargetDestroyed_;
-
-	case GamePlayStageContext::StageObjectiveType::ReachGoal:
-		return (stageRule_.timeLimitSec > 0.0f) && (stageElapsedSec_ >= stageRule_.timeLimitSec) && !reachedGoal_;
-
-	default:
-		return false;
-	}
+	return stageObjectiveManager_ && stageObjectiveManager_->IsStageObjectiveFailed();
 }
 
 void GamePlayWorld::SetDebugCameraEnabled(bool enabled)
@@ -532,7 +512,10 @@ void GamePlayWorld::SetDebugCameraEnabled(bool enabled)
 
 void GamePlayWorld::SetDefenseTargetDestroyed(bool destroyed)
 {
-	defenseTargetDestroyed_ = destroyed;
+	if (stageObjectiveManager_)
+	{
+		stageObjectiveManager_->SetDefenseTargetDestroyed(destroyed);
+	}
 }
 
 bool GamePlayWorld::CheckCrosshairTargetingEnemy() const
@@ -562,21 +545,26 @@ bool GamePlayWorld::CheckCrosshairTargetingEnemy() const
 
 void GamePlayWorld::AddActivatedDeviceCount(int amount)
 {
-	activatedDeviceCount_ += amount;
-	if (activatedDeviceCount_ < 0)
+	if (stageObjectiveManager_)
 	{
-		activatedDeviceCount_ = 0;
+		stageObjectiveManager_->AddActivatedDeviceCount(amount);
 	}
 }
 
 void GamePlayWorld::SetReachedGoal(bool reached)
 {
-	reachedGoal_ = reached;
+	if (stageObjectiveManager_)
+	{
+		stageObjectiveManager_->SetReachedGoal(reached);
+	}
 }
 
 void GamePlayWorld::SetBossDefeated(bool defeated)
 {
-	bossDefeated_ = defeated;
+	if (stageObjectiveManager_)
+	{
+		stageObjectiveManager_->SetBossDefeated(defeated);
+	}
 }
 
 void GamePlayWorld::CollisionUpdate()
@@ -649,35 +637,4 @@ bool GamePlayWorld::IsSightBlocked(const K4E::Segment& seg) const
 {
 	(void)seg; // 未使用
 	return false;
-}
-
-void GamePlayWorld::UpdateStageObjective(float deltaTime)
-{
-	stageElapsedSec_ += deltaTime;
-
-	switch (stageRule_.objectiveType)
-	{
-	case GamePlayStageContext::StageObjectiveType::DefendTarget:
-		if (!defenseTargetDestroyed_)
-		{
-			defendElapsedSec_ += deltaTime;
-		}
-		break;
-
-	case GamePlayStageContext::StageObjectiveType::ReachGoal:
-		// 到達判定は外部から SetReachedGoal で入れる想定
-		break;
-
-	case GamePlayStageContext::StageObjectiveType::ActivateDevices:
-		// 装置起動数は外部から AddActivatedDeviceCount で入れる想定
-		break;
-
-	case GamePlayStageContext::StageObjectiveType::DefeatBoss:
-		// ボス撃破は外部から SetBossDefeated で入れる想定
-		break;
-
-	case GamePlayStageContext::StageObjectiveType::ClearAllWaves:
-	default:
-		break;
-	}
 }

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.h
@@ -5,7 +5,7 @@
 #include "HUDManager.h"
 #include "WaveManager.h"
 #include "Stage.h"
-#include "GamePlayStageContext.h"
+#include "StageObjectiveManager.h"
 #include <SkyBox.h>
 #include "EnemyHPBarManager.h"
 #include "ItemManager.h"
@@ -46,6 +46,7 @@ public: /// ---------- メンバ関数 ---------- ///
 
 	void SetDebugCameraEnabled(bool enabled);
 
+	// TODO: 実オブジェクト破壊判定が入るまでの仮API。
 	void SetDefenseTargetDestroyed(bool destroyed);
 
 	CharacterWorld& GetCharacters() { return characters_; }
@@ -66,9 +67,11 @@ public: /// ---------- メンバ関数 ---------- ///
 
 	bool CheckCrosshairTargetingEnemy() const;
 
-	// 仮の進捗更新API
+	// TODO: 実オブジェクト接触判定が入るまでの仮API。
 	void AddActivatedDeviceCount(int amount = 1);
+	// TODO: 実オブジェクト接触判定が入るまでの仮API。
 	void SetReachedGoal(bool reached);
+	// TODO: 実オブジェクト接触判定が入るまでの仮API。
 	void SetBossDefeated(bool defeated);
 
 private: /// ---------- メンバ関数 ---------- ///
@@ -78,7 +81,6 @@ private: /// ---------- メンバ関数 ---------- ///
 	bool TryGetDirectionalLightFromManager(K4E::Vector3& outDirection) const;
 	bool IsSightBlocked(const K4E::Segment& seg) const;
 
-	void UpdateStageObjective(float deltaTime);
 
 private: /// ---------- メンバ変数 ---------- ///
 
@@ -107,15 +109,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	float shadowNearZ_ = 0.1f;
 	float shadowFarZ_ = 120.0f;
 
-	GamePlayStageContext::StageRule stageRule_{};
-
-	int activatedDeviceCount_ = 0;
-	float defendElapsedSec_ = 0.0f;
-	float stageElapsedSec_ = 0.0f;
-
-	bool reachedGoal_ = false;
-	bool bossDefeated_ = false;
-	bool defenseTargetDestroyed_ = false;
+	std::unique_ptr<StageObjectiveManager> stageObjectiveManager_ = nullptr;
 
 	float lastBulletUpdateMs_ = 0.0f;
 	float lastCollisionUpdateMs_ = 0.0f;

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/StageObjectiveManager.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/StageObjectiveManager.cpp
@@ -1,0 +1,115 @@
+#define NOMINMAX
+#include "StageObjectiveManager.h"
+
+#include <algorithm>
+
+void StageObjectiveManager::Initialize(const GamePlayStageContext& stageContext)
+{
+	stageRule_ = stageContext.GetCurrentStageRule();
+
+	// ステージ配置点の個数を保持し、ルール未指定時の目的達成数に使う。
+	devicePointCount_ = static_cast<int>(stageContext.GetDevicePoints().size());
+	defenseTargetPointCount_ = static_cast<int>(stageContext.GetDefenseTargetPoints().size());
+	goalPointCount_ = static_cast<int>(stageContext.GetGoalPoints().size());
+	hasBossSpawnPoint_ = stageContext.HasBossSpawnPoint();
+
+	activatedDeviceCount_ = 0;
+	defendElapsedSec_ = 0.0f;
+	stageElapsedSec_ = 0.0f;
+	reachedGoal_ = false;
+	bossDefeated_ = false;
+	defenseTargetDestroyed_ = false;
+}
+
+void StageObjectiveManager::Update(float deltaTime)
+{
+	stageElapsedSec_ += deltaTime;
+
+	switch (stageRule_.objectiveType)
+	{
+	case GamePlayStageContext::StageObjectiveType::DefendTarget:
+		// 防衛中は対象が破壊されていない時間だけをクリア判定に積む。
+		if (!defenseTargetDestroyed_)
+		{
+			defendElapsedSec_ += deltaTime;
+		}
+		break;
+
+	case GamePlayStageContext::StageObjectiveType::ReachGoal:
+	case GamePlayStageContext::StageObjectiveType::ActivateDevices:
+	case GamePlayStageContext::StageObjectiveType::DefeatBoss:
+	case GamePlayStageContext::StageObjectiveType::ClearAllWaves:
+	default:
+		break;
+	}
+}
+
+bool StageObjectiveManager::IsStageObjectiveCleared(bool allWavesCleared) const
+{
+	switch (stageRule_.objectiveType)
+	{
+	case GamePlayStageContext::StageObjectiveType::ClearAllWaves:
+		// WAVEは既存WaveManagerの全ウェーブクリア状態をそのまま採用する。
+		return allWavesCleared;
+
+	case GamePlayStageContext::StageObjectiveType::ActivateDevices:
+		// SEARCHは必要数が未指定ならDevicePoint数をクリア条件にする。
+		return activatedDeviceCount_ >= GetRequiredDeviceCount();
+
+	case GamePlayStageContext::StageObjectiveType::DefendTarget:
+		// DEFENSEはDefenseTargetPointが破壊されず防衛時間を満たしたらクリアにする。
+		return !defenseTargetDestroyed_ && defendElapsedSec_ >= stageRule_.defendTimeSec;
+
+	case GamePlayStageContext::StageObjectiveType::ReachGoal:
+		// ESCAPEはGoalPoint到達通知をクリア条件にする。
+		return reachedGoal_;
+
+	case GamePlayStageContext::StageObjectiveType::DefeatBoss:
+		// BOSSはBossSpawnPointから出したボスの撃破通知をクリア条件にする。
+		return bossDefeated_;
+	}
+
+	return false;
+}
+
+bool StageObjectiveManager::IsStageObjectiveFailed() const
+{
+	switch (stageRule_.objectiveType)
+	{
+	case GamePlayStageContext::StageObjectiveType::DefendTarget:
+		// DEFENSEは防衛対象破壊通知を失敗条件にする。
+		return defenseTargetDestroyed_;
+
+	case GamePlayStageContext::StageObjectiveType::ReachGoal:
+		// ESCAPEは制限時間ありのステージだけ時間切れを失敗にする。
+		return (stageRule_.timeLimitSec > 0.0f) && (stageElapsedSec_ >= stageRule_.timeLimitSec) && !reachedGoal_;
+
+	default:
+		return false;
+	}
+}
+
+void StageObjectiveManager::AddActivatedDeviceCount(int amount)
+{
+	activatedDeviceCount_ = std::max(0, activatedDeviceCount_ + amount);
+}
+
+void StageObjectiveManager::SetReachedGoal(bool reached)
+{
+	reachedGoal_ = reached;
+}
+
+void StageObjectiveManager::SetBossDefeated(bool defeated)
+{
+	bossDefeated_ = defeated;
+}
+
+void StageObjectiveManager::SetDefenseTargetDestroyed(bool destroyed)
+{
+	defenseTargetDestroyed_ = destroyed;
+}
+
+int StageObjectiveManager::GetRequiredDeviceCount() const
+{
+	return (stageRule_.requiredDeviceCount > 0) ? stageRule_.requiredDeviceCount : devicePointCount_;
+}

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/StageObjectiveManager.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/StageObjectiveManager.h
@@ -1,0 +1,56 @@
+#pragma once
+#include "GamePlayStageContext.h"
+
+/// -------------------------------------------------------------
+///                 ステージ目的の進行状態管理クラス
+/// -------------------------------------------------------------
+class StageObjectiveManager
+{
+public: /// ---------- メンバ関数 ---------- ///
+
+	void Initialize(const GamePlayStageContext& stageContext);
+	void Update(float deltaTime);
+
+	bool UsesWaveSystem() const { return stageRule_.useWaveSystem; }
+	float GetStageElapsedSec() const { return stageElapsedSec_; }
+	int GetActivatedDeviceCount() const { return activatedDeviceCount_; }
+	int GetDevicePointCount() const { return devicePointCount_; }
+	int GetDefenseTargetPointCount() const { return defenseTargetPointCount_; }
+	int GetGoalPointCount() const { return goalPointCount_; }
+	bool HasBossSpawnPoint() const { return hasBossSpawnPoint_; }
+	bool HasReachedGoal() const { return reachedGoal_; }
+	bool IsBossDefeated() const { return bossDefeated_; }
+	bool IsDefenseTargetDestroyed() const { return defenseTargetDestroyed_; }
+	bool IsStageObjectiveCleared(bool allWavesCleared) const;
+	bool IsStageObjectiveFailed() const;
+
+	// TODO: 実オブジェクト接触判定が入るまでの仮API。
+	void AddActivatedDeviceCount(int amount = 1);
+	// TODO: 実オブジェクト接触判定が入るまでの仮API。
+	void SetReachedGoal(bool reached);
+	// TODO: 実オブジェクト接触判定が入るまでの仮API。
+	void SetBossDefeated(bool defeated);
+	// TODO: 実オブジェクト破壊判定が入るまでの仮API。
+	void SetDefenseTargetDestroyed(bool destroyed);
+
+private: /// ---------- メンバ関数 ---------- ///
+
+	int GetRequiredDeviceCount() const;
+
+private: /// ---------- メンバ変数 ---------- ///
+
+	GamePlayStageContext::StageRule stageRule_{};
+
+	int devicePointCount_ = 0;
+	int defenseTargetPointCount_ = 0;
+	int goalPointCount_ = 0;
+	bool hasBossSpawnPoint_ = false;
+
+	int activatedDeviceCount_ = 0;
+	float defendElapsedSec_ = 0.0f;
+	float stageElapsedSec_ = 0.0f;
+
+	bool reachedGoal_ = false;
+	bool bossDefeated_ = false;
+	bool defenseTargetDestroyed_ = false;
+};

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -276,6 +276,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="ApplicationLayer\Scene\ShadowTestScene\ShadowTestScene.cpp" />
     <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\UI\ResultMenu.cpp" />
     <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\World\WaveManager.cpp" />
+    <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\World\StageObjectiveManager.cpp" />
     <ClCompile Include="ApplicationLayer\UISystem\WaveUI\WaveUI.cpp" />
     <ClCompile Include="ApplicationLayer\Character\Player\Component\PlayerWeaponVisualComponent.cpp" />
     <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\DebugTools\GamePlayDebugTools.cpp" />
@@ -904,6 +905,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="ApplicationLayer\Scene\ShadowTestScene\ShadowTestScene.h" />
     <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\UI\ResultMenu.h" />
     <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\World\WaveManager.h" />
+    <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\World\StageObjectiveManager.h" />
     <ClInclude Include="ApplicationLayer\UISystem\WaveUI\WaveUI.h" />
     <ClInclude Include="ApplicationLayer\Character\Player\Component\PlayerWeaponVisualComponent.h" />
     <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\DebugTools\GamePlayDebugTools.h" />

--- a/Project/Ken4lowEngine.vcxproj.filters
+++ b/Project/Ken4lowEngine.vcxproj.filters
@@ -340,6 +340,9 @@
     <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\World\WaveManager.cpp">
       <Filter>ApplicationLayer\Scene\GamePlayScene\World</Filter>
     </ClCompile>
+    <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\World\StageObjectiveManager.cpp">
+      <Filter>ApplicationLayer\Scene\GamePlayScene\World</Filter>
+    </ClCompile>
     <ClCompile Include="ApplicationLayer\Character\Boss\Components\BossAnimationComponent.cpp">
       <Filter>ApplicationLayer\Character\Boss\Components</Filter>
     </ClCompile>
@@ -1153,6 +1156,9 @@
       <Filter>ApplicationLayer\Scene\GamePlayScene\World</Filter>
     </ClInclude>
     <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\World\WaveManager.h">
+      <Filter>ApplicationLayer\Scene\GamePlayScene\World</Filter>
+    </ClInclude>
+    <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\World\StageObjectiveManager.h">
       <Filter>ApplicationLayer\Scene\GamePlayScene\World</Filter>
     </ClInclude>
     <ClInclude Include="ApplicationLayer\Character\Boss\Components\BossAnimationComponent.h">


### PR DESCRIPTION
### Motivation
- Reduce `GamePlayWorld` responsibility by extracting runtime stage objective state and rules into a dedicated manager. 
- Preserve existing `WaveManager` behavior for wave-based stages while enabling clear support for `WAVE`/`SEARCH`/`DEFENSE`/`ESCAPE`/`BOSS` stage types defined by `StageObjectiveType`. 
- Make the flow easier to extend when adding new stage types and keep stage configuration in `GamePlayStageContext`. 

### Description
- Added a new class `StageObjectiveManager` (`Project/ApplicationLayer/Scene/GamePlayScene/World/StageObjectiveManager.h` and `.cpp`) that owns runtime objective state (`activatedDeviceCount`, `defendElapsedSec`, `stageElapsedSec`, `reachedGoal`, `bossDefeated`, `defenseTargetDestroyed`) and implements `IsStageObjectiveCleared` / `IsStageObjectiveFailed` for `ClearAllWaves`, `ActivateDevices`, `DefendTarget`, `ReachGoal`, and `DefeatBoss` stage types. 
- Updated `GamePlayWorld` to own a `std::unique_ptr<StageObjectiveManager>` and delegate objective updates, checks and the temporary progress APIs to it; removed the migrated runtime state and `UpdateStageObjective` from `GamePlayWorld`. 
- Ensured `WaveManager` is left intact but its `Start`/`Update`/wave setup only run when `UsesWaveSystem()` is true (i.e. stages with `useWaveSystem`), so non-wave stages no longer run wave logic. 
- Exposed temporary helper APIs in `StageObjectiveManager` and `GamePlayWorld` for integration points until real contact/interaction code is added: `AddActivatedDeviceCount()`, `SetReachedGoal()`, `SetBossDefeated()`, `SetDefenseTargetDestroyed()`; each is marked with a `TODO`/comment indicating it is a placeholder. 
- Registered the new `.cpp` and `.h` in `Project/Ken4lowEngine.vcxproj` and `Project/Ken4lowEngine.vcxproj.filters` so the project includes the new files. 
- Added short explanatory comments in the new manager where behavior is tied to spawn points (device points, defense targets, goal points, boss spawn). 

### Testing
- Parsed `Project/Ken4lowEngine.vcxproj` and `Project/Ken4lowEngine.vcxproj.filters` as XML to validate the project file changes succeeded. (succeeded) 
- Performed static checks to confirm runtime objective state and `UpdateStageObjective` were removed from `GamePlayWorld` and that `GamePlayWorld` delegates to `StageObjectiveManager`. (succeeded) 
- Verified `git` index and `diff` consistency for the modified/added files. (succeeded) 
- Attempted to run a full Visual Studio build (`msbuild`) for the solution but `msbuild` is not available in the Linux container used for the automation, so a native build was not executed in this environment. (skipped due to environment)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0a83aba678832d9b403de4adcc25b0)