### PR TITLE
Improve ImGui Content Browser: image previews, preview cache and UI polish

### DIFF
--- a/Project/Engine/Editor/EditorAssetBrowser.cpp
+++ b/Project/Engine/Editor/EditorAssetBrowser.cpp
@@ -46,16 +46,33 @@ namespace Ken4lowEngine
 		std::string GetIcon(EditorAssetCategory category, const std::filesystem::path& extension)
 		{
 			const std::string ext = ToLower(extension.string());
+			if (ext == ".png")
+			{
+				return "[PNG]";
+			}
+			if (ext == ".jpg" || ext == ".jpeg")
+			{
+				return "[JPG]";
+			}
+			if (ext == ".dds")
+			{
+				return "[DDS]";
+			}
+
 			switch (category)
 			{
 			case EditorAssetCategory::Textures:
-				return (ext == ".dds") ? "[DDS]" : "[TEX]";
+				return "[TEX]";
 			case EditorAssetCategory::Models:
-				return (ext == ".gltf" || ext == ".glb") ? "[GLTF]" : "[MESH]";
+				if (ext == ".gltf" || ext == ".glb")
+				{
+					return "[GLTF]";
+				}
+				return "[KMESH]";
 			case EditorAssetCategory::Shaders:
 				return "[HLSL]";
 			case EditorAssetCategory::Fonts:
-				return (ext == ".ttf" || ext == ".otf") ? "[FONT]" : "[FNT]";
+				return (ext == ".ttf") ? "[TTF]" : "[FONT]";
 			default:
 				return "[FILE]";
 			}
@@ -105,6 +122,12 @@ namespace Ken4lowEngine
 			EditorAssetEntry asset{};
 			asset.label = ToUtf8Path(entry.path().filename());
 			asset.icon = GetIcon(category_, entry.path().extension());
+			asset.absolutePath = ToUtf8Path(std::filesystem::absolute(entry.path(), error));
+			if (error)
+			{
+				asset.absolutePath = ToUtf8Path(entry.path());
+				error.clear();
+			}
 			asset.relativePath = ToUtf8Path(std::filesystem::relative(entry.path(), projectDir_, error));
 			if (error)
 			{
@@ -127,8 +150,17 @@ namespace Ken4lowEngine
 			entries_.push_back(asset);
 		}
 
-		std::sort(entries_.begin(), entries_.end(), [](const EditorAssetEntry& lhs, const EditorAssetEntry& rhs)
+		std::sort(entries_.begin(), entries_.end(), [this](const EditorAssetEntry& lhs, const EditorAssetEntry& rhs)
 			{
+				if (category_ == EditorAssetCategory::Textures)
+				{
+					const bool lhsImage = IsImageExtension(lhs.extension);
+					const bool rhsImage = IsImageExtension(rhs.extension);
+					if (lhsImage != rhsImage)
+					{
+						return lhsImage;
+					}
+				}
 				return lhs.relativePath < rhs.relativePath;
 			});
 		RebuildFilteredEntries();
@@ -215,6 +247,12 @@ namespace Ken4lowEngine
 	const char* EditorAssetBrowser::GetViewModeName(EditorAssetViewMode mode)
 	{
 		return mode == EditorAssetViewMode::Sources ? "Sources" : "Compiled";
+	}
+
+	bool EditorAssetBrowser::IsImageExtension(const std::string& extension)
+	{
+		const std::string ext = ToLower(extension);
+		return ext == ".png" || ext == ".jpg" || ext == ".jpeg" || ext == ".dds" || ext == ".bmp";
 	}
 
 	void EditorAssetBrowser::RebuildFilteredEntries()

--- a/Project/Engine/Editor/EditorAssetBrowser.h
+++ b/Project/Engine/Editor/EditorAssetBrowser.h
@@ -28,6 +28,7 @@ namespace Ken4lowEngine
 		std::string label;
 		std::string icon;
 		std::string relativePath;
+		std::string absolutePath;
 		std::string extension;
 		std::string modifiedTime;
 		uintmax_t sizeBytes = 0;
@@ -52,6 +53,7 @@ namespace Ken4lowEngine
 
 		static const char* GetCategoryName(EditorAssetCategory category);
 		static const char* GetViewModeName(EditorAssetViewMode mode);
+		static bool IsImageExtension(const std::string& extension);
 
 	private:
 		void RebuildFilteredEntries();

--- a/Project/Engine/Editor/EditorTexturePreviewCache.cpp
+++ b/Project/Engine/Editor/EditorTexturePreviewCache.cpp
@@ -1,0 +1,181 @@
+#include "EditorTexturePreviewCache.h"
+
+#include "DirectXCommon.h"
+#include "SRVManager.h"
+#include "TextureManager.h"
+
+#include <algorithm>
+#include <cctype>
+#include <exception>
+#include <system_error>
+#include <vector>
+
+#include <d3dx12.h>
+
+namespace Ken4lowEngine
+{
+	namespace
+	{
+		std::string HResultToMessage(HRESULT hr)
+		{
+			return "Preview unavailable (HRESULT=0x" + std::to_string(static_cast<unsigned long>(hr)) + ")";
+		}
+	}
+
+	EditorTexturePreviewCache::~EditorTexturePreviewCache()
+	{
+		Clear();
+	}
+
+	const EditorTexturePreview& EditorTexturePreviewCache::GetOrLoad(const std::filesystem::path& filePath)
+	{
+		std::error_code error;
+		if (!std::filesystem::exists(filePath, error) || !std::filesystem::is_regular_file(filePath, error))
+		{
+			emptyPreview_ = {};
+			emptyPreview_.failed = true;
+			emptyPreview_.message = "Preview unavailable: file does not exist.";
+			return emptyPreview_;
+		}
+
+		const std::string key = NormalizeKey(filePath);
+		auto found = cache_.find(key);
+		if (found != cache_.end())
+		{
+			return found->second.preview;
+		}
+
+		CachedTexture texture = LoadPreview(filePath);
+		auto [inserted, _] = cache_.emplace(key, std::move(texture));
+		return inserted->second.preview;
+	}
+
+	void EditorTexturePreviewCache::Clear()
+	{
+		for (auto& [_, texture] : cache_)
+		{
+			if (texture.srvIndex != UINT32_MAX)
+			{
+				SRVManager::GetInstance()->Free(texture.srvIndex);
+				texture.srvIndex = UINT32_MAX;
+			}
+			texture.resource.Reset();
+		}
+		cache_.clear();
+		emptyPreview_ = {};
+	}
+
+	bool EditorTexturePreviewCache::IsPreviewableImage(const std::string& extension)
+	{
+		const std::string ext = ToLower(extension);
+		return ext == ".png" || ext == ".jpg" || ext == ".jpeg" || ext == ".dds" || ext == ".bmp";
+	}
+
+	EditorTexturePreviewCache::CachedTexture EditorTexturePreviewCache::LoadPreview(const std::filesystem::path& filePath) const
+	{
+		CachedTexture cached{};
+		DirectXCommon* dxCommon = DirectXCommon::GetInstance();
+		if (!dxCommon || !dxCommon->GetDevice() || !dxCommon->GetCommandManager())
+		{
+			cached.preview.failed = true;
+			cached.preview.message = "Preview unavailable: DirectX device is not ready.";
+			return cached;
+		}
+
+		const std::string extension = ToLower(filePath.extension().string());
+		DirectX::ScratchImage image{};
+		DirectX::TexMetadata metadata{};
+		HRESULT hr = S_OK;
+		const std::wstring pathW = filePath.wstring();
+		if (extension == ".dds")
+		{
+			hr = DirectX::LoadFromDDSFile(pathW.c_str(), DirectX::DDS_FLAGS_NONE, &metadata, image);
+		}
+		else
+		{
+			hr = DirectX::LoadFromWICFile(pathW.c_str(), DirectX::WIC_FLAGS_FORCE_SRGB, &metadata, image);
+		}
+
+		if (FAILED(hr) || image.GetImageCount() == 0)
+		{
+			cached.preview.failed = true;
+			cached.preview.message = HResultToMessage(hr) + ": " + ToUtf8Path(filePath);
+			return cached;
+		}
+
+		if (metadata.dimension != DirectX::TEX_DIMENSION_TEXTURE2D || metadata.IsCubemap())
+		{
+			cached.preview.failed = true;
+			cached.preview.width = static_cast<uint32_t>(metadata.width);
+			cached.preview.height = static_cast<uint32_t>(metadata.height);
+			cached.preview.message = "Preview unavailable: only Texture2D images can be displayed.";
+			return cached;
+		}
+
+		cached.preview.width = static_cast<uint32_t>(metadata.width);
+		cached.preview.height = static_cast<uint32_t>(metadata.height);
+
+		try
+		{
+			cached.resource = TextureManager::CreateTextureResource(dxCommon->GetDevice(), metadata);
+			cached.resource->SetName(L"EditorTexturePreview");
+			ComPtr<ID3D12Resource> intermediate = TextureManager::UploadTextureData(
+				cached.resource.Get(),
+				image,
+				dxCommon->GetDevice(),
+				dxCommon->GetCommandManager()->GetCommandList());
+			dxCommon->GetCommandManager()->ExecuteAndWait();
+
+			cached.srvIndex = SRVManager::GetInstance()->Allocate();
+			D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc{};
+			srvDesc.Format = metadata.format;
+			srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+			srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2D;
+			srvDesc.Texture2D.MipLevels = UINT(metadata.mipLevels);
+			dxCommon->GetDevice()->CreateShaderResourceView(
+				cached.resource.Get(),
+				&srvDesc,
+				SRVManager::GetInstance()->GetCPUDescriptorHandle(cached.srvIndex));
+
+			cached.preview.loaded = true;
+			cached.preview.srvHandleGPU = SRVManager::GetInstance()->GetGPUDescriptorHandle(cached.srvIndex);
+			cached.preview.message.clear();
+		}
+		catch (const std::exception& e)
+		{
+			if (cached.srvIndex != UINT32_MAX)
+			{
+				SRVManager::GetInstance()->Free(cached.srvIndex);
+				cached.srvIndex = UINT32_MAX;
+			}
+			cached.resource.Reset();
+			cached.preview.loaded = false;
+			cached.preview.failed = true;
+			cached.preview.message = std::string("Preview unavailable: ") + e.what();
+		}
+
+		return cached;
+	}
+
+	std::string EditorTexturePreviewCache::NormalizeKey(const std::filesystem::path& filePath) const
+	{
+		std::error_code error;
+		const std::filesystem::path absolute = std::filesystem::weakly_canonical(filePath, error);
+		return ToLower(ToUtf8Path(error ? std::filesystem::absolute(filePath, error) : absolute));
+	}
+
+	std::string EditorTexturePreviewCache::ToLower(std::string value)
+	{
+		std::transform(value.begin(), value.end(), value.begin(), [](unsigned char c)
+			{
+				return static_cast<char>(std::tolower(c));
+			});
+		return value;
+	}
+
+	std::string EditorTexturePreviewCache::ToUtf8Path(const std::filesystem::path& path)
+	{
+		return path.generic_string();
+	}
+
+} // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorTexturePreviewCache.h
+++ b/Project/Engine/Editor/EditorTexturePreviewCache.h
@@ -1,0 +1,52 @@
+#pragma once
+
+#include "DX12Include.h"
+
+#include <DirectXTex.h>
+#include <cstdint>
+#include <filesystem>
+#include <string>
+#include <unordered_map>
+
+namespace Ken4lowEngine
+{
+	class DirectXCommon;
+
+	struct EditorTexturePreview
+	{
+		bool loaded = false;
+		bool failed = false;
+		std::string message;
+		uint32_t width = 0;
+		uint32_t height = 0;
+		D3D12_GPU_DESCRIPTOR_HANDLE srvHandleGPU{};
+	};
+
+	class EditorTexturePreviewCache
+	{
+	public:
+		~EditorTexturePreviewCache();
+
+		const EditorTexturePreview& GetOrLoad(const std::filesystem::path& filePath);
+		void Clear();
+
+		static bool IsPreviewableImage(const std::string& extension);
+
+	private:
+		struct CachedTexture
+		{
+			EditorTexturePreview preview{};
+			ComPtr<ID3D12Resource> resource;
+			uint32_t srvIndex = UINT32_MAX;
+		};
+
+		CachedTexture LoadPreview(const std::filesystem::path& filePath) const;
+		std::string NormalizeKey(const std::filesystem::path& filePath) const;
+		static std::string ToLower(std::string value);
+		static std::string ToUtf8Path(const std::filesystem::path& path);
+
+		std::unordered_map<std::string, CachedTexture> cache_;
+		EditorTexturePreview emptyPreview_{};
+	};
+
+} // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorWindowManager.cpp
+++ b/Project/Engine/Editor/EditorWindowManager.cpp
@@ -12,9 +12,12 @@
 #include <algorithm>
 #include <array>
 #include <cstring>
+#include <cstdio>
 #include <vector>
 #include <filesystem>
 #include <string>
+#include <sstream>
+#include <iomanip>
 
 #ifdef USE_IMGUI
 #include <imgui.h>
@@ -41,6 +44,40 @@ namespace Ken4lowEngine
 		{
 			// F8キャプチャはFPS操作Sceneだけで有効にする。
 			return GetCurrentEditorInputPolicy() == EditorInputPolicy::FpsCapture;
+		}
+
+		std::string FormatBytes(uintmax_t bytes)
+		{
+			std::ostringstream stream;
+			if (bytes >= 1024ull * 1024ull)
+			{
+				stream << std::fixed << std::setprecision(2) << (static_cast<double>(bytes) / (1024.0 * 1024.0)) << " MB";
+			}
+			else if (bytes >= 1024ull)
+			{
+				stream << std::fixed << std::setprecision(2) << (static_cast<double>(bytes) / 1024.0) << " KB";
+			}
+			else
+			{
+				stream << bytes << " bytes";
+			}
+			return stream.str();
+		}
+
+#ifdef USE_IMGUI
+		void DrawDetailRow(const char* label, const std::string& value)
+		{
+			ImGui::TextDisabled("%s", label);
+			ImGui::SameLine(115.0f);
+			ImGui::TextWrapped("%s", value.empty() ? "(none)" : value.c_str());
+		}
+#endif // USE_IMGUI
+
+		std::string GetParentPathText(const EditorAssetEntry& entry)
+		{
+			const std::filesystem::path relativePath(entry.relativePath);
+			const std::filesystem::path parent = relativePath.parent_path();
+			return parent.empty() ? "." : parent.generic_string();
 		}
 	}
 
@@ -730,6 +767,11 @@ namespace Ken4lowEngine
 				}
 				if (ImGui::Button(EditorAssetBrowser::GetCategoryName(category)))
 				{
+					if (assetBrowser_.GetCategory() != category)
+					{
+						// カテゴリ変更時は古いPreview SRVを解放して本編Texture管理と分離する。
+						texturePreviewCache_.Clear();
+					}
 					assetBrowser_.SetCategory(category);
 				}
 				if (selected)
