### PR TITLE
Add ImGui Content Browser, Build service and Output Log (batch runner)

### DIFF
--- a/Project/Engine/Editor/EditorAssetBrowser.cpp
+++ b/Project/Engine/Editor/EditorAssetBrowser.cpp
@@ -1,0 +1,272 @@
+#include "EditorAssetBrowser.h"
+
+#include "EditorOutputLog.h"
+
+#include <algorithm>
+#include <cctype>
+#include <ctime>
+#include <chrono>
+#include <iomanip>
+#include <sstream>
+
+namespace Ken4lowEngine
+{
+	namespace
+	{
+		std::string ToUtf8Path(const std::filesystem::path& path)
+		{
+			return path.generic_string();
+		}
+
+		std::string ToLower(std::string value)
+		{
+			std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c)
+				{
+					return static_cast<char>(std::tolower(c));
+				});
+			return value;
+		}
+
+		std::string FormatFileTime(const std::filesystem::file_time_type& fileTime)
+		{
+			const auto systemTime = std::chrono::time_point_cast<std::chrono::system_clock::duration>(
+				fileTime - std::filesystem::file_time_type::clock::now() + std::chrono::system_clock::now());
+			const std::time_t timeValue = std::chrono::system_clock::to_time_t(systemTime);
+			std::tm localTime{};
+#ifdef _WIN32
+			localtime_s(&localTime, &timeValue);
+#else
+			localtime_r(&timeValue, &localTime);
+#endif
+			std::ostringstream stream;
+			stream << std::put_time(&localTime, "%Y-%m-%d %H:%M:%S");
+			return stream.str();
+		}
+
+		std::string GetIcon(EditorAssetCategory category, const std::filesystem::path& extension)
+		{
+			const std::string ext = ToLower(extension.string());
+			switch (category)
+			{
+			case EditorAssetCategory::Textures:
+				return (ext == ".dds") ? "[DDS]" : "[TEX]";
+			case EditorAssetCategory::Models:
+				return (ext == ".gltf" || ext == ".glb") ? "[GLTF]" : "[MESH]";
+			case EditorAssetCategory::Shaders:
+				return "[HLSL]";
+			case EditorAssetCategory::Fonts:
+				return (ext == ".ttf" || ext == ".otf") ? "[FONT]" : "[FNT]";
+			default:
+				return "[FILE]";
+			}
+		}
+	}
+
+	void EditorAssetBrowser::Initialize(EditorOutputLog* log)
+	{
+		log_ = log;
+		projectDir_ = ResolveProjectDir();
+		// Editor起動時にResources配下の実ファイルを初回スキャンする。
+		Refresh();
+	}
+
+	void EditorAssetBrowser::Refresh()
+	{
+		entries_.clear();
+		const std::filesystem::path root = ResolveAssetRoot(category_, viewMode_);
+		if (!std::filesystem::exists(root) || !std::filesystem::is_directory(root))
+		{
+			if (log_)
+			{
+				log_->Warning("Content Browser folder not found: " + ToUtf8Path(root));
+			}
+			RebuildFilteredEntries();
+			return;
+		}
+
+		std::error_code error;
+		for (const auto& entry : std::filesystem::recursive_directory_iterator(root, std::filesystem::directory_options::skip_permission_denied, error))
+		{
+			if (error)
+			{
+				if (log_)
+				{
+					log_->Warning("Content Browser scan warning: " + error.message());
+				}
+				error.clear();
+				continue;
+			}
+			if (!entry.is_regular_file(error))
+			{
+				error.clear();
+				continue;
+			}
+
+			EditorAssetEntry asset{};
+			asset.label = ToUtf8Path(entry.path().filename());
+			asset.icon = GetIcon(category_, entry.path().extension());
+			asset.relativePath = ToUtf8Path(std::filesystem::relative(entry.path(), projectDir_, error));
+			if (error)
+			{
+				asset.relativePath = ToUtf8Path(entry.path());
+				error.clear();
+			}
+			asset.extension = entry.path().extension().string();
+			asset.sizeBytes = entry.file_size(error);
+			if (error)
+			{
+				asset.sizeBytes = 0;
+				error.clear();
+			}
+			asset.modifiedTime = FormatFileTime(entry.last_write_time(error));
+			if (error)
+			{
+				asset.modifiedTime = "Unknown";
+				error.clear();
+			}
+			entries_.push_back(asset);
+		}
+
+		std::sort(entries_.begin(), entries_.end(), [](const EditorAssetEntry& lhs, const EditorAssetEntry& rhs)
+			{
+				return lhs.relativePath < rhs.relativePath;
+			});
+		RebuildFilteredEntries();
+
+		if (log_)
+		{
+			log_->Info("Content Browser refreshed: " + std::to_string(entries_.size()) + " files from " + ToUtf8Path(root));
+		}
+	}
+
+	void EditorAssetBrowser::SetCategory(EditorAssetCategory category)
+	{
+		if (category_ == category)
+		{
+			return;
+		}
+		category_ = category;
+		selectedRelativePath_.clear();
+		// カテゴリ変更時は対象Resourceフォルダを即座に再スキャンする。
+		Refresh();
+	}
+
+	void EditorAssetBrowser::SetViewMode(EditorAssetViewMode mode)
+	{
+		if (viewMode_ == mode)
+		{
+			return;
+		}
+		viewMode_ = mode;
+		selectedRelativePath_.clear();
+		// Sources/Compiled切替時もBlender出力や変換済みファイルを取り直す。
+		Refresh();
+	}
+
+	void EditorAssetBrowser::SetSearchFilter(const std::string& filter)
+	{
+		searchFilter_ = filter;
+		RebuildFilteredEntries();
+	}
+
+	void EditorAssetBrowser::Select(std::size_t filteredIndex)
+	{
+		if (filteredIndex < filteredEntries_.size())
+		{
+			selectedRelativePath_ = filteredEntries_[filteredIndex].relativePath;
+		}
+	}
+
+	const EditorAssetEntry* EditorAssetBrowser::GetSelectedEntry() const
+	{
+		if (selectedRelativePath_.empty())
+		{
+			return nullptr;
+		}
+		auto found = std::find_if(filteredEntries_.begin(), filteredEntries_.end(), [this](const EditorAssetEntry& entry)
+			{
+				return entry.relativePath == selectedRelativePath_;
+			});
+		return found == filteredEntries_.end() ? nullptr : &(*found);
+	}
+
+	std::filesystem::path EditorAssetBrowser::GetCurrentRoot() const
+	{
+		return ResolveAssetRoot(category_, viewMode_);
+	}
+
+	const char* EditorAssetBrowser::GetCategoryName(EditorAssetCategory category)
+	{
+		switch (category)
+		{
+		case EditorAssetCategory::Textures:
+			return "Textures";
+		case EditorAssetCategory::Models:
+			return "Models";
+		case EditorAssetCategory::Shaders:
+			return "Shaders";
+		case EditorAssetCategory::Fonts:
+			return "Fonts";
+		default:
+			return "Assets";
+		}
+	}
+
+	const char* EditorAssetBrowser::GetViewModeName(EditorAssetViewMode mode)
+	{
+		return mode == EditorAssetViewMode::Sources ? "Sources" : "Compiled";
+	}
+
+	void EditorAssetBrowser::RebuildFilteredEntries()
+	{
+		filteredEntries_.clear();
+		const std::string filter = ToLower(searchFilter_);
+		for (const EditorAssetEntry& entry : entries_)
+		{
+			const std::string haystack = ToLower(entry.relativePath + " " + entry.label);
+			if (filter.empty() || haystack.find(filter) != std::string::npos)
+			{
+				filteredEntries_.push_back(entry);
+			}
+		}
+	}
+
+	std::filesystem::path EditorAssetBrowser::ResolveProjectDir() const
+	{
+		std::error_code error;
+		std::filesystem::path cursor = std::filesystem::current_path(error);
+		for (int i = 0; i < 8 && !cursor.empty(); ++i)
+		{
+			const std::filesystem::path direct = cursor;
+			if (std::filesystem::exists(direct / "Resources", error) && std::filesystem::exists(direct / "Tools" / "Scripts", error))
+			{
+				return direct;
+			}
+			const std::filesystem::path childProject = cursor / "Project";
+			if (std::filesystem::exists(childProject / "Resources", error) && std::filesystem::exists(childProject / "Tools" / "Scripts", error))
+			{
+				return childProject;
+			}
+			cursor = cursor.parent_path();
+		}
+		return std::filesystem::current_path(error) / "Project";
+	}
+
+	std::filesystem::path EditorAssetBrowser::ResolveAssetRoot(EditorAssetCategory category, EditorAssetViewMode mode) const
+	{
+		switch (category)
+		{
+		case EditorAssetCategory::Textures:
+			return projectDir_ / "Resources" / "Textures" / GetViewModeName(mode);
+		case EditorAssetCategory::Models:
+			return projectDir_ / "Resources" / "Models" / GetViewModeName(mode);
+		case EditorAssetCategory::Shaders:
+			return projectDir_ / "Resources" / "Shaders";
+		case EditorAssetCategory::Fonts:
+			return projectDir_ / "Resources" / "Fonts" / GetViewModeName(mode);
+		default:
+			return projectDir_ / "Resources";
+		}
+	}
+
+} // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorAssetBrowser.h
+++ b/Project/Engine/Editor/EditorAssetBrowser.h
@@ -1,0 +1,71 @@
+#pragma once
+
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace Ken4lowEngine
+{
+	class EditorOutputLog;
+
+	enum class EditorAssetCategory
+	{
+		Textures,
+		Models,
+		Shaders,
+		Fonts
+	};
+
+	enum class EditorAssetViewMode
+	{
+		Sources,
+		Compiled
+	};
+
+	struct EditorAssetEntry
+	{
+		std::string label;
+		std::string icon;
+		std::string relativePath;
+		std::string extension;
+		std::string modifiedTime;
+		uintmax_t sizeBytes = 0;
+	};
+
+	class EditorAssetBrowser
+	{
+	public:
+		void Initialize(EditorOutputLog* log);
+		void Refresh();
+		void SetCategory(EditorAssetCategory category);
+		void SetViewMode(EditorAssetViewMode mode);
+		void SetSearchFilter(const std::string& filter);
+		void Select(std::size_t filteredIndex);
+
+		EditorAssetCategory GetCategory() const { return category_; }
+		EditorAssetViewMode GetViewMode() const { return viewMode_; }
+		const std::string& GetSearchFilter() const { return searchFilter_; }
+		const std::vector<EditorAssetEntry>& GetFilteredEntries() const { return filteredEntries_; }
+		const EditorAssetEntry* GetSelectedEntry() const;
+		std::filesystem::path GetCurrentRoot() const;
+
+		static const char* GetCategoryName(EditorAssetCategory category);
+		static const char* GetViewModeName(EditorAssetViewMode mode);
+
+	private:
+		void RebuildFilteredEntries();
+		std::filesystem::path ResolveProjectDir() const;
+		std::filesystem::path ResolveAssetRoot(EditorAssetCategory category, EditorAssetViewMode mode) const;
+
+		EditorOutputLog* log_ = nullptr;
+		std::filesystem::path projectDir_;
+		EditorAssetCategory category_ = EditorAssetCategory::Textures;
+		EditorAssetViewMode viewMode_ = EditorAssetViewMode::Sources;
+		std::string searchFilter_;
+		std::vector<EditorAssetEntry> entries_;
+		std::vector<EditorAssetEntry> filteredEntries_;
+		std::string selectedRelativePath_;
+	};
+
+} // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorAssetBuildService.cpp
+++ b/Project/Engine/Editor/EditorAssetBuildService.cpp
@@ -1,0 +1,235 @@
+#include "EditorAssetBuildService.h"
+
+#include "EditorOutputLog.h"
+
+#include <chrono>
+#include <string>
+
+namespace Ken4lowEngine
+{
+	namespace
+	{
+		std::string PathForLog(const std::filesystem::path& path)
+		{
+			return path.generic_string();
+		}
+	}
+
+	void EditorAssetBuildService::Initialize(EditorOutputLog* log)
+	{
+		log_ = log;
+		projectDir_ = ResolveProjectDir();
+		statusText_ = "Idle";
+		if (log_)
+		{
+			log_->Info("Asset Build Service ready. ProjectDir=" + PathForLog(projectDir_));
+		}
+	}
+
+	bool EditorAssetBuildService::StartBuild(EditorAssetBuildKind kind)
+	{
+		Update();
+		if (running_.load())
+		{
+			if (log_)
+			{
+				log_->Warning("Asset build is already running; ignored request: " + std::string(GetBuildName(kind)));
+			}
+			return false;
+		}
+
+		running_ = true;
+		hasLastResult_ = false;
+		lastBuildSucceeded_ = false;
+		statusText_ = std::string("Running ") + GetBuildName(kind) + "...";
+		// Build要求はUIを止めないようバックグラウンドで順番に処理する。
+		buildFuture_ = std::async(std::launch::async, [this, kind]()
+			{
+				return RunBuildSequence(kind);
+			});
+		return true;
+	}
+
+	void EditorAssetBuildService::Update()
+	{
+		if (!running_.load() || !buildFuture_.valid())
+		{
+			return;
+		}
+
+		if (buildFuture_.wait_for(std::chrono::seconds(0)) == std::future_status::ready)
+		{
+			lastBuildSucceeded_ = buildFuture_.get();
+			hasLastResult_ = true;
+			running_ = false;
+			statusText_ = lastBuildSucceeded_ ? "Last build succeeded" : "Last build failed";
+		}
+	}
+
+	bool EditorAssetBuildService::RunBuildSequence(EditorAssetBuildKind kind)
+	{
+		bool succeeded = true;
+		if (log_)
+		{
+			log_->Info("Build started: " + std::string(GetBuildName(kind)));
+		}
+
+		for (EditorAssetBuildKind singleKind : ExpandBuildKinds(kind))
+		{
+			if (!RunSingleBuild(singleKind))
+			{
+				succeeded = false;
+				break;
+			}
+		}
+
+		if (log_)
+		{
+			if (succeeded)
+			{
+				log_->Info("Build completed: " + std::string(GetBuildName(kind)));
+			}
+			else
+			{
+				log_->Error("Build failed: " + std::string(GetBuildName(kind)));
+			}
+		}
+		return succeeded;
+	}
+
+	bool EditorAssetBuildService::RunSingleBuild(EditorAssetBuildKind kind)
+	{
+		const std::filesystem::path batchFile = GetBatchFile(kind);
+		const std::string configuration =
+#ifdef _DEBUG
+			"Debug";
+#else
+			"Release";
+#endif
+
+		if (log_)
+		{
+			log_->Info("Running " + std::string(GetBuildName(kind)) + ": " + PathForLog(batchFile));
+		}
+
+		const EditorProcessResult result = processRunner_.RunBatchFile(
+			batchFile,
+			{ projectDir_.string(), configuration },
+			projectDir_,
+			[this](const std::string& line)
+			{
+				if (log_)
+				{
+					std::string message = line;
+					while (!message.empty() && (message.back() == '\n' || message.back() == '\r'))
+					{
+						message.pop_back();
+					}
+					if (message.empty())
+					{
+						return;
+					}
+					// 外部プロセス出力は最低限の分類でOutput Logへ流す。
+					if (message.find("error") != std::string::npos || message.find("Error") != std::string::npos || message.find("ERROR") != std::string::npos)
+					{
+						log_->Error(message);
+					}
+					else if (message.find("warning") != std::string::npos || message.find("Warning") != std::string::npos || message.find("WARNING") != std::string::npos)
+					{
+						log_->Warning(message);
+					}
+					else
+					{
+						log_->Info(message);
+					}
+				}
+			});
+
+		if (!result.launched)
+		{
+			if (log_)
+			{
+				log_->Error("Failed to launch " + std::string(GetBuildName(kind)));
+			}
+			return false;
+		}
+
+		if (result.exitCode != 0)
+		{
+			if (log_)
+			{
+				log_->Error(std::string(GetBuildName(kind)) + " exited with code " + std::to_string(result.exitCode));
+			}
+			return false;
+		}
+
+		if (log_)
+		{
+			log_->Info(std::string(GetBuildName(kind)) + " succeeded.");
+		}
+		return true;
+	}
+
+	std::filesystem::path EditorAssetBuildService::ResolveProjectDir() const
+	{
+		std::error_code error;
+		std::filesystem::path cursor = std::filesystem::current_path(error);
+		for (int i = 0; i < 8 && !cursor.empty(); ++i)
+		{
+			if (std::filesystem::exists(cursor / "Resources", error) && std::filesystem::exists(cursor / "Tools" / "Scripts", error))
+			{
+				return cursor;
+			}
+			const std::filesystem::path childProject = cursor / "Project";
+			if (std::filesystem::exists(childProject / "Resources", error) && std::filesystem::exists(childProject / "Tools" / "Scripts", error))
+			{
+				return childProject;
+			}
+			cursor = cursor.parent_path();
+		}
+		return std::filesystem::current_path(error) / "Project";
+	}
+
+	std::filesystem::path EditorAssetBuildService::GetBatchFile(EditorAssetBuildKind kind) const
+	{
+		switch (kind)
+		{
+		case EditorAssetBuildKind::Textures:
+			return projectDir_ / "Tools" / "Scripts" / "RunBuildTextures.bat";
+		case EditorAssetBuildKind::Meshes:
+			return projectDir_ / "Tools" / "Scripts" / "RunBuildMeshes.bat";
+		case EditorAssetBuildKind::Fonts:
+			return projectDir_ / "Tools" / "Scripts" / "RunBuildFonts.bat";
+		default:
+			return {};
+		}
+	}
+
+	std::vector<EditorAssetBuildKind> EditorAssetBuildService::ExpandBuildKinds(EditorAssetBuildKind kind) const
+	{
+		if (kind == EditorAssetBuildKind::All)
+		{
+			// Build All Assetsは変換依存を見やすくするためTextures→Meshes→Fontsで固定実行する。
+			return { EditorAssetBuildKind::Textures, EditorAssetBuildKind::Meshes, EditorAssetBuildKind::Fonts };
+		}
+		return { kind };
+	}
+
+	const char* EditorAssetBuildService::GetBuildName(EditorAssetBuildKind kind)
+	{
+		switch (kind)
+		{
+		case EditorAssetBuildKind::Textures:
+			return "Build Textures";
+		case EditorAssetBuildKind::Meshes:
+			return "Build Meshes";
+		case EditorAssetBuildKind::Fonts:
+			return "Build Fonts";
+		case EditorAssetBuildKind::All:
+			return "Build All Assets";
+		default:
+			return "Build Assets";
+		}
+	}
+
+} // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorAssetBuildService.h
+++ b/Project/Engine/Editor/EditorAssetBuildService.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "EditorProcessRunner.h"
+
+#include <atomic>
+#include <filesystem>
+#include <future>
+#include <string>
+#include <vector>
+
+namespace Ken4lowEngine
+{
+	class EditorOutputLog;
+
+	enum class EditorAssetBuildKind
+	{
+		Textures,
+		Meshes,
+		Fonts,
+		All
+	};
+
+	class EditorAssetBuildService
+	{
+	public:
+		void Initialize(EditorOutputLog* log);
+		bool StartBuild(EditorAssetBuildKind kind);
+		void Update();
+		bool IsRunning() const { return running_.load(); }
+		bool HasLastResult() const { return hasLastResult_; }
+		bool WasLastBuildSuccessful() const { return lastBuildSucceeded_; }
+		const std::string& GetStatusText() const { return statusText_; }
+
+	private:
+		bool RunBuildSequence(EditorAssetBuildKind kind);
+		bool RunSingleBuild(EditorAssetBuildKind kind);
+		std::filesystem::path ResolveProjectDir() const;
+		std::filesystem::path GetBatchFile(EditorAssetBuildKind kind) const;
+		std::vector<EditorAssetBuildKind> ExpandBuildKinds(EditorAssetBuildKind kind) const;
+		static const char* GetBuildName(EditorAssetBuildKind kind);
+
+		EditorOutputLog* log_ = nullptr;
+		EditorProcessRunner processRunner_;
+		std::filesystem::path projectDir_;
+		std::future<bool> buildFuture_;
+		std::atomic_bool running_ = false;
+		bool hasLastResult_ = false;
+		bool lastBuildSucceeded_ = false;
+		std::string statusText_ = "Idle";
+	};
+
+} // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorOutputLog.cpp
+++ b/Project/Engine/Editor/EditorOutputLog.cpp
@@ -1,0 +1,53 @@
+#include "EditorOutputLog.h"
+
+namespace Ken4lowEngine
+{
+	void EditorOutputLog::Add(EditorLogLevel level, const std::string& message)
+	{
+		std::lock_guard<std::mutex> lock(mutex_);
+		entries_.push_back({ level, message });
+	}
+
+	void EditorOutputLog::Info(const std::string& message)
+	{
+		Add(EditorLogLevel::Info, message);
+	}
+
+	void EditorOutputLog::Warning(const std::string& message)
+	{
+		Add(EditorLogLevel::Warning, message);
+	}
+
+	void EditorOutputLog::Error(const std::string& message)
+	{
+		Add(EditorLogLevel::Error, message);
+	}
+
+	void EditorOutputLog::Clear()
+	{
+		std::lock_guard<std::mutex> lock(mutex_);
+		entries_.clear();
+	}
+
+	std::vector<EditorLogEntry> EditorOutputLog::GetEntries() const
+	{
+		std::lock_guard<std::mutex> lock(mutex_);
+		return entries_;
+	}
+
+	const char* ToString(EditorLogLevel level)
+	{
+		switch (level)
+		{
+		case EditorLogLevel::Info:
+			return "Info";
+		case EditorLogLevel::Warning:
+			return "Warning";
+		case EditorLogLevel::Error:
+			return "Error";
+		default:
+			return "Info";
+		}
+	}
+
+} // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorOutputLog.h
+++ b/Project/Engine/Editor/EditorOutputLog.h
@@ -1,0 +1,39 @@
+#pragma once
+
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace Ken4lowEngine
+{
+	enum class EditorLogLevel
+	{
+		Info,
+		Warning,
+		Error
+	};
+
+	struct EditorLogEntry
+	{
+		EditorLogLevel level = EditorLogLevel::Info;
+		std::string message;
+	};
+
+	class EditorOutputLog
+	{
+	public:
+		void Add(EditorLogLevel level, const std::string& message);
+		void Info(const std::string& message);
+		void Warning(const std::string& message);
+		void Error(const std::string& message);
+		void Clear();
+		std::vector<EditorLogEntry> GetEntries() const;
+
+	private:
+		mutable std::mutex mutex_;
+		std::vector<EditorLogEntry> entries_;
+	};
+
+	const char* ToString(EditorLogLevel level);
+
+} // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorProcessRunner.cpp
+++ b/Project/Engine/Editor/EditorProcessRunner.cpp
@@ -1,0 +1,103 @@
+#include "EditorProcessRunner.h"
+
+#include <array>
+#include <cstdio>
+#include <sstream>
+
+#ifdef _WIN32
+#include <windows.h>
+#endif
+
+namespace Ken4lowEngine
+{
+	namespace
+	{
+		std::string QuoteCommandArgument(const std::string& value)
+		{
+			std::string quoted = "\"";
+			for (char c : value)
+			{
+				if (c == '"')
+				{
+					quoted += "\\\"";
+				}
+				else
+				{
+					quoted += c;
+				}
+			}
+			quoted += "\"";
+			return quoted;
+		}
+
+		std::string PathToString(const std::filesystem::path& path)
+		{
+#ifdef _WIN32
+			return path.string();
+#else
+			return path.generic_string();
+#endif
+		}
+	}
+
+	EditorProcessResult EditorProcessRunner::RunBatchFile(
+		const std::filesystem::path& batchFile,
+		const std::vector<std::string>& arguments,
+		const std::filesystem::path& workingDirectory,
+		const std::function<void(const std::string&)>& onOutput) const
+	{
+		EditorProcessResult result{};
+		if (!std::filesystem::exists(batchFile))
+		{
+			if (onOutput)
+			{
+				onOutput("Batch file not found: " + batchFile.string());
+			}
+			return result;
+		}
+
+#ifdef _WIN32
+		// バッチファイルはcmd経由で実行し、stdout/stderrをOutput Logへ転送する。
+		std::ostringstream command;
+		command << "cd /d " << QuoteCommandArgument(PathToString(workingDirectory)) << " && ";
+		command << QuoteCommandArgument(PathToString(batchFile));
+		for (const std::string& argument : arguments)
+		{
+			command << ' ' << QuoteCommandArgument(argument);
+		}
+		command << " 2>&1";
+
+		const std::string fullCommand = "cmd /S /C \"" + command.str() + "\"";
+		FILE* pipe = _popen(fullCommand.c_str(), "r");
+		if (!pipe)
+		{
+			if (onOutput)
+			{
+				onOutput("Failed to launch process: " + fullCommand);
+			}
+			return result;
+		}
+
+		result.launched = true;
+		std::array<char, 512> buffer{};
+		while (fgets(buffer.data(), static_cast<int>(buffer.size()), pipe))
+		{
+			if (onOutput)
+			{
+				onOutput(std::string(buffer.data()));
+			}
+		}
+		result.exitCode = _pclose(pipe);
+#else
+		(void)arguments;
+		(void)workingDirectory;
+		if (onOutput)
+		{
+			onOutput("Asset build batch execution is only supported on Windows.");
+		}
+		result.exitCode = -1;
+#endif
+		return result;
+	}
+
+} // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorProcessRunner.h
+++ b/Project/Engine/Editor/EditorProcessRunner.h
@@ -1,0 +1,26 @@
+#pragma once
+
+#include <filesystem>
+#include <functional>
+#include <string>
+#include <vector>
+
+namespace Ken4lowEngine
+{
+	struct EditorProcessResult
+	{
+		int exitCode = -1;
+		bool launched = false;
+	};
+
+	class EditorProcessRunner
+	{
+	public:
+		EditorProcessResult RunBatchFile(
+			const std::filesystem::path& batchFile,
+			const std::vector<std::string>& arguments,
+			const std::filesystem::path& workingDirectory,
+			const std::function<void(const std::string&)>& onOutput) const;
+	};
+
+} // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorWindowManager.cpp
+++ b/Project/Engine/Editor/EditorWindowManager.cpp
@@ -10,7 +10,11 @@
 #include <SceneManager.h>
 
 #include <algorithm>
