### PR TITLE
Fix EquipIntro weapon raise animation not updating

### DIFF
--- a/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.cpp
+++ b/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.cpp
@@ -175,6 +175,14 @@ void CharacterWorld::Update(float dt)
 	}
 }
 
+void CharacterWorld::UpdatePlayerOnly(float dt)
+{
+	if (player_)
+	{
+		player_->Update(dt);
+	}
+}
+
 void CharacterWorld::WarmupStartGameplayVisuals()
 {
 	if (player_)

--- a/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.h
+++ b/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.h
@@ -41,6 +41,7 @@ public: /// ---------- メンバ関数 ---------- ///
 	void Finalize();
 
 	void Update(float dt);
+	void UpdatePlayerOnly(float dt);
 	void WarmupStartGameplayVisuals();
 	void SetStartGameplayVisualsVisible(bool visible);
 	void Draw();

--- a/Project/ApplicationLayer/Character/Player/Component/PlayerWeaponVisualComponent.cpp
+++ b/Project/ApplicationLayer/Character/Player/Component/PlayerWeaponVisualComponent.cpp
@@ -228,7 +228,19 @@ void PlayerWeaponVisualComponent::DrawImGui()
 		ImGui::DragFloat("Equip Duration", &equipDuration_, 0.01f, 0.05f, 1.0f, "%.2f");
 		ImGui::DragFloat("Equip Start Offset Y", &equipStartOffsetY_, 0.01f, -2.0f, 0.0f, "%.2f");
 		ImGui::DragFloat("Equip Start Pitch Deg", &equipStartPitchDeg_, 0.5f, -45.0f, 0.0f, "%.1f");
-		ImGui::Text("Equip Animating: %s", equipAnimating_ ? "true" : "false");
+		const float equipNormalizedT = Clamp01((equipDuration_ > 0.001f) ? (equipTimer_ / equipDuration_) : 1.0f);
+		const float equipEaseOut = 1.0f - (1.0f - equipNormalizedT) * (1.0f - equipNormalizedT);
+		const K4E::Vector3 equipCurrentOffset = { 0.0f, (1.0f - equipEaseOut) * equipStartOffsetY_, 0.0f };
+		ImGui::Text("Equip animation enabled: %s", enableEquipAnimation_ ? "true" : "false");
+		ImGui::Text("IsEquipAnimating: %s", IsEquipAnimating() ? "true" : "false");
+		ImGui::Text("Equip elapsed time: %.3f", equipTimer_);
+		ImGui::Text("Equip duration: %.3f", equipDuration_);
+		ImGui::Text("Equip normalized t: %.3f", equipNormalizedT);
+		ImGui::Text("Equip current offset: (%.3f, %.3f, %.3f)", equipCurrentOffset.x, equipCurrentOffset.y, equipCurrentOffset.z);
+		if (ImGui::Button("Play Equip Animation"))
+		{
+			StartEquipAnimation();
+		}
 
 		if (ImGui::Button("Reset Weapon Size"))
 		{

--- a/Project/ApplicationLayer/Character/Player/Player.cpp
+++ b/Project/ApplicationLayer/Character/Player/Player.cpp
@@ -240,6 +240,11 @@ void Player::UpdateWeaponBeforeMotor(float deltaTime, InputFrameContext& ctx)
 		SuppressActionInputDuringReload(ctx.rawSnap);
 	}
 
+	if (weaponVisual_.IsEquipAnimating())
+	{
+		SuppressActionInputDuringReload(ctx.rawSnap);
+	}
+
 	weaponController_.HandleWheelSwitch(ctx.rawSnap);
 
 	weapon_.UpdateAndHandleInput(deltaTime, ctx.rawSnap);

--- a/Project/ApplicationLayer/Scene/GamePlayScene/Camera/GamePlayIntroDirector.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/Camera/GamePlayIntroDirector.cpp
@@ -295,6 +295,7 @@ void GamePlayIntroDirector::Update(
 {
 	if (flow.GetState() == GamePlayFlow::State::EquipIntro)
 	{
+		world.UpdateEquipIntro(deltaTime);
 		if (auto* player = world.GetCharacters().GetPlayer())
 		{
 			if (!player->IsWeaponEquipAnimating())

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
@@ -304,6 +304,29 @@ void GamePlayWorld::UpdateIntroVisuals()
 	}
 }
 
+void GamePlayWorld::UpdateEquipIntro(float deltaTime)
+{
+	if (stage_)
+	{
+		stage_->Update();
+	}
+
+	// EquipIntro中でも武器構えアニメーションだけは更新する。
+	characters_.UpdatePlayerOnly(deltaTime);
+
+	UpdateShadowLightViewProjection();
+	if (stage_)
+	{
+		stage_->UpdateShadowMatrix(shadowLightViewProjection_);
+	}
+	characters_.UpdateShadowMatrix(shadowLightViewProjection_);
+
+	if (skyBox_)
+	{
+		skyBox_->Update();
+	}
+}
+
 void GamePlayWorld::Draw3D(bool hideCharactersDuringIntro)
 {
 	K4E::SkyBoxManager::GetInstance()->SetRenderSetting();

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.h
@@ -24,6 +24,7 @@ public: /// ---------- メンバ関数 ---------- ///
 	void Update(float deltaTime);
 
 	void UpdateIntroVisuals();
+	void UpdateEquipIntro(float deltaTime);
 	void WarmupStartGameplayForIntro();
 	void SetStartGameplayVisualsVisible(bool visible);
 


### PR DESCRIPTION
### Motivation
- The equip (raise) animation did not play during the intro because world/game update early-returned and the weapon visual animation timer was not advanced each frame. 
- We need the intro camera to finish, then run the equip animation (and prevent player actions while it runs) without progressing enemies/waves/bullets. 
- Also provide ImGui debug controls so pressing Play reliably restarts the equip animation from time 0 for debugging.

### Description
- Add `CharacterWorld::UpdatePlayerOnly(float dt)` to update only the player (camera, viewmodel, weapon visuals) without advancing enemies, waves, bullets, or collisions. 
- Add `GamePlayWorld::UpdateEquipIntro(float deltaTime)` and call it from `GamePlayIntroDirector::Update` when `GamePlayFlow::State::EquipIntro` to keep player/viewmodel updates running during the equip intro. 
- Suppress action input earlier in the frame by checking `weaponVisual_.IsEquipAnimating()` before `weapon_.UpdateAndHandleInput(...)` so attack/reload/switch cannot interrupt Equip animation. 
- Expand weapon visual ImGui debug UI to display `Equip animation enabled`, `IsEquipAnimating`, `Equip elapsed time`, `Equip duration`, `Equip normalized t`, `Equip current offset`, and add a `Play Equip Animation` button that calls `StartEquipAnimation()` (always restarts from timer 0). 
- Add a clarifying comment at the `UpdateEquipIntro` call site: `// EquipIntro中でも武器構えアニメーションだけは更新する。`.
- Key modified files: `Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.h/.cpp`, `Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.h/.cpp`, `Project/ApplicationLayer/Scene/GamePlayScene/Camera/GamePlayIntroDirector.cpp`, `Project/ApplicationLayer/Character/Player/Player.cpp`, and `Project/ApplicationLayer/Character/Player/Component/PlayerWeaponVisualComponent.cpp`.

### Testing
- Attempted to build with `msbuild Ken4lowEngine.sln /p:Configuration=Debug /p:Platform=x64`, but the environment returned `/bin/bash: msbuild: command not found`, so no binary build was produced here. 
- Verified source changes and updated files via repository inspection and local code review; debug ImGui entries and the new `UpdateEquipIntro`/`UpdatePlayerOnly` hooks are present. 
- No automated unit tests were executed in this environment due to missing build tools. Please run a Debug x64 build and smoke-test in the editor to confirm: ImGui Play moves the weapon from below to normal position, the equip animation blocks firing/reload/switch, and the flow transitions to `Playing` only after the equip completes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0f266b90dc832dbb0e6909a7e095ea)