### PR TITLE
Add approximate Rect/Sphere AreaLight support (no shadows)

### DIFF
--- a/Project/Engine/Graphics/Lighting/LightManager.cpp
+++ b/Project/Engine/Graphics/Lighting/LightManager.cpp
@@ -171,9 +171,9 @@ namespace Ken4lowEngine
 		std::vector<PunctualLightGPU> gpuLights;
 		gpuLights.reserve(punctualLights_.size());
 		for (const auto& L : punctualLights_) {
-			if (L.lightType == 0) continue;           // 無効はスキップ
+			if (L.lightType == 0 || L.enabled == 0u) continue;           // 無効はスキップ
 			PunctualLightGPU C = L;
-			if (C.lightType == 1 || C.lightType == 3) // Dir/Spot は方向を正規化して安全に
+			if (C.lightType == 1 || C.lightType == 3 || C.lightType == 4 || C.lightType == 5) // Dir/Spot/Area は方向を正規化
 				C.direction = Vector3::Normalize(C.direction);
 			gpuLights.push_back(C);
 		}
@@ -225,6 +225,7 @@ namespace Ken4lowEngine
 		const float   dirLen = 1.5f;                      // 方向線の長さ
 
 		for (const auto& L : punctualLights_) {
+			if (L.enabled == 0u) { continue; }
 			switch (L.lightType) {
 			case 1: { // Directional
 				Vector3 base = { 0.0f, 3.0f, 0.0f };
@@ -275,6 +276,30 @@ namespace Ken4lowEngine
 				// 必要なら開き角をリングで表現する処理も追加可能
 				break;
 			}
+			case 4: { // RectArea (approx)
+				const Vector4 colArea = { 0.4f, 1.0f, 0.4f, 1.0f };
+				Vector3 d = Vector3::Normalize(L.direction);
+				Vector3 up = (std::fabs(d.y) > 0.95f) ? Vector3{ 1.0f,0.0f,0.0f } : Vector3{ 0.0f,1.0f,0.0f };
+				Vector3 right = Vector3::Normalize(Vector3::Cross(up, d));
+				up = Vector3::Normalize(Vector3::Cross(d, right));
+				float hw = std::max(L.areaSize.x * 0.5f, 0.05f);
+				float hh = std::max(L.areaSize.y * 0.5f, 0.05f);
+				Vector3 c = L.position;
+				Vector3 p0 = c + right * hw + up * hh;
+				Vector3 p1 = c - right * hw + up * hh;
+				Vector3 p2 = c - right * hw - up * hh;
+				Vector3 p3 = c + right * hw - up * hh;
+				wf->DrawLine(p0, p1, colArea); wf->DrawLine(p1, p2, colArea);
+				wf->DrawLine(p2, p3, colArea); wf->DrawLine(p3, p0, colArea);
+				wf->DrawLine(c, c + d * dirLen, colArea);
+				break;
+			}
+			case 5: { // SphereArea (approx)
+				const Vector4 colAreaSphere = { 0.6f, 1.0f, 0.4f, 1.0f };
+				wf->DrawSphere(L.position, std::max(L.areaSize.z, 0.1f), colAreaSphere);
+				if (L.distance > 0.0f) { wf->DrawSphere(L.position, L.distance, { colAreaSphere.x,colAreaSphere.y,colAreaSphere.z,0.45f }); }
+				break;
+			}
 			default:
 				break;
 			}
@@ -294,7 +319,7 @@ namespace Ken4lowEngine
 		if (!punctualLights_.empty())
 		{
 			const auto& first = punctualLights_.front();
-			const char* summaryTypes[] = { "None", "Directional", "Point", "Spot" };
+			const char* summaryTypes[] = { "None", "Directional", "Point", "Spot", "RectArea", "SphereArea" };
 			const uint32_t typeIndex = (first.lightType < static_cast<uint32_t>(IM_ARRAYSIZE(summaryTypes))) ? first.lightType : 0;
 			Vector3 eulerDeg = DirectionToEulerDeg(first.direction);
 			ImGui::Text("Light #0 Type: %s", summaryTypes[typeIndex]);
@@ -329,6 +354,10 @@ namespace Ken4lowEngine
 			L.color = { 1,1,1,1 };
 			L.intensity = 1.0f;
 			L.direction = { 0,-1,0 };
+			L.areaSize = { 2.0f, 2.0f, 1.0f };
+			L.distance = 10.0f;
+			L.decay = 1.0f;
+			L.enabled = 1u;
 			punctualLights_.push_back(L);
 		}
 		ImGui::SameLine();
@@ -346,7 +375,7 @@ namespace Ken4lowEngine
 			ImGui::Text("Light #%zu", i);
 
 			int type = static_cast<int>(L.lightType);
-			const char* types[] = { "None","Directional","Point","Spot" };
+			const char* types[] = { "None","Directional","Point","Spot","RectArea","SphereArea" };
 			if (ImGui::Combo("Type", &type, types, IM_ARRAYSIZE(types)))
 			{
 				L.lightType = static_cast<uint32_t>(type);
@@ -354,6 +383,8 @@ namespace Ken4lowEngine
 
 			ImGui::ColorEdit4("Color", &L.color.x);
 			ImGui::SliderFloat("Intensity", &L.intensity, 0.0f, 20.0f);
+			bool enabled = (L.enabled != 0u);
+			if (ImGui::Checkbox("Enabled", &enabled)) { L.enabled = enabled ? 1u : 0u; }
 
 			if (L.lightType == 1)
 			{
@@ -393,6 +424,34 @@ namespace Ken4lowEngine
 				ImGui::SliderFloat("cosOuter", &L.cosAngle, 0.0f, 1.0f);
 				if (L.cosFalloffStart < L.cosAngle) L.cosFalloffStart = L.cosAngle;
 			}
+			else if (L.lightType == 4)
+			{
+				// 疑似AreaLightは矩形面の最近点を仮想PointLightとして扱う近似モデル。
+				ImGui::SliderFloat3("Position", &L.position.x, -50.0f, 50.0f);
+				Vector3 eulerDeg = DirectionToEulerDeg(L.direction);
+				bool changed = false;
+				changed |= ImGui::DragFloat("Pitch (X)", &eulerDeg.x, 0.5f, -89.0f, 89.0f, "%.1f deg");
+				changed |= ImGui::DragFloat("Yaw (Y)", &eulerDeg.y, 0.5f, -180.0f, 180.0f, "%.1f deg");
+				if (changed) { L.direction = EulerDegToDirection(eulerDeg); }
+				ImGui::SliderFloat("Width", &L.areaSize.x, 0.1f, 50.0f);
+				ImGui::SliderFloat("Height", &L.areaSize.y, 0.1f, 50.0f);
+				ImGui::SliderFloat("Range", &L.distance, 0.1f, 200.0f);
+				ImGui::SliderFloat("Decay", &L.decay, 0.0f, 10.0f);
+			}
+			else if (L.lightType == 5)
+			{
+				ImGui::SliderFloat3("Position", &L.position.x, -50.0f, 50.0f);
+				if (ImGui::SliderFloat3("Direction", &L.direction.x, -1.0f, 1.0f)) { L.direction = Vector3::Normalize(L.direction); }
+				ImGui::SliderFloat("Radius", &L.areaSize.z, 0.1f, 50.0f);
+				ImGui::SliderFloat("Range", &L.distance, 0.1f, 200.0f);
+				ImGui::SliderFloat("Decay", &L.decay, 0.0f, 10.0f);
+			}
+			ImGui::Text("AreaLight active: %s", (L.enabled && (L.lightType == 4 || L.lightType == 5)) ? "true" : "false");
+			ImGui::Text("AreaLight type: %s", (L.lightType == 4) ? "RectArea" : ((L.lightType == 5) ? "SphereArea" : "N/A"));
+			ImGui::Text("area size: (%.2f, %.2f, %.2f)", L.areaSize.x, L.areaSize.y, L.areaSize.z);
+			ImGui::Text("range: %.2f  intensity: %.2f", L.distance, L.intensity);
+			ImGui::Text("light direction: (%.2f, %.2f, %.2f)", L.direction.x, L.direction.y, L.direction.z);
+			ImGui::Text("debug wire visible: %s", ((L.enabled != 0u) && (L.lightType == 4 || L.lightType == 5)) ? "true" : "false");
 
 			if (ImGui::Button("Remove"))
 			{
@@ -405,7 +464,8 @@ namespace Ken4lowEngine
 		}
 
 		ImGui::Separator();
-				const bool hasPointLight = std::any_of(punctualLights_.begin(), punctualLights_.end(), [](const PunctualLightGPU& light) { return light.lightType == 2 && light.intensity > 0.0f; });
+		const bool hasPointLight = std::any_of(punctualLights_.begin(), punctualLights_.end(), [](const PunctualLightGPU& light) { return light.lightType == 2 && light.intensity > 0.0f && light.enabled != 0u; });
+		const bool hasAreaLight = std::any_of(punctualLights_.begin(), punctualLights_.end(), [](const PunctualLightGPU& light) { return (light.lightType == 4 || light.lightType == 5) && light.intensity > 0.0f && light.enabled != 0u; });
 		const bool hasShadowCaster = (GetActiveShadowCasterType() != ShadowCasterType::None);
 		if (!hasShadowCaster && hasPointLight)
 		{
@@ -435,6 +495,11 @@ namespace Ken4lowEngine
 		else
 		{
 			ImGui::Text("PointLight Shadow: Not Implemented");
+		}
+		if (hasAreaLight)
+		{
+			ImGui::TextColored(ImVec4(0.75f, 1.0f, 0.75f, 1.0f), "AreaLight Shadow: Not Implemented");
+			ImGui::Text("AreaLight Model: Approximation");
 		}
 		for (const auto& L : punctualLights_)
 		{
@@ -472,7 +537,7 @@ namespace Ken4lowEngine
 	{
 		for (const auto& light : punctualLights_)
 		{
-			if (light.intensity <= 0.0f) { continue; }
+			if (light.intensity <= 0.0f || light.enabled == 0u) { continue; }
 			if (light.lightType == 3) { return ShadowCasterType::Spot; }
 			if (light.lightType == 1) { return ShadowCasterType::Directional; }
 		}
@@ -574,6 +639,7 @@ namespace Ken4lowEngine
 		light.color = { 1.0f, 1.0f, 1.0f, 1.0f };
 		light.intensity = 1.0f;
 		light.direction = Vector3::Normalize({ 0.3f, -1.0f, 0.2f });
+		light.enabled = 1u;
 
 		punctualLights_.clear();
 		punctualLights_.push_back(light);

--- a/Project/Engine/Graphics/Lighting/LightManager.h
+++ b/Project/Engine/Graphics/Lighting/LightManager.h
@@ -34,7 +34,7 @@ namespace Ken4lowEngine
 		// パンクチュアルライトの構造体
 		struct PunctualLightGPU
 		{
-			uint32_t lightType;		// ライトの種類（0：ライトなし、1：平行光源、2：点光源、3：スポットライト）
+			uint32_t lightType;		// ライトの種類（0：None、1：Directional、2：Point、3：Spot、4：RectArea、5：SphereArea）
 			Vector4 color;			// ライトの色 （全ライト共通）
 			float intensity;		// 輝度 （全ライト共通）
 			Vector3 position;		// ライトの位置 （点光源、スポットライト用）
@@ -44,6 +44,8 @@ namespace Ken4lowEngine
 			float distance;			// ライトの届く最大距離 （スポットライト用）
 			float cosFalloffStart;	// 開始角度 （スポットライト用）
 			float cosAngle;			// スポットライトの余弦 （スポットライト用）
+			Vector3 areaSize;		// 疑似AreaLightサイズ (x=width, y=height, z=unused/radius)
+			uint32_t enabled;		// 0: disabled, 1: enabled
 		};
 
 		

--- a/Project/Resources/Shaders/Object3D/LightingCommon.hlsli
+++ b/Project/Resources/Shaders/Object3D/LightingCommon.hlsli
@@ -10,6 +10,8 @@ static const uint LIGHT_TYPE_NONE = 0;
 static const uint LIGHT_TYPE_DIRECTIONAL = 1;
 static const uint LIGHT_TYPE_POINT = 2;
 static const uint LIGHT_TYPE_SPOT = 3;
+static const uint LIGHT_TYPE_RECT_AREA = 4;
+static const uint LIGHT_TYPE_SPHERE_AREA = 5;
 
 struct PunctualLight
 {
@@ -23,6 +25,8 @@ struct PunctualLight
     float distance;
     float cosFalloffStart;
     float cosAngle;
+    float3 areaSize;
+    uint enabled;
 };
 
 struct LightingSettings
@@ -154,6 +158,31 @@ LightingTerms EvaluateSpotLight(
     return terms;
 }
 
+LightingTerms EvaluateRectAreaLightApprox(PunctualLight light, float3 worldPosition, float3 normal, float3 viewDir, float shininess)
+{
+    LightingTerms terms = MakeEmptyLightingTerms();
+    float3 dir = normalize(light.direction);
+    float3 up = (abs(dir.y) > 0.95f) ? float3(1.0f, 0.0f, 0.0f) : float3(0.0f, 1.0f, 0.0f);
+    float3 right = normalize(cross(up, dir));
+    up = normalize(cross(dir, right));
+    float2 halfSize = max(light.areaSize.xy * 0.5f, 0.05f.xx);
+    float3 local = worldPosition - light.position;
+    float2 uv = float2(dot(local, right), dot(local, up));
+    float2 clamped = clamp(uv, -halfSize, halfSize);
+    // 面上最近点を仮想PointLightとして使う軽量近似AreaLight。
+    float3 virtualPoint = light.position + right * clamped.x + up * clamped.y;
+    float3 toL = virtualPoint - worldPosition;
+    float d = length(toL);
+    float3 lightDir = toL / max(d, kMinLightLength);
+    float range = max(light.distance, kMinRange);
+    float atten = pow(saturate(1.0f - d / range), max(light.decay, kMinRange)) * step(d, range);
+    float NdotL = saturate(dot(normal, lightDir));
+    float3 lightColor = light.color.rgb * (light.intensity * atten);
+    terms.diffuse = lightColor * NdotL;
+    terms.specular = lightColor * ComputeSpecular(normal, lightDir, viewDir, shininess) * NdotL;
+    return terms;
+}
+
 float3 AccumulateLighting(
     StructuredBuffer<PunctualLight> punctualLights,
     uint lightCount,
@@ -175,6 +204,7 @@ float3 AccumulateLighting(
     {
         PunctualLight light = punctualLights[i];
         LightingTerms terms = MakeEmptyLightingTerms();
+        if (light.enabled == 0) { continue; }
 
         if (light.lightType == LIGHT_TYPE_DIRECTIONAL)
         {
@@ -211,6 +241,11 @@ float3 AccumulateLighting(
                 shininess,
                 shadowMap,
                 shadowSampler);
+            activeLightCount++;
+        }
+        else if (light.lightType == LIGHT_TYPE_RECT_AREA || light.lightType == LIGHT_TYPE_SPHERE_AREA)
+        {
+            terms = EvaluateRectAreaLightApprox(light, worldPosition, normal, viewDir, shininess);
             activeLightCount++;
         }
         else

--- a/Project/Resources/Shaders/Skinning/SkinningObject3d.PS.hlsl
+++ b/Project/Resources/Shaders/Skinning/SkinningObject3d.PS.hlsl
@@ -24,7 +24,7 @@ struct Camera
 // パンクチュアルライトの定数バッファ
 struct PunctualLight
 {
-    uint lightType; // ライトの種類（0：ライトなし、1：平行光源、2：点光源、3：スポットライト）
+    uint lightType; // ライトの種類（0：None、1：Directional、2：Point、3：Spot、4：RectArea、5：SphereArea）
     float4 color; // ライトの色 （全ライト共通）
     float intensity; // 輝度 （全ライト共通）
     float3 position; // ライトの位置 （点光源、スポットライト用）
@@ -34,6 +34,8 @@ struct PunctualLight
     float distance; // ライトの届く最大距離 （スポットライト用）
     float cosFalloffStart; // 開始角度 （スポットライト用）
     float cosAngle; // スポットライトの余弦 （スポットライト用）
+    float3 areaSize; // 疑似AreaLightサイズ (x=width, y=height, z=radius)
+    uint enabled; // 有効フラグ
 };
 
 struct LightInfo
@@ -88,6 +90,7 @@ PixelShaderOutput main(VertexShaderOutput input)
     for (uint i = 0; i < gLightInfo.gLightCount; ++i)
     {
         PunctualLight L = gPunctualLights[i]; // ★ gLights → gPunctualLights
+        if (L.enabled == 0) { continue; }
 
         float atten = 1.0;
         float3 Ldir = normalize(L.direction);
@@ -135,6 +138,26 @@ PixelShaderOutput main(VertexShaderOutput input)
             float NdotL = saturate(dot(normal, Ldir));
 
             lightSum += L.color.rgb * (L.intensity * atten * spot * NdotL);
+        }
+        else if (L.lightType == 4 || L.lightType == 5)
+        {
+            float3 dir = normalize(L.direction);
+            float3 up = (abs(dir.y) > 0.95f) ? float3(1, 0, 0) : float3(0, 1, 0);
+            float3 right = normalize(cross(up, dir));
+            up = normalize(cross(dir, right));
+            float2 halfSize = max(L.areaSize.xy * 0.5, 0.05.xx);
+            float3 local = position - L.position;
+            float2 uv = float2(dot(local, right), dot(local, up));
+            float2 clamped = clamp(uv, -halfSize, halfSize);
+            // 最近点を仮想PointLight化して広い面光源っぽい照明を作る。
+            float3 virtualPoint = L.position + right * clamped.x + up * clamped.y;
+            float3 toL = virtualPoint - position;
+            float d = length(toL);
+            Ldir = toL / max(d, 1e-4);
+            float range = max(L.distance, 1e-3);
+            atten = pow(saturate(1.0 - d / range), max(L.decay, 1e-3));
+            float NdotL = saturate(dot(normal, Ldir));
+            lightSum += L.color.rgb * (L.intensity * atten * NdotL);
         }
         else
         {


### PR DESCRIPTION
### Motivation
- Revert of PointLight shadow work is preserved while improving scene lighting by adding inexpensive, visually pleasing pseudo-AreaLight types without implementing costly area shadows.
- Provide a lightweight RectArea (優先) and SphereArea approximation so large soft-looking illumination can be authorable from the Light Editor without changing existing shadow/spot behaviors.

### Description
- Added new light types (`RectArea`=4, `SphereArea`=5) and extended `PunctualLightGPU` with `areaSize` and `enabled`, and treat `enabled==0` lights as inactive during update/upload and rendering.
- Extended `LightManager` ImGui UI to create/edit AreaLights (Type, Enabled, Color, Intensity, Position, Rotation/Direction, Width/Height or Radius, Range, Decay) and added textual debug/status lines indicating AreaLight limitations.
- Implemented debug wire visualizers: rectangle plane + direction line for `RectArea` and radius/range spheres for `SphereArea`, drawn via existing `Wireframe` debug path.
- Shader changes: added `LIGHT_TYPE_RECT_AREA`/`LIGHT_TYPE_SPHERE_AREA`, added `areaSize`/`enabled` to HLSL `PunctualLight`, implemented `EvaluateRectAreaLightApprox` that finds the closest point on the rect (clamp to rectangle) and treats it as a virtual point for distance attenuation + N·L/specular, and wired the logic into `AccumulateLighting`; updated `SkinningObject3d.PS` with the same approximation branch; no area shadows added.

### Testing
- Ran repository sanity/inspection commands and basic repo checks (`git status --short`) and committed the changes successfully; file diffs show updates to: `LightManager.h`, `LightManager.cpp`, `LightingCommon.hlsli`, and `SkinningObject3d.PS.hlsl`.
- No automated build or render tests were executed in this PR (Debug/Release builds and visual verification are recommended as the next step).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0e9956f5a8832d9591e771d6d82315)