### PR TITLE
Add ImGui texture/viewport debug panels and global sampler override for blur diagnosis

### DIFF
--- a/Project/Engine/Editor/EditorWindowManager.cpp
+++ b/Project/Engine/Editor/EditorWindowManager.cpp
@@ -5,6 +5,8 @@
 #include "ImGuiManager.h"
 #include "PostEffectManager.h"
 #include "GameViewportConstants.h"
+#include "TextureManager.h"
+#include "PipelineStatePresets.h"
 #include <Input.h>
 #include <LightManager.h>
 #include <SceneManager.h>
@@ -179,6 +181,8 @@ namespace Ken4lowEngine
 		DrawDetails();
 		DrawContentBrowser();
 		DrawOutputLog();
+		if (windowState_.showTextureDebug) { DrawTextureDebug(); }
+		if (windowState_.showViewportDebug) { DrawViewportDebug(); }
 		DrawScene();
 #endif // USE_IMGUI
 	}
@@ -224,6 +228,8 @@ namespace Ken4lowEngine
 				ImGui::MenuItem("Post Effect Settings", nullptr, &windowState_.showPostEffectSettings);
 				ImGui::MenuItem("Display", nullptr, &windowState_.showDisplay);
 				ImGui::MenuItem("Parameters", nullptr, &windowState_.showParameters);
+				ImGui::MenuItem("Texture Debug", nullptr, &windowState_.showTextureDebug);
+				ImGui::MenuItem("Viewport Debug", nullptr, &windowState_.showViewportDebug);
 				ImGui::EndMenu();
 			}
 
@@ -565,6 +571,64 @@ namespace Ken4lowEngine
 		}
 		ImGui::End();
 #endif // USE_IMGUI
+	}
+
+	void EditorWindowManager::DrawTextureDebug()
+	{
+#ifdef USE_IMGUI
+		if (!ImGui::Begin("Texture Debug", &windowState_.showTextureDebug))
+		{
+			ImGui::End();
+			return;
+		}
+		int mode = static_cast<int>(PipelineStatePresets::GetSamplerDebugMode());
+		if (ImGui::RadioButton("Default Sampler", mode == 0)) { mode = 0; }
+		ImGui::SameLine();
+		if (ImGui::RadioButton("Force Point Sampler", mode == 1)) { mode = 1; }
+		ImGui::SameLine();
+		if (ImGui::RadioButton("Force Linear Sampler", mode == 2)) { mode = 2; }
+		PipelineStatePresets::SetSamplerDebugMode(static_cast<PipelineStatePresets::SamplerDebugMode>(mode));
+		const auto infos = TextureManager::GetInstance()->GetAllTextureDebugInfos();
+		ImGui::Text("Loaded Texture Count: %d", static_cast<int>(infos.size()));
+		ImGui::Separator();
+		for (const auto& info : infos)
+		{
+			ImGui::Text("Loaded: %s", info.loadedPath.c_str());
+			ImGui::Text("Source: %s", info.sourcePath.c_str());
+			ImGui::Text("Compiled DDS: %s", info.compiledDdsPath.c_str());
+			ImGui::Text("Width/Height: %llu x %llu", info.metadata.width, info.metadata.height);
+			ImGui::Text("Format: %d", static_cast<int>(info.metadata.format));
+			ImGui::Text("MipCount: %llu", info.metadata.mipLevels);
+			ImGui::Text("PixelArt/noMip: %s", info.isPixelArtOrNoMip ? "true" : "false");
+			ImGui::Text("Sampler: %s", mode == 1 ? "Point(Forced)" : (mode == 2 ? "Linear(Forced)" : "Pipeline Default"));
+			ImGui::Text("LastUpdate: %s", info.lastWriteTime.empty() ? "(unknown)" : info.lastWriteTime.c_str());
+			ImGui::Separator();
+		}
+		ImGui::End();
+#endif
+	}
+
+	void EditorWindowManager::DrawViewportDebug()
+	{
+#ifdef USE_IMGUI
+		if (!ImGui::Begin("Viewport Debug", &windowState_.showViewportDebug))
+		{
+			ImGui::End();
+			return;
+		}
+		const float rtW = static_cast<float>(GameViewportConstants::Width);
+		const float rtH = static_cast<float>(GameViewportConstants::Height);
+		const ImVec2 client = ImGui::GetIO().DisplaySize;
+		const float sx = (rtW > 0.0f) ? (mainViewportSize_.x / rtW) : 0.0f;
+		const float sy = (rtH > 0.0f) ? (mainViewportSize_.y / rtH) : 0.0f;
+		ImGui::Text("RenderTexture Size: %.0f x %.0f", rtW, rtH);
+		ImGui::Text("Viewport Draw Size: %.1f x %.1f", mainViewportSize_.x, mainViewportSize_.y);
+		ImGui::Text("ScaleX/ScaleY: %.3f / %.3f", sx, sy);
+		ImGui::Text("Fit To Window: true");
+		ImGui::Text("1:1 Mode: %s", (std::abs(sx - 1.0f) < 0.01f && std::abs(sy - 1.0f) < 0.01f) ? "true" : "false");
+		ImGui::Text("Client Size: %.1f x %.1f", client.x, client.y);
+		ImGui::End();
+#endif
 	}
 
 	Vector2 EditorWindowManager::ConvertScreenToMainViewportPosition(const Vector2& screenPosition) const

