### PR TITLE
Add weapon-specific enemy death knockback reactions

### DIFF
--- a/Project/ApplicationLayer/Character/Bullet/Bullet.cpp
+++ b/Project/ApplicationLayer/Character/Bullet/Bullet.cpp
@@ -227,6 +227,17 @@ void Bullet::ConfigureSplashDamage(float radius, int damage, bool canDamageSelf)
 	}
 }
 
+void Bullet::SetWeaponMetadata(int32_t weaponID, EWeaponCategory category, EDeathKnockbackType deathType, float deathPower, float deathUpPower, float deathExplosionRadius, float deathImpulseScale)
+{
+	weaponID_ = weaponID;
+	weaponCategory_ = category;
+	deathKnockbackType_ = deathType;
+	deathKnockbackPower_ = std::max(0.0f, deathPower);
+	deathKnockbackUpPower_ = std::max(0.0f, deathUpPower);
+	deathExplosionRadius_ = std::max(0.0f, deathExplosionRadius);
+	deathImpulseScale_ = std::max(0.01f, deathImpulseScale);
+}
+
 void Bullet::KillAndMoveFar()
 {
 	// Exit 解決用に 1フレーム残す

--- a/Project/ApplicationLayer/Character/Bullet/Bullet.h
+++ b/Project/ApplicationLayer/Character/Bullet/Bullet.h
@@ -7,6 +7,7 @@
 #include <Vector4.h>
 
 #include <memory>
+#include "WeaponMasterData.h"
 
 namespace K4E = ::Ken4lowEngine;
 
@@ -42,6 +43,7 @@ public: /// ---------- メンバ関数 ---------- ///
 	bool IsDead() const { return isDead_; }
 	bool IsRemovable() const { return removable_; }
 	int GetDamage() const { return damage_; }
+	const K4E::Vector3& GetMoveVelocity() const { return moveVelocity_; }
 
 	void SetShooterPosition(const K4E::Vector3& pos) { shooterPosition_ = pos; }
 	const K4E::Vector3& GetShooterPosition() const { return shooterPosition_; }
@@ -60,6 +62,14 @@ public: /// ---------- メンバ関数 ---------- ///
 	bool HasSplashDamage() const { return splashRadius_ > 0.0f && splashDamage_ > 0; }
 	float GetSplashRadius() const { return splashRadius_; }
 	int GetSplashDamage() const { return splashDamage_; }
+	void SetWeaponMetadata(int32_t weaponID, EWeaponCategory category, EDeathKnockbackType deathType, float deathPower, float deathUpPower, float deathExplosionRadius, float deathImpulseScale);
+	int32_t GetWeaponID() const { return weaponID_; }
+	EWeaponCategory GetWeaponCategory() const { return weaponCategory_; }
+	EDeathKnockbackType GetDeathKnockbackType() const { return deathKnockbackType_; }
+	float GetDeathKnockbackPower() const { return deathKnockbackPower_; }
+	float GetDeathKnockbackUpPower() const { return deathKnockbackUpPower_; }
+	float GetDeathExplosionRadius() const { return deathExplosionRadius_; }
+	float GetDeathImpulseScale() const { return deathImpulseScale_; }
 
 private: /// ---------- メンバ関数 ---------- ///
 
@@ -81,6 +91,13 @@ private: /// ---------- メンバ変数 ---------- ///
 	int splashDamage_ = 0;
 	bool splashCanDamageSelf_ = false;
 	bool splashTriggered_ = false;
+	int32_t weaponID_ = 0;
+	EWeaponCategory weaponCategory_ = EWeaponCategory::Primary;
+	EDeathKnockbackType deathKnockbackType_ = EDeathKnockbackType::Default;
+	float deathKnockbackPower_ = 8.0f;
+	float deathKnockbackUpPower_ = 2.0f;
+	float deathExplosionRadius_ = 0.0f;
+	float deathImpulseScale_ = 1.0f;
 
 	std::unique_ptr<K4E::Object3D> model_ = nullptr;
 	bool drawModel_ = true;
@@ -100,4 +117,3 @@ private: /// ---------- メンバ変数 ---------- ///
 	K4E::Vector3 prevPos_ = { 0.0f, 0.0f, 0.0f };
 	K4E::Vector3 scale_ = { 0.1f, 0.1f, 0.1f };
 };
