### PR TITLE
Add SpotLight-priority shadow controls and tighten punctual direct-light falloff

### DIFF
--- a/Project/Engine/Graphics/Lighting/LightManager.cpp
+++ b/Project/Engine/Graphics/Lighting/LightManager.cpp
@@ -403,6 +403,17 @@ namespace Ken4lowEngine
 			ImGui::PopID();
 		}
 
+		ImGui::Separator();
+		ImGui::Checkbox("Enable Shadow", &enableShadow_);
+		ImGui::SliderFloat("Shadow Bias", &shadowBias_, 0.0f, 0.01f, "%.6f");
+		ImGui::SliderFloat("Normal Bias", &normalBias_, 0.0f, 0.1f, "%.4f");
+		ImGui::SliderFloat("Shadow Strength", &shadowStrength_, 0.0f, 1.0f);
+		int shadowMapSize = static_cast<int>(shadowMapSize_);
+		if (ImGui::InputInt("Shadow Map Size", &shadowMapSize)) {
+			shadowMapSize_ = static_cast<uint32_t>(std::clamp(shadowMapSize, 256, 4096));
+			dxCommon_->SetShadowMapSize(shadowMapSize_, shadowMapSize_);
+		}
+		ImGui::Checkbox("Show ShadowMap Debug", &showShadowMapDebug_);
 		ImGui::Text("Active Lights (type!=0): will be uploaded");
 #endif // USE_IMGUI
 	}

--- a/Project/Engine/Graphics/Lighting/LightManager.h
+++ b/Project/Engine/Graphics/Lighting/LightManager.h
@@ -131,6 +131,11 @@ namespace Ken4lowEngine
 		/// <returns>PunctualLightGPU オブジェクトのベクトルへの const 参照。</returns>
 		const std::vector<PunctualLightGPU>& GetPunctualLights() const { return punctualLights_; }
 		const LightingSettingsGPU& GetLightingSettings() const { return lightingSettings_; }
+		float GetShadowBias() const { return shadowBias_; }
+		float GetNormalBias() const { return normalBias_; }
+		float GetShadowStrength() const { return shadowStrength_; }
+		bool IsShadowEnabled() const { return enableShadow_; }
+		uint32_t GetShadowMapSize() const { return shadowMapSize_; }
 		LightingSettingsGPU& GetMutableLightingSettingsForEditor() { return lightingSettings_; }
 
 		// Editor Detailsから選択中ライトだけを書き換えるため、index検証付きヘルパー経由でのみ利用する。
@@ -187,6 +192,12 @@ namespace Ken4lowEngine
 		Microsoft::WRL::ComPtr<ID3D12Resource> lightingSettingsResource_;
 		LightingSettingsGPU* lightingSettingsData_ = nullptr;
 		LightingSettingsGPU lightingSettings_{};
+		bool enableShadow_ = true;
+		float shadowBias_ = 0.00045f;
+		float normalBias_ = 0.025f;
+		float shadowStrength_ = 0.6f;
+		uint32_t shadowMapSize_ = 2048;
+		bool showShadowMapDebug_ = false;
 
 	private: /// ---------- コピー禁止 ---------- ///
 

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3D.cpp
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3D.cpp
@@ -85,33 +85,37 @@ namespace Ken4lowEngine
 		// カメラ用バッファ更新
 		cameraData->worldPosition = CameraManager::GetInstance()->GetActiveCameraPosition();
 
-		// 平行光源の向きからシャドウ行列を毎フレーム作り直す
-		Vector3 lightDir = { 0.3f, -1.0f, 0.2f }; // fallback
-
-		const auto& lights = LightManager::GetInstance()->GetPunctualLights();
+		// SpotLight優先でライト視点行列を作り、無ければDirectionalへフォールバックする。
+		Vector3 lightDir = { 0.3f, -1.0f, 0.2f };
+		Vector3 lightPos = cameraData->worldPosition - lightDir * 20.0f;
+		float spotDistance = 80.0f;
+		bool useSpotShadow = false;
+		const auto* lightMgr = LightManager::GetInstance();
+		const auto& lights = lightMgr->GetPunctualLights();
 		for (const auto& light : lights)
 		{
+			if (light.lightType == 3)
+			{
+				lightPos = light.position;
+				lightDir = Vector3::Normalize(light.direction);
+				spotDistance = std::max(light.distance, 5.0f);
+				useSpotShadow = true;
+				break;
+			}
 			if (light.lightType == 1)
 			{
 				lightDir = Vector3::Normalize(light.direction);
-				break;
 			}
 		}
 
-		// まずはカメラ中心で十分
 		const Vector3 focusPos = cameraData->worldPosition;
-
-		const Matrix4x4 lightViewProjection = Matrix4x4::MakeLightViewProjection(
-			lightDir,
-			focusPos,
-			60.0f,   // distanceFromTarget
-			35.0f,   // orthoHalfWidth
-			35.0f,   // orthoHalfHeight
-			0.1f,    // nearZ
-			120.0f   // farZ
-		);
+		const Matrix4x4 lightViewProjection = useSpotShadow
+			? Matrix4x4::MakePerspectiveFovMatrix(1.2f, 1.0f, 0.1f, spotDistance) * Matrix4x4::MakeLookAtMatrix(lightPos, lightPos + lightDir, {0.0f,1.0f,0.0f})
+			: Matrix4x4::MakeLightViewProjection(lightDir, focusPos, 60.0f, 35.0f, 35.0f, 0.1f, 120.0f);
 
 		UpdateShadowMatrix(lightViewProjection);
