### PR TITLE
Fix directional shadow frustum focus behavior and debug alignment

### DIFF
--- a/Project/Engine/Graphics/Lighting/LightManager.cpp
+++ b/Project/Engine/Graphics/Lighting/LightManager.cpp
@@ -54,6 +54,29 @@ namespace Ken4lowEngine
 
 			return Vector3::Normalize(dir);
 		}
+
+		Vector3 TransformHomogeneousPoint(const Matrix4x4& m, const Vector3& p)
+		{
+			const float x = p.x * m.m[0][0] + p.y * m.m[1][0] + p.z * m.m[2][0] + m.m[3][0];
+			const float y = p.x * m.m[0][1] + p.y * m.m[1][1] + p.z * m.m[2][1] + m.m[3][1];
+			const float z = p.x * m.m[0][2] + p.y * m.m[1][2] + p.z * m.m[2][2] + m.m[3][2];
+			const float w = p.x * m.m[0][3] + p.y * m.m[1][3] + p.z * m.m[2][3] + m.m[3][3];
+			if (std::fabs(w) < 1e-6f) { return { x, y, z }; }
+			return { x / w, y / w, z / w };
+		}
+
+		void DrawFrustumWireframeFromLightVP(Wireframe* wf, const Matrix4x4& lightViewProjection, const Vector4& color)
+		{
+			Matrix4x4 inv = Matrix4x4::Inverse(lightViewProjection);
+			const Vector3 ndcCorners[8] = {
+				{-1.0f,-1.0f,0.0f},{1.0f,-1.0f,0.0f},{1.0f,1.0f,0.0f},{-1.0f,1.0f,0.0f},
+				{-1.0f,-1.0f,1.0f},{1.0f,-1.0f,1.0f},{1.0f,1.0f,1.0f},{-1.0f,1.0f,1.0f}
+			};
+			Vector3 wpos[8];
+			for (int i = 0; i < 8; ++i) { wpos[i] = TransformHomogeneousPoint(inv, ndcCorners[i]); }
+			const int e[12][2] = { {0,1},{1,2},{2,3},{3,0},{4,5},{5,6},{6,7},{7,4},{0,4},{1,5},{2,6},{3,7} };
+			for (auto& edge : e) { wf->DrawLine(wpos[edge[0]], wpos[edge[1]], color); }
+		}
 	}
 
 	LightManager* LightManager::GetInstance()
@@ -258,6 +281,7 @@ namespace Ken4lowEngine
 				const float crossSize = 0.15f;
 				wf->DrawLine(base - right * crossSize, base + right * crossSize, colDir);
 				wf->DrawLine(base - sideUp * crossSize, base + sideUp * crossSize, colDir);