-

--- a/Project/ApplicationLayer/Character/Bullet/BulletManager.cpp
+++ b/Project/ApplicationLayer/Character/Bullet/BulletManager.cpp
@@ -23,7 +23,14 @@ Bullet* BulletManager::Spawn(const Vector3& startPos,
 	float splashRadius,
 	int splashDamage,
 	bool splashCanDamageSelf,
-	bool drawModel
+	bool drawModel,
+	int32_t weaponID,
+	EWeaponCategory weaponCategory,
+	EDeathKnockbackType deathType,
+	float deathPower,
+	float deathUpPower,
+	float deathExplosionRadius,
+	float deathImpulseScale
 )
 {
 	auto b = std::make_unique<Bullet>();
@@ -31,6 +38,7 @@ Bullet* BulletManager::Spawn(const Vector3& startPos,
 	b->SetModelDrawEnabled(drawModel);
 	b->SetCollisionManager(collisionManager_);
 	b->ConfigureSplashDamage(splashRadius, splashDamage, splashCanDamageSelf);
+	b->SetWeaponMetadata(weaponID, weaponCategory, deathType, deathPower, deathUpPower, deathExplosionRadius, deathImpulseScale);
 
 	if (collisionManager_) collisionManager_->AddCollider(b.get());
 

--- a/Project/ApplicationLayer/Character/Bullet/BulletManager.h
+++ b/Project/ApplicationLayer/Character/Bullet/BulletManager.h
@@ -30,7 +30,14 @@ public: /// ---------- メンバ関数 ---------- ///
 		float splashRadius = 0.0f,
 		int splashDamage = 0,
 		bool splashCanDamageSelf = false,
-		bool drawModel = true
+		bool drawModel = true,
+		int32_t weaponID = 0,
+		EWeaponCategory weaponCategory = EWeaponCategory::Primary,
+		EDeathKnockbackType deathType = EDeathKnockbackType::Default,
+		float deathPower = 8.0f,
+		float deathUpPower = 2.0f,
+		float deathExplosionRadius = 0.0f,
+		float deathImpulseScale = 1.0f
 		);
 
 	// 更新処理
@@ -58,4 +65,3 @@ private: /// ---------- メンバ変数 ---------- ///
 	// 弾リスト
 	std::vector<std::unique_ptr<Bullet>> bullets_;
 };
-

--- a/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.cpp
@@ -302,6 +302,7 @@ void EnemyBase::Draw()
 /// -------------------------------------------------------------
 void EnemyBase::DrawImGui()
 {
+	ImGui::Text("DeathHitPower: %.2f Up: %.2f", lastHitPower_, lastHitUpPower_);
 	if (body_.object) body_.object->DrawImGui();
 
 	for (auto& part : parts_)
@@ -500,6 +501,7 @@ void EnemyBase::StartBreakApartDeath()
 	const Vector3 center = GetCenterPosition();
 	const Vector3 hitDir = NormalizeSafe(lastHitDir_, { 0, 0, 1 });
 	const float power = (lastHitPower_ > 0.0f) ? lastHitPower_ : 1.0f;
+	const float upPower = std::max(0.0f, lastHitUpPower_);
 
 	// 体（重め）
 	{
@@ -509,7 +511,7 @@ void EnemyBase::StartBreakApartDeath()
 		const Vector3 fromCenter = NormalizeSafe(body_.transform.translate_ - center);
 		const Vector3 dir = NormalizeSafe(fromCenter + RandomUnit() * 0.35f + hitDir * p.hitBias);
 		const float speed = RandRange(2.0f, 4.5f) * power;
-		p.velocity = dir * speed + Vector3{ 0.0f, RandRange(1.0f, 3.0f) * power, 0.0f };
+		p.velocity = dir * speed + Vector3{ 0.0f, RandRange(1.0f, 3.0f) * upPower, 0.0f };
 		p.angularVel = Vector3{ RandRange(-5.0f, 5.0f), RandRange(-7.0f, 7.0f), RandRange(-5.0f, 5.0f) };
 		deathPieces_.push_back(p);
 	}
@@ -529,7 +531,7 @@ void EnemyBase::StartBreakApartDeath()
 		const float speed = RandRange(3.0f, 6.5f) * power;
 		const float up = (i == partIndices_.head) ? RandRange(2.0f, 4.0f) : RandRange(1.2f, 3.2f);
 
-		p.velocity = dir * speed + Vector3{ 0.0f, up * power, 0.0f };
+		p.velocity = dir * speed + Vector3{ 0.0f, up * upPower, 0.0f };
 		p.angularVel = Vector3{ RandRange(-10.0f, 10.0f), RandRange(-14.0f, 14.0f), RandRange(-10.0f, 10.0f) };
 		deathPieces_.push_back(p);
 	}
