### PR TITLE
Fix editor preview cache shutdown order

### DIFF
--- a/Project/Engine/Core/Application/Framework.cpp
+++ b/Project/Engine/Core/Application/Framework.cpp
@@ -22,8 +22,13 @@
 #include <GameTimer.h>
 
 #ifdef USE_IMGUI
+#include <Editor/EditorWindowManager.h>
 #include <ImGuiManager.h>
 #endif // USE_IMGUI
+
+#ifdef _DEBUG
+#include <D3DResourceLeakChecker.h>
+#endif // _DEBUG
 
 namespace Ken4lowEngine
 {
@@ -201,6 +206,11 @@ namespace Ken4lowEngine
 	/// -------------------------------------------------------------
 	void Framework::Finalize()
 	{
+#ifdef USE_IMGUI
+		// TextureManager/SRVManager/DirectXCommonより先にエディタ用プレビューキャッシュを解放する。
+		EditorWindowManager::GetInstance()->FinalizeEditorServices();
+#endif // USE_IMGUI
+
 		// GPUパーティクルマネージャーの終了処理
 		GpuParticleManager::GetInstance()->Finalize();
 
@@ -249,6 +259,11 @@ namespace Ken4lowEngine
 
 		// SRVManagerの終了処理
 		SRVManager::GetInstance()->Finalize();
+
+#ifdef _DEBUG
+		// DirectXCommon本体を破棄する前にManager解放後のD3D12ライブオブジェクトを報告する。
+		D3DResourceLeakChecker::ReportLiveObjects();
+#endif // _DEBUG
 
 		// DirectX共通クラスの終了処理
 		dxCommon_->Finalize();

--- a/Project/Engine/DebugTools/LeakCheck/D3DResourceLeakChecker.cpp
+++ b/Project/Engine/DebugTools/LeakCheck/D3DResourceLeakChecker.cpp
@@ -11,12 +11,22 @@ namespace Ken4lowEngine
 #pragma comment(lib, "dxgi.lib")
 #pragma comment(lib, "d3d12.lib")
 
+bool D3DResourceLeakChecker::hasReported_ = false;
+
 /// -------------------------------------------------------------
-///			　				デストラクタ
+///			 				デストラクタ
 /// -------------------------------------------------------------
 D3DResourceLeakChecker::~D3DResourceLeakChecker()
 {
-	// リソースリークチェック
+	if (!hasReported_)
+	{
+		ReportLiveObjects();
+	}
+}
+
+void D3DResourceLeakChecker::ReportLiveObjects()
+{
+	// DirectXCommon破棄前に呼べるよう、ライブオブジェクト報告処理を明示関数へ分離する。
 	Microsoft::WRL::ComPtr<IDXGIDebug> debug;
 
 	// デバッグインターフェースの取得
@@ -26,6 +36,7 @@ D3DResourceLeakChecker::~D3DResourceLeakChecker()
 		debug->ReportLiveObjects(DXGI_DEBUG_ALL, DXGI_DEBUG_RLO_ALL);   // 全てのライブオブジェクトを報告
 		debug->ReportLiveObjects(DXGI_DEBUG_APP, DXGI_DEBUG_RLO_ALL);   // アプリケーションのライブオブジェクトを報告
 		debug->ReportLiveObjects(DXGI_DEBUG_D3D12, DXGI_DEBUG_RLO_ALL); // D3D12のライブオブジェクトを報告
+		hasReported_ = true;
 	}
 }
 

--- a/Project/Engine/DebugTools/LeakCheck/D3DResourceLeakChecker.h
+++ b/Project/Engine/DebugTools/LeakCheck/D3DResourceLeakChecker.h
@@ -14,6 +14,14 @@ public: /// ---------- メンバ関数 ---------- ///
 	/// デストラクタ
 	/// </summary>
 	~D3DResourceLeakChecker();
+
+	/// <summary>
+	/// 現時点のD3D/DXGIライブオブジェクトを報告します。
+	/// </summary>
+	static void ReportLiveObjects();
+
+private:
+	static bool hasReported_;
 };
 
 

