### PR TITLE
Investigate UV and texture conversion path

### DIFF
--- a/Project/Engine/Graphics/Renderer/Object3D/Object3DPipelineSet.cpp
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3DPipelineSet.cpp
@@ -145,9 +145,10 @@ namespace Ken4lowEngine
 
 			staticSamplers[0] = {};
 			staticSamplers[0].Filter = D3D12_FILTER_MIN_MAG_MIP_POINT;
-			staticSamplers[0].AddressU = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
-			staticSamplers[0].AddressV = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
-			staticSamplers[0].AddressW = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
+			// UV が 1 を超えるステージ/地面テクスチャを繰り返し表示できるようにする。
+			staticSamplers[0].AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+			staticSamplers[0].AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
+			staticSamplers[0].AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
 			staticSamplers[0].ComparisonFunc = D3D12_COMPARISON_FUNC_NEVER;
 			staticSamplers[0].ShaderRegister = 0;
 			staticSamplers[0].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;

--- a/Project/Engine/Graphics/Resource/Model/AssimpLoader.cpp
+++ b/Project/Engine/Graphics/Resource/Model/AssimpLoader.cpp
@@ -1,10 +1,13 @@
 #include "AssimpLoader.h"
 #include "TextureManager.h"
 #include "ModelPathResolver.h"
+#include "LogString.h"
 
 #include <cassert>
 #include <cctype>
 #include <stdexcept>
+#include <algorithm>
+#include <format>
 
 namespace Ken4lowEngine
 {
@@ -142,6 +145,11 @@ namespace Ken4lowEngine
 			const bool hasNormals = (mesh->HasNormals() && mesh->mNormals != nullptr);
 			const bool hasUV0 = (mesh->HasTextureCoords(0) && mesh->mTextureCoords[0] != nullptr);
 
+#ifdef _DEBUG
+			Log(std::format("[AssimpLoader][UV] model={} mesh=\"{}\" vertices={} hasUV0={}\n",
+				modelFilePath, mesh->mName.C_Str(), mesh->mNumVertices, hasUV0 ? "true" : "false"));
+#endif
+
 			// -------------------------------------------------
 			// 頂点情報の読み出し
 			// -------------------------------------------------
@@ -164,12 +172,23 @@ namespace Ken4lowEngine
 				if (hasUV0)
 				{
 					const aiVector3D& texcoord = mesh->mTextureCoords[0][vertexIndex];
+					// Assimp の UV0 をそのまま保持し、V反転は明示オプション側だけで行う。
 					sub.vertices[vertexIndex].texcoord = { texcoord.x, texcoord.y };
 				}
 				else
 				{
+					// UV が無い頂点だけ 0,0 にして、Debugログで UV 欠落を切り分けられるようにする。
 					sub.vertices[vertexIndex].texcoord = { 0.0f, 0.0f };
 				}
+
+#ifdef _DEBUG
+				if (vertexIndex < 5)
+				{
+					Log(std::format("[AssimpLoader][UV] model={} mesh=\"{}\" vertex={} uv=({:.6f}, {:.6f})\n",
+						modelFilePath, mesh->mName.C_Str(), vertexIndex,
+						sub.vertices[vertexIndex].texcoord.x, sub.vertices[vertexIndex].texcoord.y));
+				}
+#endif
 			}
 
 			// -------------------------------------------------

--- a/Project/Engine/Graphics/Resource/Model/KMeshLoader.cpp
+++ b/Project/Engine/Graphics/Resource/Model/KMeshLoader.cpp
@@ -6,6 +6,9 @@
 #include <vector>
 #include <string>
 #include <filesystem>
+#include <algorithm>
+#include <format>
+#include "LogString.h"
 
 namespace Ken4lowEngine
 {
@@ -105,6 +108,17 @@ namespace Ken4lowEngine
 			}
 		}
 
+#ifdef _DEBUG
+		const bool hasUV0 = (header.flags & (1u << 1)) != 0;
+		Log(std::format("[KMeshLoader][UV] file={} vertices={} hasUV0={}\n",
+			filePath.generic_string(), header.vertexCount, hasUV0 ? "true" : "false"));
+		for (size_t i = 0; i < std::min<size_t>(fileVertices.size(), 5); ++i)
+		{
+			Log(std::format("[KMeshLoader][UV] file={} vertex={} uv=({:.6f}, {:.6f})\n",
+				filePath.generic_string(), i, fileVertices[i].u, fileVertices[i].v));
+		}
+#endif
+
 		// ---------------------------------------------------------
 		// 5. インデックス配列読込
 		// ---------------------------------------------------------
@@ -173,22 +187,26 @@ namespace Ken4lowEngine
 
 			SubMesh subMesh{};
 