+#include <array>
+#include <cstring>
 #include <vector>
+#include <filesystem>
+#include <string>
 
 #ifdef USE_IMGUI
 #include <imgui.h>
@@ -21,6 +25,11 @@ namespace Ken4lowEngine
 
 	namespace
 	{
+		std::string ToUtf8Path(const std::filesystem::path& path)
+		{
+			return path.generic_string();
+		}
+
 		EditorInputPolicy GetCurrentEditorInputPolicy()
 		{
 			BaseScene* scene = SceneManager::GetInstance()->GetCurrentScene();
@@ -44,6 +53,15 @@ namespace Ken4lowEngine
 	void EditorWindowManager::Draw()
 	{
 #ifdef USE_IMGUI
+		InitializeEditorServices();
+		const bool buildWasRunning = assetBuildService_.IsRunning();
+		assetBuildService_.Update();
+		if (buildWasRunning && !assetBuildService_.IsRunning() && assetBuildService_.WasLastBuildSuccessful())
+		{
+			// Build完了後はCompiled側の変換結果を確認しやすいようContent Browserを再スキャンする。
+			assetBrowser_.Refresh();
+		}
+
 		auto* input = Input::GetInstance();
 		if (input->TriggerRawKey(DIK_F8) && IsFpsCapturePolicy())
 		{
@@ -183,11 +201,34 @@ namespace Ken4lowEngine
 
 		if (ImGui::BeginMenu("Build"))
 		{
-			ImGui::MenuItem("Build Textures");
-			ImGui::MenuItem("Build Meshes");
-			ImGui::MenuItem("Build Fonts");
+			const bool buildRunning = assetBuildService_.IsRunning();
+			// BuildメニューはTools/Scriptsの既存batを実行する入口にする。
+			if (buildRunning)
+			{
+				ImGui::BeginDisabled();
+			}
+			if (ImGui::MenuItem("Build Textures"))
+			{
+				assetBuildService_.StartBuild(EditorAssetBuildKind::Textures);
+			}
+			if (ImGui::MenuItem("Build Meshes"))
+			{
+				assetBuildService_.StartBuild(EditorAssetBuildKind::Meshes);
+			}
+			if (ImGui::MenuItem("Build Fonts"))
+			{
+				assetBuildService_.StartBuild(EditorAssetBuildKind::Fonts);
+			}
 			ImGui::Separator();
-			ImGui::MenuItem("Build All Assets");
+			if (ImGui::MenuItem("Build All Assets"))
+			{
+				assetBuildService_.StartBuild(EditorAssetBuildKind::All);
+			}
+			if (buildRunning)
+			{
+				ImGui::EndDisabled();
+			}
+			ImGui::TextUnformatted(assetBuildService_.GetStatusText().c_str());
 			ImGui::EndMenu();
 		}
 
@@ -261,7 +302,19 @@ namespace Ken4lowEngine
 				playController->Stop();
 			}
 			ImGui::SameLine();
-			ImGui::Button("Build");
+			// ToolbarのBuildボタンから全アセット変換を実行する。
+			if (assetBuildService_.IsRunning())
+			{
+				ImGui::BeginDisabled();
+			}
+			if (ImGui::Button("Build"))
+			{
+				assetBuildService_.StartBuild(EditorAssetBuildKind::All);
+			}
+			if (assetBuildService_.IsRunning())
+			{
+				ImGui::EndDisabled();
+			}
 			ImGui::SameLine();
 			ImGui::TextUnformatted("|");
 			ImGui::SameLine();
@@ -655,18 +708,122 @@ namespace Ken4lowEngine
 			return;
 		}
 
-		// Content Browserは後でResources配下のアセット列挙へ接続するため仮フォルダを表示する
+		// Content BrowserはResources配下の実ファイル列挙と選択詳細を表示する。
 		if (ImGui::Begin("Content Browser", &windowState_.showContentBrowser))
 		{
-			ImGui::TextUnformatted("/Resources");
+			const std::array<EditorAssetCategory, 4> categories = {
+				EditorAssetCategory::Textures,
+				EditorAssetCategory::Models,
+				EditorAssetCategory::Shaders,
+				EditorAssetCategory::Fonts
+			};
+			for (EditorAssetCategory category : categories)
+			{
+				if (category != categories.front())
+				{
+					ImGui::SameLine();
+				}
+				const bool selected = assetBrowser_.GetCategory() == category;
+				if (selected)
+				{
+					ImGui::PushStyleColor(ImGuiCol_Button, ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive));
+				}
+				if (ImGui::Button(EditorAssetBrowser::GetCategoryName(category)))
+				{
+					assetBrowser_.SetCategory(category);
+				}
+				if (selected)
+				{
+					ImGui::PopStyleColor();
+				}
+			}
+
 			ImGui::Separator();
-			ImGui::Button("Textures");
+			const bool sourceSelected = assetBrowser_.GetViewMode() == EditorAssetViewMode::Sources;
+			if (sourceSelected)
+			{
+				ImGui::PushStyleColor(ImGuiCol_Button, ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive));
+			}
+			if (ImGui::Button("Sources"))
+			{
+				assetBrowser_.SetViewMode(EditorAssetViewMode::Sources);
+			}
+			if (sourceSelected)
+			{
+				ImGui::PopStyleColor();
+			}
 			ImGui::SameLine();
-			ImGui::Button("Models");
+			const bool compiledSelected = assetBrowser_.GetViewMode() == EditorAssetViewMode::Compiled;
+			if (compiledSelected)
+			{
+				ImGui::PushStyleColor(ImGuiCol_Button, ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive));
+			}
+			if (ImGui::Button("Compiled"))
+			{
+				assetBrowser_.SetViewMode(EditorAssetViewMode::Compiled);
+			}
+			if (compiledSelected)
+			{
+				ImGui::PopStyleColor();
+			}
 			ImGui::SameLine();
