### PR TITLE
Adjust stage camera range and lighting setup

### DIFF
--- a/Project/ApplicationLayer/DebugTools/StageChunk/StageChunkDebugController.cpp
+++ b/Project/ApplicationLayer/DebugTools/StageChunk/StageChunkDebugController.cpp
@@ -1,6 +1,7 @@
 #include "StageChunkDebugController.h"
 
 #include "Stage.h"
+#include "CameraManager.h"
 
 #include <cstddef>
 
@@ -82,6 +83,10 @@ void StageChunkDebugController::DrawImGuiContent(K4E::Stage* stage)
 	ImGui::Text("Chunk外扱いで描画したObject数: %d", stats.chunkOutsideDrawObjectCount);
 	ImGui::Text("Chunk Culling対象外Object数: %d", stats.chunkCullingIgnoredObjectCount);
 	ImGui::Text("大きすぎてChunk Culling除外されたObject数: %d", stats.largeObjectExcludedCount);
+	if (const auto* mainCamera = K4E::CameraManager::GetInstance()->GetMainCamera())
+	{
+		ImGui::Text("MainCamera Near/Far: %.3f / %.1f", mainCamera->GetNearClip(), mainCamera->GetFarClip());
+	}
 	ImGui::TextWrapped("可視Chunkは緑、カリングChunkは赤、Object Boundsは青、Chunk Culling対象外Boundsは黄で表示します。");
 	ImGui::TextWrapped("床や壁など大きいBoundsは複数Chunk登録または安全側でChunk Culling対象外にし、見えているObjectを消さないようにDraw側だけを制御します。");
 #else

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
@@ -87,6 +87,12 @@ void GamePlayWorld::Initialize(GamePlayStageContext& stageContext)
 
 	if (auto* player = characters_.GetPlayer())
 	{
+		if (auto* camera = player->GetCamera())
+		{
+			// 遠景のステージパーツが途中で消えないように、GamePlay中のみFarClipを安全側に広げる。
+			camera->SetFarClip(1600.0f);
+		}
+
 		player->SetSpawnOffset({ 0.0f, 0.0f, 0.0f });
 
 		if (stageContext.HasPlayerSpawnPoint())
@@ -99,6 +105,14 @@ void GamePlayWorld::Initialize(GamePlayStageContext& stageContext)
 		}
 
 		characters_.Update(0.0f);
+	}
+
+	{
+		// 空だけ明るく地面が沈む見え方を避けるため、LightEditor互換の設定値をGamePlay初期値として少しだけ持ち上げる。
+		auto& lighting = LightManager::GetInstance()->GetMutableLightingSettingsForEditor();
+		lighting.ambientColor.w = std::max(lighting.ambientColor.w, 0.22f);
+		lighting.exposure = std::max(lighting.exposure, 1.10f);
+		lighting.specularStrength = std::max(lighting.specularStrength, 0.08f);
 	}
 
 	if (stage_)

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3D.cpp
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3D.cpp
@@ -212,7 +212,7 @@ namespace Ken4lowEngine
 		commandList->SetGraphicsRootConstantBufferView(9, shadowParameterResource_->GetGPUVirtualAddress()); // シャドウマップ用行列
 		commandList->SetGraphicsRootDescriptorTable(10, shadowMapHandle_); // シャドウマップのSRV
 
-		// StageChunk 経由でも Mesh 単位の既存カリングを残し、Chunk 内の不可視 Mesh はさらに Draw を抑制する。
+		// StageChunk で可視判定済みのメッシュは二重カリングで欠けないよう、Stage専用ObjectはMesh単位Frustum判定をスキップする。
 		auto& meshes = model_->GetMeshes();
 		const size_t drawCount = meshIndices ? meshIndices->size() : meshes.size();
 		for (size_t drawIndex = 0; drawIndex < drawCount; ++drawIndex)
@@ -225,7 +225,10 @@ namespace Ken4lowEngine
 
 			const BoundingSphere meshBounds = GetMeshWorldBounds(i);
 			const bool hasMeshBounds = HasMeshWorldBounds(i);
-			const bool meshVisible = object3DCommon->ShouldDrawMesh(meshBounds, frustumCullingEnabled_, hasMeshBounds);
+			const bool skipMeshFrustumForStageChunk = (meshIndices != nullptr) && isStageObjectCullingUnit_;
+			const bool meshVisible = skipMeshFrustumForStageChunk
+				? true
+				: object3DCommon->ShouldDrawMesh(meshBounds, frustumCullingEnabled_, hasMeshBounds);
 			DrawBoundsDebug(meshBounds, meshVisible);
 			if (!meshVisible)
 			{


### PR DESCRIPTION
### Motivation
- Fix visual artifacts where distant stage/floor/buildings disappeared (appeared as holes) and where lighting made ground/buildings look unnaturally flat while keeping existing lighting/shadow systems intact.
- Narrowly isolate changes to GamePlayStage rendering and debugging so other scenes (title, stage select, debug scenes) are unaffected.

### Description
- Skip per-mesh frustum re-check when drawing meshes selected by StageChunk for stage-designated objects to avoid double-culling holes (`Object3D.cpp`), with an explanatory 1-line comment.
- Expand the GamePlay main camera `FarClip` during gameplay initialization to `1600.0f` to reduce distant pop-in while keeping near/far behavior otherwise unchanged (`GamePlayWorld.cpp`), with a comment explaining the intent.
- Raise conservative minimums for editor-exposed lighting fields (`ambientColor.w`, `exposure`, `specularStrength`) via `GetMutableLightingSettingsForEditor()` so ground/building appearance is improved without overriding stronger manual editor settings (`GamePlayWorld.cpp`).
- Add `MainCamera Near/Far` readout to the StageChunk Culling Debug ImGui window to help distinguish camera clip vs chunk-culling as the cause (`StageChunkDebugController.cpp`).

### Testing
- Attempted a Debug x64 build with `msbuild Ken4lowEngine.sln /p:Configuration=Debug /p:Platform=x64`, which failed in this environment due to `msbuild: command not found` (no successful build performed).
- Ran repository grep/inspection commands (`rg`, `sed`, file diffs) to verify the change locations and that the edits are limited to the intended GamePlay/StageChunk/Debug files and that the added comments and ImGui text are present (these checks succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f1c1ca520832daf99a1057b90f6f8)