### PR TITLE
ステージ開始/武器切替時のEquipIntro追加と武器構えアニメーション実装

### DIFF
--- a/Project/ApplicationLayer/Character/Player/Component/PlayerWeaponVisualComponent.cpp
+++ b/Project/ApplicationLayer/Character/Player/Component/PlayerWeaponVisualComponent.cpp
@@ -141,6 +141,15 @@ void PlayerWeaponVisualComponent::Initialize()
 void PlayerWeaponVisualComponent::Update(float deltaTime, bool isADS)
 {
 	RebuildIfWeaponChanged();
+	if (equipAnimating_)
+	{
+		equipTimer_ += deltaTime;
+		if (equipTimer_ >= equipDuration_)
+		{
+			equipTimer_ = equipDuration_;
+			equipAnimating_ = false;
+		}
+	}
 
 	const float targetReloadAlpha = reloadViewActive_ ? 1.0f : 0.0f;
 	reloadPoseAlpha_ = Approach(reloadPoseAlpha_, targetReloadAlpha, reloadPoseBlendSpeed_, deltaTime);
@@ -214,6 +223,12 @@ void PlayerWeaponVisualComponent::DrawImGui()
 		ImGui::Text("Reload rotation is now controlled by the right arm.");
 		ImGui::DragFloat3("Reload Weapon Offset", &reloadWeaponOffset_.x, 0.01f, -3.0f, 3.0f, "%.2f");
 		ImGui::DragFloat("Reload Blend Speed", &reloadPoseBlendSpeed_, 0.1f, 1.0f, 40.0f, "%.1f");
+		ImGui::Separator();
+		ImGui::Checkbox("Enable Equip Animation", &enableEquipAnimation_);
+		ImGui::DragFloat("Equip Duration", &equipDuration_, 0.01f, 0.05f, 1.0f, "%.2f");
+		ImGui::DragFloat("Equip Start Offset Y", &equipStartOffsetY_, 0.01f, -2.0f, 0.0f, "%.2f");
+		ImGui::DragFloat("Equip Start Pitch Deg", &equipStartPitchDeg_, 0.5f, -45.0f, 0.0f, "%.1f");
+		ImGui::Text("Equip Animating: %s", equipAnimating_ ? "true" : "false");
 
 		if (ImGui::Button("Reset Weapon Size"))
 		{
@@ -229,6 +244,24 @@ void PlayerWeaponVisualComponent::SetReloadViewModelState(bool isReloading, floa
 	reloadViewActive_ = isReloading;
 	reloadViewTimer_ = reloadTimer;
 	reloadViewDuration_ = std::max(0.01f, reloadDuration);
+}
+
+void PlayerWeaponVisualComponent::StartEquipAnimation()
+{
+	// カメラ演出後や武器切り替え時に、下から構える装備アニメーションを再生する。
+	if (!enableEquipAnimation_)
+	{
+		equipAnimating_ = false;
+		equipTimer_ = equipDuration_;
+		return;
+	}
+	equipAnimating_ = true;
+	equipTimer_ = 0.0f;
+}
+
+bool PlayerWeaponVisualComponent::IsEquipAnimating() const
+{
+	return enableEquipAnimation_ && equipAnimating_;
 }
 
 void PlayerWeaponVisualComponent::ForceRefresh()
@@ -329,7 +362,12 @@ void PlayerWeaponVisualComponent::SyncToHand(bool isADS)
 	const K4E::Vector3 weaponWorldScale = modelScale_ * viewModelScaleMultiplier_;
 	const float reloadT = SmoothStep01(reloadPoseAlpha_);
 	const K4E::Vector3 reloadOffset = reloadWeaponOffset_ * reloadT;
-	const K4E::Vector3 totalLocalOffset = localPos + handSocketLocalOffset_ + reloadOffset;
+	const float equipT = Clamp01((equipDuration_ > 0.001f) ? (equipTimer_ / equipDuration_) : 1.0f);
+	const float equipEaseOut = 1.0f - (1.0f - equipT) * (1.0f - equipT);
+	const float equipPosY = (1.0f - equipEaseOut) * equipStartOffsetY_;
+	const float equipPitch = (1.0f - equipEaseOut) * ToRadians(equipStartPitchDeg_);
+	const K4E::Vector3 equipOffset = { 0.0f, equipPosY, 0.0f };
+	const K4E::Vector3 totalLocalOffset = localPos + handSocketLocalOffset_ + reloadOffset + equipOffset;
 
 	K4E::Matrix4x4 localMatrix{};
 	if (useQuaternionRotation_)
@@ -340,18 +378,21 @@ void PlayerWeaponVisualComponent::SyncToHand(bool isADS)
 		}
 
 		const K4E::Quaternion baseRotation = isADS ? adsLocalQuaternion_ : hipLocalQuaternion_;
+		const K4E::Quaternion equipPitchQ = K4E::Quaternion::MakeRotateAxisAngleQuaternion({ 1.0f, 0.0f, 0.0f }, equipPitch);
 		const K4E::Quaternion totalRotation = K4E::Quaternion::Normalize(
 			K4E::Quaternion::Multiply(baseRotation, handSocketLocalQuaternion_));
+		const K4E::Quaternion animatedRotation = K4E::Quaternion::Normalize(
+			K4E::Quaternion::Multiply(equipPitchQ, totalRotation));
 
 		localMatrix = K4E::Matrix4x4::MakeAffineMatrix(
 			weaponWorldScale,
-			totalRotation,
+			animatedRotation,
 			totalLocalOffset);
 	}
 	else
 	{
 		const K4E::Vector3 localRot = isADS ? adsLocalRotate_ : hipLocalRotate_;
-		const K4E::Vector3 totalLocalRotate = localRot + handSocketLocalRotate_;
+		const K4E::Vector3 totalLocalRotate = localRot + handSocketLocalRotate_ + K4E::Vector3{ equipPitch, 0.0f, 0.0f };
 
 		localMatrix = K4E::Matrix4x4::MakeAffineMatrix(
 			weaponWorldScale,

--- a/Project/ApplicationLayer/Character/Player/Component/PlayerWeaponVisualComponent.h
+++ b/Project/ApplicationLayer/Character/Player/Component/PlayerWeaponVisualComponent.h
@@ -41,6 +41,8 @@ public: /// ---------- メンバ関数 ---------- ///
 
 	// リロード中の武器表示補正を更新する
 	void SetReloadViewModelState(bool isReloading, float reloadTimer, float reloadDuration);
+	void StartEquipAnimation();
+	bool IsEquipAnimating() const;
 
 	// 現在の見た目を強制再構築したいときに使う
 	void ForceRefresh();
@@ -114,6 +116,12 @@ private: /// ---------- メンバ変数 ---------- ///
 	float reloadPoseBlendSpeed_ = 14.0f;
 	K4E::Vector3 reloadWeaponOffset_{ 0.0f, 0.0f, 0.0f };
 	K4E::Vector3 reloadWeaponRotDeg_{ 0.0f, 0.0f, 0.0f };
+	bool enableEquipAnimation_ = true;
+	bool equipAnimating_ = false;
+	float equipTimer_ = 0.0f;
+	float equipDuration_ = 0.32f;
+	float equipStartOffsetY_ = -0.75f;
+	float equipStartPitchDeg_ = -10.0f;
 
 	// 銃口のローカル位置。モデルによってずれる場合はここを調整する
 	K4E::Vector3 muzzleLocalOffset_{ 0.0f, -0.02f, 0.85f };
@@ -129,4 +137,3 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	bool refreshRequested_ = false;	std::string appliedModelPath_;
 };
-

--- a/Project/ApplicationLayer/Character/Player/Player.cpp
+++ b/Project/ApplicationLayer/Character/Player/Player.cpp
@@ -263,6 +263,12 @@ void Player::UpdateWeaponBeforeMotor(float deltaTime, InputFrameContext& ctx)
 		ctx.reload.isReloading,
 		ctx.reload.reloadTimer,
 		ctx.reload.reloadSec);