-			ImGui::Button("Shaders");
+			if (ImGui::Button("Refresh"))
+			{
+				assetBrowser_.Refresh();
+			}
+
+			char filterBuffer[256] = {};
+			const std::string& currentFilter = assetBrowser_.GetSearchFilter();
+			std::strncpy(filterBuffer, currentFilter.c_str(), sizeof(filterBuffer) - 1);
+			if (ImGui::InputText("Search", filterBuffer, sizeof(filterBuffer)))
+			{
+				assetBrowser_.SetSearchFilter(filterBuffer);
+			}
+			ImGui::Text("Root: %s", ToUtf8Path(assetBrowser_.GetCurrentRoot()).c_str());
+			ImGui::Separator();
+
+			const float detailsWidth = 330.0f;
+			if (ImGui::BeginChild("AssetList", ImVec2(-detailsWidth, 0.0f), true))
+			{
+				const auto& entries = assetBrowser_.GetFilteredEntries();
+				if (entries.empty())
+				{
+					ImGui::TextUnformatted("No assets found.");
+				}
+				for (std::size_t index = 0; index < entries.size(); ++index)
+				{
+					const EditorAssetEntry& entry = entries[index];
+					const EditorAssetEntry* selectedEntry = assetBrowser_.GetSelectedEntry();
+					const bool isSelected = selectedEntry && selectedEntry->relativePath == entry.relativePath;
+					const std::string label = entry.icon + " " + entry.relativePath + "##asset" + std::to_string(index);
+					if (ImGui::Selectable(label.c_str(), isSelected))
+					{
+						assetBrowser_.Select(index);
+					}
+				}
+			}
+			ImGui::EndChild();
 			ImGui::SameLine();