@@ -639,6 +641,38 @@ void EnemyBase::OnBulletHit(Collider* bulletCollider)
 		if (auto* bullet = bulletCollider->GetOwner<Bullet>())
 		{
 			damage = std::max(1, bullet->GetDamage());
+			const Vector3 bulletDir = NormalizeSafe(bullet->GetMoveVelocity(), NormalizeSafe(hitDir, { 0.0f, 0.0f, 1.0f }));
+			const Vector3 attackerDir = NormalizeSafe(GetCenterPosition() - bullet->GetShooterPosition(), bulletDir);
+			const EDeathKnockbackType kbType = bullet->GetDeathKnockbackType();
+			// 最後に受けた武器情報から死亡時の吹っ飛び方向と強さを決める
+			switch (kbType)
+			{
+			case EDeathKnockbackType::Sniper:
+				hitDir = bulletDir;
+				hitPower = bullet->GetDeathKnockbackPower() * bullet->GetDeathImpulseScale();
+				lastHitUpPower_ = std::max(0.3f, bullet->GetDeathKnockbackUpPower());
+				break;
+			case EDeathKnockbackType::Heavy:
+				hitDir = NormalizeSafe(bulletDir + Vector3{ 0.0f, 0.35f, 0.0f }, attackerDir);
+				hitPower = bullet->GetDeathKnockbackPower() * bullet->GetDeathImpulseScale();
+				lastHitUpPower_ = bullet->GetDeathKnockbackUpPower();
+				break;
+			case EDeathKnockbackType::Explosion:
+			{
+				Vector3 outDir = NormalizeSafe(GetCenterPosition() - bulletCollider->GetCenterPosition(), attackerDir);
+				hitDir = NormalizeSafe(outDir + Vector3{ 0.0f, 0.55f, 0.0f }, attackerDir);
+				hitPower = bullet->GetDeathKnockbackPower() * bullet->GetDeathImpulseScale();
+				lastHitUpPower_ = std::max(2.0f, bullet->GetDeathKnockbackUpPower());
+				break;
+			}
+			case EDeathKnockbackType::Light:
+			case EDeathKnockbackType::Default:
+			default:
+				hitDir = attackerDir;
+				hitPower = bullet->GetDeathKnockbackPower() * bullet->GetDeathImpulseScale();
+				lastHitUpPower_ = bullet->GetDeathKnockbackUpPower();
+				break;
+			}
 		}
 	}
 

--- a/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.h
@@ -207,6 +207,7 @@ protected:
 	// ---- last hit info (for death impulse) ----
 	K4E::Vector3 lastHitDir_{ 0.0f, 0.0f, 0.0f };
 	float lastHitPower_ = 1.0f;
+	float lastHitUpPower_ = 2.0f;
 
 	// ---- break apart sim ----
 	bool deathBreakActive_ = false;

--- a/Project/ApplicationLayer/WeaponSystem/WeaponMasterData/WeaponInstance.cpp
+++ b/Project/ApplicationLayer/WeaponSystem/WeaponMasterData/WeaponInstance.cpp
@@ -318,7 +318,14 @@ void WeaponInstance::FireShot(K4E::Camera* cam, BulletManager* bulletMgr, Collis
 			params_.splashRadius,
 			params_.splashDamage,
 			params_.splashCanDamageSelf,
-			params_.drawProjectileModel);
+			params_.drawProjectileModel,
+			params_.weaponID,
+			params_.weaponCategory,
+			params_.deathKnockbackType,
+			params_.deathKnockbackPower,
+			params_.deathKnockbackUpPower,
+			params_.deathExplosionRadius,
+			params_.deathImpulseScale);
 	}
 }
 

