### PR TITLE
Add Texture2DArray support for PointLight shadow maps (6-face array)

### DIFF
--- a/Project/Engine/Graphics/Descriptor/DSV/DSVManager.cpp
+++ b/Project/Engine/Graphics/Descriptor/DSV/DSVManager.cpp
@@ -114,6 +114,31 @@ namespace Ken4lowEngine
 		return depthBuffer;
 	}
 
+	ComPtr<ID3D12Resource> DSVManager::CreateShadowMapArrayResource(uint32_t width, uint32_t height, uint16_t arraySize)
+	{
+		D3D12_RESOURCE_DESC depthDesc{};
+		depthDesc.Dimension = D3D12_RESOURCE_DIMENSION_TEXTURE2D;
+		depthDesc.Width = width;
+		depthDesc.Height = height;
+		depthDesc.DepthOrArraySize = arraySize;
+		depthDesc.MipLevels = 1;
+		depthDesc.Format = DXGI_FORMAT_R32_TYPELESS;
+		depthDesc.SampleDesc.Count = 1;
+		depthDesc.Layout = D3D12_TEXTURE_LAYOUT_UNKNOWN;
+		depthDesc.Flags = D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL;
+
+		D3D12_CLEAR_VALUE clearValue{};
+		clearValue.Format = DXGI_FORMAT_D32_FLOAT;
+		clearValue.DepthStencil.Depth = 1.0f;
+		clearValue.DepthStencil.Stencil = 0;
+
+		CD3DX12_HEAP_PROPERTIES heapProps(D3D12_HEAP_TYPE_DEFAULT);
+		ComPtr<ID3D12Resource> depthBuffer;
+		HRESULT hr = dxCommon_->GetDevice()->CreateCommittedResource(&heapProps, D3D12_HEAP_FLAG_NONE, &depthDesc, D3D12_RESOURCE_STATE_DEPTH_WRITE, &clearValue, IID_PPV_ARGS(&depthBuffer));
+		assert(SUCCEEDED(hr) && "Failed to create Shadow Map Array Resource!");
+		return depthBuffer;
+	}
+
 
 	/// -------------------------------------------------------------
 	///				DSVを確保（未使用のインデックスを取得）
@@ -196,6 +221,21 @@ namespace Ken4lowEngine
 		dsvDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2D;
 		dsvDesc.Flags = D3D12_DSV_FLAG_NONE;
 		dsvDesc.Texture2D.MipSlice = 0;
+
+		dxCommon_->GetDevice()->CreateDepthStencilView(resource, &dsvDesc, GetCPUDescriptorHandle(dsvIndex));
+	}
+
+	void DSVManager::CreateDSVForShadowMapArraySlice(uint32_t dsvIndex, ID3D12Resource* resource, uint32_t arraySlice)
+	{
+		assert(resource && "ShadowMap array resource is null!");
+
+		D3D12_DEPTH_STENCIL_VIEW_DESC dsvDesc{};
+		dsvDesc.Format = DXGI_FORMAT_D32_FLOAT;
+		dsvDesc.ViewDimension = D3D12_DSV_DIMENSION_TEXTURE2DARRAY;
+		dsvDesc.Flags = D3D12_DSV_FLAG_NONE;
+		dsvDesc.Texture2DArray.MipSlice = 0;
+		dsvDesc.Texture2DArray.FirstArraySlice = arraySlice;
+		dsvDesc.Texture2DArray.ArraySize = 1;
 
 		dxCommon_->GetDevice()->CreateDepthStencilView(resource, &dsvDesc, GetCPUDescriptorHandle(dsvIndex));
 	}

--- a/Project/Engine/Graphics/Descriptor/DSV/DSVManager.h
+++ b/Project/Engine/Graphics/Descriptor/DSV/DSVManager.h
@@ -56,6 +56,7 @@ public: /// ---------- メンバ関数 ---------- ///
 	ComPtr<ID3D12Resource> CreateDepthStencilBuffer(uint32_t width, uint32_t height, DXGI_FORMAT format, D3D12_CLEAR_VALUE& outClearValue);
 
 	ComPtr<ID3D12Resource> CreateShadowMapResource(uint32_t width, uint32_t height);
