### PR TITLE
Unify shadow caster selection, expose active shadow light in ImGui, and sync gameplay shadow matrix

### DIFF
--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
@@ -27,11 +27,22 @@ using namespace Ken4lowEngine;
 void GamePlayWorld::Initialize(GamePlayStageContext& stageContext)
 {
 	const auto stageAssets = stageContext.GetCurrentStageAssets();
+	auto* lightManager = LightManager::GetInstance();
+
+	// GamePlayScene開始時に前シーンのライト状態が残らないよう、基本ライトを明示的に再構成する。
+	auto& gameplayLights = lightManager->GetMutablePunctualLightsForEditor();
+	gameplayLights.clear();
+	lightManager->AddDefaultDirectionalLight();
+	lightManager->SetShadowCasterLightIndex(-1);
+	lightManager->SetShadowFocusMode(K4E::LightManager::ShadowFocusMode::StageCenter);
+	lightManager->SetManualShadowFocusPosition({ 0.0f, 0.0f, 0.0f });
+	lightManager->SetDirectionalShadowFrustum(120.0f, 120.0f, 0.1f, 180.0f);
+	lightManager->SetShadowMapSize(2048);
 
 	K4E::Vector3 dummy{};
 	if (!TryGetDirectionalLightFromManager(dummy))
 	{
-		LightManager::GetInstance()->AddDefaultDirectionalLight();
+		lightManager->AddDefaultDirectionalLight();
 	}
 
 	skyBox_ = std::make_unique<K4E::SkyBox>();
@@ -615,16 +626,6 @@ void GamePlayWorld::CollisionUpdate()
 
 void GamePlayWorld::UpdateShadowLightViewProjection()
 {
-	K4E::Vector3 lightDir = shadowLightDirection_;
-
-	K4E::Vector3 managerDir{};
-	if (TryGetDirectionalLightFromManager(managerDir))
-	{
-		lightDir = managerDir;
-	}
-
-	lightDir = K4E::Vector3::Normalize(lightDir);
-
 	K4E::Vector3 center = { 0.0f, 0.0f, 0.0f };
 	if (auto* player = characters_.GetPlayer())
 	{
@@ -634,25 +635,7 @@ void GamePlayWorld::UpdateShadowLightViewProjection()
 		}
 	}
 
-	K4E::Vector3 eye = center - lightDir * shadowDistance_;
-	K4E::Vector3 up = { 0.0f, 1.0f, 0.0f };
-
-	if (std::abs(K4E::Vector3::Dot(lightDir, up)) > 0.99f)
-	{
-		up = { 0.0f, 0.0f, 1.0f };
-	}
-
-	K4E::Matrix4x4 view = K4E::Matrix4x4::MakeLookAtMatrix(eye, center, up);
-
-	K4E::Matrix4x4 proj = K4E::Matrix4x4::MakeOrthographicMatrix(
-		-shadowOrthoHalfWidth_,
-		shadowOrthoHalfHeight_,
-		shadowOrthoHalfWidth_,
-		-shadowOrthoHalfHeight_,
-		shadowNearZ_,
-		shadowFarZ_);
-
-	shadowLightViewProjection_ = K4E::Matrix4x4::Multiply(view, proj);
+	shadowLightViewProjection_ = K4E::LightManager::GetInstance()->BuildShadowLightViewProjection(center);
 }
 
 bool GamePlayWorld::TryGetDirectionalLightFromManager(K4E::Vector3& outDirection) const

--- a/Project/Engine/Graphics/Lighting/LightManager.cpp
+++ b/Project/Engine/Graphics/Lighting/LightManager.cpp
@@ -525,6 +525,8 @@ namespace Ken4lowEngine
 		ImGui::DragFloat3("Manual Shadow Focus Position", &manualShadowFocusPosition_.x, 0.1f);
 		ImGui::SliderFloat("Shadow Focus Offset", &directionalShadowFocusOffset_, -200.0f, 200.0f, "%.2f");
 		ImGui::SliderFloat("Spot Shadow NearZ", &spotShadowNearZ_, 0.01f, 50.0f, "%.3f");