@@ -746,6 +788,11 @@ namespace Ken4lowEngine
 			}
 			if (ImGui::Button("Sources"))
 			{
+				if (!sourceSelected)
+				{
+					// Sources/Compiled切替時は選択画像のPreviewキャッシュを破棄する。
+					texturePreviewCache_.Clear();
+				}
 				assetBrowser_.SetViewMode(EditorAssetViewMode::Sources);
 			}
 			if (sourceSelected)
@@ -760,6 +807,11 @@ namespace Ken4lowEngine
 			}
 			if (ImGui::Button("Compiled"))
 			{
+				if (!compiledSelected)
+				{
+					// Sources/Compiled切替時は選択画像のPreviewキャッシュを破棄する。
+					texturePreviewCache_.Clear();
+				}
 				assetBrowser_.SetViewMode(EditorAssetViewMode::Compiled);
 			}
 			if (compiledSelected)
@@ -769,6 +821,8 @@ namespace Ken4lowEngine
 			ImGui::SameLine();
 			if (ImGui::Button("Refresh"))
 			{
+				// Refreshではファイル変更後の画像を再ロードできるようPreviewキャッシュも消す。
+				texturePreviewCache_.Clear();
 				assetBrowser_.Refresh();
 			}
 
@@ -778,17 +832,27 @@ namespace Ken4lowEngine
 			// snprintfで検索フィルタ文字列を安全に固定長バッファへコピーする。
 			std::snprintf(filterBuffer, sizeof(filterBuffer), "%s", currentFilter.c_str());
 