+	ComPtr<ID3D12Resource> CreateShadowMapArrayResource(uint32_t width, uint32_t height, uint16_t arraySize);
 
 	/// <summary>
 	/// 空いている DSV インデックスを 1 つ確保して返します。<br/>
@@ -93,6 +94,7 @@ public: /// ---------- メンバ関数 ---------- ///
 	void CreateDSVForTexture2D(uint32_t dsvIndex, ID3D12Resource* resource);
 
 	void CreateDSVForShadowMap(uint32_t dsvIndex, ID3D12Resource* resource);
+	void CreateDSVForShadowMapArraySlice(uint32_t dsvIndex, ID3D12Resource* resource, uint32_t arraySlice);
 
 public: /// ---------- ゲッター ---------- ///
 

--- a/Project/Engine/Graphics/Descriptor/SRV/SRVManager.cpp
+++ b/Project/Engine/Graphics/Descriptor/SRV/SRVManager.cpp
@@ -130,6 +130,25 @@ namespace Ken4lowEngine
 		dxCommon_->GetDevice()->CreateShaderResourceView(shadowMap, &srvDesc, GetCPUDescriptorHandle(srvIndex));
 	}
 
+	void SRVManager::CreateSRVForShadowMapArray(uint32_t srvIndex, ID3D12Resource* shadowMap, uint32_t arraySize)
+	{
+		assert(shadowMap && "shadowMap array resource is null in CreateSRVForShadowMapArray");
+
+		D3D12_SHADER_RESOURCE_VIEW_DESC srvDesc{};
+		srvDesc.Format = DXGI_FORMAT_R32_FLOAT;
+		srvDesc.Shader4ComponentMapping = D3D12_DEFAULT_SHADER_4_COMPONENT_MAPPING;
+		srvDesc.ViewDimension = D3D12_SRV_DIMENSION_TEXTURE2DARRAY;
+		srvDesc.Texture2DArray.MostDetailedMip = 0;
+		srvDesc.Texture2DArray.MipLevels = 1;
+		srvDesc.Texture2DArray.FirstArraySlice = 0;
+		srvDesc.Texture2DArray.ArraySize = arraySize;
+		srvDesc.Texture2DArray.PlaneSlice = 0;
+		srvDesc.Texture2DArray.ResourceMinLODClamp = 0.0f;
+
+		// PointLight向けの6面深度配列をまとめて参照できるSRVを作成する。
+		dxCommon_->GetDevice()->CreateShaderResourceView(shadowMap, &srvDesc, GetCPUDescriptorHandle(srvIndex));
+	}
+
 
 	/// -------------------------------------------------------------
 	///						ヒープセットコマンド

--- a/Project/Engine/Graphics/Descriptor/SRV/SRVManager.h
+++ b/Project/Engine/Graphics/Descriptor/SRV/SRVManager.h
@@ -61,6 +61,7 @@ namespace Ken4lowEngine
 		void CreateSRVForStructureBuffer(uint32_t srvIndex, ID3D12Resource* pResource, UINT numElements, UINT structureByteStride);
 
 		void CreateSRVForShadowMap(uint32_t srvIndex, ID3D12Resource* shadowMap);
+		void CreateSRVForShadowMapArray(uint32_t srvIndex, ID3D12Resource* shadowMap, uint32_t arraySize);
 
 		/// <summary>
 		/// 描画前に、この SRV ヒープをコマンドリストへセットします。<br/>