--- a/Project/Engine/Editor/EditorWindowManager.h
+++ b/Project/Engine/Editor/EditorWindowManager.h
@@ -26,6 +26,8 @@ namespace Ken4lowEngine
 		// WindowメニューのRenderingカテゴリで切り替える描画調整ウィンドウです。
 		bool showParameters = true;
 		bool showDisplay = true;
+		bool showTextureDebug = true;
+		bool showViewportDebug = true;
 		bool showPostEffectSettings = true;
 		bool showLightEditor = true;
 
@@ -84,6 +86,8 @@ namespace Ken4lowEngine
 		void DrawDetails();
 		void DrawContentBrowser();
 		void DrawOutputLog();
+		void DrawTextureDebug();
+		void DrawViewportDebug();
 		void DrawScene();
 		void InitializeEditorServices();
 		void FinalizeEditorServices();

--- a/Project/Engine/Graphics/Pipeline/PipelineStatePresets.cpp
+++ b/Project/Engine/Graphics/Pipeline/PipelineStatePresets.cpp
@@ -2,6 +2,10 @@
 
 namespace Ken4lowEngine::PipelineStatePresets
 {
+	namespace
+	{
+		SamplerDebugMode gSamplerDebugMode = SamplerDebugMode::Default;
+	}
 
 	D3D12_BLEND_DESC MakeBlendAlpha()
 	{
@@ -69,5 +73,29 @@ namespace Ken4lowEngine::PipelineStatePresets
 		desc.DepthWriteMask = D3D12_DEPTH_WRITE_MASK_ZERO;
 		desc.DepthFunc = D3D12_COMPARISON_FUNC_LESS_EQUAL;
 		return desc;
+	}
+
+	D3D12_FILTER ResolveSamplerFilter(D3D12_FILTER defaultFilter)
+	{
+		// Sampler由来のぼやけ切り分け用に全Pipelineのフィルタを一括上書きできるようにする。
+		if (gSamplerDebugMode == SamplerDebugMode::ForcePoint)
+		{
+			return D3D12_FILTER_MIN_MAG_MIP_POINT;
+		}
+		if (gSamplerDebugMode == SamplerDebugMode::ForceLinear)
+		{
+			return D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+		}
+		return defaultFilter;
+	}
+
+	void SetSamplerDebugMode(SamplerDebugMode mode)
+	{
+		gSamplerDebugMode = mode;
+	}
+
+	SamplerDebugMode GetSamplerDebugMode()
+	{
+		return gSamplerDebugMode;
 	}
 };

