### PR TITLE
Output LogにPerformance表示を統合しCPU/メモリ表示を追加

### DIFF
--- a/Project/Engine/Editor/EditorWindowManager.cpp
+++ b/Project/Engine/Editor/EditorWindowManager.cpp
@@ -1180,6 +1180,11 @@ namespace Ken4lowEngine
 		// Output LogはEditorOutputLogのバッファを描画し、Build/Content Browserの結果を集約する。
 		if (ImGui::Begin("Output Log", &windowState_.showOutputLog))
 		{
+			const float fps = ImGui::GetIO().Framerate;
+			const float deltaSeconds = (fps > 0.0f) ? (1.0f / fps) : 0.0f;
+			outputLogPerformanceMonitor_.Update(deltaSeconds, fps);
+			const PerformanceStats& performanceStats = outputLogPerformanceMonitor_.GetStats();
+
 			if (ImGui::Button("Clear"))
 			{
 				outputLog_.Clear();
@@ -1194,6 +1199,30 @@ namespace Ken4lowEngine
 				ImGui::Text("FPS: %.1f", ImGui::GetIO().Framerate);
 			}
 			ImGui::Separator();
+			// OutLogから実行時負荷を確認できるようにPerformance情報を描画する。
+			if (ImGui::CollapsingHeader("Performance", ImGuiTreeNodeFlags_DefaultOpen))
+			{
+				const char* displayModeLabels[] = { "FPS", "FrameTime(ms)" };
+				int displayMode = static_cast<int>(outputLogPerformanceDisplayMode_);
+				if (ImGui::Combo("Display Mode", &displayMode, displayModeLabels, IM_ARRAYSIZE(displayModeLabels)))
+				{
+					outputLogPerformanceDisplayMode_ = static_cast<OutputLogPerformanceDisplayMode>(displayMode);
+				}
+
+				if (outputLogPerformanceDisplayMode_ == OutputLogPerformanceDisplayMode::FPS)
+				{
+					ImGui::Text("FPS: %.1f", performanceStats.fps);
+				}
+				else
+				{
+					ImGui::Text("FrameTime(ms): %.2f", performanceStats.frameTimeMs);
+				}
+				ImGui::Text("FrameTime(ms): %.2f", performanceStats.frameTimeMs);
+				ImGui::Text("CPU Usage: %.1f%%", performanceStats.cpuUsagePercent);
+				ImGui::Text("Process CPU Usage: %.1f%%", performanceStats.processCpuUsagePercent);
+				ImGui::Text("Memory Usage MB: %.1f", performanceStats.memoryUsageMB);
+				ImGui::Separator();
+			}
 
 			if (ImGui::BeginChild("OutputLogScroll", ImVec2(0.0f, 0.0f), true, ImGuiWindowFlags_HorizontalScrollbar))
 			{

--- a/Project/Engine/Editor/EditorWindowManager.h
+++ b/Project/Engine/Editor/EditorWindowManager.h
@@ -5,6 +5,7 @@
 #include "EditorAssetBuildService.h"
 #include "EditorOutputLog.h"
 #include "EditorTexturePreviewCache.h"
+#include "PerformanceMonitor.h"
 
 namespace Ken4lowEngine
 {
@@ -74,6 +75,12 @@ namespace Ken4lowEngine
 	class EditorWindowManager
 	{
 	public:
+		enum class OutputLogPerformanceDisplayMode
+		{
+			FPS = 0,
+			FrameTimeMs = 1
+		};
+
 		static EditorWindowManager* GetInstance();
 
 		void Draw();
@@ -128,6 +135,8 @@ namespace Ken4lowEngine
 		bool editorServicesInitialized_ = false; // USE_IMGUI時だけEditorサービスを遅延初期化する。
 		bool outputLogAutoScroll_ = true; // Output Logの末尾追従設定をUI状態として保持する。
 		bool openRebuildDefaultLayoutPopup_ = false; // Rebuild Default Layoutを即時実行せず確認Popupへ遅延する。
+		PerformanceMonitor outputLogPerformanceMonitor_{}; // Output Logで表示するパフォーマンス計測状態を保持する。
+		OutputLogPerformanceDisplayMode outputLogPerformanceDisplayMode_ = OutputLogPerformanceDisplayMode::FPS; // Output Log内のFPS/ms切り替え状態を保持する。
 	};
 
 } // namespace Ken4lowEngine


### PR DESCRIPTION
### Motivation
- OutLog（"Output Log"）ウィンドウ内でFPS/CPU/プロセスCPU/メモリを確認したい要求に応えるため、既存のPerformanceMonitorをOutLogに表示する導線を追加しました。 
- 既存の別ウィンドウへの表示（例: GamePlay の "Performance Monitor"）は維持しつつ、OutLogでも同等の情報と表示モード切替を提供する意図です。

### Description
- `EditorWindowManager` に `PerformanceMonitor` 用メンバ `outputLogPerformanceMonitor_` と表示モード列挙 `OutputLogPerformanceDisplayMode` を追加しました (ファイル: `Project/Engine/Editor/EditorWindowManager.h`).
- `DrawOutputLog()` 内で毎フレーム `PerformanceMonitor::Update(deltaSeconds, fps)` を呼び、`Performance` 折りたたみヘッダを追加して `FPS / FrameTime(ms) / CPU Usage / Process CPU Usage / Memory Usage MB` を描画するようにしました (ファイル: `Project/Engine/Editor/EditorWindowManager.cpp`).
- OutLog 内に FPS/ms 切替用の `Display Mode` コンボを追加し、既存のログ表示（Clear / Auto Scroll / Build 表示 / ログ一覧）は変更せずに維持しています。
- 変更箇所には意図が分かる1行コメントを追加しています: `// OutLogから実行時負荷を確認できるようにPerformance情報を描画する。` (ファイル: `Project/Engine/Editor/EditorWindowManager.cpp`).

### Testing
- Debug x64 ビルドの実行を試みましたが、実行環境に `msbuild` が存在しなかったためビルドは実行できず、ビルドは未検証です (failed: `msbuild: command not found`).
- 静的ファイル差分確認とソース検索で、`DrawOutputLog()` に `Update` と描画ロジックが追加されていることを確認しました (ソース参照のみ、成功)。
- 自動化テストはこの変更で実行されておらず、実行環境でのビルド通過確認を行うことを推奨します。
- 懸念点としては `PerformanceMonitor` 側の更新間隔が既存の 0.5 秒になっているため即時反映が必要な場面では遅延して見える点と、実機でのビルド／実行確認が未完了な点があります。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1051437890832db33423e99eefd370)