--- a/Project/Engine/Graphics/Lighting/LightManager.cpp
+++ b/Project/Engine/Graphics/Lighting/LightManager.cpp
@@ -427,6 +427,10 @@ namespace Ken4lowEngine
 		}
 		ImGui::Checkbox("Show ShadowMap Debug", &showShadowMapDebug_);
 		ImGui::Checkbox("Show Shadow Factor", &showShadowFactorDebug_);
+		const bool pointShadowReady = (dxCommon_ && dxCommon_->GetShadowMapRenderTarget()) ? dxCommon_->GetShadowMapRenderTarget()->IsPointShadowArrayReady() : false;
+		ImGui::Text("PointLight Shadow Resource: %s", pointShadowReady ? "Ready" : "Not Ready");
+		ImGui::Text("PointLight Shadow Type: Texture2DArray(6)");
+		ImGui::Text("PointLight Shadow is not applied yet");
 				if (hasPointLight)
 		{
 			ImGui::TextColored(ImVec4(1.0f, 0.75f, 0.2f, 1.0f), "PointLight Shadow: Not Implemented (Cube ShadowMap required)");

--- a/Project/Engine/Graphics/RenderTarget/Shadow/ShadowMapRenderTarget.cpp
+++ b/Project/Engine/Graphics/RenderTarget/Shadow/ShadowMapRenderTarget.cpp
@@ -26,6 +26,7 @@ namespace Ken4lowEngine
 	{
 		ReleaseDescriptors();
 		shadowMapResource_.Reset();
+		pointShadowArrayResource_.Reset();
 		dxCommon_ = nullptr;
 	}
 
@@ -40,6 +41,12 @@ namespace Ken4lowEngine
 		);
 		// ShadowMapRenderTargetにも名前を付け、深度RTのDebugLayer出力を特定しやすくする。
 		shadowMapResource_->SetName(L"ShadowMapRenderTarget");
+		pointShadowArrayResource_ = DSVManager::GetInstance()->CreateShadowMapArrayResource(
+			settings_.width,
+			settings_.height,
+			6
+		);
+		pointShadowArrayResource_->SetName(L"PointShadowMapArrayRenderTarget");
 
 		// 新規生成直後は depth write 状態
 		resourceState_ = D3D12_RESOURCE_STATE_DEPTH_WRITE;
@@ -74,6 +81,23 @@ namespace Ken4lowEngine
 		{
 			srvManager->CreateSRVForShadowMap(shadowMapSrvIndex_, shadowMapResource_.Get());
 		}
+
+		for (uint32_t face = 0; face < 6; ++face)
+		{
+			if (!hasCreatedPointShadowArrayDSV_[face])
+			{
+				pointShadowArrayDsvIndices_[face] = dsvManager->Allocate();
+				hasCreatedPointShadowArrayDSV_[face] = true;
+			}
+			dsvManager->CreateDSVForShadowMapArraySlice(pointShadowArrayDsvIndices_[face], pointShadowArrayResource_.Get(), face);
+		}
+		if (!hasCreatedPointShadowArraySRV_)
+		{
+			pointShadowArraySrvIndex_ = srvManager->Allocate();
+			hasCreatedPointShadowArraySRV_ = true;
+		}
+		// PointLightの6方向深度を1つのTexture2DArray SRVで参照できるようにする。
+		srvManager->CreateSRVForShadowMapArray(pointShadowArraySrvIndex_, pointShadowArrayResource_.Get(), 6);
 	}
 
 	/// -------------------------------------------------------------
@@ -96,6 +120,21 @@ namespace Ken4lowEngine
 			srvManager->Free(shadowMapSrvIndex_);
 			shadowMapSrvIndex_ = UINT32_MAX;
 			hasCreatedSRV_ = false;
+		}
+		for (uint32_t face = 0; face < 6; ++face)
+		{
+			if (hasCreatedPointShadowArrayDSV_[face])
+			{
+				dsvManager->Free(pointShadowArrayDsvIndices_[face]);
+				pointShadowArrayDsvIndices_[face] = UINT32_MAX;
+				hasCreatedPointShadowArrayDSV_[face] = false;
+			}
+		}
+		if (hasCreatedPointShadowArraySRV_)
+		{
+			srvManager->Free(pointShadowArraySrvIndex_);
+			pointShadowArraySrvIndex_ = UINT32_MAX;
+			hasCreatedPointShadowArraySRV_ = false;
 		}
 	}
 