+		ImGui::InputInt("Shadow Caster Light Index", &shadowCasterLightIndex_);
+		shadowCasterLightIndex_ = std::clamp(shadowCasterLightIndex_, -1, static_cast<int32_t>(punctualLights_.size()) - 1);
 
 		directionalShadowDistance_ = std::clamp(directionalShadowDistance_, 1.0f, 500.0f);
 		directionalShadowWidth_ = std::clamp(directionalShadowWidth_, 5.0f, 300.0f);
@@ -575,7 +577,15 @@ namespace Ken4lowEngine
 		}
 		const char* activeCasterName = (casterType == ShadowCasterType::Directional) ? "Directional" : (casterType == ShadowCasterType::Spot) ? "Spot" : "None";
 		ImGui::SeparatorText("Shadow Debug");
-		ImGui::Text("Active Shadow Caster: %s", activeCasterName);
+		ImGui::Text("Active Shadow Caster Type: %s", activeCasterName);
+		int32_t activeLightIndex = -1;
+		PunctualLightGPU activeLight{};
+		ShadowCasterType activeType = ShadowCasterType::None;
+		const bool hasActiveLight = TryGetActiveShadowCasterLightInfo(activeLightIndex, activeLight, activeType);
+		ImGui::Text("Active Shadow Light Index: %d", hasActiveLight ? activeLightIndex : -1);
+		ImGui::Text("Active Shadow Light Direction: (%.3f, %.3f, %.3f)", hasActiveLight ? activeLight.direction.x : 0.0f, hasActiveLight ? activeLight.direction.y : 0.0f, hasActiveLight ? activeLight.direction.z : 0.0f);
+		ImGui::Text("Active Shadow Light Enabled: %s", (hasActiveLight && activeLight.enabled != 0u) ? "true" : "false");
+		ImGui::Text("Active Shadow Light Intensity: %.3f", hasActiveLight ? activeLight.intensity : 0.0f);
 		ImGui::Text("Shadow Focus Position: (%.2f, %.2f, %.2f)", currentShadowFocusPosition_.x, currentShadowFocusPosition_.y, currentShadowFocusPosition_.z);
 		ImGui::Text("Shadow Direction: (%.3f, %.3f, %.3f)", currentShadowDirection_.x, currentShadowDirection_.y, currentShadowDirection_.z);
 		ImGui::Text("Shadow Distance: %.2f", directionalShadowDistance_);