+		shadowParameterData_->shadowBias = lightMgr->GetShadowBias();
+		shadowParameterData_->normalBias = lightMgr->GetNormalBias();
 	}
 
 	void Object3D::UpdateWithWorldMatrix(const Matrix4x4& worldMatrix)
@@ -155,8 +159,7 @@ namespace Ken4lowEngine
 
 		// シャドウマップ用の行列を GPU に転送
 		shadowParameterData_->lightViewProjection = lightViewProjection;
-		shadowParameterData_->shadowBias = 0.00045f;
-		shadowParameterData_->normalBias = 0.025f;
+
 	}
 
 	/// -------------------------------------------------------------

--- a/Project/Resources/Shaders/Object3D/LightingCommon.hlsli
+++ b/Project/Resources/Shaders/Object3D/LightingCommon.hlsli
@@ -108,14 +108,15 @@ LightingTerms EvaluatePointLight(
     float3 lightDir = toL / max(d, kMinLightLength);
 
     float range = max(light.radius, kMinRange);
-    float atten = pow(saturate(1.0f - d / range), max(light.decay, kMinRange));
+    float rangeMask = step(d, range);
+    float atten = pow(saturate(1.0f - d / range), max(light.decay, kMinRange)) * rangeMask;
 
-    // 点光源も通常Lambertで拡散光を計算する。
+    // ライト範囲外はDirect Lightを0にしてAmbientだけ残す。
     float NdotL = saturate(dot(normal, lightDir));
     float3 lightColor = light.color.rgb * (light.intensity * atten);
 
     terms.diffuse = lightColor * NdotL;
-    terms.specular = lightColor * ComputeSpecular(normal, lightDir, viewDir, shininess);
+    terms.specular = lightColor * ComputeSpecular(normal, lightDir, viewDir, shininess) * NdotL;
     return terms;
 }
 
@@ -133,18 +134,19 @@ LightingTerms EvaluateSpotLight(
     float3 lightDir = toL / max(d, kMinLightLength);
 
     float range = max(light.distance, kMinRange);
-    float atten = pow(saturate(1.0f - d / range), max(light.decay, kMinRange));
+    float rangeMask = step(d, range);
+    float atten = pow(saturate(1.0f - d / range), max(light.decay, kMinRange)) * rangeMask;
 
     float3 dir = normalize(light.direction);
     float ct = dot(-dir, lightDir);
-    float spot = smoothstep(light.cosAngle, light.cosFalloffStart, ct);
+    float spot = smoothstep(light.cosAngle, light.cosFalloffStart, ct) * step(light.cosAngle, ct);
 
     // スポット光もHalf Lambertではなく通常Lambertを基本にする。
     float NdotL = saturate(dot(normal, lightDir));
     float3 lightColor = light.color.rgb * (light.intensity * atten * spot);
 
     terms.diffuse = lightColor * NdotL;
-    terms.specular = lightColor * ComputeSpecular(normal, lightDir, viewDir, shininess);
+    terms.specular = lightColor * ComputeSpecular(normal, lightDir, viewDir, shininess) * NdotL;
     return terms;
 }
 


### PR DESCRIPTION
### Motivation
- 点光源/スポットライトで直接光が届かない場所まで明るく見えてしまう問題を修正し、まずはスポットシャドウを優先して実装するための変更です。 
- デバッグしやすいようにImGuiのLight Editorからシャドウ関連パラメータを調整可能にします。 

### Description
- シェーダ修正: `Project/Resources/Shaders/Object3D/LightingCommon.hlsli` の `EvaluatePointLight` / `EvaluateSpotLight` にレンジマスク(`step(d, range)`)とスポット角外マスク、及び `specular` に `NdotL` を乗算して「光が届かない場所でのDirect寄与とハイライト漏れ」を抑制しました。 
- SpotLight シャドウ行列: `Project/Engine/Graphics/Renderer/Object3D/Object3D.cpp` の `Update()` でスポットライトを優先してライト視点行列を生成し、存在時は `MakeLookAtMatrix` + `MakePerspectiveFovMatrix` を用いて Shadow VP を作成するようにしました。 
- シャドウパラメータ連携: `Object3D` 側で `shadowParameterData_->lightViewProjection` に加え、`shadowBias`/`normalBias` を `LightManager` 側の値から取得して反映するようにしました。 
- Light Editor (ImGui): `Project/Engine/Graphics/Lighting/LightManager.cpp` に以下のデバッグ項目を追加しました: `Enable Shadow`, `Shadow Bias`, `Normal Bias`, `Shadow Strength`, `Shadow Map Size`（`DirectXCommon::SetShadowMapSize` に接続）および `Show ShadowMap Debug`。 
- LightManager 拡張: `Project/Engine/Graphics/Lighting/LightManager.h` にシャドウ設定の保持メンバと getter を追加しました（`enableShadow_`, `shadowBias_`, `normalBias_`, `shadowStrength_`, `shadowMapSize_`, `showShadowMapDebug_`）。 
- ファイル一覧（変更済み）: `LightingCommon.hlsli`, `Object3D.cpp`, `LightManager.h`, `LightManager.cpp`. 
- PointLight シャドウ実装は今回見送り（B案）とし、まずは範囲外/減衰/Direct/Ambient 分離を修正しました。 

### Testing
- 自動チェックとして `git diff --check` を実行して問題がないことを確認しました。 
- 変更はコミット済みですが、Debug/Release のフルビルドやレンダー動作の自動化テストはこの環境では実行していません。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e7f31ecd4832dada36d189ad400f9)