### PR TITLE
Restore DebugScene ImGui entry (Debug builds) and add Point sampling option for low-res Object3D textures

### DIFF
--- a/Project/Engine/Editor/EditorWindowManager.cpp
+++ b/Project/Engine/Editor/EditorWindowManager.cpp
@@ -1247,6 +1247,11 @@ namespace Ken4lowEngine
 			if (ImGui::Button("StageSelectScene")) { SceneManager::GetInstance()->ChangeScene("StageSelectScene"); }
 			ImGui::SameLine();
 			if (ImGui::Button("GamePlayScene")) { SceneManager::GetInstance()->ChangeScene("GamePlayScene"); }
+#ifdef _DEBUG
+			ImGui::SameLine();
+			// DebugScene は開発用導線だけ残し、キー入力遷移は復活させない。
+			if (ImGui::Button("DebugScene")) { SceneManager::GetInstance()->ChangeScene("DebugScene"); }
+#endif
 		}
 		ImGui::End();
 #endif // USE_IMGUI

--- a/Project/Engine/Graphics/Material/Material.cpp
+++ b/Project/Engine/Graphics/Material/Material.cpp
@@ -26,6 +26,7 @@ namespace Ken4lowEngine
 		materialData_->reflection = 0.0f;							 // 反射なし
 		materialData_->uvTransform = Matrix4x4::MakeIdentity();		 // UV はそのまま
 		materialData_->roughness = 0.5f;							 // 中程度の粗さ
+		materialData_->usePointSampling = 0.0f;					 // 既定は従来どおり Linear
 	}
 
 
@@ -41,6 +42,7 @@ namespace Ken4lowEngine
 			materialData_->reflection = this->materialData_->reflection;			 // シェーディングの強さ
 			materialData_->uvTransform = this->materialData_->uvTransform;		 // UV変換行列
 			materialData_->roughness = this->materialData_->roughness;			 // 粗さ
+			materialData_->usePointSampling = this->materialData_->usePointSampling;
 		}
 	}
 

--- a/Project/Engine/Graphics/Material/Material.h
+++ b/Project/Engine/Graphics/Material/Material.h
@@ -24,7 +24,8 @@ public: /// ---------- 構造体 ---------- ///
 		Matrix4x4 uvTransform;  // UV変換行列 : bytes 64
 		float reflection;		// 反射率 : bytes 4
 		float roughness;		// 粗さ : bytes 4
-		float padding2[2];		// パディング : bytes 8
+		float usePointSampling; // 1.0f で Point Sampler を使用 : bytes 4
+		float padding2;			// パディング : bytes 4
 	};
 
 public: /// ---------- メンバ変数 ---------- ///
@@ -120,6 +121,7 @@ public: /// ---------- セッタ ---------- ///
 	/// </summary>
 	/// <param name="uvTransform">UV 座標に適用する 4x4 行列。</param>
 	void SetUVTransform(const Matrix4x4& uvTransform) { materialData_->uvTransform = uvTransform; }
+	void SetUsePointSampling(bool enabled) { materialData_->usePointSampling = enabled ? 1.0f : 0.0f; }
 
 private: /// ---------- メンバ変数 ---------- ///
 

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3D.cpp
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3D.cpp
@@ -15,10 +15,20 @@
 #include "Wireframe.h"
 
 #include <algorithm>
+#include <cctype>
 #include <cmath>
 
 namespace Ken4lowEngine
 {
+	namespace
+	{
+		bool ShouldUsePointSamplingForTexture(const std::string& texturePath)
+		{
+			std::string lowered = texturePath;
+			std::transform(lowered.begin(), lowered.end(), lowered.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+			return lowered.find("face") != std::string::npos || lowered.find("pixel") != std::string::npos || lowered.find("dot") != std::string::npos;
+		}
+	}
 
 
 	/// -------------------------------------------------------------
@@ -255,6 +265,8 @@ namespace Ken4lowEngine
 			if (i < materialSRVs_.size())
 			{
 				TextureManager::GetInstance()->SetGraphicsRootDescriptorTable(commandList, 2, materialSRVs_[i]);
+				material_.SetUsePointSampling(i < materialUsePointSampling_.size() ? materialUsePointSampling_[i] : false);
+				material_.Update();
 			}
 			meshes[i].Draw();
 		}
@@ -288,6 +300,7 @@ namespace Ken4lowEngine
 		if (model_)
 		{
 			materialSRVs_ = model_->GetMaterialSRVs(); // 共有モデルから初期値をコピー
+			materialUsePointSampling_ = model_->GetMaterialPointSamplingFlags();
 		}
 	}
 
