### PR TITLE
Unify ImGui performance metrics with engine-side timer values

### DIFF
--- a/Project/ApplicationLayer/Scene/GamePlayScene/DebugTools/GamePlayDebugTools.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/DebugTools/GamePlayDebugTools.cpp
@@ -23,6 +23,7 @@
 #include <Editor/EditorWindowManager.h>
 #endif
 #include <Editor/EditorPlayController.h>
+#include <GameTimer.h>
 
 
 void GamePlayDebugTools::Initialize()
@@ -135,8 +136,10 @@ void GamePlayDebugTools::DrawImGui(GamePlayWorld* world)
 
 	auto& characters = world->GetCharacters();
 
-	const float fps = ImGui::GetIO().Framerate;
-	const float deltaSeconds = (fps > 0.0f) ? (1.0f / fps) : 0.0f;
+		const auto* gameTimer = K4E::GameTimer::GetInstance();
+	const float fps = gameTimer->GetFPS();
+	const float deltaSeconds = gameTimer->GetDeltaTime();
+	// FPS表示はImGuiの内部値ではなく、エンジン側の計測値に統一する。
 	performanceMonitor_.Update(deltaSeconds, fps);
 	const auto& perfStats = performanceMonitor_.GetStats();
 	// WindowメニューのScene Debug/Rendering表示フラグをGamePlay系デバッグUIと共有する

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
@@ -19,6 +19,7 @@
 
 #ifdef USE_IMGUI
 #include <imgui.h>
+#include <GameTimer.h>
 #endif
 
 using namespace Ken4lowEngine;
@@ -416,7 +417,7 @@ void GamePlayWorld::DrawGameDebugImGui()
 	ImGui::Text("Player Dead: %s", IsPlayerDead() ? "true" : "false");
 	ImGui::Text("Enemies: %d", characters_.GetEnemyCount());
 
-	const float fps = ImGui::GetIO().Framerate;
+	const float fps = K4E::GameTimer::GetInstance()->GetFPS();
 	const auto* particleManager = K4E::ParticleManager::GetInstance();
 	const auto* gpuParticleManager = K4E::GpuParticleManager::GetInstance();
 

--- a/Project/Engine/DebugTools/Performance/PerformanceMonitor.cpp
+++ b/Project/Engine/DebugTools/Performance/PerformanceMonitor.cpp
@@ -20,7 +20,7 @@ namespace
 void PerformanceMonitor::Update(float deltaSeconds, float fps)
 {
 	stats_.fps = fps;
-	stats_.frameTimeMs = (fps > 0.0f) ? (1000.0f / fps) : 0.0f;
+	stats_.frameTimeMs = (deltaSeconds > 0.0f) ? (deltaSeconds * 1000.0f) : 0.0f;
 
 	fpsHistory_[historyWriteIndex_] = stats_.fps;
 	frameTimeHistory_[historyWriteIndex_] = stats_.frameTimeMs;

--- a/Project/Engine/Editor/EditorWindowManager.cpp
+++ b/Project/Engine/Editor/EditorWindowManager.cpp
@@ -28,6 +28,7 @@
 
 #ifdef _WIN32
 #include <shellapi.h>
+#include <GameTimer.h>
 #endif // _WIN32
 
 namespace Ken4lowEngine
@@ -1180,8 +1181,10 @@ namespace Ken4lowEngine
 		// Output LogはEditorOutputLogのバッファを描画し、Build/Content Browserの結果を集約する。
 		if (ImGui::Begin("Output Log", &windowState_.showOutputLog))
 		{
-			const float fps = ImGui::GetIO().Framerate;
-			const float deltaSeconds = (fps > 0.0f) ? (1.0f / fps) : 0.0f;
+						const auto* gameTimer = K4E::GameTimer::GetInstance();
+			const float fps = gameTimer->GetFPS();
+			const float deltaSeconds = gameTimer->GetDeltaTime();
+			// FPS表示はImGuiの内部値ではなく、エンジン側の計測値に統一する。
 			outputLogPerformanceMonitor_.Update(deltaSeconds, fps);
 			const PerformanceStats& performanceStats = outputLogPerformanceMonitor_.GetStats();
 
@@ -1196,7 +1199,7 @@ namespace Ken4lowEngine
 			if (windowState_.debugShowFps)
 			{
 				ImGui::SameLine();
-				ImGui::Text("FPS: %.1f", ImGui::GetIO().Framerate);
+				ImGui::Text("FPS: %.1f", performanceStats.fps);
 			}
 			ImGui::Separator();
 			// OutLogから実行時負荷を確認できるようにPerformance情報を描画する。


### PR DESCRIPTION
### Motivation
- Ensure FPS and FrameTime are sourced from a single engine-side measurement (`GameTimer`/`FPSCounter`) instead of `ImGui::GetIO().Framerate` to avoid divergent measurements and make UI a pure presentation layer.
- Keep CPU/process CPU/memory collection in the `PerformanceMonitor` and have ImGui only display `PerformanceStats` so all metrics are centralized.

### Description
- Changed `PerformanceMonitor::Update` to compute `frameTimeMs` from the provided `deltaSeconds` (`deltaSeconds * 1000.0f`) instead of deriving it from `fps`.
- Replaced direct uses of `ImGui::GetIO().Framerate` in UI code with engine timer values by calling `K4E::GameTimer::GetInstance()->GetFPS()` and `GetDeltaTime()` in `EditorWindowManager::DrawOutputLog`, `GamePlayDebugTools::DrawImGui`, and `GamePlayWorld::DrawGameDebugImGui` and adjusted displayed values to read from `PerformanceStats`.
- Added `#include <GameTimer.h>` where needed and added the comment `// FPS表示はImGuiの内部値ではなく、エンジン側の計測値に統一する。` in the modified ImGui drawing paths to document intent.
- Kept CPU/process CPU/memory sampling inside `PerformanceMonitor` and left UI code responsible only for fetching `performanceMonitor_.GetStats()` and rendering the values.

### Testing
- Ran `rg -n "GetIO\(\)\.Framerate" Project --glob '!Project/Externals/**'` and confirmed there are no remaining uses of `ImGui::GetIO().Framerate` in project source (externals excluded), which succeeded.
- Verified modified files compile-locally for syntax by static inspection in the container (no compile toolchain run), and confirmed `PerformanceMonitor` history and getters are used unchanged by UI paths.
- Attempted a Debug x64 build with `msbuild Project/Ken4lowEngine.sln /p:Configuration=Debug /p:Platform=x64`, but the environment lacks `msbuild` so the build could not be performed in this container (command failed with `msbuild: command not found`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1053b1a100832db11cbf038ffb1bca)