-			if (ImGui::InputText("Search", filterBuffer, sizeof(filterBuffer)))
+			ImGui::SetNextItemWidth(std::max(160.0f, ImGui::GetContentRegionAvail().x * 0.45f));
+			if (ImGui::InputTextWithHint("##ContentBrowserSearch", "Search assets...", filterBuffer, sizeof(filterBuffer)))
 			{
 				assetBrowser_.SetSearchFilter(filterBuffer);
 			}
+			ImGui::SameLine();
+			ImGui::TextDisabled("%zu assets", assetBrowser_.GetFilteredEntries().size());
 
-			ImGui::Text("Root: %s", ToUtf8Path(assetBrowser_.GetCurrentRoot()).c_str());
+			if (ImGui::TreeNodeEx("Root", ImGuiTreeNodeFlags_DefaultOpen))
+			{
+				ImGui::TextDisabled("%s", ToUtf8Path(assetBrowser_.GetCurrentRoot()).c_str());
+				ImGui::TreePop();
+			}
 			ImGui::Separator();
 
-			const float detailsWidth = 330.0f;
-			if (ImGui::BeginChild("AssetList", ImVec2(-detailsWidth, 0.0f), true))
+			const float availableWidth = ImGui::GetContentRegionAvail().x;
+			const float detailsWidth = std::clamp(availableWidth * 0.38f, 300.0f, 460.0f);
+			if (ImGui::BeginChild("AssetList", ImVec2(-detailsWidth - ImGui::GetStyle().ItemSpacing.x, 0.0f), true, ImGuiWindowFlags_HorizontalScrollbar))
 			{
+				ImGui::TextDisabled("Assets");
+				ImGui::Separator();
 				const auto& entries = assetBrowser_.GetFilteredEntries();
 				if (entries.empty())
 				{
@@ -799,17 +863,31 @@ namespace Ken4lowEngine
 					const EditorAssetEntry& entry = entries[index];
 					const EditorAssetEntry* selectedEntry = assetBrowser_.GetSelectedEntry();
 					const bool isSelected = selectedEntry && selectedEntry->relativePath == entry.relativePath;
-					const std::string label = entry.icon + " " + entry.relativePath + "##asset" + std::to_string(index);
-					if (ImGui::Selectable(label.c_str(), isSelected))
+					const std::string rowId = "##asset" + std::to_string(index);
+					ImGui::PushID(static_cast<int>(index));
+					if (ImGui::Selectable(rowId.c_str(), isSelected, ImGuiSelectableFlags_SpanAllColumns, ImVec2(0.0f, 42.0f)))
 					{
 						assetBrowser_.Select(index);
 					}
+					const ImVec2 rowCursorAfter = ImGui::GetCursorScreenPos();
+					if (ImGui::IsItemVisible())
+					{
+						const ImVec2 rowMin = ImGui::GetItemRectMin();
+						ImGui::SetCursorScreenPos(ImVec2(rowMin.x + 8.0f, rowMin.y + 5.0f));
+						ImGui::TextColored(ImVec4(0.75f, 0.9f, 1.0f, 1.0f), "%s", entry.icon.c_str());
+						ImGui::SameLine(66.0f);
+						ImGui::TextUnformatted(entry.label.c_str());
+						ImGui::SetCursorScreenPos(ImVec2(rowMin.x + 66.0f, rowMin.y + 23.0f));
+						ImGui::TextDisabled("%s", GetParentPathText(entry).c_str());
+						ImGui::SetCursorScreenPos(rowCursorAfter);
+					}
+					ImGui::PopID();
 				}
 			}
 			ImGui::EndChild();
 			ImGui::SameLine();
 