--- a/Project/ApplicationLayer/WeaponSystem/WeaponMasterData/WeaponMasterData.h
+++ b/Project/ApplicationLayer/WeaponSystem/WeaponMasterData/WeaponMasterData.h
@@ -34,6 +34,15 @@ enum class EWeaponCategory : uint8_t
 	Heavy      // ヘビー
 };
 
+enum class EDeathKnockbackType : uint8_t
+{
+	Default,
+	Light,
+	Sniper,
+	Heavy,
+	Explosion,
+};
+
 /// ---------- 射撃モード定義 ---------- ///
 enum class EFireMode : uint8_t
 {
@@ -365,6 +374,15 @@ struct FWeaponSounds
 	std::string impactSoundPath = "";				// ヒット音のパス
 };
 
+struct FWeaponDeathReaction
+{
+	EDeathKnockbackType type = EDeathKnockbackType::Default;
+	float power = 8.0f;
+	float upPower = 2.0f;
+	float explosionRadius = 0.0f;
+	float impulseScale = 1.0f;
+};
+
 /// ---------- メイン構造体 ---------- ///
 struct FWeaponMasterData
 {
@@ -391,6 +409,9 @@ struct FWeaponMasterData
 
 	/// ---------- VFXデータ ---------- ///
 	FWeaponVfx vfxData;
+
+	/// ---------- 敵死亡時の吹っ飛び設定 ---------- ///
+	FWeaponDeathReaction deathReaction;
 
 	/// ---------- ソケットデータ ---------- ///
 	FWeaponSockets socketData;

--- a/Project/ApplicationLayer/WeaponSystem/WeaponMasterData/WeaponMasterDataLoader.cpp
+++ b/Project/ApplicationLayer/WeaponSystem/WeaponMasterData/WeaponMasterDataLoader.cpp
@@ -179,6 +179,18 @@ static bool ParseEnum_EReticleType(const json& v, EReticleType& out)
 	if (s == "scope") { out = EReticleType::Scope; return true; }
 	return false;
 }
+static bool ParseEnum_EDeathKnockbackType(const json& v, EDeathKnockbackType& out)
+{
+	if (v.is_number_integer()) { out = static_cast<EDeathKnockbackType>(v.get<int>()); return true; }
+	if (!v.is_string()) return false;
+	const std::string s = ToLower(v.get<std::string>());
+	if (s == "default") { out = EDeathKnockbackType::Default; return true; }
+	if (s == "light") { out = EDeathKnockbackType::Light; return true; }
+	if (s == "sniper") { out = EDeathKnockbackType::Sniper; return true; }
+	if (s == "heavy") { out = EDeathKnockbackType::Heavy; return true; }
+	if (s == "explosion") { out = EDeathKnockbackType::Explosion; return true; }
+	return false;
+}
 
 template<typename TEnum, typename TParser>
 static void ReadEnumIfExists(const json& j, const char* key, TEnum& outValue, TParser& parser)
@@ -459,6 +471,14 @@ static void from_json(const json& j, FWeaponSounds& v)
 	ReadIfExists(j, "equipSoundPath", v.equipSoundPath);
 	ReadIfExists(j, "impactSoundPath", v.impactSoundPath);
 }
+static void from_json(const json& j, FWeaponDeathReaction& v)
+{
+	ReadEnumIfExists(j, "type", v.type, ParseEnum_EDeathKnockbackType);
+	ReadIfExists(j, "power", v.power);
+	ReadIfExists(j, "upPower", v.upPower);
+	ReadIfExists(j, "explosionRadius", v.explosionRadius);
+	ReadIfExists(j, "impulseScale", v.impulseScale);
+}
 
 static void from_json(const json& j, FWeaponMasterData& v)
 {
@@ -473,6 +493,7 @@ static void from_json(const json& j, FWeaponMasterData& v)
 	if (j.contains("assetData"))    v.assetData = j.at("assetData").get<FWeaponAssets>();
 	if (j.contains("soundData"))    v.soundData = j.at("soundData").get<FWeaponSounds>();
 	if (j.contains("vfxData"))      v.vfxData = j.at("vfxData").get<FWeaponVfx>();
+	if (j.contains("deathReaction")) v.deathReaction = j.at("deathReaction").get<FWeaponDeathReaction>();
 	if (j.contains("socketData"))   v.socketData = j.at("socketData").get<FWeaponSockets>();
 
 	ReadOptionalIfExists(j, "meleeData", v.meleeData);

--- a/Project/ApplicationLayer/WeaponSystem/WeaponMasterData/WeaponMasterDataWriter.cpp
+++ b/Project/ApplicationLayer/WeaponSystem/WeaponMasterData/WeaponMasterDataWriter.cpp
@@ -93,6 +93,18 @@ namespace
 		default: return "none";
 		}
 	}