--- a/Project/Engine/Graphics/Pipeline/PipelineStatePresets.h
+++ b/Project/Engine/Graphics/Pipeline/PipelineStatePresets.h
@@ -3,6 +3,12 @@
 
 namespace Ken4lowEngine::PipelineStatePresets
 {
+	enum class SamplerDebugMode
+	{
+		Default = 0,
+		ForcePoint,
+		ForceLinear
+	};
 
 	D3D12_BLEND_DESC MakeBlendAlpha();
 	D3D12_BLEND_DESC MakeBlendOpaque();
@@ -13,5 +19,8 @@ namespace Ken4lowEngine::PipelineStatePresets
 	D3D12_DEPTH_STENCIL_DESC MakeDepthDisable();
 	D3D12_DEPTH_STENCIL_DESC MakeDepthReadWrite();
 	D3D12_DEPTH_STENCIL_DESC MakeDepthReadOnly();
+	D3D12_FILTER ResolveSamplerFilter(D3D12_FILTER defaultFilter);
+	void SetSamplerDebugMode(SamplerDebugMode mode);
+	SamplerDebugMode GetSamplerDebugMode();
 
 }

--- a/Project/Engine/Graphics/PostEffect/Pipeline/PostEffectPipelineBuilder.cpp
+++ b/Project/Engine/Graphics/PostEffect/Pipeline/PostEffectPipelineBuilder.cpp
@@ -1,6 +1,7 @@
 #include "PostEffectPipelineBuilder.h"
 #include "DirectXCommon.h"
 #include "ShaderCompiler.h"
+#include "PipelineStatePresets.h"
 
 #include <cassert>
 #include <vector>
@@ -66,7 +67,7 @@ namespace Ken4lowEngine
 		D3D12_STATIC_SAMPLER_DESC samplers[2] = {};
 
 		// s0: バイリニア
-		samplers[0].Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+		samplers[0].Filter = PipelineStatePresets::ResolveSamplerFilter(D3D12_FILTER_MIN_MAG_MIP_LINEAR);
 		samplers[0].AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
 		samplers[0].AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
 		samplers[0].AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
@@ -306,7 +307,7 @@ namespace Ken4lowEngine
 		rootParams[3].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
 
 		D3D12_STATIC_SAMPLER_DESC samplerDesc[2]{};
-		samplerDesc[0].Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+		samplerDesc[0].Filter = PipelineStatePresets::ResolveSamplerFilter(D3D12_FILTER_MIN_MAG_MIP_LINEAR);
 		samplerDesc[0].AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
 		samplerDesc[0].AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
 		samplerDesc[0].AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;

--- a/Project/Engine/Graphics/Renderer/Animation/Pipeline/AnimationPipelineBuilder.cpp
+++ b/Project/Engine/Graphics/Renderer/Animation/Pipeline/AnimationPipelineBuilder.cpp
@@ -89,7 +89,7 @@ namespace Ken4lowEngine
 		descriptionRootSignature.Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
 
 		D3D12_STATIC_SAMPLER_DESC staticSamplers[1] = {};
-		staticSamplers[0].Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+		staticSamplers[0].Filter = PipelineStatePresets::ResolveSamplerFilter(D3D12_FILTER_MIN_MAG_MIP_LINEAR);
 		staticSamplers[0].AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
 		staticSamplers[0].AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
 		staticSamplers[0].AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
@@ -314,7 +314,7 @@ namespace Ken4lowEngine
 		rootParams[5].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
 
 		D3D12_STATIC_SAMPLER_DESC samplerDesc[1]{};
-		samplerDesc[0].Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+		samplerDesc[0].Filter = PipelineStatePresets::ResolveSamplerFilter(D3D12_FILTER_MIN_MAG_MIP_LINEAR);
 		samplerDesc[0].AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
 		samplerDesc[0].AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
 		samplerDesc[0].AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;

--- a/Project/Engine/Graphics/Renderer/GpuParticle/Pipeline/GpuParticleMeshPipeline.cpp
+++ b/Project/Engine/Graphics/Renderer/GpuParticle/Pipeline/GpuParticleMeshPipeline.cpp
@@ -4,6 +4,7 @@
 
 #include "BlendStateFactory.h"
 #include "ShaderCompiler.h"
+#include "PipelineStatePresets.h"
 #include "GpuParticleShaderManifest.h"
 
 namespace Ken4lowEngine
@@ -66,7 +67,7 @@ void GpuParticleMeshPipeline::CreateRootSignature()
 
 	// Static Sampler（スプライトと同じで開始）
 	D3D12_STATIC_SAMPLER_DESC samplers[1]{};