+
+	if (weaponVisual_.IsEquipAnimating())
+	{
+		// 装備アニメーション中は攻撃入力を無効化する。
+		SuppressActionInputDuringReload(ctx.rawSnap);
+	}
 }
 
 void Player::FinalizeInputSnapshotForGameplay(float deltaTime, InputFrameContext& ctx)

--- a/Project/ApplicationLayer/Character/Player/Player.h
+++ b/Project/ApplicationLayer/Character/Player/Player.h
@@ -166,6 +166,8 @@ public: /// ---------- メンバ関数 ---------- ///
 	void ApplyEditedWeaponDataFromEditor(int32_t weaponID, const FWeaponMasterData& data);
 
 	void ForceRefreshWeaponVisual() { weaponVisual_.ForceRefresh(); }
+	void StartWeaponEquipAnimation() { weaponVisual_.StartEquipAnimation(); }
+	bool IsWeaponEquipAnimating() const { return weaponVisual_.IsEquipAnimating(); }
 	void SetStartGameplayVisualsVisible(bool visible);
 	void WarmupStartGameplayVisuals();
 

--- a/Project/ApplicationLayer/Character/Player/PlayerWeaponController.cpp
+++ b/Project/ApplicationLayer/Character/Player/PlayerWeaponController.cpp
@@ -89,6 +89,7 @@ void PlayerWeaponController::HandleWheelSwitch(InputSnapshot& snap)
 	if (visual_)
 	{
 		visual_->ForceRefresh();
+		visual_->StartEquipAnimation();
 	}
 }
 

