### PR TITLE
Apply equip offset to full ViewModel (arms + weapon) and add Z offset control

### DIFF
--- a/Project/ApplicationLayer/Character/Player/Component/PlayerViewComponent.cpp
+++ b/Project/ApplicationLayer/Character/Player/Component/PlayerViewComponent.cpp
@@ -162,6 +162,13 @@ void PlayerViewComponent::SetReloadViewModelState(bool isReloading, float reload
 	}
 }
 
+void PlayerViewComponent::SetEquipViewModelState(bool isAnimating, const K4E::Vector3& offset, float pitchRad)
+{
+	equipViewActive_ = isAnimating;
+	equipViewOffset_ = offset;
+	equipViewPitchRad_ = pitchRad;
+}
+
 void PlayerViewComponent::UpdateLook(float dt, const InputSnapshot& input)
 {
 	fpsCamera_.SetDeltaTime(dt);
@@ -577,6 +584,13 @@ void PlayerViewComponent::UpdateFirstPersonArmPose(float dt)
 	leftArmTr_->translate_ = Lerp(leftHipPos, aimLeftPos_ + pitchLeftOffset, t);
 	rightArmTr_->translate_ = Lerp(rightHipPos, aimRightPos_ + pitchRightOffset, t);
 
+	// 腕と武器をまとめて構えさせるため、EquipオフセットはViewModel全体に適用する。
+	if (equipViewActive_)
+	{
+		leftArmTr_->translate_ += equipViewOffset_;
+		rightArmTr_->translate_ += equipViewOffset_;
+	}
+
 	// 位置はPitch回転で回さない。
 	// 上下視点時の画面内維持は pitchLeftOffset / pitchRightOffset で行う。
 	//const float viewPitch = camPitch_ * armPitchFollow_;
@@ -603,6 +617,12 @@ void PlayerViewComponent::UpdateFirstPersonArmPose(float dt)
 	rrot.x += vmKickPitch_;
 	rrot.y += vmKickYaw_;
 	rrot.z += vmKickRoll_;
+
+	if (equipViewActive_)
+	{
+		lrot.x += equipViewPitchRad_;
+		rrot.x += equipViewPitchRad_;
+	}
 
 	// リロード姿勢へ入る → 装填する押し込み → 戻る。
 	if (reloadT > 0.0f)

--- a/Project/ApplicationLayer/Character/Player/Component/PlayerViewComponent.h
+++ b/Project/ApplicationLayer/Character/Player/Component/PlayerViewComponent.h
@@ -54,6 +54,7 @@ public: /// ---------- メンバ関数 ---------- ///
 
 	void SetAiming(bool on);
 	void SetReloadViewModelState(bool isReloading, float reloadTimer, float reloadDuration);
+	void SetEquipViewModelState(bool isAnimating, const K4E::Vector3& offset, float pitchRad);
 
 	float GetYaw() const { return fpsCamera_.GetYaw(); }
 	K4E::Camera* GetCamera() { return fpsCamera_.GetCamera(); }
@@ -229,6 +230,9 @@ private: /// ---------- メンバ変数 ---------- ///
 	K4E::Vector3 reloadLeftArmRotDeg_{ -4.0f, -8.0f, 10.0f };
 	K4E::Vector3 reloadLoadLeftArmOffset_{ -0.04f, 0.01f, -0.16f };
 	K4E::Vector3 reloadLoadLeftArmRotDeg_{ 3.0f, 4.0f, -6.0f };
+	bool equipViewActive_ = false;
+	K4E::Vector3 equipViewOffset_{ 0.0f, 0.0f, 0.0f };
+	float equipViewPitchRad_ = 0.0f;
 
 	// ---- Melee view animation ----
 	bool meleeSwingActive_ = false;

--- a/Project/ApplicationLayer/Character/Player/Component/PlayerWeaponVisualComponent.cpp
+++ b/Project/ApplicationLayer/Character/Player/Component/PlayerWeaponVisualComponent.cpp
@@ -227,10 +227,10 @@ void PlayerWeaponVisualComponent::DrawImGui()
 		ImGui::Checkbox("Enable Equip Animation", &enableEquipAnimation_);
 		ImGui::DragFloat("Equip Duration", &equipDuration_, 0.01f, 0.05f, 1.0f, "%.2f");
 		ImGui::DragFloat("Equip Start Offset Y", &equipStartOffsetY_, 0.01f, -2.0f, 0.0f, "%.2f");
+		ImGui::DragFloat("Equip Start Offset Z", &equipStartOffsetZ_, 0.01f, -0.5f, 0.5f, "%.2f");
 		ImGui::DragFloat("Equip Start Pitch Deg", &equipStartPitchDeg_, 0.5f, -45.0f, 0.0f, "%.1f");
 		const float equipNormalizedT = Clamp01((equipDuration_ > 0.001f) ? (equipTimer_ / equipDuration_) : 1.0f);
-		const float equipEaseOut = 1.0f - (1.0f - equipNormalizedT) * (1.0f - equipNormalizedT);
-		const K4E::Vector3 equipCurrentOffset = { 0.0f, (1.0f - equipEaseOut) * equipStartOffsetY_, 0.0f };
+		const K4E::Vector3 equipCurrentOffset = GetCurrentEquipOffset();
 		ImGui::Text("Equip animation enabled: %s", enableEquipAnimation_ ? "true" : "false");
 		ImGui::Text("IsEquipAnimating: %s", IsEquipAnimating() ? "true" : "false");
 		ImGui::Text("Equip elapsed time: %.3f", equipTimer_);
@@ -374,11 +374,8 @@ void PlayerWeaponVisualComponent::SyncToHand(bool isADS)
 	const K4E::Vector3 weaponWorldScale = modelScale_ * viewModelScaleMultiplier_;
 	const float reloadT = SmoothStep01(reloadPoseAlpha_);
 	const K4E::Vector3 reloadOffset = reloadWeaponOffset_ * reloadT;
-	const float equipT = Clamp01((equipDuration_ > 0.001f) ? (equipTimer_ / equipDuration_) : 1.0f);
-	const float equipEaseOut = 1.0f - (1.0f - equipT) * (1.0f - equipT);
-	const float equipPosY = (1.0f - equipEaseOut) * equipStartOffsetY_;
-	const float equipPitch = (1.0f - equipEaseOut) * ToRadians(equipStartPitchDeg_);
-	const K4E::Vector3 equipOffset = { 0.0f, equipPosY, 0.0f };
+	const K4E::Vector3 equipOffset = GetCurrentEquipOffset();
+	const float equipPitch = GetCurrentEquipPitchRad();
 	const K4E::Vector3 totalLocalOffset = localPos + handSocketLocalOffset_ + reloadOffset + equipOffset;
 
 	K4E::Matrix4x4 localMatrix{};
@@ -438,6 +435,20 @@ bool PlayerWeaponVisualComponent::LoadWeaponModel(const std::string& modelPath)
 K4E::Vector3 PlayerWeaponVisualComponent::TransformWeaponLocalPoint(const K4E::Vector3& localPoint) const
 {
 	return K4E::Matrix4x4::Transform(localPoint, weaponWorldMatrix_);
+}
+
+K4E::Vector3 PlayerWeaponVisualComponent::GetCurrentEquipOffset() const
+{
+	const float equipT = Clamp01((equipDuration_ > 0.001f) ? (equipTimer_ / equipDuration_) : 1.0f);
+	const float equipEaseOut = 1.0f - (1.0f - equipT) * (1.0f - equipT);
+	return { 0.0f, (1.0f - equipEaseOut) * equipStartOffsetY_, (1.0f - equipEaseOut) * equipStartOffsetZ_ };
+}
+
+float PlayerWeaponVisualComponent::GetCurrentEquipPitchRad() const
+{
+	const float equipT = Clamp01((equipDuration_ > 0.001f) ? (equipTimer_ / equipDuration_) : 1.0f);
+	const float equipEaseOut = 1.0f - (1.0f - equipT) * (1.0f - equipT);
+	return (1.0f - equipEaseOut) * ToRadians(equipStartPitchDeg_);
 }
 
 void PlayerWeaponVisualComponent::InitializeRotationQuaternionsFromEuler()

--- a/Project/ApplicationLayer/Character/Player/Component/PlayerWeaponVisualComponent.h
+++ b/Project/ApplicationLayer/Character/Player/Component/PlayerWeaponVisualComponent.h
@@ -43,6 +43,8 @@ public: /// ---------- メンバ関数 ---------- ///
 	void SetReloadViewModelState(bool isReloading, float reloadTimer, float reloadDuration);
 	void StartEquipAnimation();
 	bool IsEquipAnimating() const;
+	K4E::Vector3 GetCurrentEquipOffset() const;
+	float GetCurrentEquipPitchRad() const;
 
 	// 現在の見た目を強制再構築したいときに使う
 	void ForceRefresh();
@@ -121,6 +123,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	float equipTimer_ = 0.0f;
 	float equipDuration_ = 0.32f;
 	float equipStartOffsetY_ = -0.75f;
+	float equipStartOffsetZ_ = 0.0f;
 	float equipStartPitchDeg_ = -10.0f;
 
 	// 銃口のローカル位置。モデルによってずれる場合はここを調整する

--- a/Project/ApplicationLayer/Character/Player/Player.cpp
+++ b/Project/ApplicationLayer/Character/Player/Player.cpp
@@ -268,6 +268,10 @@ void Player::UpdateWeaponBeforeMotor(float deltaTime, InputFrameContext& ctx)
 		ctx.reload.isReloading,
 		ctx.reload.reloadTimer,
 		ctx.reload.reloadSec);