@@ -590,42 +600,70 @@ namespace Ken4lowEngine
 
 	LightManager::ShadowCasterType LightManager::GetActiveShadowCasterType() const
 	{
-		for (const auto& light : punctualLights_)
+		int32_t activeIndex = -1;
+		PunctualLightGPU activeLight{};
+		ShadowCasterType activeType = ShadowCasterType::None;
+		if (TryGetActiveShadowCasterLightInfo(activeIndex, activeLight, activeType))
 		{
-			if (light.intensity <= 0.0f || light.enabled == 0u) { continue; }
-			if (light.lightType == 3) { return ShadowCasterType::Spot; }
-			if (light.lightType == 1) { return ShadowCasterType::Directional; }
+			return activeType;
 		}
 		return ShadowCasterType::None;
+	}
+
+	bool LightManager::TryGetActiveShadowCasterLightInfo(int32_t& outIndex, PunctualLightGPU& outLight, ShadowCasterType& outType) const
+	{
+		const auto isCandidate = [](const PunctualLightGPU& light)
+			{
+				return light.intensity > 0.0f && light.enabled != 0u && (light.lightType == 1 || light.lightType == 3);
+			};
+		if (shadowCasterLightIndex_ >= 0 && shadowCasterLightIndex_ < static_cast<int32_t>(punctualLights_.size()))
+		{
+			const auto& selected = punctualLights_[shadowCasterLightIndex_];
+			if (isCandidate(selected))
+			{
+				outIndex = shadowCasterLightIndex_;
+				outLight = selected;
+				outType = (selected.lightType == 3) ? ShadowCasterType::Spot : ShadowCasterType::Directional;
+				return true;
+			}
+		}
+		for (int32_t i = 0; i < static_cast<int32_t>(punctualLights_.size()); ++i)
+		{
+			const auto& light = punctualLights_[i];
+			// Shadowに使うライト選択条件を統一して、無効ライトが影行列に使われないようにする
+			if (!isCandidate(light)) { continue; }
+			outIndex = i;
+			outLight = light;
+			outType = (light.lightType == 3) ? ShadowCasterType::Spot : ShadowCasterType::Directional;
+			return true;
+		}
+		return false;
 	}
 
 	Matrix4x4 LightManager::BuildShadowLightViewProjection(const Vector3& focusPosition) const
 	{
 		Vector3 lightDir = { 0.3f, -1.0f, 0.2f };
-		for (const auto& light : punctualLights_)
+		int32_t activeIndex = -1;
+		PunctualLightGPU activeLight{};
+		ShadowCasterType casterType = ShadowCasterType::None;
+		if (TryGetActiveShadowCasterLightInfo(activeIndex, activeLight, casterType))
 		{
-			if (light.lightType == 1 && light.intensity > 0.0f)
+			if (casterType == ShadowCasterType::Directional)
 			{
-				lightDir = Vector3::Normalize(light.direction);
-				break;
+				lightDir = Vector3::Normalize(activeLight.direction);
 			}
 		}
 
-		if (GetActiveShadowCasterType() == ShadowCasterType::Spot)
+		if (casterType == ShadowCasterType::Spot)
 		{
-			for (const auto& light : punctualLights_)
-			{
-				if (light.lightType != 3 || light.intensity <= 0.0f) { continue; }
-				const float spotDistance = std::max(light.distance, 5.0f);
-				const float spotOuterCos = std::clamp(light.cosAngle, 0.01f, 0.999f);
-				const float outerAngle = std::acos(spotOuterCos) * 2.0f;
-				const float fovY = std::clamp(outerAngle, 0.15f, 3.0f);
-				// SpotLightの方向でShadowMap用ViewProjectionを生成する。
-				const Matrix4x4 view = Matrix4x4::MakeLookAtMatrix(light.position, light.position + Vector3::Normalize(light.direction), { 0.0f,1.0f,0.0f });
-				const Matrix4x4 proj = Matrix4x4::MakePerspectiveFovMatrix(fovY, 1.0f, spotShadowNearZ_, spotDistance);
-				// SpotLight Shadow は world * view * projection の順で評価できる行列を返す。
-				return Matrix4x4::Multiply(view, proj);
-			}
+			const auto& light = activeLight;
+			const float spotDistance = std::max(light.distance, 5.0f);
+			const float spotOuterCos = std::clamp(light.cosAngle, 0.01f, 0.999f);
+			const float outerAngle = std::acos(spotOuterCos) * 2.0f;
+			const float fovY = std::clamp(outerAngle, 0.15f, 3.0f);
+			const Matrix4x4 view = Matrix4x4::MakeLookAtMatrix(light.position, light.position + Vector3::Normalize(light.direction), { 0.0f,1.0f,0.0f });
+			const Matrix4x4 proj = Matrix4x4::MakePerspectiveFovMatrix(fovY, 1.0f, spotShadowNearZ_, spotDistance);
+			return Matrix4x4::Multiply(view, proj);
 		}
 
 		Vector3 directionalFocusPosition = focusPosition;

--- a/Project/Engine/Graphics/Lighting/LightManager.h
+++ b/Project/Engine/Graphics/Lighting/LightManager.h
@@ -159,6 +159,13 @@ namespace Ken4lowEngine
 		LightingSettingsGPU& GetMutableLightingSettingsForEditor() { return lightingSettings_; }
 		ShadowCasterType GetActiveShadowCasterType() const;
 		Matrix4x4 BuildShadowLightViewProjection(const Vector3& focusPosition) const;
+		bool TryGetActiveShadowCasterLightInfo(int32_t& outIndex, PunctualLightGPU& outLight, ShadowCasterType& outType) const;
+		void SetShadowCasterLightIndex(int32_t index) { shadowCasterLightIndex_ = index; }
+		int32_t GetShadowCasterLightIndex() const { return shadowCasterLightIndex_; }
+		void SetShadowFocusMode(ShadowFocusMode mode) { shadowFocusMode_ = mode; }
+		void SetManualShadowFocusPosition(const Vector3& pos) { manualShadowFocusPosition_ = pos; }
+		void SetDirectionalShadowFrustum(float width, float height, float nearZ, float farZ) { directionalShadowWidth_ = width; directionalShadowHeight_ = height; directionalShadowNearZ_ = nearZ; directionalShadowFarZ_ = farZ; }
+		void SetShadowMapSize(uint32_t size) { shadowMapSize_ = size; }
 
 		// Editor Detailsから選択中ライトだけを書き換えるため、index検証付きヘルパー経由でのみ利用する。
 		std::vector<PunctualLightGPU>& GetMutablePunctualLightsForEditor() { return punctualLights_; }
@@ -235,6 +242,7 @@ namespace Ken4lowEngine
 		mutable Vector3 currentShadowDirection_ = { 0.0f, -1.0f, 0.0f };
 		mutable Matrix4x4 currentShadowLightViewProjection_ = Matrix4x4::MakeIdentity();
 		float spotShadowNearZ_ = 0.1f;
+		int32_t shadowCasterLightIndex_ = -1;
 
 	private: /// ---------- コピー禁止 ---------- ///
 


### PR DESCRIPTION
### Motivation
- Fix mismatch between which punctual light is reported as the active shadow caster and which light is actually used to build the shadow view-projection, which caused visible shadow frustum/shadow clipping differences in GamePlayScene.
- Make shadow caster selection explicit when multiple Directional/Spot lights exist and avoid using disabled lights for shadow matrix generation.
- Prevent stale lights from previous scenes affecting GamePlayScene by ensuring a reproducible default lighting state on world initialization.

### Description
- Added a unified selection helper `TryGetActiveShadowCasterLightInfo(int32_t&, PunctualLightGPU&, ShadowCasterType&)` and `shadowCasterLightIndex_` to `LightManager` so both `GetActiveShadowCasterType()` and `BuildShadowLightViewProjection()` use identical enabled/intensity/type filtering (skip `enabled == 0` and `intensity <= 0`).
- Exposed shadow diagnostics and control in ImGui (`DrawPunctualLightsInspector`): `Active Shadow Caster Type`, `Active Shadow Light Index`, `Active Shadow Light Direction`, `Active Shadow Light Enabled`, `Active Shadow Light Intensity`, and an `Shadow Caster Light Index` input (use `-1` for auto selection).
- Made `BuildShadowLightViewProjection()` consult the unified helper and use the selected light (or auto-selected valid light) when producing directional or spot shadow matrices, and added the comment `// Shadowに使うライト選択条件を統一して、無効ライトが影行列に使われないようにする` as requested.
- Replaced GamePlayWorld's independent shadow matrix math with a single source of truth by calling `LightManager::BuildShadowLightViewProjection(center)` in `GamePlayWorld::UpdateShadowLightViewProjection()` so debug frustum and runtime shadow matrix are aligned.
- On GamePlay startup (`GamePlayWorld::Initialize`) clear punctual lights and bootstrap a safe gameplay lighting configuration (clear lights, add default directional light, set shadow focus to `StageCenter`, set frustum to 120x120, near/far 0.1/180, and shadow map size 2048) to avoid leftover lights across scene transitions.
- Header API additions to `LightManager.h`: `TryGetActiveShadowCasterLightInfo`, setters/getters for `shadowCasterLightIndex_`, setters for focus/frustum/manual focus and shadow map size.
- Modified files: `Project/Engine/Graphics/Lighting/LightManager.h`, `Project/Engine/Graphics/Lighting/LightManager.cpp`, `Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp`.

### Testing
- Attempted an automated Debug x64 build with `msbuild Ken4lowEngine.sln /p:Configuration=Debug /p:Platform=x64`, but the environment lacked `msbuild` and the build could not be run (failure: `msbuild: command not found`).
- Performed static code inspection via repository search and opened modified files to verify the new selection helper is used by both the inspector and shadow matrix generation and that `GamePlayWorld` now uses `LightManager::BuildShadowLightViewProjection()`; these checks succeeded in the local editing environment but are not a substitute for a full build.
- No unit/integration tests were executed in this environment due to lack of Windows build tools. If desired, a CI or local Windows Debug x64 build should be run to validate rendering and confirm the shadow frustum debug lines now match the runtime shadow.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a10693e69ec832d8cb2c3a329069db2)