@@ -303,6 +316,7 @@ namespace Ken4lowEngine
 		{
 			srv = h;
 		}
+		materialUsePointSampling_.assign(materialSRVs_.size(), ShouldUsePointSamplingForTexture(texturePath));
 	}
 
 	/// -------------------------------------------------------------
@@ -314,6 +328,8 @@ namespace Ken4lowEngine
 
 		TextureManager::GetInstance()->LoadTexture(texturePath);
 		materialSRVs_[index] = TextureManager::GetInstance()->GetSrvHandleGPU(texturePath);
+		if (index >= materialUsePointSampling_.size()) { materialUsePointSampling_.resize(materialSRVs_.size(), false); }
+		materialUsePointSampling_[index] = ShouldUsePointSamplingForTexture(texturePath);
 	}
 
 	size_t Object3D::GetSubmeshCount() const

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3D.h
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3D.h
@@ -140,6 +140,7 @@ namespace Ken4lowEngine
 		float alpha = 1.0f; // α値
 
 		std::vector<D3D12_GPU_DESCRIPTOR_HANDLE> materialSRVs_; // サブメッシュごとのテクスチャ SRV ハンドルを保存するベクター
+		std::vector<bool> materialUsePointSampling_;
 
 		// 環境マップのテクスチャ
 		D3D12_GPU_DESCRIPTOR_HANDLE environmentMapHandle_{};

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3DPipelineSet.cpp
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3DPipelineSet.cpp
@@ -52,7 +52,7 @@ namespace Ken4lowEngine
 		D3D12_ROOT_SIGNATURE_DESC MakeObject3DRootSignatureDesc(
 			std::array<D3D12_DESCRIPTOR_RANGE, 5>& ranges,
 			std::array<D3D12_ROOT_PARAMETER, Object3DRootParameterIndex::kCount>& rootParameters,
-			std::array<D3D12_STATIC_SAMPLER_DESC, 2>& staticSamplers)
+			std::array<D3D12_STATIC_SAMPLER_DESC, 3>& staticSamplers)
 		{
 			ranges[0] = {};
 			ranges[0].BaseShaderRegister = 0;
@@ -172,6 +172,10 @@ namespace Ken4lowEngine
 			staticSamplers[1].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
 			staticSamplers[1].MaxLOD = D3D12_FLOAT32_MAX;
 
+			staticSamplers[2] = staticSamplers[0];
+			staticSamplers[2].Filter = D3D12_FILTER_MIN_MAG_MIP_POINT;
+			staticSamplers[2].ShaderRegister = 2;
+
 			D3D12_ROOT_SIGNATURE_DESC desc{};
 			desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
 			desc.NumParameters = static_cast<UINT>(rootParameters.size());
@@ -260,7 +264,7 @@ namespace Ken4lowEngine
 		{
 			std::array<D3D12_DESCRIPTOR_RANGE, 5> ranges{};
 			std::array<D3D12_ROOT_PARAMETER, Object3DRootParameterIndex::kCount> rootParameters{};
-			std::array<D3D12_STATIC_SAMPLER_DESC, 2> staticSamplers{};
+		std::array<D3D12_STATIC_SAMPLER_DESC, 3> staticSamplers{};
 
 			D3D12_ROOT_SIGNATURE_DESC rootSigDesc =
 				MakeObject3DRootSignatureDesc(ranges, rootParameters, staticSamplers);

--- a/Project/Engine/Graphics/Resource/Model/Model.cpp
+++ b/Project/Engine/Graphics/Resource/Model/Model.cpp
@@ -5,9 +5,19 @@
 
 #include <algorithm>
 #include <limits>
+#include <cctype>
 
 namespace Ken4lowEngine
 {
+	namespace
+	{
+		bool ShouldUsePointSampling(const std::string& texturePath)
+		{
+			std::string lowered = texturePath;
+			std::transform(lowered.begin(), lowered.end(), lowered.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+			return lowered.find("face") != std::string::npos || lowered.find("pixel") != std::string::npos || lowered.find("dot") != std::string::npos;
+		}
+	}
 
 	void Model::Initialize(const std::string& filePath)
 	{
@@ -15,9 +25,11 @@ namespace Ken4lowEngine
 
 		meshes_.clear();
 		materialSRVs_.clear();
+		materialUsePointSampling_.clear();
 
 		meshes_.reserve(modelData_.subMeshes.size());
 		materialSRVs_.reserve(modelData_.subMeshes.size());
+		materialUsePointSampling_.reserve(modelData_.subMeshes.size());
 
 		static const std::string kDefaultTexturePath = "Effects/white.dds";
 
@@ -33,6 +45,8 @@ namespace Ken4lowEngine
 
 			TextureManager::GetInstance()->LoadTexture(texturePath);
 			materialSRVs_.push_back(TextureManager::GetInstance()->GetSrvHandleGPU(texturePath));
+			// face/pixel系はデフォルトで Point Sampling を有効化し、まず見た目のぼやけを防ぐ。
+			materialUsePointSampling_.push_back(ShouldUsePointSampling(texturePath));
 
 			Mesh mesh{};
 			mesh.Initialize(sub.vertices, sub.indices);

--- a/Project/Engine/Graphics/Resource/Model/Model.h
+++ b/Project/Engine/Graphics/Resource/Model/Model.h
@@ -31,12 +31,14 @@ namespace Ken4lowEngine
 		
 		const std::vector<D3D12_GPU_DESCRIPTOR_HANDLE>& GetMaterialSRVs() const { return materialSRVs_; }
 		std::vector<D3D12_GPU_DESCRIPTOR_HANDLE>& GetMaterialSRVs() { return materialSRVs_; }
+		const std::vector<bool>& GetMaterialPointSamplingFlags() const { return materialUsePointSampling_; }
 
 	private:
 
 		ModelData modelData_;
 		std::vector<Mesh> meshes_;
 		std::vector<D3D12_GPU_DESCRIPTOR_HANDLE> materialSRVs_;
+		std::vector<bool> materialUsePointSampling_{};
 		BoundingSphere localBounds_{};
 		bool hasLocalBounds_ = false;
 		std::vector<BoundingSphere> meshLocalBounds_{};

--- a/Project/Resources/Shaders/Object3D/Object3d.PS.hlsl
+++ b/Project/Resources/Shaders/Object3D/Object3d.PS.hlsl
@@ -14,7 +14,8 @@ struct Material
     float4x4 uvTransform;
     float reflectionRate;
     float roughness;
-    float2 padding1;
+    float usePointSampling;
+    float padding1;
 };
 
 struct Camera
@@ -52,6 +53,7 @@ Texture2D<float> gShadowMap : register(t4);
 
 SamplerState gSampler : register(s0);
 SamplerComparisonState gShadowSampler : register(s1);
+SamplerState gPointSampler : register(s2);
 
 static const float kAlphaDiscardThreshold = 0.001f;
 
@@ -66,7 +68,10 @@ PixelShaderOutput main(VertexShaderOutput input)
 
     float4 transformedUV = mul(float4(input.texcoord, 0.0f, 1.0f), gMaterial.uvTransform);
     // SRGB SRV は Sample 時点で線形化されるため、手動の pow による二重変換を避ける。
-    float4 textureColor = gTexture.Sample(gSampler, transformedUV.xy);
+    // 低解像度テクスチャでは Point、通常モデルは Linear を使い分ける。
+    float4 textureColor = (gMaterial.usePointSampling > 0.5f)
+        ? gTexture.Sample(gPointSampler, transformedUV.xy)
+        : gTexture.Sample(gSampler, transformedUV.xy);
 
     float3 worldPosition = input.worldPosition;
     float3 normal = normalize(input.normal);


### PR DESCRIPTION
### Motivation
- Scene ImGui lost the DebugScene entry after UI rework, so restore a debug-only pathway without reintroducing key-based scene switches. 
- Low-resolution/pixel-art textures (e.g. face sprites) were blurred by linear filtering, so provide a safe way to use point sampling for those textures while keeping existing linear behavior unchanged. 
- Avoid large design changes and preserve existing visuals for normal 3D/weapon models by making point-sampling opt-in/heuristic only.

### Description
- Re-enabled a DebugScene button in the Scene ImGui window guarded by `_DEBUG` and added a one-line comment clarifying that key-driven scene transitions are not restored (`Project/Engine/Editor/EditorWindowManager.cpp`).
- Added a `usePointSampling` flag to the material constant buffer and a setter `SetUsePointSampling` so shaders can select sampling mode per-material (`Project/Engine/Graphics/Material/Material.h`, `Project/Engine/Graphics/Material/Material.cpp`).
- Added a point static sampler (`s2`) with `Filter = D3D12_FILTER_MIN_MAG_MIP_POINT` to the Object3D root signature and pipeline (`Project/Engine/Graphics/Renderer/Object3D/Object3DPipelineSet.cpp`).
- Updated Object3D pixel shader to declare `gPointSampler : register(s2)` and choose between linear (`s0`) and point (`s2`) sampling based on `gMaterial.usePointSampling` (`Project/Resources/Shaders/Object3D/Object3d.PS.hlsl`).
- Introduced per-submesh point-sampling flags in `Model` and propagated them to `Object3D`; added a lightweight filename heuristic (checks for `face`/`pixel`/`dot`) to default point-sampling for likely low-res textures while preserving existing defaults and allowing `SetTextureForAll`/`SetTextureForSubmesh` to update the flag (`Project/Engine/Graphics/Resource/Model/Model.h`, `Project/Engine/Graphics/Resource/Model/Model.cpp`, `Project/Engine/Graphics/Renderer/Object3D/Object3D.h`, `Project/Engine/Graphics/Renderer/Object3D/Object3D.cpp`).
- Changed files: `EditorWindowManager.cpp`, `Material.h`, `Material.cpp`, `Object3DPipelineSet.cpp`, `Object3d.PS.hlsl`, `Model.h`, `Model.cpp`, `Object3D.h`, `Object3D.cpp`.
- Notes on areas modified: Sampler config added in `Object3DPipelineSet.cpp` (s2 point sampler), Material CB changed in `Material.{h,cpp}`, sampling selection logic in `Object3d.PS.hlsl`, texture->point-sampling heuristics and flags in `Model.*` and per-draw propagation in `Object3D.*`.

### Testing
- Ran repository searches to confirm `PhysicalScene` / `ShadowTestScene` references are not present and to locate affected code paths, and those searches returned expected/zero results. (succeeded)
- Verified the Scene ImGui code now contains a `_DEBUG`-guarded `DebugScene` button and includes an explanatory comment. (succeeded)
- Verified the HLSL sampler registers and root-signature static sampler array were updated so `s0`=linear, `s1`=shadow compare, `s2`=point are consistent between shader and C++ root signature. (succeeded)
- Committed the changes to the local repo to record the update. (succeeded)
- Manual render/build tests were not executed in this environment, so please run a Debug build and visually verify that the Scene ImGui shows `DebugScene` only in Debug, that key-driven scene switching remains absent, and that low-resolution face textures appear crisp (point sampling) while normal models remain visually unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e6f05d3c8832db71282e96b5ddad2)