### PR TITLE
Add ImGui Performance Monitor (FPS/ms toggle, CPU/Memory, history graph)

### DIFF
--- a/Project/ApplicationLayer/Scene/GamePlayScene/DebugTools/GamePlayDebugTools.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/DebugTools/GamePlayDebugTools.cpp
@@ -134,6 +134,11 @@ void GamePlayDebugTools::DrawImGui(GamePlayWorld* world)
 	if (!world) { return; }
 
 	auto& characters = world->GetCharacters();
+
+	const float fps = ImGui::GetIO().Framerate;
+	const float deltaSeconds = (fps > 0.0f) ? (1.0f / fps) : 0.0f;
+	performanceMonitor_.Update(deltaSeconds, fps);
+	const auto& perfStats = performanceMonitor_.GetStats();
 	// WindowメニューのScene Debug/Rendering表示フラグをGamePlay系デバッグUIと共有する
 	auto& editorWindowState = K4E::EditorWindowManager::GetInstance()->GetWindowState();
 
@@ -146,11 +151,61 @@ void GamePlayDebugTools::DrawImGui(GamePlayWorld* world)
 		{
 			ImGui::Text("Debug Camera: %s", isDebugCamera_ ? "ON" : "OFF");
 			ImGui::Text("Debug Freeze (F10): %s", isImGuiFreeze_ ? "ON" : "OFF");
-			ImGui::Text("FPS: %.1f", ImGui::GetIO().Framerate);
+			if (performanceDisplayMode_ == PerformanceDisplayMode::FPS)
+			{
+				ImGui::Text("FPS: %.1f", perfStats.fps);
+			}
+			else
+			{
+				ImGui::Text("Frame: %.2f ms", perfStats.frameTimeMs);
+			}
 			world->DrawGameDebugImGui();
 		}
 		ImGui::End();
 	}
+	if (showPerformanceMonitor_)
+	{
+		if (ImGui::Begin("Performance Monitor", &showPerformanceMonitor_))
+		{
+			ImGui::Checkbox("Show Graph", &showPerformanceGraph_);
+			const char* displayModeLabels[] = { "FPS", "FrameTime(ms)" };
+			int displayMode = static_cast<int>(performanceDisplayMode_);
+			if (ImGui::Combo("Display Mode", &displayMode, displayModeLabels, IM_ARRAYSIZE(displayModeLabels)))
+			{
+				performanceDisplayMode_ = static_cast<PerformanceDisplayMode>(displayMode);
+			}
+
+			if (performanceDisplayMode_ == PerformanceDisplayMode::FPS)
+			{
+				ImGui::Text("FPS: %.1f", perfStats.fps);
+			}
+			else
+			{
+				ImGui::Text("Frame: %.2f ms", perfStats.frameTimeMs);
+			}
+
+			ImGui::Text("FrameTime: %.2f ms", perfStats.frameTimeMs);
+			ImGui::Text("CPU Usage: %.1f%%", perfStats.cpuUsagePercent);
+			ImGui::Text("Process CPU Usage: %.1f%%", perfStats.processCpuUsagePercent);
+			ImGui::Text("Memory Usage: %.1f MB", perfStats.memoryUsageMB);
+
+			if (showPerformanceGraph_)
+			{
+				if (performanceDisplayMode_ == PerformanceDisplayMode::FPS)
+				{
+					const auto& history = performanceMonitor_.GetFpsHistory();
+					ImGui::PlotLines("FPS History", history.data(), static_cast<int>(history.size()), 0, nullptr, 0.0f, 240.0f, ImVec2(0.0f, 90.0f));
+				}
+				else
+				{
+					const auto& history = performanceMonitor_.GetFrameTimeHistory();
+					ImGui::PlotLines("FrameTime History", history.data(), static_cast<int>(history.size()), 0, nullptr, 0.0f, 50.0f, ImVec2(0.0f, 90.0f));
+				}
+			}
+		}
+		ImGui::End();
+	}
+
 
 	if (editorWindowState.showPlayerDebug)
 	{

--- a/Project/ApplicationLayer/Scene/GamePlayScene/DebugTools/GamePlayDebugTools.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/DebugTools/GamePlayDebugTools.h
@@ -2,6 +2,7 @@
 #include <cstdint>
 #include "ApplicationLayer/DebugTools/StageChunk/StageChunkDebugController.h"
 #include "ApplicationLayer/DebugTools/Occlusion/OcclusionDebugController.h"
+#include "PerformanceMonitor.h"
 
 /// ---------- 前方宣言 ---------- ///
 namespace Ken4lowEngine { class Input; }
@@ -46,6 +47,16 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	bool weaponEditorInitialized_ = false;
 	int32_t lastAppliedWeaponID_ = 0;
+	enum class PerformanceDisplayMode
+	{
+		FPS = 0,
+		FrameTimeMs = 1
+	};
+
+	K4E::PerformanceMonitor performanceMonitor_{};
+	PerformanceDisplayMode performanceDisplayMode_ = PerformanceDisplayMode::FPS;
+	bool showPerformanceMonitor_ = true;
+	bool showPerformanceGraph_ = true;
 	StageChunkDebugController stageChunkDebugController_{};
 	OcclusionDebugController occlusionDebugController_{};
 };