+				DrawFrustumWireframeFromLightVP(wf, currentShadowLightViewProjection_, { 0.1f, 0.9f, 1.0f, 1.0f });
 				break;
 			}
 			case 2: { // Point
@@ -495,7 +519,11 @@ namespace Ken4lowEngine
 		ImGui::SliderFloat("Directional Shadow Height", &directionalShadowHeight_, 5.0f, 300.0f, "%.2f");
 		ImGui::SliderFloat("Directional Shadow NearZ", &directionalShadowNearZ_, 0.01f, 50.0f, "%.3f");
 		ImGui::SliderFloat("Directional Shadow FarZ", &directionalShadowFarZ_, 1.01f, 1000.0f, "%.2f");
-		ImGui::SliderFloat("Directional Shadow Focus Offset", &directionalShadowFocusOffset_, -200.0f, 200.0f, "%.2f");
+		const char* focusModeItems[] = { "Camera", "Player", "StageCenter", "Manual" };
+		int focusMode = static_cast<int>(shadowFocusMode_);
+		if (ImGui::Combo("Shadow Focus Mode", &focusMode, focusModeItems, IM_ARRAYSIZE(focusModeItems))) { shadowFocusMode_ = static_cast<ShadowFocusMode>(focusMode); }
+		ImGui::DragFloat3("Manual Shadow Focus Position", &manualShadowFocusPosition_.x, 0.1f);
+		ImGui::SliderFloat("Shadow Focus Offset", &directionalShadowFocusOffset_, -200.0f, 200.0f, "%.2f");
 		ImGui::SliderFloat("Spot Shadow NearZ", &spotShadowNearZ_, 0.01f, 50.0f, "%.3f");
 
 		directionalShadowDistance_ = std::clamp(directionalShadowDistance_, 1.0f, 500.0f);
@@ -548,6 +576,9 @@ namespace Ken4lowEngine
 		const char* activeCasterName = (casterType == ShadowCasterType::Directional) ? "Directional" : (casterType == ShadowCasterType::Spot) ? "Spot" : "None";
 		ImGui::SeparatorText("Shadow Debug");
 		ImGui::Text("Active Shadow Caster: %s", activeCasterName);
+		ImGui::Text("Shadow Focus Position: (%.2f, %.2f, %.2f)", currentShadowFocusPosition_.x, currentShadowFocusPosition_.y, currentShadowFocusPosition_.z);
+		ImGui::Text("Shadow Direction: (%.3f, %.3f, %.3f)", currentShadowDirection_.x, currentShadowDirection_.y, currentShadowDirection_.z);
+		ImGui::Text("Shadow Distance: %.2f", directionalShadowDistance_);
 		ImGui::Text("Shadow Width / Height: %.2f / %.2f", directionalShadowWidth_, directionalShadowHeight_);
 		ImGui::Text("Shadow Near / Far: %.3f / %.2f", directionalShadowNearZ_, directionalShadowFarZ_);
 		ImGui::Text("Shadow Map Size: %u", shadowMapSize_);
@@ -597,8 +628,21 @@ namespace Ken4lowEngine
 			}
 		}
 
-		const Vector3 directionalFocusPosition = focusPosition + Vector3{ 0.0f, directionalShadowFocusOffset_, 0.0f };
-		return Matrix4x4::MakeLightViewProjection(lightDir, directionalFocusPosition, directionalShadowDistance_, directionalShadowWidth_, directionalShadowHeight_, directionalShadowNearZ_, directionalShadowFarZ_);
+		Vector3 directionalFocusPosition = focusPosition;
+		if (shadowFocusMode_ == ShadowFocusMode::Manual || shadowFocusMode_ == ShadowFocusMode::StageCenter)
+		{
+			// Shadow Frustumの中心を調整できるようにして、ステージ全体を影範囲に収めやすくする
+			directionalFocusPosition = manualShadowFocusPosition_;
+		}
+		directionalFocusPosition += Vector3{ 0.0f, directionalShadowFocusOffset_, 0.0f };
+		const float shadowNear = std::clamp(directionalShadowNearZ_, 0.01f, 500.0f);
+		const float shadowFar = std::max(directionalShadowFarZ_, shadowNear + 1.0f);
+		const Matrix4x4 lightViewProjection = Matrix4x4::MakeLightViewProjection(
+			lightDir, directionalFocusPosition, directionalShadowDistance_, directionalShadowWidth_, directionalShadowHeight_, shadowNear, shadowFar);
+		currentShadowFocusPosition_ = directionalFocusPosition;
+		currentShadowDirection_ = lightDir;
+		currentShadowLightViewProjection_ = lightViewProjection;
+		return lightViewProjection;
 	}
 
 	void LightManager::DrawImGui(bool* pOpen)

--- a/Project/Engine/Graphics/Lighting/LightManager.h
+++ b/Project/Engine/Graphics/Lighting/LightManager.h
@@ -56,6 +56,14 @@ namespace Ken4lowEngine
 			Directional = 1,
 			Spot = 2,
 		};
