### PR TITLE
Shadow Frustum デバッグが 91 以上で消える問題の修正（逆行列判定とNaNガード強化）

### DIFF
--- a/Project/Engine/Graphics/Lighting/LightManager.cpp
+++ b/Project/Engine/Graphics/Lighting/LightManager.cpp
@@ -10,6 +10,7 @@
 #include <numbers>    // 円周率（C++20）
 #include <algorithm>  // std::clamp
 #include <cmath>      // sin/cos/atan2/asin/acos
+#include <array>
 
 namespace Ken4lowEngine
 {
@@ -67,13 +68,24 @@ namespace Ken4lowEngine
 
 		void DrawFrustumWireframeFromLightVP(Wireframe* wf, const Matrix4x4& lightViewProjection, const Vector4& color)
 		{
-			Matrix4x4 inv = Matrix4x4::Inverse(lightViewProjection);
+			Matrix4x4 inv{};
+			if (!Matrix4x4::TryInverse(lightViewProjection, inv))
+			{
+				return;
+			}
 			const Vector3 ndcCorners[8] = {
 				{-1.0f,-1.0f,0.0f},{1.0f,-1.0f,0.0f},{1.0f,1.0f,0.0f},{-1.0f,1.0f,0.0f},
 				{-1.0f,-1.0f,1.0f},{1.0f,-1.0f,1.0f},{1.0f,1.0f,1.0f},{-1.0f,1.0f,1.0f}
 			};
 			Vector3 wpos[8];
-			for (int i = 0; i < 8; ++i) { wpos[i] = TransformHomogeneousPoint(inv, ndcCorners[i]); }
+			for (int i = 0; i < 8; ++i)
+			{
+				wpos[i] = TransformHomogeneousPoint(inv, ndcCorners[i]);
+				if (!std::isfinite(wpos[i].x) || !std::isfinite(wpos[i].y) || !std::isfinite(wpos[i].z))
+				{
+					return;
+				}
+			}
 			const int e[12][2] = { {0,1},{1,2},{2,3},{3,0},{4,5},{5,6},{6,7},{7,4},{0,4},{1,5},{2,6},{3,7} };
 			for (auto& edge : e) { wf->DrawLine(wpos[edge[0]], wpos[edge[1]], color); }
 		}
@@ -591,6 +603,8 @@ namespace Ken4lowEngine
 		ImGui::Text("Shadow Distance: %.2f", directionalShadowDistance_);
 		ImGui::Text("Shadow Width / Height: %.2f / %.2f", directionalShadowWidth_, directionalShadowHeight_);
 		ImGui::Text("Shadow Near / Far: %.3f / %.2f", directionalShadowNearZ_, directionalShadowFarZ_);
+		ImGui::Text("Applied Shadow Width / Height: %.2f / %.2f", currentShadowFrustumWidth_, currentShadowFrustumHeight_);
+		ImGui::Text("Applied Shadow Near / Far: %.3f / %.2f", currentShadowFrustumNearZ_, currentShadowFrustumFarZ_);
 		ImGui::Text("Shadow Map Size: %u", shadowMapSize_);
 		ImGui::Text("Shadow Bias / Normal Bias: %.6f / %.4f", shadowBias_, normalBias_);
 		ImGui::Text("Active Lights (type!=0): will be uploaded");
@@ -673,13 +687,20 @@ namespace Ken4lowEngine
 			directionalFocusPosition = manualShadowFocusPosition_;
 		}
 		directionalFocusPosition += Vector3{ 0.0f, directionalShadowFocusOffset_, 0.0f };
+		const float shadowWidth = std::max(std::fabs(directionalShadowWidth_), 0.01f);
+		const float shadowHeight = std::max(std::fabs(directionalShadowHeight_), 0.01f);
 		const float shadowNear = std::clamp(directionalShadowNearZ_, 0.01f, 500.0f);
 		const float shadowFar = std::max(directionalShadowFarZ_, shadowNear + 1.0f);
+		// Shadow Frustum debugは実際のLightViewProjectionから復元し、サイズに関係なく描画する
 		const Matrix4x4 lightViewProjection = Matrix4x4::MakeLightViewProjection(
-			lightDir, directionalFocusPosition, directionalShadowDistance_, directionalShadowWidth_, directionalShadowHeight_, shadowNear, shadowFar);
+			lightDir, directionalFocusPosition, directionalShadowDistance_, shadowWidth, shadowHeight, shadowNear, shadowFar);
 		currentShadowFocusPosition_ = directionalFocusPosition;
 		currentShadowDirection_ = lightDir;
 		currentShadowLightViewProjection_ = lightViewProjection;
+		currentShadowFrustumWidth_ = shadowWidth;
+		currentShadowFrustumHeight_ = shadowHeight;
+		currentShadowFrustumNearZ_ = shadowNear;
+		currentShadowFrustumFarZ_ = shadowFar;
 		return lightViewProjection;
 	}
 

--- a/Project/Engine/Graphics/Lighting/LightManager.h
+++ b/Project/Engine/Graphics/Lighting/LightManager.h
@@ -241,6 +241,10 @@ namespace Ken4lowEngine
 		mutable Vector3 currentShadowFocusPosition_ = { 0.0f, 0.0f, 0.0f };
 		mutable Vector3 currentShadowDirection_ = { 0.0f, -1.0f, 0.0f };
 		mutable Matrix4x4 currentShadowLightViewProjection_ = Matrix4x4::MakeIdentity();