--- a/Project/Engine/DebugTools/Performance/PerformanceMonitor.cpp
+++ b/Project/Engine/DebugTools/Performance/PerformanceMonitor.cpp
@@ -1,0 +1,118 @@
+#include "PerformanceMonitor.h"
+
+#define NOMINMAX
+#include <Windows.h>
+#include <psapi.h>
+
+namespace
+{
+	unsigned long long ToUInt64(const FILETIME& fileTime)
+	{
+		ULARGE_INTEGER value{};
+		value.LowPart = fileTime.dwLowDateTime;
+		value.HighPart = fileTime.dwHighDateTime;
+		return value.QuadPart;
+	}
+}
+
+void K4E::PerformanceMonitor::Update(float deltaSeconds, float fps)
+{
+	stats_.fps = fps;
+	stats_.frameTimeMs = (fps > 0.0f) ? (1000.0f / fps) : 0.0f;
+
+	fpsHistory_[historyWriteIndex_] = stats_.fps;
+	frameTimeHistory_[historyWriteIndex_] = stats_.frameTimeMs;
+	historyWriteIndex_ = (historyWriteIndex_ + 1) % kHistorySize;
+
+	statsRefreshAccumulator_ += static_cast<double>(deltaSeconds);
+	if (statsRefreshAccumulator_ >= 0.5)
+	{
+		// CPU使用率は毎フレームではなく一定間隔で更新して計測負荷を抑える。
+		UpdateSystemStats();
+		statsRefreshAccumulator_ = 0.0;
+	}
+}
+
+void K4E::PerformanceMonitor::UpdateSystemStats()
+{
+	stats_.cpuUsagePercent = ComputeCpuUsagePercent();
+	stats_.processCpuUsagePercent = ComputeProcessCpuUsagePercent();
+
+	PROCESS_MEMORY_COUNTERS_EX memoryCounter{};
+	if (GetProcessMemoryInfo(GetCurrentProcess(), reinterpret_cast<PROCESS_MEMORY_COUNTERS*>(&memoryCounter), sizeof(memoryCounter)))
+	{
+		stats_.memoryUsageMB = static_cast<float>(memoryCounter.WorkingSetSize) / (1024.0f * 1024.0f);
+	}
+}
+
+float K4E::PerformanceMonitor::ComputeCpuUsagePercent()
+{
+	FILETIME idleTime{}, kernelTime{}, userTime{};
+	if (!GetSystemTimes(&idleTime, &kernelTime, &userTime))
+	{
+		return stats_.cpuUsagePercent;
+	}
+
+	const unsigned long long currentIdle = ToUInt64(idleTime);
+	const unsigned long long currentKernel = ToUInt64(kernelTime);
+	const unsigned long long currentUser = ToUInt64(userTime);
+
+	if (prevSystemKernel_ == 0 && prevSystemUser_ == 0)
+	{
+		prevSystemIdle_ = currentIdle;
+		prevSystemKernel_ = currentKernel;
+		prevSystemUser_ = currentUser;
+		return stats_.cpuUsagePercent;
+	}
+
+	const unsigned long long kernelDelta = currentKernel - prevSystemKernel_;
+	const unsigned long long userDelta = currentUser - prevSystemUser_;
+	const unsigned long long idleDelta = currentIdle - prevSystemIdle_;
+	const unsigned long long total = kernelDelta + userDelta;
+
+	prevSystemIdle_ = currentIdle;
+	prevSystemKernel_ = currentKernel;
+	prevSystemUser_ = currentUser;
+
+	if (total == 0)
+	{
+		return stats_.cpuUsagePercent;
+	}
+
+	const double usage = (1.0 - (static_cast<double>(idleDelta) / static_cast<double>(total))) * 100.0;
+	return static_cast<float>((usage < 0.0) ? 0.0 : usage);
+}
+
+float K4E::PerformanceMonitor::ComputeProcessCpuUsagePercent()
+{
+	FILETIME createTime{}, exitTime{}, kernelTime{}, userTime{};
+	if (!GetProcessTimes(GetCurrentProcess(), &createTime, &exitTime, &kernelTime, &userTime))
+	{
+		return stats_.processCpuUsagePercent;
+	}
+
+	const unsigned long long currentKernel = ToUInt64(kernelTime);
+	const unsigned long long currentUser = ToUInt64(userTime);
+
+	if (prevProcessKernel_ == 0 && prevProcessUser_ == 0)
+	{
+		prevProcessKernel_ = currentKernel;
+		prevProcessUser_ = currentUser;
+		return stats_.processCpuUsagePercent;
+	}
+
+	const unsigned long long kernelDelta = currentKernel - prevProcessKernel_;
+	const unsigned long long userDelta = currentUser - prevProcessUser_;
+	const unsigned long long processDelta = kernelDelta + userDelta;
+
+	prevProcessKernel_ = currentKernel;
+	prevProcessUser_ = currentUser;
+
+	SYSTEM_INFO systemInfo{};
+	GetSystemInfo(&systemInfo);
+	const unsigned int cpuCount = (systemInfo.dwNumberOfProcessors == 0) ? 1 : systemInfo.dwNumberOfProcessors;
+
+	const double interval100ns = 0.5 * 10000000.0;
+	const double usage = (static_cast<double>(processDelta) / (interval100ns * static_cast<double>(cpuCount))) * 100.0;
+	return static_cast<float>((usage < 0.0) ? 0.0 : usage);
+}