--- a/Project/Engine/Editor/EditorTexturePreviewCache.cpp
+++ b/Project/Engine/Editor/EditorTexturePreviewCache.cpp
@@ -52,6 +52,14 @@ namespace Ken4lowEngine
 
 	void EditorTexturePreviewCache::Clear()
 	{
+		const bool hasCachedResources = !cache_.empty();
+		DirectXCommon* dxCommon = DirectXCommon::GetInstance();
+		if (hasCachedResources && dxCommon && dxCommon->GetCommandManager())
+		{
+			// プレビュー画像を参照していたGPU処理を待ってからD3D12Resource/SRVを破棄する。
+			dxCommon->GetCommandManager()->ExecuteAndWait();
+		}
+
 		for (auto& [_, texture] : cache_)
 		{
 			if (texture.srvIndex != UINT32_MAX)
@@ -59,6 +67,7 @@ namespace Ken4lowEngine
 				SRVManager::GetInstance()->Free(texture.srvIndex);
 				texture.srvIndex = UINT32_MAX;
 			}
+			texture.preview = {};
 			texture.resource.Reset();
 		}
 		cache_.clear();

--- a/Project/Engine/Editor/EditorWindowManager.cpp
+++ b/Project/Engine/Editor/EditorWindowManager.cpp
@@ -1237,4 +1237,19 @@ namespace Ken4lowEngine
 #endif // USE_IMGUI
 	}
 
+	void EditorWindowManager::FinalizeEditorServices()
+	{
+#ifdef USE_IMGUI
+		if (!editorServicesInitialized_)
+		{
+			return;
+		}
+
+		// DirectXCommon/SRVManager破棄前にプレビュー用SRVとD3D12Resourceを明示解放する。
+		texturePreviewCache_.Clear();
+		outputLog_.Info("[Editor] Preview cache cleared.");
+		editorServicesInitialized_ = false;
+#endif // USE_IMGUI
+	}
+
 } // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorWindowManager.h
+++ b/Project/Engine/Editor/EditorWindowManager.h
@@ -84,6 +84,7 @@ namespace Ken4lowEngine
 		void DrawContentBrowser();
 		void DrawOutputLog();
 		void InitializeEditorServices();
+		void FinalizeEditorServices();
 
 		/// <summary>
 		/// スクリーン座標をMain Viewport左上基準へ変換する入口です。


### PR DESCRIPTION
### Motivation
- Prevent D3D12 Live Object warnings by ensuring editor preview SRV/resources are released before `DirectXCommon` is destroyed.
- Make live-object reporting usable before `DirectXCommon` teardown to help debug remaining references.

### Description
- Added `EditorWindowManager::FinalizeEditorServices()` and declaration in `EditorWindowManager.h` to allow explicit shutdown of editor-only services.  The finalizer calls `texturePreviewCache_.Clear()` and logs `[Editor] Preview cache cleared.`.
- Modified `EditorTexturePreviewCache::Clear()` to wait for in-flight GPU work via `CommandManager::ExecuteAndWait()`, free SRV indices with `SRVManager::Free()`, reset the preview state, and release `ID3D12Resource` objects before clearing the cache.
- Updated `Framework::Finalize()` to call `EditorWindowManager::FinalizeEditorServices()` (under `USE_IMGUI`) before tearing down `TextureManager`/`SRVManager`/`DirectXCommon` so preview resources are released in the correct order.
- Extended `D3DResourceLeakChecker` with a static `ReportLiveObjects()` and a `hasReported_` flag, and call `ReportLiveObjects()` (in `_DEBUG`) after manager finalization but before `DirectXCommon::Finalize()` so live-object reports reflect manager teardown.

### Testing
- Ran `git diff --check` to validate no whitespace/errors in diffs (succeeded). 
- Attempted to build with `msbuild Project/Ken4lowEngine.sln /p:Configuration=Debug /p:Platform=x64` but `msbuild` is not available in this environment so a full build could not be executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0b20ba1f8c832db873bb04128dd088)