-			ImGui::Button("Fonts");
+
+			if (ImGui::BeginChild("AssetDetails", ImVec2(0.0f, 0.0f), true))
+			{
+				ImGui::TextUnformatted("Selected Asset");
+				ImGui::Separator();
+				const EditorAssetEntry* selectedEntry = assetBrowser_.GetSelectedEntry();
+				if (!selectedEntry)
+				{
+					ImGui::TextUnformatted("No asset selected.");
+				}
+				else
+				{
+					ImGui::Text("Type: %s %s", selectedEntry->icon.c_str(), EditorAssetBrowser::GetCategoryName(assetBrowser_.GetCategory()));
+					ImGui::Text("Path: %s", selectedEntry->relativePath.c_str());
+					ImGui::Text("Extension: %s", selectedEntry->extension.empty() ? "(none)" : selectedEntry->extension.c_str());
+					ImGui::Text("Size: %.2f KB (%llu bytes)", static_cast<double>(selectedEntry->sizeBytes) / 1024.0, static_cast<unsigned long long>(selectedEntry->sizeBytes));
+					ImGui::Text("Modified: %s", selectedEntry->modifiedTime.c_str());
+				}
+			}
+			ImGui::EndChild();
 		}
 		ImGui::End();
 #endif // USE_IMGUI