-	samplers[0].Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+	samplers[0].Filter = PipelineStatePresets::ResolveSamplerFilter(D3D12_FILTER_MIN_MAG_MIP_LINEAR);
 	samplers[0].AddressU = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
 	samplers[0].AddressV = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
 	samplers[0].AddressW = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3DPipelineSet.cpp
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3DPipelineSet.cpp
@@ -151,7 +151,7 @@ namespace Ken4lowEngine
 			rootParameters[kLightingSettingsCBV].Descriptor.ShaderRegister = 5;
 
 			staticSamplers[0] = {};
-			staticSamplers[0].Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+			staticSamplers[0].Filter = PipelineStatePresets::ResolveSamplerFilter(D3D12_FILTER_MIN_MAG_MIP_LINEAR);
 			// UV が 1 を超えるステージ/地面テクスチャを繰り返し表示できるようにする。
 			staticSamplers[0].AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
 			staticSamplers[0].AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;

--- a/Project/Engine/Graphics/Renderer/Particle/Manager/ParticleManager.cpp
+++ b/Project/Engine/Graphics/Renderer/Particle/Manager/ParticleManager.cpp
@@ -6,6 +6,7 @@
 #include <TextureManager.h>
 #include "BlendStateFactory.h"
 #include "ShaderCompiler.h"
+#include "PipelineStatePresets.h"
 #include "Camera.h"
 #include <ImGuiManager.h>
 #include <DebugCamera.h>
@@ -484,7 +485,7 @@ namespace Ken4lowEngine
 		descriptionRootSignature.NumParameters = _countof(rootParameters);								//配列の長さ
 
 		D3D12_STATIC_SAMPLER_DESC staticSamplers[1] = {};
-		staticSamplers[0].Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;										//バイリニアフィルタ
+		staticSamplers[0].Filter = PipelineStatePresets::ResolveSamplerFilter(D3D12_FILTER_MIN_MAG_MIP_LINEAR);										//バイリニアフィルタ
 		staticSamplers[0].AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;									//0～1の範囲外をリピート
 		staticSamplers[0].AddressV = D3D12_TEXTURE_ADDRESS_MODE_CLAMP;
 		staticSamplers[0].AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;

--- a/Project/Engine/Graphics/Renderer/SkyBox/SkyBoxPipelineSet.cpp
+++ b/Project/Engine/Graphics/Renderer/SkyBox/SkyBoxPipelineSet.cpp
@@ -63,7 +63,7 @@ namespace Ken4lowEngine
 			rootParameters[2].DescriptorTable.NumDescriptorRanges = 1;
 
 			*staticSampler = {};
-			staticSampler->Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
+			staticSampler->Filter = PipelineStatePresets::ResolveSamplerFilter(D3D12_FILTER_MIN_MAG_MIP_LINEAR);
 			staticSampler->AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
 			staticSampler->AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
 			staticSampler->AddressW = D3D12_TEXTURE_ADDRESS_MODE_WRAP;

--- a/Project/Engine/Graphics/Resource/Texture/TextureManager.cpp
+++ b/Project/Engine/Graphics/Resource/Texture/TextureManager.cpp
@@ -9,6 +9,7 @@
 #include <cctype>
 #include <filesystem>
 #include <format>
+#include <chrono>
 
 #include <d3dx12.h>
 
@@ -23,6 +24,39 @@ namespace Ken4lowEngine
 	{
 		static TextureManager instance;
 		return &instance;
+	}
+	std::vector<TextureManager::TextureDebugInfo> TextureManager::GetAllTextureDebugInfos() const
+	{
+		std::vector<TextureDebugInfo> infos;
+		infos.reserve(textureDatas.size());
+		for (const auto& [path, data] : textureDatas)
+		{
+			TextureDebugInfo info{};
+			info.loadedPath = path;
+			info.compiledDdsPath = path;
+			info.metadata = data.metaData;
+			const std::string lower = ToLowerString(path);
+			info.isPixelArtOrNoMip = (lower.find("pixelart") != std::string::npos) || (lower.find("nomip") != std::string::npos);
+			if (lower.find("resources/textures/compiled/") != std::string::npos)
+			{
+				info.sourcePath = path;
+				const size_t p = ToLowerString(info.sourcePath).find("/compiled/");
+				if (p != std::string::npos) { info.sourcePath.replace(p, 10, "/Sources/"); }
+				if (info.sourcePath.ends_with(".dds")) { info.sourcePath.replace(info.sourcePath.size() - 4, 4, ".png"); }
+			}
+			try
+			{
+				if (std::filesystem::exists(path))
+				{
+					auto ftime = std::filesystem::last_write_time(path);
+					const auto sctp = std::chrono::time_point_cast<std::chrono::system_clock::duration>(ftime - decltype(ftime)::clock::now() + std::chrono::system_clock::now());
+					info.lastWriteTime = std::format("{:%F %T}", sctp);
+				}
+			}
+			catch (...) {}
+			infos.push_back(std::move(info));
+		}
+		return infos;
 	}
 
 	void TextureManager::Initialize(DirectXCommon* dxCommon)