-			// -------------------------------------------------
-			// 頂点は現段階では全体頂点配列をそのまま持たせる
-			// -------------------------------------------------
-			// 現在の kmesh 形式では submesh ごとの vertex range を保存していないため、
-			// ひとまず全頂点を各 SubMesh に入れる形にしている。
-			//
-			// これは最適ではないが、まず導入を進めるための安全策。
-			// 将来的には
-			//   - vertexOffset
-			//   - vertexCount
-			// を BinarySubmeshHeader に追加するとより綺麗になる。
-			subMesh.vertices.resize(fileVertices.size());
-			for (size_t i = 0; i < fileVertices.size(); ++i)
+			const bool hasStoredVertexRange = smHeader.vertexCount != 0;
+			const uint32_t vertexBegin = hasStoredVertexRange ? smHeader.vertexOffset : 0;
+			const uint32_t vertexCount = hasStoredVertexRange ? smHeader.vertexCount : static_cast<uint32_t>(fileVertices.size());
+			const uint32_t vertexEnd = vertexBegin + vertexCount;
+			if (vertexEnd > fileVertices.size())
 			{
-				subMesh.vertices[i] = ConvertVertex(fileVertices[i]);
+				throw std::runtime_error("Submesh vertex range out of bounds: " + filePath.generic_string());
 			}
+
+			// kmesh に保存されたサブメッシュ頂点範囲だけを読み戻し、UVを含む頂点レイアウトを維持する。
+			subMesh.vertices.resize(vertexCount);
+			for (uint32_t i = 0; i < vertexCount; ++i)
+			{
+				subMesh.vertices[i] = ConvertVertex(fileVertices[vertexBegin + i]);
+			}
+
+#ifdef _DEBUG
+			Log(std::format("[KMeshLoader][UV] submesh={} texture=\"{}\" vertexOffset={} vertexCount={} indexOffset={} indexCount={} rangeFallback={}\n",
+				smIndex, textureRef, vertexBegin, vertexCount, smHeader.indexOffset, smHeader.indexCount, hasStoredVertexRange ? "false" : "true"));
+#endif
 
 			// -------------------------------------------------
 			// インデックスはこのサブメッシュ範囲だけ抜き出す
@@ -204,7 +222,12 @@ namespace Ken4lowEngine
 			subMesh.indices.reserve(smHeader.indexCount);
 			for (uint32_t i = beginIndex; i < endIndex; ++i)
 			{
-				subMesh.indices.push_back(fileIndices[i]);
+				if (fileIndices[i] < vertexBegin || fileIndices[i] >= vertexEnd)
+				{
+					throw std::runtime_error("Submesh index references a vertex outside its range: " + filePath.generic_string());
+				}
+				// サブメッシュ内のローカル頂点配列に合わせてインデックスを再基準化する。
+				subMesh.indices.push_back(fileIndices[i] - vertexBegin);
 			}
 
 			// マテリアルのテクスチャ参照

--- a/Project/Engine/Graphics/Resource/Model/KMeshLoader.h
+++ b/Project/Engine/Graphics/Resource/Model/KMeshLoader.h
@@ -68,6 +68,8 @@ namespace Ken4lowEngine
 			uint32_t indexOffset;
 			uint32_t indexCount;
 			uint32_t textureRefLength;
+			uint32_t vertexOffset;
+			uint32_t vertexCount;
 
 			float aabbMin[3];
 			float aabbMax[3];

--- a/Project/Engine/Graphics/Resource/Texture/TextureManager.cpp
+++ b/Project/Engine/Graphics/Resource/Texture/TextureManager.cpp
@@ -8,6 +8,7 @@
 #include <algorithm>
 #include <cctype>
 #include <filesystem>
+#include <format>
 
 #include <d3dx12.h>
 
@@ -166,6 +167,12 @@ namespace Ken4lowEngine
 		}
 
 		const auto& meta0 = image.GetMetadata();
+#ifdef _DEBUG
+		Log(std::format("[TextureManager] Loaded texture={} source={} format={} size={}x{} mipLevels={} srgb={} alphaMode={}\n",
+			filePathStr, isDDS ? "DDS" : "WIC", static_cast<int>(meta0.format),
+			meta0.width, meta0.height, meta0.mipLevels,
+			DirectX::IsSRGB(meta0.format) ? "true" : "false", static_cast<int>(meta0.GetAlphaMode())));
+#endif
 		const bool isLegacyTall = (!isDDS) && (meta0.width == meta0.height * 2);
 
 		DirectX::ScratchImage normalized{};
@@ -209,6 +216,12 @@ namespace Ken4lowEngine
 
 		TextureData& textureData = textureDatas[filePathStr];
 		textureData.metaData = uploadImage->GetMetadata();
+#ifdef _DEBUG
+		// DDS 読み込み後の最終メタデータを出力し、sRGB/通常フォーマット取り違えを切り分ける。
+		Log(std::format("[TextureManager] Upload texture={} format={} mipLevels={} srgb={}\n",
+			filePathStr, static_cast<int>(textureData.metaData.format), textureData.metaData.mipLevels,
+			DirectX::IsSRGB(textureData.metaData.format) ? "true" : "false"));
+#endif
 		textureData.resource = CreateTextureResource(dxCommon_->GetDevice(), textureData.metaData);
 		textureData.resource->SetName(L"TextureResource");
 

--- a/Project/Resources/Shaders/Object3D/Object3d.PS.hlsl
+++ b/Project/Resources/Shaders/Object3D/Object3d.PS.hlsl
@@ -64,8 +64,8 @@ PixelShaderOutput main(VertexShaderOutput input)
     PixelShaderOutput output;
 
     float4 transformedUV = mul(float4(input.texcoord, 0.0f, 1.0f), gMaterial.uvTransform);
+    // SRGB SRV は Sample 時点で線形化されるため、手動の pow による二重変換を避ける。
     float4 textureColor = gTexture.Sample(gSampler, transformedUV.xy);