@@ -680,17 +837,66 @@ namespace Ken4lowEngine
 			return;
 		}
 
-		// Output Logは後でエンジンログへ接続するため仮ログ行だけ表示する
+		// Output LogはEditorOutputLogのバッファを描画し、Build/Content Browserの結果を集約する。
 		if (ImGui::Begin("Output Log", &windowState_.showOutputLog))
 		{
-			ImGui::TextUnformatted("[Editor] UE5-style editor shell initialized.");
-			ImGui::TextUnformatted("[Editor] Dock panels from the Window menu.");
+			if (ImGui::Button("Clear"))
+			{
+				outputLog_.Clear();
+			}
+			ImGui::SameLine();
+			ImGui::Checkbox("Auto Scroll", &outputLogAutoScroll_);
+			ImGui::SameLine();
+			ImGui::Text("Build: %s", assetBuildService_.GetStatusText().c_str());
 			if (windowState_.debugShowFps)
 			{
+				ImGui::SameLine();
 				ImGui::Text("FPS: %.1f", ImGui::GetIO().Framerate);
 			}
+			ImGui::Separator();
+
+			if (ImGui::BeginChild("OutputLogScroll", ImVec2(0.0f, 0.0f), true, ImGuiWindowFlags_HorizontalScrollbar))
+			{
+				const std::vector<EditorLogEntry> entries = outputLog_.GetEntries();
+				for (const EditorLogEntry& entry : entries)
+				{
+					ImVec4 color = ImGui::GetStyleColorVec4(ImGuiCol_Text);
+					if (entry.level == EditorLogLevel::Warning)
+					{
+						color = ImVec4(1.0f, 0.82f, 0.2f, 1.0f);
+					}
+					else if (entry.level == EditorLogLevel::Error)
+					{
+						color = ImVec4(1.0f, 0.25f, 0.25f, 1.0f);
+					}
+					ImGui::PushStyleColor(ImGuiCol_Text, color);
+					ImGui::TextWrapped("[%s] %s", ToString(entry.level), entry.message.c_str());
+					ImGui::PopStyleColor();
+				}
+				if (outputLogAutoScroll_ && ImGui::GetScrollY() >= ImGui::GetScrollMaxY() - 4.0f)
+				{
+					ImGui::SetScrollHereY(1.0f);
+				}
+			}
+			ImGui::EndChild();
 		}
 		ImGui::End();