--- a/Project/Engine/DebugTools/Performance/PerformanceMonitor.h
+++ b/Project/Engine/DebugTools/Performance/PerformanceMonitor.h
@@ -1,0 +1,46 @@
+#pragma once
+
+#include <array>
+#include <cstddef>
+
+namespace K4E
+{
+	struct PerformanceStats
+	{
+		float fps = 0.0f;
+		float frameTimeMs = 0.0f;
+		float cpuUsagePercent = 0.0f;
+		float processCpuUsagePercent = 0.0f;
+		float memoryUsageMB = 0.0f;
+	};
+
+	class PerformanceMonitor
+	{
+	public:
+		static constexpr size_t kHistorySize = 240;
+
+		void Update(float deltaSeconds, float fps);
+		const PerformanceStats& GetStats() const { return stats_; }
+		const std::array<float, kHistorySize>& GetFpsHistory() const { return fpsHistory_; }
+		const std::array<float, kHistorySize>& GetFrameTimeHistory() const { return frameTimeHistory_; }
+
+	private:
+		void UpdateSystemStats();
+		float ComputeCpuUsagePercent();
+		float ComputeProcessCpuUsagePercent();
+
+	private:
+		PerformanceStats stats_{};
+		std::array<float, kHistorySize> fpsHistory_{};
+		std::array<float, kHistorySize> frameTimeHistory_{};
+		size_t historyWriteIndex_ = 0;
+
+		double statsRefreshAccumulator_ = 0.0;
+
+		unsigned long long prevSystemIdle_ = 0;
+		unsigned long long prevSystemKernel_ = 0;
+		unsigned long long prevSystemUser_ = 0;
+		unsigned long long prevProcessKernel_ = 0;
+		unsigned long long prevProcessUser_ = 0;
+	};
+}

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -275,6 +275,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="ApplicationLayer\UISystem\WaveUI\WaveUI.cpp" />
     <ClCompile Include="ApplicationLayer\Character\Player\Component\PlayerWeaponVisualComponent.cpp" />
     <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\DebugTools\GamePlayDebugTools.cpp" />
+    <ClCompile Include="Engine\DebugTools\Performance\PerformanceMonitor.cpp" />
     <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\Core\GamePlayFlow.cpp" />
     <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\Camera\GamePlayIntroDirector.cpp" />
     <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\Core\GamePlayStageContext.cpp" />
@@ -904,6 +905,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="ApplicationLayer\UISystem\WaveUI\WaveUI.h" />
     <ClInclude Include="ApplicationLayer\Character\Player\Component\PlayerWeaponVisualComponent.h" />
     <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\DebugTools\GamePlayDebugTools.h" />