-			if (ImGui::BeginChild("AssetDetails", ImVec2(0.0f, 0.0f), true))
+			if (ImGui::BeginChild("AssetDetails", ImVec2(0.0f, 0.0f), true, ImGuiWindowFlags_AlwaysVerticalScrollbar))
 			{
 				ImGui::TextUnformatted("Selected Asset");
 				ImGui::Separator();
@@ -820,11 +898,52 @@ namespace Ken4lowEngine
 				}
 				else
 				{
-					ImGui::Text("Type: %s %s", selectedEntry->icon.c_str(), EditorAssetBrowser::GetCategoryName(assetBrowser_.GetCategory()));
-					ImGui::Text("Path: %s", selectedEntry->relativePath.c_str());
-					ImGui::Text("Extension: %s", selectedEntry->extension.empty() ? "(none)" : selectedEntry->extension.c_str());
-					ImGui::Text("Size: %.2f KB (%llu bytes)", static_cast<double>(selectedEntry->sizeBytes) / 1024.0, static_cast<unsigned long long>(selectedEntry->sizeBytes));
-					ImGui::Text("Modified: %s", selectedEntry->modifiedTime.c_str());
+					const bool isImage = EditorAssetBrowser::IsImageExtension(selectedEntry->extension);
+					DrawDetailRow("File", selectedEntry->label);
+					DrawDetailRow("Category", std::string(EditorAssetBrowser::GetCategoryName(assetBrowser_.GetCategory())) + " / " + EditorAssetBrowser::GetViewModeName(assetBrowser_.GetViewMode()));
+					DrawDetailRow("Relative", selectedEntry->relativePath);
+					DrawDetailRow("Absolute", selectedEntry->absolutePath);
+					DrawDetailRow("Extension", selectedEntry->extension.empty() ? "(none)" : selectedEntry->extension);
+					DrawDetailRow("Size", FormatBytes(selectedEntry->sizeBytes) + " (" + std::to_string(static_cast<unsigned long long>(selectedEntry->sizeBytes)) + " bytes)");
+					DrawDetailRow("Modified", selectedEntry->modifiedTime);
+					DrawDetailRow("Source", EditorAssetBrowser::GetViewModeName(assetBrowser_.GetViewMode()));
+					ImGui::Separator();
+
+					if (isImage)
+					{
+						// 選択中の画像だけをロードし、同一パスはEditorTexturePreviewCacheで再利用する。
+						const EditorTexturePreview& preview = texturePreviewCache_.GetOrLoad(std::filesystem::u8path(selectedEntry->absolutePath));
+						if (preview.width > 0 && preview.height > 0)
+						{
+							DrawDetailRow("Resolution", std::to_string(preview.width) + " x " + std::to_string(preview.height));
+						}
+						ImGui::TextDisabled("Preview");
+						const float maxPreviewWidth = std::max(80.0f, ImGui::GetContentRegionAvail().x - 8.0f);
+						if (preview.loaded && preview.srvHandleGPU.ptr != 0 && preview.width > 0 && preview.height > 0)
+						{
+							const float aspect = static_cast<float>(preview.width) / static_cast<float>(preview.height);
+							ImVec2 previewSize(maxPreviewWidth, maxPreviewWidth / aspect);
+							const float maxPreviewHeight = std::max(120.0f, ImGui::GetContentRegionAvail().y * 0.55f);
+							if (previewSize.y > maxPreviewHeight)
+							{
+								previewSize.y = maxPreviewHeight;
+								previewSize.x = previewSize.y * aspect;
+							}
+							ImGui::Image(static_cast<ImTextureID>(preview.srvHandleGPU.ptr), previewSize);
+						}
+						else
+						{
+							ImGui::TextWrapped("%s", preview.message.empty() ? "Preview unavailable" : preview.message.c_str());
+						}
+					}
+					else
+					{
+						ImGui::TextDisabled("Preview");
+						ImGui::BeginDisabled();
+						ImGui::Button(selectedEntry->icon.c_str(), ImVec2(std::min(160.0f, ImGui::GetContentRegionAvail().x), 88.0f));
+						ImGui::EndDisabled();
+						ImGui::TextWrapped("%s preview is not implemented yet.", EditorAssetBrowser::GetCategoryName(assetBrowser_.GetCategory()));
+					}
 				}
 			}
 			ImGui::EndChild();