+#endif // USE_IMGUI
+	}
+
+	void EditorWindowManager::InitializeEditorServices()
+	{
+#ifdef USE_IMGUI
+		if (editorServicesInitialized_)
+		{
+			return;
+		}
+
+		// Editor専用サービスはImGui有効時だけ初期化し、通常ビルドの依存を増やさない。
+		outputLog_.Info("[Editor] UE5-style editor shell initialized.");
+		assetBrowser_.Initialize(&outputLog_);
+		assetBuildService_.Initialize(&outputLog_);
+		editorServicesInitialized_ = true;
 #endif // USE_IMGUI
 	}
 

--- a/Project/Engine/Editor/EditorWindowManager.h
+++ b/Project/Engine/Editor/EditorWindowManager.h
@@ -1,6 +1,9 @@
 #pragma once
 #include "Vector2.h"
 #include "EditorSelection.h"
+#include "EditorAssetBrowser.h"
+#include "EditorAssetBuildService.h"
+#include "EditorOutputLog.h"
 
 namespace Ken4lowEngine
 {
@@ -79,6 +82,7 @@ namespace Ken4lowEngine
 		void DrawDetails();
 		void DrawContentBrowser();
 		void DrawOutputLog();
+		void InitializeEditorServices();
 
 		/// <summary>
 		/// スクリーン座標をMain Viewport左上基準へ変換する入口です。
@@ -109,6 +113,11 @@ namespace Ken4lowEngine
 		Vector2 mainViewportSize_ = { 0.0f, 0.0f }; // Main Viewport内でGameRenderTargetを表示しているサイズ
 		EditorInputDebugInfo inputDebugInfo_{}; // Toolbarへゲーム入力ゲートの状態を可視化する
 		EditorSelection selection_{}; // World OutlinerとDetailsで共有する軽量な選択状態
+		EditorOutputLog outputLog_{}; // Content BrowserとBuild結果を表示するエディタ用ログバッファ
+		EditorAssetBrowser assetBrowser_{}; // Resources配下の実ファイル列挙を担当するContent Browserモデル
+		EditorAssetBuildService assetBuildService_{}; // Tools/Scriptsのアセットビルド実行を担当するサービス
+		bool editorServicesInitialized_ = false; // USE_IMGUI時だけEditorサービスを遅延初期化する。
+		bool outputLogAutoScroll_ = true; // Output Logの末尾追従設定をUI状態として保持する。
 		bool openRebuildDefaultLayoutPopup_ = false; // Rebuild Default Layoutを即時実行せず確認Popupへ遅延する。
 	};
 

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -321,7 +321,11 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="Engine\Core\Transform\WorldTransform.cpp" />
     <ClCompile Include="Engine\Core\Transform\WorldTransformEx.cpp" />
     <ClCompile Include="Engine\DebugTools\ImGui\ImGuiManager.cpp" />