--- a/Project/Engine/Graphics/Resource/Texture/TextureManager.h
+++ b/Project/Engine/Graphics/Resource/Texture/TextureManager.h
@@ -27,6 +27,15 @@ namespace Ken4lowEngine
 		};
 
 	public:
+		struct TextureDebugInfo
+		{
+			std::string loadedPath;
+			std::string sourcePath;
+			std::string compiledDdsPath;
+			DirectX::TexMetadata metadata{};
+			bool isPixelArtOrNoMip = false;
+			std::string lastWriteTime;
+		};
 		static TextureManager* GetInstance();
 
 		void Initialize(DirectXCommon* dxCommon);
@@ -64,6 +73,7 @@ namespace Ken4lowEngine
 		// 追加
 		void BuildTexturePathIndex();
 		std::string FindCompiledTexturePath(const std::string& query) const;
+		std::vector<TextureDebugInfo> GetAllTextureDebugInfos() const;
 
 	private:
 		std::string NormalizeTexturePath(const std::string& filePath);


### PR DESCRIPTION
### Motivation
- Provide diagnostic visibility to locate where texture blurring occurs across TextureConverter / Sampler / DDS / Editor Viewport without large design changes. 
- Allow rapid, temporary verification whether sampling state (point vs linear) is the root cause by exposing a global sampler override. 
- Expose actual loaded/compiled texture paths and DDS metadata to confirm which assets the runtime is using and whether mipmaps/no-mip rules were applied.

### Description
- Added two ImGui editor panels `Texture Debug` and `Viewport Debug` with menu toggles under `Window -> Rendering`, and wired their draw calls into `EditorWindowManager::Draw()`; the panels show texture paths, metadata, mip counts, pixel-art/no-mip heuristics, last-write timestamps, RenderTexture size, displayed size, scale, 1:1 status and client size (see `EditorWindowManager.*`).
- Added `TextureManager::TextureDebugInfo` and `TextureManager::GetAllTextureDebugInfos()` which return loaded/compiled path, inferred source path, `DirectX::TexMetadata`, pixel-art/no-mip flag, and last write time for each loaded texture (see `TextureManager.*`).
- Added sampler diagnostic API in `PipelineStatePresets`: `SamplerDebugMode` enum, `ResolveSamplerFilter()`, `SetSamplerDebugMode()` and `GetSamplerDebugMode()`, implemented with an intent comment and a global debug-mode variable to let pipelines resolve to `D3D12_FILTER_MIN_MAG_MIP_POINT` or `D3D12_FILTER_MIN_MAG_MIP_LINEAR` when requested.
- Replaced direct uses of `D3D12_FILTER_MIN_MAG_MIP_LINEAR` / `D3D12_FILTER_ANISOTROPIC` in key pipeline root-signature/static-sampler initializations with `PipelineStatePresets::ResolveSamplerFilter(...)` for cross-pipeline force-point/force-linear diagnostics (Object3D, Animation/Skinned, Skybox, GpuParticle, Particle, PostEffect), and added ImGui radio buttons to switch modes at runtime (see modified pipeline files and `EditorWindowManager` UI).

### Testing
- No automated unit/integration tests were executed in this environment; build/run was not performed here. 
- Repository changes were staged and committed successfully (`git commit` completed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e78cff9a4832d84bb055c631ad5e9)