--- a/Project/Engine/Editor/EditorWindowManager.h
+++ b/Project/Engine/Editor/EditorWindowManager.h
@@ -4,6 +4,7 @@
 #include "EditorAssetBrowser.h"
 #include "EditorAssetBuildService.h"
 #include "EditorOutputLog.h"
+#include "EditorTexturePreviewCache.h"
 
 namespace Ken4lowEngine
 {
@@ -115,6 +116,7 @@ namespace Ken4lowEngine
 		EditorSelection selection_{}; // World OutlinerとDetailsで共有する軽量な選択状態
 		EditorOutputLog outputLog_{}; // Content BrowserとBuild結果を表示するエディタ用ログバッファ
 		EditorAssetBrowser assetBrowser_{}; // Resources配下の実ファイル列挙を担当するContent Browserモデル
+		EditorTexturePreviewCache texturePreviewCache_{}; // Content Browserの選択画像だけをSRV化してプレビューするキャッシュ
 		EditorAssetBuildService assetBuildService_{}; // Tools/Scriptsのアセットビルド実行を担当するサービス
 		bool editorServicesInitialized_ = false; // USE_IMGUI時だけEditorサービスを遅延初期化する。
 		bool outputLogAutoScroll_ = true; // Output Logの末尾追従設定をUI状態として保持する。

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -327,6 +327,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="Engine\Editor\EditorPlayController.cpp" />
     <ClCompile Include="Engine\Editor\EditorProcessRunner.cpp" />
     <ClCompile Include="Engine\Editor\EditorSelection.cpp" />
+    <ClCompile Include="Engine\Editor\EditorTexturePreviewCache.cpp" />
     <ClCompile Include="Engine\Editor\EditorWindowManager.cpp" />
     <ClCompile Include="Engine\DebugTools\LeakCheck\D3DResourceLeakChecker.cpp" />
     <ClCompile Include="Engine\Graphics\Camera\Core\Camera.cpp" />
@@ -966,6 +967,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="Engine\Editor\EditorTransformAccess.h" />
     <ClInclude Include="Engine\Editor\EditorPlayController.h" />
     <ClInclude Include="Engine\Editor\EditorSelection.h" />
+    <ClInclude Include="Engine\Editor\EditorTexturePreviewCache.h" />
     <ClInclude Include="Engine\Editor\EditorWindowManager.h" />
     <ClInclude Include="Engine\DebugTools\LeakCheck\D3DResourceLeakChecker.h" />
     <ClInclude Include="Engine\Graphics\Camera\Core\Camera.h" />

--- a/Project/Ken4lowEngine.vcxproj.filters
+++ b/Project/Ken4lowEngine.vcxproj.filters
@@ -493,6 +493,9 @@
     <ClCompile Include="Engine\Editor\EditorSelection.cpp">
       <Filter>Engine\Editor</Filter>
     </ClCompile>
+    <ClCompile Include="Engine\Editor\EditorTexturePreviewCache.cpp">
+      <Filter>Engine\Editor</Filter>
+    </ClCompile>
     <ClCompile Include="Engine\Editor\EditorWindowManager.cpp">
       <Filter>Engine\Editor</Filter>
     </ClCompile>
@@ -1336,6 +1339,9 @@
       <Filter>Engine\Editor</Filter>
     </ClInclude>
     <ClInclude Include="Engine\Editor\EditorSelection.h">
+      <Filter>Engine\Editor</Filter>
+    </ClInclude>
+    <ClInclude Include="Engine\Editor\EditorTexturePreviewCache.h">
       <Filter>Engine\Editor</Filter>
     </ClInclude>
     <ClInclude Include="Engine\Editor\EditorWindowManager.h">


### PR DESCRIPTION
### Motivation
- Content Browser を視覚的に把握しやすくし、画像アセットを素早く確認できるようにするための改善を行いました。\n- 一覧の可読性と Selected Asset の情報量を増やし、将来のモデルプレビューやホットリロード拡張に備えた分離されたプレビュー管理を導入します。\n
### Description
- 画像プレビュー用クラス `EditorTexturePreviewCache` を追加し、選択中の画像だけをロードしてパスごとに SRV をキャッシュ・管理し、`Clear()` で解放できる仕組みを実装しました。失敗時はメッセージを返して安全に扱います。\n- `EditorAssetEntry` に `absolutePath` を追加し、`EditorAssetBrowser` に拡張子ベースのラベル付け（PNG/JPG/DDS/GLTF/KMESH/HLSL/TTF など）と、Textures カテゴリで画像ファイルを優先的に上に持ってくるソートを追加しました。\n- `EditorWindowManager` 側で `EditorTexturePreviewCache` を保持し、カテゴリ/ビュー切替・Refresh 時にキャッシュをクリアするようにしてプレビューと本編 TextureManager/SRV の競合を避けるようにしました。\n- Content Browser UI を改善し、検索欄にプレースホルダ `Search assets...` を追加、Root を折りたたみ表示、一覧はアイコン＋ファイル名＋小さめの親パス表示の高さ付き行にし選択行をわかりやすくしました。\n- Selected Asset 詳細パネルをスクロール可能に拡張して、ファイル名／カテゴリ+Source／相対/絶対パス／拡張子／サイズ（人間可読）／更新日時／（画像の場合）解像度とアスペクト比を維持した `ImGui::Image` プレビューを表示するようにしました。非画像ファイルはカテゴリ別プレースホルダーを表示します。\n- 新規ファイル `EditorTexturePreviewCache.h/.cpp` を Visual Studio プロジェクト（`.vcxproj` / `.vcxproj.filters`）へ登録しました。\n
### Testing
- `git diff --check` を実行して差分に問題がないことを確認（成功）。\n- Visual Studio プロジェクトファイルの整合性を Python の `xml.etree.ElementTree.parse()` で検証し、`.vcxproj` と `.vcxproj.filters` の XML が正しくパースされることを確認（成功）。\n- この環境では `msbuild` が利用できなかったため実際の Visual Studio ビルドは行っておらず、フルビルドは別環境で実行してください（ビルド未実行）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b12dace5c832dbd3bfb2cfdf0e75a)