+    <ClCompile Include="Engine\Editor\EditorAssetBrowser.cpp" />
+    <ClCompile Include="Engine\Editor\EditorAssetBuildService.cpp" />
+    <ClCompile Include="Engine\Editor\EditorOutputLog.cpp" />
     <ClCompile Include="Engine\Editor\EditorPlayController.cpp" />
+    <ClCompile Include="Engine\Editor\EditorProcessRunner.cpp" />
     <ClCompile Include="Engine\Editor\EditorSelection.cpp" />
     <ClCompile Include="Engine\Editor\EditorWindowManager.cpp" />
     <ClCompile Include="Engine\DebugTools\LeakCheck\D3DResourceLeakChecker.cpp" />
@@ -954,7 +958,11 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="Engine\Core\Transform\WorldTransform.h" />
     <ClInclude Include="Engine\Core\Transform\WorldTransformEx.h" />
     <ClInclude Include="Engine\DebugTools\ImGui\ImGuiManager.h" />
+    <ClInclude Include="Engine\Editor\EditorAssetBrowser.h" />
+    <ClInclude Include="Engine\Editor\EditorAssetBuildService.h" />
     <ClInclude Include="Engine\Editor\EditorObjectInfo.h" />
+    <ClInclude Include="Engine\Editor\EditorOutputLog.h" />
+    <ClInclude Include="Engine\Editor\EditorProcessRunner.h" />
     <ClInclude Include="Engine\Editor\EditorTransformAccess.h" />
     <ClInclude Include="Engine\Editor\EditorPlayController.h" />
     <ClInclude Include="Engine\Editor\EditorSelection.h" />