+	static std::string DeathKnockbackTypeToStr(EDeathKnockbackType t)
+	{
+		switch (t)
+		{
+		case EDeathKnockbackType::Default: return "default";
+		case EDeathKnockbackType::Light: return "light";
+		case EDeathKnockbackType::Sniper: return "sniper";
+		case EDeathKnockbackType::Heavy: return "heavy";
+		case EDeathKnockbackType::Explosion: return "explosion";
+		default: return "default";
+		}
+	}
 
 	static bool EndsWith(const std::string& str, const std::string& suffix)
 	{
@@ -275,6 +287,13 @@ bool WeaponMasterDataWriter::SaveOne(const std::filesystem::path& filePath, cons
 		{"impactScale", data.vfxData.impactScale},
 		{"meleeSwingScale", data.vfxData.meleeSwingScale},
 		{"meleeHitScale", data.vfxData.meleeHitScale},
+	};
+	j["deathReaction"] = {
+		{"type", DeathKnockbackTypeToStr(data.deathReaction.type)},
+		{"power", data.deathReaction.power},
+		{"upPower", data.deathReaction.upPower},
+		{"explosionRadius", data.deathReaction.explosionRadius},
+		{"impulseScale", data.deathReaction.impulseScale},
 	};
 
 	// ---------- socketData ----------

--- a/Project/ApplicationLayer/WeaponSystem/WeaponMasterData/WeaponParams.h
+++ b/Project/ApplicationLayer/WeaponSystem/WeaponMasterData/WeaponParams.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstdint>
+#include "WeaponMasterData.h"
 
 /// -------------------------------------------------------------
 ///  WeaponParams
@@ -11,6 +12,12 @@ struct WeaponParams
 {
 	// --- Identity ---
 	int32_t weaponID = 0;
+	EWeaponCategory weaponCategory = EWeaponCategory::Primary;
+	EDeathKnockbackType deathKnockbackType = EDeathKnockbackType::Default;
+	float deathKnockbackPower = 8.0f;
+	float deathKnockbackUpPower = 2.0f;
+	float deathExplosionRadius = 0.0f;
+	float deathImpulseScale = 1.0f;
 
 	// --- Basic ---
 	bool    isAutomatic = false;

--- a/Project/ApplicationLayer/WeaponSystem/WeaponMasterData/WeaponSystem.cpp
+++ b/Project/ApplicationLayer/WeaponSystem/WeaponMasterData/WeaponSystem.cpp
@@ -207,6 +207,12 @@ WeaponParams WeaponSystem::BuildParams(const FWeaponMasterData& md)
 	WeaponParams p{};
 
 	p.weaponID = md.coreData.weaponID;
+	p.weaponCategory = md.coreData.category;
+	p.deathKnockbackType = md.deathReaction.type;
+	p.deathKnockbackPower = md.deathReaction.power;
+	p.deathKnockbackUpPower = md.deathReaction.upPower;
+	p.deathExplosionRadius = md.deathReaction.explosionRadius;
+	p.deathImpulseScale = md.deathReaction.impulseScale;
 	p.isAutomatic = md.bIsAutomatic;
 	p.canToggleFireMode = md.bCanToggleFireMode;
 	p.drawProjectileModel = (md.coreData.category == EWeaponCategory::Heavy);

--- a/Project/Resources/JSON/weapons/heavy/MG-58_6.json
+++ b/Project/Resources/JSON/weapons/heavy/MG-58_6.json
@@ -162,5 +162,12 @@
         "shellEjectVfxPath": "",
         "tracerScale": 1.5,
         "tracerVfxPath": ""
+    },
+    "deathReaction": {
+        "type": "explosion",
+        "power": 18.0,
+        "upPower": 10.0,
+        "explosionRadius": 6.0,
+        "impulseScale": 1.0
     }
 }