+
+		enum class ShadowFocusMode : uint32_t
+		{
+			Camera = 0,
+			Player = 1,
+			StageCenter = 2,
+			Manual = 3,
+		};
 // ライト数CB
 		struct LightInfo
 		{
@@ -221,6 +229,11 @@ namespace Ken4lowEngine
 		float directionalShadowNearZ_ = 0.1f;
 		float directionalShadowFarZ_ = 120.0f;
 		float directionalShadowFocusOffset_ = 0.0f;
+		ShadowFocusMode shadowFocusMode_ = ShadowFocusMode::Camera;
+		Vector3 manualShadowFocusPosition_ = { 0.0f, 0.0f, 0.0f };
+		mutable Vector3 currentShadowFocusPosition_ = { 0.0f, 0.0f, 0.0f };
+		mutable Vector3 currentShadowDirection_ = { 0.0f, -1.0f, 0.0f };
+		mutable Matrix4x4 currentShadowLightViewProjection_ = Matrix4x4::MakeIdentity();
 		float spotShadowNearZ_ = 0.1f;
 
 	private: /// ---------- コピー禁止 ---------- ///

--- a/Project/Engine/Math/Matrix/Matrix4x4.cpp
+++ b/Project/Engine/Math/Matrix/Matrix4x4.cpp
@@ -291,9 +291,13 @@ namespace Ken4lowEngine
 		Vector3 dir = Vector3::Normalize(lightDirection);
 		Vector3 eye = target - dir * distanceFromTarget;
 		Vector3 up = { 0.0f, 1.0f, 0.0f };
+		const float width = std::max(std::fabs(orthoHalfWidth), 0.01f);
+		const float height = std::max(std::fabs(orthoHalfHeight), 0.01f);
+		const float shadowNear = std::max(nearZ, 0.001f);
+		const float shadowFar = std::max(farZ, shadowNear + 0.001f);
 
 		Matrix4x4 view = Matrix4x4::MakeLookAtMatrix(eye, target, up);
-		Matrix4x4 proj = Matrix4x4::MakeOrthographicMatrix(-orthoHalfWidth, orthoHalfHeight, orthoHalfWidth, -orthoHalfHeight, nearZ, farZ);
+		Matrix4x4 proj = Matrix4x4::MakeOrthographicMatrix(-width, height, width, -height, shadowNear, shadowFar);
 
 		return Matrix4x4::Multiply(view, proj);
 	}


### PR DESCRIPTION
### Motivation
- Directional shadow frustum did not respond to large `Shadow Width`/`Shadow Height` because focus positioning and LightViewProjection construction were not reliably mapped to the orthographic projection and debug visualization. 
- Need to allow editors to move the shadow frustum center independently (manual focus) so the stage can be covered instead of always following the camera. 
- Debug wireframe must reflect the actual `lightViewProjection` used by shadow sampling so visualized frustum matches rendered shadows.

### Description
- Added `ShadowFocusMode` enum and editor controls (`Shadow Focus Mode`, `Manual Shadow Focus Position`, `Shadow Focus Offset`) to `LightManager` so focus can be `Camera/Player/StageCenter/Manual`. 
- `LightManager::BuildShadowLightViewProjection()` now chooses the focus position (uses manual position for `Manual`/`StageCenter` modes), clamps `near/far`, caches `currentShadowFocusPosition_`, `currentShadowDirection_` and `currentShadowLightViewProjection_` for debug. 
- Implemented frustum debug draw that reconstructs 8 world-space corners from the inverse of the actual `lightViewProjection` and draws a wireframe (`TransformHomogeneousPoint()` + `DrawFrustumWireframeFromLightVP()`), ensuring debug matches runtime shadow VP. 
- Hardened `Matrix4x4::MakeLightViewProjection()` to use absolute/min clamped `width/height` and safe `near/far` before building the orthographic projection so `Directional` lights behave as true orthographic projection and respect the width/height parameters.
- Kept changes localized to `LightManager` and VP construction and preserved existing Spot shadow path and existing shadow UI (bias/normal bias/strength/map size).

### Testing
- Attempted to build `Debug x64` via `msbuild`, but the environment lacks `msbuild` so the build could not be executed (build failed in this environment). 
- No automated unit tests were run in this environment; changes are limited and should be validated with an in-engine run: open `Light Editor`, toggle `Shadow Focus Mode`, adjust `Manual Shadow Focus Position` and `Directional Shadow Width/Height/NearZ/FarZ`, and verify the debug frustum and rendered shadow match.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10605b3e50832da90ba5ba47c8d043)