--- a/Project/Ken4lowEngine.vcxproj.filters
+++ b/Project/Ken4lowEngine.vcxproj.filters
@@ -475,7 +475,19 @@
     <ClCompile Include="Engine\DebugTools\ImGui\ImGuiManager.cpp">
       <Filter>Engine\DebugTools\ImGui</Filter>
     </ClCompile>
+    <ClCompile Include="Engine\Editor\EditorAssetBrowser.cpp">
+      <Filter>Engine\Editor</Filter>
+    </ClCompile>
+    <ClCompile Include="Engine\Editor\EditorAssetBuildService.cpp">
+      <Filter>Engine\Editor</Filter>
+    </ClCompile>
+    <ClCompile Include="Engine\Editor\EditorOutputLog.cpp">
+      <Filter>Engine\Editor</Filter>
+    </ClCompile>
     <ClCompile Include="Engine\Editor\EditorPlayController.cpp">
+      <Filter>Engine\Editor</Filter>
+    </ClCompile>
+    <ClCompile Include="Engine\Editor\EditorProcessRunner.cpp">
       <Filter>Engine\Editor</Filter>
     </ClCompile>
     <ClCompile Include="Engine\Editor\EditorSelection.cpp">
@@ -1302,7 +1314,19 @@
     <ClInclude Include="Engine\DebugTools\ImGui\ImGuiManager.h">
       <Filter>Engine\DebugTools\ImGui</Filter>
     </ClInclude>
+    <ClInclude Include="Engine\Editor\EditorAssetBrowser.h">
+      <Filter>Engine\Editor</Filter>
+    </ClInclude>
+    <ClInclude Include="Engine\Editor\EditorAssetBuildService.h">
+      <Filter>Engine\Editor</Filter>
+    </ClInclude>
     <ClInclude Include="Engine\Editor\EditorObjectInfo.h">
+      <Filter>Engine\Editor</Filter>
+    </ClInclude>
+    <ClInclude Include="Engine\Editor\EditorOutputLog.h">
+      <Filter>Engine\Editor</Filter>
+    </ClInclude>
+    <ClInclude Include="Engine\Editor\EditorProcessRunner.h">
       <Filter>Engine\Editor</Filter>
     </ClInclude>
     <ClInclude Include="Engine\Editor\EditorTransformAccess.h">


### PR DESCRIPTION
### Motivation
- Provide a real Content Browser in the ImGui editor that enumerates files under `Resources` so Blender outputs and converted assets are discoverable without editing code. 
- Hook the existing build scripts (`RunBuildTextures.bat`, `RunBuildMeshes.bat`, `RunBuildFonts.bat`) into the editor so users can run asset conversion from the UI. 
- Surface build and content warnings/errors in an editor-local Output Log and make the system safe for missing folders, path quirks and asynchronous execution.

### Description
- Added `EditorAssetBrowser` (`EditorAssetBrowser.h/.cpp`) that scans `Resources` recursively, supports categories (`Textures/Models/Shaders/Fonts`), `Sources/Compiled` view modes, search filter, selection, and displays relative path/extension/size/modified time and simple icons.
- Added `EditorOutputLog` (`EditorOutputLog.h/.cpp`) providing thread-safe `Info/Warning/Error` entries, `Clear()` and `GetEntries()` used by the UI with simple color coding.
- Added `EditorProcessRunner` (`EditorProcessRunner.h/.cpp`) to execute batch files on Windows via `cmd /S /C`, quote arguments, capture `stdout/stderr`, and stream lines to a callback; on non-Windows it emits a friendly message.
- Added `EditorAssetBuildService` (`EditorAssetBuildService.h/.cpp`) that runs builds asynchronously, prevents double-start, expands `All` to `Textures->Meshes->Fonts` sequence, forwards `ProjectDir` and `Configuration` to batch scripts, and routes process output into `EditorOutputLog` classifying warnings/errors.
- Wired UI: `EditorWindowManager` was updated to hold and initialize `EditorAssetBrowser`, `EditorAssetBuildService`, and `EditorOutputLog`; the Build menu and toolbar `Build` button now call the service; Content Browser and Output Log panels render real data (Refresh, Search, Auto Scroll, Clear, status text, color-coded log lines).
- Project integration: added new sources/headers to `Project/Ken4lowEngine.vcxproj` and `.filters` so the files participate in the Visual Studio project.
- Safety and platform notes: missing/invalid folders are warned to `EditorOutputLog` (no crash), paths are quoted for external processes, external batch execution is implemented for Windows only, and UI disables build controls while a build is running.

### Testing
- Compiled new modules individually: ran `g++ -std=c++20 -IProject/Engine/Editor -c Project/Engine/Editor/EditorOutputLog.cpp`, `EditorAssetBrowser.cpp`, `EditorProcessRunner.cpp` and `EditorAssetBuildService.cpp` and they produced object files successfully (new-file compilation checks passed).
- Verified Visual Studio project XML parses successfully using `python3` XML parse checks on `Project/Ken4lowEngine.vcxproj` and `Project/Ken4lowEngine.vcxproj.filters` (both `ok`).
- Ran `git diff --check` to ensure no whitespace/conflicts; it passed.
- Attempted full compile of `EditorWindowManager.cpp` in this Linux container but it failed due to missing Windows SDK header (`Windows.h`); this is an environment limitation rather than a change failure (Windows-target build expected to succeed in normal dev environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b0ba9c52c832dbf0e634737e0ec5d)