+    <ClInclude Include="Engine\DebugTools\Performance\PerformanceMonitor.h" />
     <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\Core\GamePlayFlow.h" />
     <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\Camera\GamePlayIntroDirector.h" />
     <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\Core\GamePlayStageContext.h" />

--- a/Project/Ken4lowEngine.vcxproj.filters
+++ b/Project/Ken4lowEngine.vcxproj.filters
@@ -322,6 +322,9 @@
     <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\DebugTools\GamePlayDebugTools.cpp">
       <Filter>ApplicationLayer\Scene\GamePlayScene\DebugTools</Filter>
     </ClCompile>
+    <ClCompile Include="Engine\DebugTools\Performance\PerformanceMonitor.cpp">
+      <Filter>Engine\DebugTools\Performance</Filter>
+    </ClCompile>
     <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\UI\PauseMenu.cpp">
       <Filter>ApplicationLayer\Scene\GamePlayScene\UI</Filter>
     </ClCompile>
@@ -1148,6 +1151,9 @@
     </ClInclude>
     <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\DebugTools\GamePlayDebugTools.h">
       <Filter>ApplicationLayer\Scene\GamePlayScene\DebugTools</Filter>
+    </ClInclude>
+    <ClInclude Include="Engine\DebugTools\Performance\PerformanceMonitor.h">
+      <Filter>Engine\DebugTools\Performance</Filter>
     </ClInclude>
     <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\UI\PauseMenu.h">
       <Filter>ApplicationLayer\Scene\GamePlayScene\UI</Filter>
@@ -2160,6 +2166,9 @@
     </Filter>
     <Filter Include="Engine\DebugTools\LeakCheck">
       <UniqueIdentifier>{bd073444-12ba-466e-a454-d34a895aedec}</UniqueIdentifier>
+    </Filter>
+    <Filter Include="Engine\DebugTools\Performance">
+      <UniqueIdentifier>{9c3e7268-6baf-4921-883f-c352f310bb89}</UniqueIdentifier>
     </Filter>
     <Filter Include="Engine\Math\Geometry">
       <UniqueIdentifier>{63652bd2-b119-4bc3-b8d6-f67ecaf916b0}</UniqueIdentifier>


### PR DESCRIPTION
### Motivation
- Provide runtime performance metrics (FPS/frame time, CPU, process CPU, memory) in the existing ImGui debug UI so developers can inspect performance without external tools.
- Keep measurement and UI rendering separated and avoid changing existing FPS behavior or game flow code paths.
- Sample system/process stats at a limited frequency to avoid additional runtime overhead during normal execution.

### Description
- Added `PerformanceStats` and `PerformanceMonitor` in `Project/Engine/DebugTools/Performance` to collect FPS, frame time (ms), CPU usage, process CPU usage and process memory (MB), and to maintain 240-sample history buffers (`PerformanceMonitor.h` / `PerformanceMonitor.cpp`).
- Integrated the monitor into `GamePlayDebugTools` by adding `performanceMonitor_`, `PerformanceDisplayMode` enum, `showPerformanceMonitor_` and `showPerformanceGraph_`, and drawing a new ImGui window `Performance Monitor` with a combo to switch between `FPS` / `FrameTime(ms)`, text stats and `ImGui::PlotLines` history (FPS or frame time) (`GamePlayDebugTools.h` / `GamePlayDebugTools.cpp`).
- Use Windows APIs (`GetSystemTimes`, `GetProcessTimes`, `GetProcessMemoryInfo`) with a 0.5s refresh cadence for CPU/memory sampling to reduce measurement overhead and include an inline comment: `// CPU使用率は毎フレームではなく一定間隔で更新して計測負荷を抑える`.
- Updated project files to compile/include the new sources and added a VS filter: `Project/Ken4lowEngine.vcxproj` and `Project/Ken4lowEngine.vcxproj.filters` now reference the new monitor files.

### Testing
- Attempted an automated Debug x64 build with: `msbuild Ken4lowEngine.sln /t:Build /p:Configuration=Debug /p:Platform=x64`, but the container does not provide `msbuild` so the build could not be executed here (`msbuild: command not found`).
- No other automated tests were run in this environment; changes were committed locally and project files updated to include the new files so a Windows Debug x64 build in a proper environment is the recommended next step.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a0fe9d1971c832d860ad7bf2dbf0b6d)