-    textureColor.rgb = pow(textureColor.rgb, 2.2f);
 
     float3 worldPosition = input.worldPosition;
     float3 normal = normalize(input.normal);

--- a/Project/Tools/MeshConverter/MeshConverter.cpp
+++ b/Project/Tools/MeshConverter/MeshConverter.cpp
@@ -1,4 +1,4 @@
-﻿#define NOMINMAX
+#define NOMINMAX
 #include "MeshConverter.h"
 
 #include <iostream>
@@ -8,6 +8,7 @@
 #include <cfloat>
 #include <filesystem>
 #include <cstdlib>
+#include <iomanip>
 
 // Assimp
 #include <assimp/Importer.hpp>
@@ -222,6 +223,9 @@ bool MeshConverter::WriteBinary(
 		smHeader.indexOffset = sm.indexOffset;
 		smHeader.indexCount = sm.indexCount;
 		smHeader.textureRefLength = static_cast<uint32_t>(sm.textureRef.size());
+		// Runtime がサブメッシュ頂点範囲を復元できるよう、kmesh に頂点範囲も保存する。
+		smHeader.vertexOffset = sm.vertexOffset;
+		smHeader.vertexCount = sm.vertexCount;
 		smHeader.aabbMin[0] = sm.aabbMin[0];
 		smHeader.aabbMin[1] = sm.aabbMin[1];
 		smHeader.aabbMin[2] = sm.aabbMin[2];
@@ -320,8 +324,15 @@ bool MeshConverter::ConvertModelToBinary(const std::string& filePath, int numOpt
 			return false;
 		}
 
+		const bool meshHasUV0 = mesh->HasTextureCoords(0) && mesh->mTextureCoords[0] != nullptr;
 		hasNormal |= mesh->HasNormals();
-		hasUV |= mesh->HasTextureCoords(0);
+		hasUV |= meshHasUV0;
+
+#ifdef _DEBUG
+		std::cerr << "[MeshConverter][UV] mesh=\"" << mesh->mName.C_Str()
+			<< "\" vertices=" << mesh->mNumVertices
+			<< " hasUV0=" << (meshHasUV0 ? "true" : "false") << "\n";
+#endif
 
 		const uint32_t baseVertex = static_cast<uint32_t>(vertices.size());
 		const uint32_t baseIndex = static_cast<uint32_t>(indices.size());
@@ -373,6 +384,8 @@ bool MeshConverter::ConvertModelToBinary(const std::string& filePath, int numOpt
 
 		Submesh sm{};
 		sm.indexOffset = baseIndex;
+		sm.vertexOffset = baseVertex;
+		sm.vertexCount = mesh->mNumVertices;
 		sm.aabbMin[0] = sm.aabbMin[1] = sm.aabbMin[2] = +FLT_MAX;
 		sm.aabbMax[0] = sm.aabbMax[1] = sm.aabbMax[2] = -FLT_MAX;
 
@@ -388,10 +401,20 @@ bool MeshConverter::ConvertModelToBinary(const std::string& filePath, int numOpt
 			}
 
 			aiVector3D uv(0, 0, 0);
-			if (mesh->HasTextureCoords(0))
+			if (meshHasUV0)
 			{
 				uv = mesh->mTextureCoords[0][i];
 			}
+
+#ifdef _DEBUG
+			if (i < 5)
+			{
+				std::cerr << std::fixed << std::setprecision(6)
+					<< "[MeshConverter][UV] mesh=\"" << mesh->mName.C_Str()
+					<< "\" vertex=" << i
+					<< " uv=(" << uv.x << ", " << uv.y << ")\n";
+			}
+#endif
 
 			if (opt.leftHanded)
 			{

--- a/Project/Tools/MeshConverter/MeshConverter.h
+++ b/Project/Tools/MeshConverter/MeshConverter.h
@@ -69,6 +69,8 @@ private:
 	{
 		uint32_t indexOffset = 0;
 		uint32_t indexCount = 0;
+		uint32_t vertexOffset = 0;
+		uint32_t vertexCount = 0;
 		std::string textureRef;
 
 		float aabbMin[3] = { 0.0f, 0.0f, 0.0f };

--- a/Project/Tools/Scripts/BuildTextures.ps1
+++ b/Project/Tools/Scripts/BuildTextures.ps1
@@ -179,7 +179,9 @@ foreach ($file in $sourceFiles) {
         Remove-Item $generatedDdsPath -Force
     }
 
+    # PNG→DDS の最終配置先も出し、Sources と Compiled の対応を追跡できるようにする。
     Write-Host "[BuildTextures] Convert: $relative"
+    Write-Host "[BuildTextures] Output : $finalOutputPath"
 
     $exitCode = Invoke-TextureConverter `
         -ExePath $textureConverterExe `

--- a/Project/Tools/TextureConverter/TextureConverter.cpp
+++ b/Project/Tools/TextureConverter/TextureConverter.cpp
@@ -3,88 +3,97 @@
 #include <windows.h>
 
 using namespace std;
-// DirectX–¼‘O‹óŠÔ‚ğg—p
+// DirectXåå‰ç©ºé–“ã‚’ä½¿ç”¨
 using namespace DirectX;
 
 /// -------------------------------------------------------------
-///			ƒeƒNƒXƒ`ƒƒ‚ğWICŒ`®‚©‚çDDSŒ`®‚É•ÏŠ·‚·‚éˆ—
+///			ãƒ†ã‚¯ã‚¹ãƒãƒ£ã‚’WICå½¢å¼ã‹ã‚‰DDSå½¢å¼ã«å¤‰æ›ã™ã‚‹å‡¦ç†
 /// -------------------------------------------------------------
 void TextureConverter::ConvertTextureWICToDDS(const std::string& filePath, int numOptions, char* options[])
 {
-	// WICŒ`®‚ÌƒeƒNƒXƒ`ƒƒ‚ğ“Ç‚İ‚Ş
+	// WICå½¢å¼ã®ãƒ†ã‚¯ã‚¹ãƒãƒ£ã‚’èª­ã¿è¾¼ã‚€
 	LoadWICTextureFromFile(filePath);
 
-	// DDSŒ`®‚É•ÏŠ·‚µ‚Ä•Û‘¶‚·‚éˆ—‚ğ‚±‚±‚É’Ç‰Á‚·‚é
+	// DDSå½¢å¼ã«å¤‰æ›ã—ã¦ä¿å­˜ã™ã‚‹å‡¦ç†ã‚’ã“ã“ã«è¿½åŠ ã™ã‚‹
 	SaveDDSTextureToFile(numOptions, options);
 }
 
 /// -------------------------------------------------------------
-///					g—p•û–@‚ğo—Í‚·‚éˆ—
+///					ä½¿ç”¨æ–¹æ³•ã‚’å‡ºåŠ›ã™ã‚‹å‡¦ç†
 /// -------------------------------------------------------------
 void TextureConverter::OoutputUsage()
 {
-	cout << "‰æ‘œƒtƒ@ƒCƒ‹‚ğWICŒ`®‚©‚çDDSŒ`®‚É•ÏŠ·‚µ‚Ü‚·B" << endl;
-	cout << endl; // ‹ós
-	cout << "TextureConverter [ƒhƒ‰ƒCƒu:][ƒpƒX][ƒtƒ@ƒCƒ‹–¼]" << endl;
-	cout << endl; // ‹ós
-	cout << " [ƒhƒ‰ƒCƒu:][ƒpƒX][ƒtƒ@ƒCƒ‹–¼]: •ÏŠ·‚·‚éWICŒ`®‚Ì‰æ‘œƒtƒ@ƒCƒ‹‚ÌƒpƒX‚ğw’è‚µ‚Ü‚·B" << endl;
-	cout << endl; // ‹ós
-	cout << " [-ml level]: ƒ~ƒbƒvƒŒƒxƒ‹‚ğw’è‚µ‚Ü‚·B0‚ğw’è‚·‚é‚Æ1x1‚Ü‚Å‚Ìƒtƒ‹ƒ~ƒbƒvƒ}ƒbƒvƒ`ƒF[ƒ“‚ğ¶¬‚µ‚Ü‚·B" << endl;
+
+#ifdef _DEBUG
+	std::wcout << L"[TextureConverter] Input PNG/WIC: " << wideFilePath
+		<< L" format=" << static_cast<int>(metadate_.format)
+		<< L" size=" << metadate_.width << L"x" << metadate_.height
+		<< L" mipLevels=" << metadate_.mipLevels
+		<< L" srgb=" << (DirectX::IsSRGB(metadate_.format) ? L"true" : L"false")
+		<< L" alphaMode=" << static_cast<int>(metadate_.GetAlphaMode()) << std::endl;
+#endif
+	cout << "ç”»åƒãƒ•ã‚¡ã‚¤ãƒ«ã‚’WICå½¢å¼ã‹ã‚‰DDSå½¢å¼ã«å¤‰æ›ã—ã¾ã™ã€‚" << endl;
+	cout << endl; // ç©ºè¡Œ
+	cout << "TextureConverter [ãƒ‰ãƒ©ã‚¤ãƒ–:][ãƒ‘ã‚¹][ãƒ•ã‚¡ã‚¤ãƒ«å]" << endl;
+	cout << endl; // ç©ºè¡Œ
+	cout << " [ãƒ‰ãƒ©ã‚¤ãƒ–:][ãƒ‘ã‚¹][ãƒ•ã‚¡ã‚¤ãƒ«å]: å¤‰æ›ã™ã‚‹WICå½¢å¼ã®ç”»åƒãƒ•ã‚¡ã‚¤ãƒ«ã®ãƒ‘ã‚¹ã‚’æŒ‡å®šã—ã¾ã™ã€‚" << endl;
+	cout << endl; // ç©ºè¡Œ
+	cout << " [-ml level]: ãƒŸãƒƒãƒ—ãƒ¬ãƒ™ãƒ«ã‚’æŒ‡å®šã—ã¾ã™ã€‚0ã‚’æŒ‡å®šã™ã‚‹ã¨1x1ã¾ã§ã®ãƒ•ãƒ«ãƒŸãƒƒãƒ—ãƒãƒƒãƒ—ãƒã‚§ãƒ¼ãƒ³ã‚’ç”Ÿæˆã—ã¾ã™ã€‚" << endl;
 }
 
 /// -------------------------------------------------------------
-///				ƒeƒNƒXƒ`ƒƒƒtƒ@ƒCƒ‹“Ç‚İ‚İ(WICŒ`®)
+///				ãƒ†ã‚¯ã‚¹ãƒãƒ£ãƒ•ã‚¡ã‚¤ãƒ«èª­ã¿è¾¼ã¿(WICå½¢å¼)
 /// -------------------------------------------------------------
 void TextureConverter::LoadWICTextureFromFile(const std::string& filePath)
 {
-	// ƒtƒ@ƒCƒ‹ƒpƒX‚ğƒƒCƒh•¶š—ñ‚É•ÏŠ·
+	// ãƒ•ã‚¡ã‚¤ãƒ«ãƒ‘ã‚¹ã‚’ãƒ¯ã‚¤ãƒ‰æ–‡å­—åˆ—ã«å¤‰æ›
 	std::wstring wideFilePath = ConcertMultiByteStringToWideString(filePath);
 
-	// WICŒ`®‚ÌƒeƒNƒXƒ`ƒƒ‚ğ“Ç‚İ‚Ş
+	// WICå½¢å¼ã®ãƒ†ã‚¯ã‚¹ãƒãƒ£ã‚’èª­ã¿è¾¼ã‚€
 	HRESULT hr = LoadFromWICFile(wideFilePath.c_str(), WIC_FLAGS_NONE, &metadate_, scrachImage_);
-	assert(SUCCEEDED(hr) && "WICŒ`®‚ÌƒeƒNƒXƒ`ƒƒ‚Ì“Ç‚İ‚İ‚É¸”s‚µ‚Ü‚µ‚½B");
+	assert(SUCCEEDED(hr) && "WICå½¢å¼ã®ãƒ†ã‚¯ã‚¹ãƒãƒ£ã®èª­ã¿è¾¼ã¿ã«å¤±æ•—ã—ã¾ã—ãŸã€‚");
 
-	// ƒtƒHƒ‹ƒ_ƒpƒX‚Æƒtƒ@ƒCƒ‹–¼‚ğ•ª—£‚·‚é
+	// ãƒ•ã‚©ãƒ«ãƒ€ãƒ‘ã‚¹ã¨ãƒ•ã‚¡ã‚¤ãƒ«åã‚’åˆ†é›¢ã™ã‚‹
 	SeparateFilePath(wideFilePath);
 }
 
 /// -------------------------------------------------------------
-///			@ƒ}ƒ‹ƒ`ƒoƒCƒg•¶š—ñ‚ğƒƒCƒh•¶š—ñ‚É•ÏŠ·
+///			ã€€ãƒãƒ«ãƒãƒã‚¤ãƒˆæ–‡å­—åˆ—ã‚’ãƒ¯ã‚¤ãƒ‰æ–‡å­—åˆ—ã«å¤‰æ›
 /// -------------------------------------------------------------
 std::wstring TextureConverter::ConcertMultiByteStringToWideString(const std::string& multiByteString)
 {
-	// ƒƒCƒh•¶š—ñ‚É•ÏŠ·‚µ‚½Û‚Ì•¶š”‚ğŒvZ
+	// ãƒ¯ã‚¤ãƒ‰æ–‡å­—åˆ—ã«å¤‰æ›ã—ãŸéš›ã®æ–‡å­—æ•°ã‚’è¨ˆç®—
 	int filePathBufferSize = MultiByteToWideChar(CP_ACP, 0, multiByteString.c_str(), -1, nullptr, 0);
 
-	// ƒƒCƒh•¶š—ñ—p‚Ìƒoƒbƒtƒ@‚ğŠm•Û
+	// ãƒ¯ã‚¤ãƒ‰æ–‡å­—åˆ—ç”¨ã®ãƒãƒƒãƒ•ã‚¡ã‚’ç¢ºä¿
 	std::wstring wideString;
 	wideString.resize(filePathBufferSize);
 
-	// ƒ}ƒ‹ƒ`ƒoƒCƒg•¶š—ñ‚ğƒƒCƒh•¶š—ñ‚É•ÏŠ·
+	// ãƒãƒ«ãƒãƒã‚¤ãƒˆæ–‡å­—åˆ—ã‚’ãƒ¯ã‚¤ãƒ‰æ–‡å­—åˆ—ã«å¤‰æ›
 	MultiByteToWideChar(CP_ACP, 0, multiByteString.c_str(), -1, wideString.data(), filePathBufferSize);
 
-	// ƒƒCƒh•¶š—ñ‚ğ•Ô‚·
+	// ãƒ¯ã‚¤ãƒ‰æ–‡å­—åˆ—ã‚’è¿”ã™
 	return wideString;
 }
 
 /// -------------------------------------------------------------
-///		@		ƒtƒHƒ‹ƒ_ƒpƒX‚Æƒtƒ@ƒCƒ‹–¼‚ğ•ª—£‚·‚é
+///		ã€€		ãƒ•ã‚©ãƒ«ãƒ€ãƒ‘ã‚¹ã¨ãƒ•ã‚¡ã‚¤ãƒ«åã‚’åˆ†é›¢ã™ã‚‹
 /// -------------------------------------------------------------
 void TextureConverter::SeparateFilePath(const std::wstring& filePath)
 {
 	size_t position1 = 0;
 	std::wstring exceptExit;
 
-	// ‹æØ‚è•¶š '.' ‚ªo‚Ä‚­‚éˆê”ÔÅŒã‚Ì•”•ª‚ğŒŸõ
+	// åŒºåˆ‡ã‚Šæ–‡å­— '.' ãŒå‡ºã¦ãã‚‹ä¸€ç•ªæœ€å¾Œã®éƒ¨åˆ†ã‚’æ¤œç´¢
 	position1 = filePath.rfind(L'.');
 
-	// ŒŸõ‚ªƒqƒbƒg‚µ‚½‚ç
+	// æ¤œç´¢ãŒãƒ’ãƒƒãƒˆã—ãŸã‚‰
 	if (position1 != std::wstring::npos)
 	{
-		// ‹æØ‚è•¶š‚ÌŒã‚ë‚ğƒtƒ@ƒCƒ‹Šg’£q‚Æ‚µ‚Ä•Û‘¶
+		// åŒºåˆ‡ã‚Šæ–‡å­—ã®å¾Œã‚ã‚’ãƒ•ã‚¡ã‚¤ãƒ«æ‹¡å¼µå­ã¨ã—ã¦ä¿å­˜
 		extension_ = filePath.substr(position1 + 1, filePath.size() - position1 - 1);
 
-		// ‹æØ‚è•¶š‚Ì‘O‚Ü‚Å‚ğ”²‚«o‚·
+		// åŒºåˆ‡ã‚Šæ–‡å­—ã®å‰ã¾ã§ã‚’æŠœãå‡ºã™
 		exceptExit = filePath.substr(0, position1);
 	}
 	else
@@ -93,42 +102,42 @@ void TextureConverter::SeparateFilePath(const std::wstring& filePath)
 		exceptExit = filePath;
 	}
 
-	// ‹æØ‚è•¶š '\\' ‚ªo‚Ä‚­‚éˆê”ÔÅŒã‚Ì•”•ª‚ğŒŸõ
+	// åŒºåˆ‡ã‚Šæ–‡å­— '\\' ãŒå‡ºã¦ãã‚‹ä¸€ç•ªæœ€å¾Œã®éƒ¨åˆ†ã‚’æ¤œç´¢
 	position1 = exceptExit.rfind(L'\\');
 
-	// ŒŸõ‚ªƒqƒbƒg‚µ‚½‚ç
+	// æ¤œç´¢ãŒãƒ’ãƒƒãƒˆã—ãŸã‚‰
 	if (position1 != std::wstring::npos)
 	{
-		// ‹æØ‚è•¶š‚Ì‘O‚Ü‚Å‚ğƒtƒHƒ‹ƒ_ƒpƒX‚Æ‚µ‚Ä•Û‘¶
+		// åŒºåˆ‡ã‚Šæ–‡å­—ã®å‰ã¾ã§ã‚’ãƒ•ã‚©ãƒ«ãƒ€ãƒ‘ã‚¹ã¨ã—ã¦ä¿å­˜
 		directoryPath_ = exceptExit.substr(0, position1);
 
-		// ‹æØ‚è•¶š‚ÌŒã‚ë‚ğƒtƒ@ƒCƒ‹–¼‚Æ‚µ‚Ä•Û‘¶
+		// åŒºåˆ‡ã‚Šæ–‡å­—ã®å¾Œã‚ã‚’ãƒ•ã‚¡ã‚¤ãƒ«åã¨ã—ã¦ä¿å­˜
 		fileName_ = exceptExit.substr(position1 + 1, exceptExit.size() - position1 - 1);
 
 		return;
 	}
 
-	// ‹æØ‚è•¶š '/' ‚ªo‚Ä‚­‚éˆê”ÔÅŒã‚Ì•”•ª‚ğŒŸõ
+	// åŒºåˆ‡ã‚Šæ–‡å­— '/' ãŒå‡ºã¦ãã‚‹ä¸€ç•ªæœ€å¾Œã®éƒ¨åˆ†ã‚’æ¤œç´¢
 	position1 = exceptExit.rfind(L'/');
 
-	// ŒŸõ‚ªƒqƒbƒg‚µ‚½‚ç
+	// æ¤œç´¢ãŒãƒ’ãƒƒãƒˆã—ãŸã‚‰
 	if (position1 != std::wstring::npos)
 	{
-		// ‹æØ‚è•¶š‚Ì‘O‚Ü‚Å‚ğƒtƒHƒ‹ƒ_ƒpƒX‚Æ‚µ‚Ä•Û‘¶
+		// åŒºåˆ‡ã‚Šæ–‡å­—ã®å‰ã¾ã§ã‚’ãƒ•ã‚©ãƒ«ãƒ€ãƒ‘ã‚¹ã¨ã—ã¦ä¿å­˜
 		directoryPath_ = exceptExit.substr(0, position1);
 
-		// ‹æØ‚è•¶š‚ÌŒã‚ë‚ğƒtƒ@ƒCƒ‹–¼‚Æ‚µ‚Ä•Û‘¶
+		// åŒºåˆ‡ã‚Šæ–‡å­—ã®å¾Œã‚ã‚’ãƒ•ã‚¡ã‚¤ãƒ«åã¨ã—ã¦ä¿å­˜
 		fileName_ = exceptExit.substr(position1 + 1, exceptExit.size() - position1 - 1);
 		return;
 	}
 
-	// ‹æØ‚è•¶š‚ªŒ©‚Â‚©‚ç‚È‚©‚Á‚½ê‡AƒtƒHƒ‹ƒ_ƒpƒX‚Í‹óAƒtƒ@ƒCƒ‹–¼‚Í‚»‚Ì‚Ü‚Ü•Û‘¶
+	// åŒºåˆ‡ã‚Šæ–‡å­—ãŒè¦‹ã¤ã‹ã‚‰ãªã‹ã£ãŸå ´åˆã€ãƒ•ã‚©ãƒ«ãƒ€ãƒ‘ã‚¹ã¯ç©ºã€ãƒ•ã‚¡ã‚¤ãƒ«åã¯ãã®ã¾ã¾ä¿å­˜
 	directoryPath_ = L"";
 	fileName_ = exceptExit;
 }
 
 /// -------------------------------------------------------------
-///			 	 DDSƒeƒNƒXƒ`ƒƒ‚Æ‚µ‚Äƒtƒ@ƒCƒ‹‘‚«o‚µ
+///			 	 DDSãƒ†ã‚¯ã‚¹ãƒãƒ£ã¨ã—ã¦ãƒ•ã‚¡ã‚¤ãƒ«æ›¸ãå‡ºã—
 /// -------------------------------------------------------------
 void TextureConverter::SaveDDSTextureToFile(int numOptions, char* options[])
 {
@@ -136,49 +145,58 @@ void TextureConverter::SaveDDSTextureToFile(int numOptions, char* options[])
 
 	size_t mipLevel = 0;
 
-	// ƒ~ƒbƒvƒ}ƒbƒvƒŒƒxƒ‹”‚ğŒvZ
+	// ãƒŸãƒƒãƒ—ãƒãƒƒãƒ—ãƒ¬ãƒ™ãƒ«æ•°ã‚’è¨ˆç®—
 	for (int i = 0; i < numOptions; i++)
 	{
 		if (std::string(options[i]) == "-ml")
 		{
-			// ƒ~ƒbƒvƒŒƒxƒ‹”‚ğæ“¾
+			// ãƒŸãƒƒãƒ—ãƒ¬ãƒ™ãƒ«æ•°ã‚’å–å¾—
 			mipLevel = stoi(options[i + 1]);
 			break;
 		}
 	}
 
 	ScratchImage mipChain;
-	// ƒ~ƒbƒvƒ}ƒbƒv‚Ì¶¬
+	// ãƒŸãƒƒãƒ—ãƒãƒƒãƒ—ã®ç”Ÿæˆ
 	hr = GenerateMipMaps(scrachImage_.GetImages(), scrachImage_.GetImageCount(), scrachImage_.GetMetadata(), TEX_FILTER_DEFAULT, mipLevel, mipChain);
 
-	// ƒ~ƒbƒvƒ}ƒbƒv¶¬‚É¬Œ÷‚µ‚½ê‡
+	// ãƒŸãƒƒãƒ—ãƒãƒƒãƒ—ç”Ÿæˆã«æˆåŠŸã—ãŸå ´åˆ
 	if (SUCCEEDED(hr))
 	{
-		// ƒCƒ[ƒW‚Æƒƒ^ƒf[ƒ^‚ğAƒ~ƒbƒvƒ}ƒbƒv¶¬Œã‚Ì‚à‚Ì‚É’u‚«Š·‚¦‚é
+#ifdef _DEBUG
+	std::wcout << L"[TextureConverter] Output DDS: " << filePath
+		<< L" format=" << static_cast<int>(metadate_.format)
+		<< L" size=" << metadate_.width << L"x" << metadate_.height
+		<< L" mipLevels=" << metadate_.mipLevels
+		<< L" srgb=" << (DirectX::IsSRGB(metadate_.format) ? L"true" : L"false")
+		<< L" alphaMode=" << static_cast<int>(metadate_.GetAlphaMode()) << std::endl;
+#endif
+
+	// ÏŠãƒ^f[^O DDS Æ‚Ä•Û‘APNGDDS ÇÕ‚B
 		scrachImage_ = std::move(mipChain);
 		metadate_ = scrachImage_.GetMetadata();
 	}
 
-	// ˆ³kŒ`® : BC7‚É•ÏŠ·
+	// åœ§ç¸®å½¢å¼ : BC7ã«å¤‰æ›
 	ScratchImage convertedImage;
 	hr = Compress(scrachImage_.GetImages(), scrachImage_.GetImageCount(), metadate_,
 		DXGI_FORMAT_BC7_UNORM_SRGB, TEX_COMPRESS_BC7_QUICK | TEX_COMPRESS_SRGB_OUT | TEX_COMPRESS_PARALLEL, 1.0f, convertedImage);
 
-	// ˆ³k•ÏŠ·‚É¬Œ÷‚µ‚½ê‡
+	// åœ§ç¸®å¤‰æ›ã«æˆåŠŸã—ãŸå ´åˆ
 	if (SUCCEEDED(hr))
 	{
-		// ƒCƒ[ƒW‚Æƒƒ^ƒf[ƒ^‚ğAˆ³kŒã‚Ì‚à‚Ì‚É’u‚«Š·‚¦‚é
+		// ã‚¤ãƒ¡ãƒ¼ã‚¸ã¨ãƒ¡ã‚¿ãƒ‡ãƒ¼ã‚¿ã‚’ã€åœ§ç¸®å¾Œã®ã‚‚ã®ã«ç½®ãæ›ãˆã‚‹
 		scrachImage_ = std::move(convertedImage);
 		metadate_ = scrachImage_.GetMetadata();
 	}
 
-	// “Ç‚İ‚ñ‚¾ƒeƒNƒXƒ`ƒƒ‚ğSRGBAŒ`®‚Å•Û‘¶‚·‚é
+	// èª­ã¿è¾¼ã‚“ã ãƒ†ã‚¯ã‚¹ãƒãƒ£ã‚’SRGBAå½¢å¼ã§ä¿å­˜ã™ã‚‹
 	metadate_.format = MakeSRGB(metadate_.format);
 
-	// o—Íƒtƒ@ƒCƒ‹–¼‚ğİ’è‚·‚é
+	// å‡ºåŠ›ãƒ•ã‚¡ã‚¤ãƒ«åã‚’è¨­å®šã™ã‚‹
 	std::wstring filePath = directoryPath_ + L"\\" + fileName_ + L".dds";
 
-	// DDSŒ`®‚Åƒtƒ@ƒCƒ‹‚É•Û‘¶‚·‚é
+	// DDSå½¢å¼ã§ãƒ•ã‚¡ã‚¤ãƒ«ã«ä¿å­˜ã™ã‚‹
 	hr = SaveToDDSFile(scrachImage_.GetImages(), scrachImage_.GetImageCount(), metadate_, DDS_FLAGS_NONE, filePath.c_str());
-	assert(SUCCEEDED(hr) && "DDSŒ`®‚Å‚ÌƒeƒNƒXƒ`ƒƒ‚Ì•Û‘¶‚É¸”s‚µ‚Ü‚µ‚½B");
+	assert(SUCCEEDED(hr) && "DDSå½¢å¼ã§ã®ãƒ†ã‚¯ã‚¹ãƒãƒ£ã®ä¿å­˜ã«å¤±æ•—ã—ã¾ã—ãŸã€‚");
 }


### PR DESCRIPTION
### Motivation
- 別環境（Blender）の見た目とゲーム側表示の差異を切り分けるため、UVの取得・保存・復元とPNG→DDSの変換経路に追跡ログを入れ、不具合箇所（MeshConverter / .kmesh / Runtime / Shader / Sampler / TextureConverter）を特定する。
- 地面や道路などでUVが1を超えるモデルが正しく繰り返し表示されるようにSampler設定を確認・対応する。 

### Description
- `Tools/MeshConverter`: サブメッシュに `vertexOffset` / `vertexCount` を書き込むようにし、先頭数頂点のUVとメッシュごとのUV有無をデバッグ出力するよう追加し、既存のkmesh互換を保つためのフォールバック処理を用意した（`MeshConverter.cpp` / `MeshConverter.h`）。
- `Engine/Graphics/Resource/Model/KMeshLoader`: kmeshヘッダのサブメッシュ構造を `vertexOffset` / `vertexCount` に合わせて更新し、保存された頂点範囲だけを復元、インデックスをサブメッシュローカルに再基準化する処理とデバッグログを追加（範囲未設定時は全頂点を使用するフォールバックあり）。
- `Engine/Graphics/Resource/Model/AssimpLoader`: Assimp読み取り時のUV取得を明示し、メッシュごとのUV有無と最初の数頂点UVをデバッグ出力するログを追加して、Assimp→kmesh→Runtimeの差分を追えるようにした。
- テクスチャ関係: `Tools/TextureConverter` に変換前/後のパス・`DXGI_FORMAT`・サイズ・mip数・sRGB・alpha mode をデバッグ出力するログを追加し、Runtime側の `TextureManager` でも読み込み時とUpload時のメタデータ（format/mipLevels/sRGB/alpha）をログ出力するようにした（`TextureConverter.cpp`, `TextureManager.cpp`）。
- Sampler/Shader/表示修正: `Object3D` の静的サンプラーを `CLAMP` から `WRAP` に変更してUV>1の繰り返し表示を許可し（`Object3DPipelineSet.cpp`）、ピクセルシェーダーの手動sRGBガンマ補正（`pow(..., 2.2f)`）を削除してsRGB SRVの二重線形化を防止した（`Object3d.PS.hlsl`）。
- ビルドスクリプト: `Tools/Scripts/BuildTextures.ps1` に変換時の出力先パスログを追加し、Sources→CompiledのPNG→DDS対応を追跡できるようにした。
- 備考: 追加の包括的デバッグ出力はすべて `#ifdef _DEBUG` 節で囲まれており、通常動作に影響しないよう配慮している。

### Testing
- 実施した自動チェック: `git diff --check` を実行して差分に警告がないことを確認（成功）。
- ソース検索による差分確認: `rg` による該当ログ・関数差分の確認を行い、該当ファイル群の変更をレビューした（成功）。
- ビルド確認: この実行環境（Linuxコンテナ）には MSBuild / Visual Studio が無く、Windows向けC++プロジェクトのフルビルドは実行できなかったためコンパイル検証は未実行（注意）。
- 変更はコミット済み（`Investigate UV and texture conversion path` / HEAD `60022c1`）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0afa877e84832d8708fdb3a5b135cb)