+		mutable float currentShadowFrustumWidth_ = 35.0f;
+		mutable float currentShadowFrustumHeight_ = 35.0f;
+		mutable float currentShadowFrustumNearZ_ = 0.1f;
+		mutable float currentShadowFrustumFarZ_ = 120.0f;
 		float spotShadowNearZ_ = 0.1f;
 		int32_t shadowCasterLightIndex_ = -1;
 

--- a/Project/Engine/Graphics/Renderer/Wireframe/Wireframe.cpp
+++ b/Project/Engine/Graphics/Renderer/Wireframe/Wireframe.cpp
@@ -7,6 +7,7 @@
 #include "ResourceManager.h"
 #include "WireframeShaderManifest.h"
 #include "GameViewportConstants.h"
+#include <cmath>
 
 namespace Ken4lowEngine
 {
@@ -199,9 +200,14 @@ namespace Ken4lowEngine
 	/// -------------------------------------------------------------
 	///				　	      線を描画する処理
 	/// -------------------------------------------------------------
-	void Wireframe::DrawLine(const Vector3& start, const Vector3& end, const Vector4& color)
+void Wireframe::DrawLine(const Vector3& start, const Vector3& end, const Vector4& color)
 	{
 		if (!lineData_ || !lineData_->vertexData || lineIndex_ + 1 >= kLineMaxCount_ * kLineVertexCount)
+		{
+			return;
+		}
+		if (!std::isfinite(start.x) || !std::isfinite(start.y) || !std::isfinite(start.z) ||
+			!std::isfinite(end.x) || !std::isfinite(end.y) || !std::isfinite(end.z))
 		{
 			return;
 		}

--- a/Project/Engine/Math/Matrix/Matrix4x4.cpp
+++ b/Project/Engine/Math/Matrix/Matrix4x4.cpp
@@ -1,6 +1,7 @@
 #include "Matrix4x4.h"
 #include "Vector3.h"
 #include "Quaternion.h"
+#include <limits>
 
 namespace Ken4lowEngine
 {
@@ -178,7 +179,7 @@ namespace Ken4lowEngine
 			+ matrix.m[0][2] * (matrix.m[1][0] * matrix.m[2][1] * matrix.m[3][3] + matrix.m[1][1] * matrix.m[2][3] * matrix.m[3][0] + matrix.m[1][3] * matrix.m[2][0] * matrix.m[3][1] - matrix.m[1][3] * matrix.m[2][1] * matrix.m[3][0] - matrix.m[1][1] * matrix.m[2][0] * matrix.m[3][3] - matrix.m[1][0] * matrix.m[2][3] * matrix.m[3][1])
 			- matrix.m[0][3] * (matrix.m[1][0] * matrix.m[2][1] * matrix.m[3][2] + matrix.m[1][1] * matrix.m[2][2] * matrix.m[3][0] + matrix.m[1][2] * matrix.m[2][0] * matrix.m[3][1] - matrix.m[1][2] * matrix.m[2][1] * matrix.m[3][0] - matrix.m[1][1] * matrix.m[2][0] * matrix.m[3][2] - matrix.m[1][0] * matrix.m[2][2] * matrix.m[3][1]);
 
-		constexpr float kEpsilon = 1.0e-6f;
+		constexpr float kEpsilon = 1.0e-12f;
 
 		if (std::fabs(det) <= kEpsilon)
 		{


### PR DESCRIPTION
### Motivation
- Shadow Frustum のワイヤーフレームが幅/高さを大きくしたとき（約91以上）に描画されなくなるのは、デバッグ表示で逆行列が誤って「特異」と判定されたために 8 頂点復元に失敗し描画を中止していたことが原因と推定しました。 

### Description
- `Matrix4x4::TryInverse()` の特異判定閾値を `1e-6f` から `1e-12f` に変更して、幅/高さが大きい直交ライトVPで正当な行列が誤って非可逆と判定される現象を緩和しました（`Project/Engine/Math/Matrix/Matrix4x4.cpp`）。
- Shadow Frustum の復元処理を `TryInverse()` を使うように変更し、逆行列取得失敗時は安全にリターンするようにしてさらに復元した 8 頂点に対して `std::isfinite` チェックを追加しました（`Project/Engine/Graphics/Lighting/LightManager.cpp`）。
- `Wireframe::DrawLine()` に送る座標について NaN/Inf を弾くガードを追加し、デバッグ線バッファへ不正な座標が入らないようにしました（`Project/Engine/Graphics/Renderer/Wireframe/Wireframe.cpp`）。
- LightViewProjection に実際に適用したフラスタム値（幅/高さ/near/far）をメンバに保存して ImGui に `Applied Shadow Width / Height` として表示するようにし、UI 表示値と内部で使われる実値を突合できるようにしました（`Project/Engine/Graphics/Lighting/LightManager.h` / `LightManager.cpp`）。
- デバッグ用コメントを追加しました: `// Shadow Frustum debugは実際のLightViewProjectionから復元し、サイズに関係なく描画する`（変更点に沿った説明的コメント）。

### Testing
- コード検索（`rg`）で 90/91 固有のハードコード制限は見つからないことを確認する静的チェックを行いました（自動化コマンド実行）。
- 変更後のプロジェクトビルドを `msbuild` で試行しましたが、実行環境に `msbuild` が存在しなかったためビルドは実行できませんでした（ビルド試行は自動化で実施、失敗）。
- 影デバッグ復元と NaN/Inf ガードはコード上で組み込み、逆行列失敗時は安全に早期リターンするため不正な頂点投入は防げることを確認しました（コードレベルの自動チェック）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a113c3fcac4832d82cee655f800b2e4)