+	view_.SetEquipViewModelState(
+		weaponVisual_.IsEquipAnimating(),
+		weaponVisual_.GetCurrentEquipOffset(),
+		weaponVisual_.GetCurrentEquipPitchRad());
 
 	if (weaponVisual_.IsEquipAnimating())
 	{


### PR DESCRIPTION
### Motivation
- Fix inconsistent Equip animation where only the weapon model moved and it appeared to come from the front instead of rising from below. 
- Ensure the same Equip offset/rotation is applied to both arms and weapon so the entire ViewModel raises from the screen bottom.

### Description
- Added `GetCurrentEquipOffset()` and `GetCurrentEquipPitchRad()` to `PlayerWeaponVisualComponent` and exposed an `equipStartOffsetZ_` ImGui control to keep Z default at 0.0 and avoid forward popping. 
- Reused the weapon-side equip offset/pitch in `SyncToHand()` so weapon motion is computed from the same shared values. 
- Added `SetEquipViewModelState()` and storage in `PlayerViewComponent` and apply the Equip offset/pitch to both `leftArmTr_` and `rightArmTr_` during `UpdateFirstPersonArmPose()`, with a one-line intent comment: `// 腕と武器をまとめて構えさせるため、EquipオフセットはViewModel全体に適用する。`. 
- Wired the per-frame equip animation state from `PlayerWeaponVisualComponent` into `Player::UpdateWeaponBeforeMotor()` so camera-intro and weapon-switch equip cases behave identically, while preserving input suppression during equip.
- Modified files: `PlayerWeaponVisualComponent.h/.cpp`, `PlayerViewComponent.h/.cpp`, and `Player.cpp`.

### Testing
- Attempted a Debug x64 build with `msbuild Project/Ken4lowEngine.vcxproj /p:Configuration=Debug /p:Platform=x64 /m`, but the build could not be run in this environment because `msbuild` is not available. 
- No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fbd2efb90832d9e0067586c5db96f)