--- a/Project/Resources/JSON/weapons/melee/Knife_3.json
+++ b/Project/Resources/JSON/weapons/melee/Knife_3.json
@@ -163,5 +163,12 @@
         "shellEjectVfxPath": "",
         "tracerScale": 1.0,
         "tracerVfxPath": ""
+    },
+    "deathReaction": {
+        "type": "light",
+        "power": 6.0,
+        "upPower": 1.5,
+        "explosionRadius": 0.0,
+        "impulseScale": 1.0
     }
 }

--- a/Project/Resources/JSON/weapons/primary/M4A1_1.json
+++ b/Project/Resources/JSON/weapons/primary/M4A1_1.json
@@ -160,5 +160,12 @@
         "shellEjectVfxPath": "",
         "tracerScale": 1.0,
         "tracerVfxPath": ""
+    },
+    "deathReaction": {
+        "type": "default",
+        "power": 8.0,
+        "upPower": 2.0,
+        "explosionRadius": 0.0,
+        "impulseScale": 1.0
     }
 }

--- a/Project/Resources/JSON/weapons/sniper/SR-01_5.json
+++ b/Project/Resources/JSON/weapons/sniper/SR-01_5.json
@@ -160,5 +160,12 @@
         "shellEjectVfxPath": "",
         "tracerScale": 1.0,
         "tracerVfxPath": ""
+    },
+    "deathReaction": {
+        "type": "sniper",
+        "power": 20.0,
+        "upPower": 2.0,
+        "explosionRadius": 0.0,
+        "impulseScale": 1.0
     }
 }

--- a/Project/Resources/JSON/weapons/special/PlasmaCaster_4.json
+++ b/Project/Resources/JSON/weapons/special/PlasmaCaster_4.json
@@ -164,5 +164,12 @@
         "shellEjectVfxPath": "",
         "tracerScale": 1.0,
         "tracerVfxPath": ""
+    },
+    "deathReaction": {
+        "type": "heavy",
+        "power": 12.0,
+        "upPower": 4.0,
+        "explosionRadius": 0.0,
+        "impulseScale": 1.0
     }
 }


### PR DESCRIPTION
### Motivation
- Make enemy death knockback and death reactions configurable per-weapon so powerful weapons (snipers, heavy/explosive) produce stronger and more characteristic death flies.
- Use the last-hit weapon information (weapon ID / category / configured death params) to decide death impulse direction and strength at the moment HP reaches zero.
- Expose per-weapon tuning in WeaponMasterData/weapon JSON so designers can adjust `DeathKnockback` parameters without code changes.

### Description
- Added `EDeathKnockbackType` and `FWeaponDeathReaction` and embedded `deathReaction` into `FWeaponMasterData` so weapons can specify `type/power/upPower/explosionRadius/impulseScale`.
- Extended JSON load/save (`WeaponMasterDataLoader` / `WeaponMasterDataWriter`) to parse/emit the new `deathReaction` block (string enum supported) and populated several existing weapon JSONs with sensible defaults.
- Propagated death settings into runtime `WeaponParams` and `WeaponInstance` and passed them when spawning bullets; `Bullet` now stores weapon metadata via `SetWeaponMetadata` for later use on hit.
- Modified `EnemyBase::OnBulletHit`/death flow to consult the last-hit `Bullet` metadata and compute death knockback direction/strength by `DeathKnockbackType` (Default/Light/Sniper/Heavy/Explosion) while preserving existing `OnKilled` / collider-disable / break-apart behavior; added a short comment at the decision site explaining intent.
- Minor UI: added an ImGui readout `DeathHitPower` / `Up` in `EnemyBase::DrawImGui()` to aid tuning.

### Testing
- Attempted a Debug x64 build with `msbuild Project/Ken4lowEngine.sln /p:Configuration=Debug /p:Platform=x64`, but the environment lacks `msbuild` so the build could not be run here (automated build failed: `msbuild: command not found`).
- Ran an automated script to inject `deathReaction` into example weapon JSON files (primary/sniper/heavy/special/melee) which completed successfully.
- No other automated unit/integration tests were present or executed in this environment; runtime verification (playtesting) should be performed on a Windows dev build to confirm in-game behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fbf8023cc832d9662330634c7c88d)