--- a/Project/ApplicationLayer/Scene/GamePlayScene/Camera/GamePlayIntroDirector.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/Camera/GamePlayIntroDirector.cpp
@@ -293,6 +293,19 @@ void GamePlayIntroDirector::Update(
 	K4E::Input* input,
 	bool isDebugCamera)
 {
+	if (flow.GetState() == GamePlayFlow::State::EquipIntro)
+	{
+		if (auto* player = world.GetCharacters().GetPlayer())
+		{
+			if (!player->IsWeaponEquipAnimating())
+			{
+				flow.StartPlaying();
+				world.StartWaves();
+			}
+		}
+		return;
+	}
+
 	if (cameraPoints_.empty())
 	{
 		BeginGamePlayFromIntro(flow, stageContext, world, input, isDebugCamera);
@@ -392,7 +405,7 @@ void GamePlayIntroDirector::BeginGamePlayFromIntro(
 		introCameraRotation = camera->GetRotate();
 	}
 
-	flow.StartPlaying();
+	flow.SetState(GamePlayFlow::State::EquipIntro);
 
 	introTimer_ = 0.0f;
 	currentSegment_ = 0;
@@ -422,9 +435,8 @@ void GamePlayIntroDirector::BeginGamePlayFromIntro(
 		// 完了フレーム内でFPSカメラの初期向きを同期し、次フレーム待ちの停止感と向きの跳ねを防ぐ。
 		player->SetViewLookAngles(introCameraRotation.x, introCameraRotation.y);
 		player->SyncViewToPlayer();
+		player->StartWeaponEquipAnimation();
 	}
-
-	world.StartWaves();
 
 	if (input)
 	{

--- a/Project/ApplicationLayer/Scene/GamePlayScene/Core/GamePlayFlow.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/Core/GamePlayFlow.h
@@ -23,6 +23,7 @@ public: /// ---------- 列挙型 ---------- ///
 	enum class State
 	{
 		Intro,		// ゲーム開始前のイントロ
+		EquipIntro, // イントロ直後の武器構えアニメーション中
 		Playing,	// 通常プレイ中
 		GameClear,	// ゲームクリア
 		GameOver,	// ゲームオーバー
@@ -95,6 +96,7 @@ public: /// ---------- アクセサ ---------- ///
 
 	// イントロを再生中かどうか
 	bool IsIntro() const { return state_ == State::Intro; }
+	bool IsEquipIntro() const { return state_ == State::EquipIntro; }
 
 	// 結果画面（ゲームクリア or ゲームオーバー）にいるかどうか
 	bool IsResultState() const { return state_ == State::GameClear || state_ == State::GameOver; }
@@ -122,4 +124,3 @@ private: /// ---------- メンバ変数 ---------- ///
 	// 現在のゲーム状態
 	State state_ = State::Playing;
 };
-

--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
@@ -297,7 +297,7 @@ bool GamePlayScene::UpdateRetryTransition()
 /// -------------------------------------------------------------
 bool GamePlayScene::UpdateIntro(float deltaTime)
 {
-	if (!(flow_ && flow_->IsIntro()))
+	if (!(flow_ && (flow_->IsIntro() || flow_->IsEquipIntro())))
 	{
 		return false;
 	}
@@ -314,7 +314,7 @@ bool GamePlayScene::UpdateIntro(float deltaTime)
 	}
 
 	// 完了フレーム内に通常更新へ進め、終点で1フレーム停止して見えるのを防ぐ。
-	return flow_ && flow_->IsIntro();
+	return flow_ && (flow_->IsIntro() || flow_->IsEquipIntro());
 }
 
 /// -------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- イントロカメラ終了直後にプレイヤー視点へ切り替わった瞬間にゲームが始まり唐突に見えるため、カメラ演出後に武器を下から持ち上げる“装備（Equip）”演出を挟んで自然な遷移にする。
- 武器切替時にも同様の持ち上げ演出を再生し、演出中は攻撃入力を無効化して見た目と入力の不整合を防ぐことを目的とする。

### Description
- ゲームフローに `EquipIntro` 状態を追加し、`GamePlayFlow::State` に `EquipIntro` とアクセサ `IsEquipIntro()` を追加した (`Project/.../Core/GamePlayFlow.h`).
- イントロ終了処理を `EquipIntro` へ遷移するよう変更し、`GamePlayIntroDirector::BeginGamePlayFromIntro` でプレイヤーへ装備アニメ開始を通知するようにしたと同時に、`EquipIntro` 中は装備アニメ完了を待ってから `StartPlaying()` と `StartWaves()` を実行するようにした (`Project/.../Camera/GamePlayIntroDirector.cpp`).
- イントロ更新判定を `Intro` と `EquipIntro` 両方を対象にするように `GamePlayScene::UpdateIntro` を修正してイントロ中の通常進行を停止するようにした (`Project/.../GamePlayScene.cpp`).
- 武器ビジュアル側に装備アニメを実装して `PlayerWeaponVisualComponent` に `StartEquipAnimation() / IsEquipAnimating()`、アニメ状態・パラメータ（`enableEquipAnimation_`, `equipDuration_`, `equipStartOffsetY_`, `equipStartPitchDeg_`）と ImGui デバッグ項目を追加し、EaseOut 補間で下から持ち上げる位置オフセットと軽いピッチ回転を反映するようにした (`Project/.../PlayerWeaponVisualComponent.*`).
- ホイールによる武器切替処理で `StartEquipAnimation()` を呼ぶようにして切替時にも同じ装備アニメを再生するようにした (`Project/.../PlayerWeaponController.cpp`).
- `Player` に装備アニメを開始/参照する薄いアクセサを追加し、装備アニメ中は既存の入力抑制ルーチン（リロード時用の `SuppressActionInputDuringReload`）を再利用して攻撃/リロードなどを無効化する変更を行った (`Project/.../Player.h`, `Project/.../Player.cpp`).
- 変更点には意図の分かる1行コメントを付加している場所がある（装備アニメの開始/入力無効化等）。

### Testing
- Debug x64 ビルドを試行するために `msbuild` でのビルドを実行しましたが、この実行環境に `msbuild` が存在しないためビルドは実行されず確認できませんでした (`msbuild: command not found`).
- 変更はローカルリポジトリへステージ/コミットされており、差分はコミット `02922af` にまとめられています (`git commit` 実行は成功)。
- 自動化テスト（ユニット/CIビルド）はこの環境では実行しておらず、ローカルまたはCI上での `Debug x64` ビルド確認と動作確認をお願いします。
- 注意点としてホットバー等別経路で武器切替を行っている箇所がある場合は同様に `StartEquipAnimation()` を呼ぶ必要がある可能性があるため、該当する切替経路の動作確認もお願いします。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f248d4aec832d85f9ea61218ce80d)