--- a/Project/Engine/Graphics/RenderTarget/Shadow/ShadowMapRenderTarget.h
+++ b/Project/Engine/Graphics/RenderTarget/Shadow/ShadowMapRenderTarget.h
@@ -52,6 +52,9 @@ namespace Ken4lowEngine
 
 		uint32_t GetWidth() const { return settings_.width; }
 		uint32_t GetHeight() const { return settings_.height; }
+		ID3D12Resource* GetPointShadowArrayResource() const { return pointShadowArrayResource_.Get(); }
+		uint32_t GetPointShadowArraySrvIndex() const { return pointShadowArraySrvIndex_; }
+		bool IsPointShadowArrayReady() const { return pointShadowArrayResource_ != nullptr && hasCreatedPointShadowArraySRV_; }
 
 	private:
 		void CreateResource();
@@ -68,14 +71,19 @@ namespace Ken4lowEngine
 
 		// シャドウマップ用深度テクスチャ
 		Microsoft::WRL::ComPtr<ID3D12Resource> shadowMapResource_;
+		Microsoft::WRL::ComPtr<ID3D12Resource> pointShadowArrayResource_;
 
 		// DSV / SRV のヒープ上インデックス
 		uint32_t shadowMapDsvIndex_ = UINT32_MAX;
 		uint32_t shadowMapSrvIndex_ = UINT32_MAX;
+		uint32_t pointShadowArrayDsvIndices_[6] = { UINT32_MAX, UINT32_MAX, UINT32_MAX, UINT32_MAX, UINT32_MAX, UINT32_MAX };
+		uint32_t pointShadowArraySrvIndex_ = UINT32_MAX;
 
 		// 二重確保防止用
 		bool hasCreatedDSV_ = false;
 		bool hasCreatedSRV_ = false;
+		bool hasCreatedPointShadowArrayDSV_[6] = { false, false, false, false, false, false };
+		bool hasCreatedPointShadowArraySRV_ = false;
 
 		// viewport / scissor
 		D3D12_VIEWPORT viewport_{};


### PR DESCRIPTION
### Motivation
- Extend shadow map support to accommodate PointLight shadows by creating a 6-slice Texture2DArray and per-slice DSVs/SRV so point lights can store six directions in a single resource.
- Provide utility functions in descriptor managers to create and bind Texture2DArray depth resources and array SRVs/DSVs.

### Description
- Added `CreateShadowMapArrayResource` to `DSVManager` to create a typeless Texture2D array depth resource with depth-stencil clear value and `D3D12_RESOURCE_FLAG_ALLOW_DEPTH_STENCIL`.
- Added `CreateDSVForShadowMapArraySlice` to `DSVManager` to create a `D3D12_DSV_DIMENSION_TEXTURE2DARRAY` view for a single array slice.
- Added `CreateSRVForShadowMapArray` to `SRVManager` to create a `D3D12_SRV_DIMENSION_TEXTURE2DARRAY` SRV that references multiple array slices.
- Extended `ShadowMapRenderTarget` to allocate and own a 6-slice point shadow array resource, create per-face DSVs, and a single array SRV for sampling all six faces, and added related members/getters and cleanup logic.
- Updated `ShadowMapRenderTarget` initialization to name the new resources and updated the lighting UI to display the point shadow array status and type.
- Updated headers to expose the new functions and getters and added bookkeeping fields for per-face indices and flags.

### Testing
- Performed an automated full project build which completed successfully with the new code integrated.
- Ran the project's automated test suite (unit/integration tests) and all tests passed with no regressions detected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e94511e2c832dbcee44091d94755d)