### PR TITLE
Add Debug Viewport: separate RenderTarget, Debug camera pass and ImGui window

### DIFF
--- a/Project/Engine/Core/Application/GameApplication.cpp
+++ b/Project/Engine/Core/Application/GameApplication.cpp
@@ -163,6 +163,10 @@ namespace Ken4lowEngine
 		DrawCurrentScene2DOverlay();
 		PostEffectManager::GetInstance()->EndGameRenderTargetOverlay(); // ImGui::Imageで読むためGameRenderTargetをSRVへ戻す
 
+#ifdef _DEBUG
+		DrawDebugViewportWorld();
+#endif // _DEBUG
+
 		//--------------------------------------------
 		// 6. ImGui描画
 		//--------------------------------------------
@@ -204,13 +208,16 @@ namespace Ken4lowEngine
 	/// -------------------------------------------------------------
 	///						ゲーム本編3D描画の共通処理
 	/// -------------------------------------------------------------
-	void GameApplication::DrawCurrentScene3DPass()
+	void GameApplication::DrawCurrentScene3DPass(bool drawDebugWire)
 	{
 		// Scene 3D -> Debug Wireframe -> GPU Particle -> Particleの順をDebug/Releaseで固定する。
 		Object3DCommon::GetInstance()->BeginObject3DPass();
 		SceneManager::GetInstance()->Draw3DObjects();
 
-		Wireframe::GetInstance()->Draw();
+		if (drawDebugWire)
+		{
+			Wireframe::GetInstance()->Draw();
+		}
 		GpuParticleManager::GetInstance()->Draw();
 		ParticleManager::GetInstance()->Draw();
 	}
@@ -228,8 +235,41 @@ namespace Ken4lowEngine
 	{
 		// Debug/ReleaseともSceneRenderTargetへ3D World + Particleを描画し、PostEffect入力を必ず作る。
 		PostEffectManager::GetInstance()->BeginDraw();
-		DrawCurrentScene3DPass();
+		bool drawDebugWire = true;
+#ifdef USE_IMGUI
+#ifdef _DEBUG
+		drawDebugWire = EditorWindowManager::GetInstance()->GetWindowState().drawDebugWireInGameView;
+#endif
+#endif
+		DrawCurrentScene3DPass(drawDebugWire);
 		PostEffectManager::GetInstance()->EndDraw();
+	}
+
+	void GameApplication::DrawDebugViewportWorld()
+	{
+		auto* editorWindows = EditorWindowManager::GetInstance();
+		const auto& editorWindowState = editorWindows->GetWindowState();
+		if (!editorWindowState.showDebugViewport)
+		{
+			return;
+		}
+
+		auto* cameraManager = CameraManager::GetInstance();
+		const bool useDebugBefore = cameraManager->IsUsingDebugCamera();
+		// ゲーム画面を維持したままデバッグ確認できるよう、DebugCamera用Viewportを別RenderTargetに描画する。
+		cameraManager->SetUseDebugCamera(true);
+		Wireframe::GetInstance()->SetDebugCamera(true);
+
+		PostEffectManager::GetInstance()->BeginDebugViewportDraw();
+		bool drawDebugWire = true;
+#ifdef USE_IMGUI
+		drawDebugWire = EditorWindowManager::GetInstance()->GetWindowState().drawDebugWireInDebugView;
+#endif
+		DrawCurrentScene3DPass(drawDebugWire);
+		PostEffectManager::GetInstance()->EndDebugViewportDraw();
+
+		Wireframe::GetInstance()->SetDebugCamera(useDebugBefore);
+		cameraManager->SetUseDebugCamera(useDebugBefore);
 	}
 
 	void GameApplication::ApplyPostEffectToBackBuffer()

--- a/Project/Engine/Core/Application/GameApplication.h
+++ b/Project/Engine/Core/Application/GameApplication.h
@@ -53,13 +53,14 @@ public: /// ---------- メンバ関数 ---------- ///
 
 private:
 	// Debug/Releaseでゲーム本編の3D描画順を揃えるための共通ルート。
-	void DrawCurrentScene3DPass();
+	void DrawCurrentScene3DPass(bool drawDebugWire = true);
 
 	// Debug/ReleaseでHUD/UI/Sprite/Fontを必ず重ねるための共通ルート。
 	void DrawCurrentScene2DOverlay();
 
 	// ReleaseでもSceneRenderTarget起点の描画順に揃えるためのフェーズ分割。
 	void DrawGameWorldToSceneTarget();
+	void DrawDebugViewportWorld();
 	void ApplyPostEffectToBackBuffer();
 	void DrawGameUIToBackBuffer();
 

--- a/Project/Engine/Editor/EditorWindowManager.cpp
+++ b/Project/Engine/Editor/EditorWindowManager.cpp
@@ -194,6 +194,7 @@ namespace Ken4lowEngine
 			DrawToolbar();
 		}
 		DrawMainViewport();
+		DrawDebugViewport();
 		DrawWorldOutliner();
 		DrawDetails();
 		DrawContentBrowser();
@@ -227,6 +228,7 @@ namespace Ken4lowEngine
 			if (ImGui::BeginMenu("Common"))
 			{
 				ImGui::MenuItem("Main Viewport", nullptr, &windowState_.showMainViewport);
+				ImGui::MenuItem("Debug Viewport", nullptr, &windowState_.showDebugViewport);
 				ImGui::MenuItem("World Outliner", nullptr, &windowState_.showWorldOutliner);
 				ImGui::MenuItem("Details", nullptr, &windowState_.showDetails);
 				ImGui::MenuItem("Content Browser", nullptr, &windowState_.showContentBrowser);
@@ -491,6 +493,7 @@ namespace Ken4lowEngine
 		// Main ViewportはGameRenderTargetをDrawListで表示する固定名ウィンドウにする
 		if (ImGui::Begin("Main Viewport", &windowState_.showMainViewport, ImGuiWindowFlags_NoScrollbar))
 		{
+			ImGui::Checkbox("Draw Debug Wire In Game View", &windowState_.drawDebugWireInGameView);
 			const ImVec2 availableSize = ImGui::GetContentRegionAvail();
 			auto* postEffectManager = PostEffectManager::GetInstance();
 			const float renderTargetWidth = static_cast<float>(GameViewportConstants::Width);
@@ -611,6 +614,32 @@ namespace Ken4lowEngine
 		}
 		ImGui::End();
 #endif // USE_IMGUI
+	}
+
+	void EditorWindowManager::DrawDebugViewport()
+	{
+#ifdef USE_IMGUI
+#ifdef _DEBUG
+		if (!windowState_.showDebugViewport) { return; }
+		if (ImGui::Begin("Debug Viewport", &windowState_.showDebugViewport, ImGuiWindowFlags_NoScrollbar))
+		{
+			ImGui::Checkbox("Draw Debug Wire In Debug View", &windowState_.drawDebugWireInDebugView);
+			const ImVec2 availableSize = ImGui::GetContentRegionAvail();
+			const ImVec2 imageSize = FitImageSize(GameViewportConstants::Width, GameViewportConstants::Height, availableSize);
+			const ImVec2 cursor = ImGui::GetCursorScreenPos();
+			const ImVec2 offset((availableSize.x - imageSize.x) * 0.5f, (availableSize.y - imageSize.y) * 0.5f);
+			const ImVec2 min(cursor.x + std::max(0.0f, offset.x), cursor.y + std::max(0.0f, offset.y));
+			const ImVec2 max(min.x + imageSize.x, min.y + imageSize.y);
+			const auto debugSrv = PostEffectManager::GetInstance()->GetDebugRenderTargetSrvHandleGPU();
+			if (debugSrv.ptr != 0 && imageSize.x > 1.0f && imageSize.y > 1.0f)
+			{
+				ImGui::GetWindowDrawList()->AddImage(static_cast<ImTextureID>(debugSrv.ptr), min, max, ImVec2(0, 0), ImVec2(1, 1));
+			}
+			ImGui::InvisibleButton("DebugViewportImageArea", availableSize);
+		}
+		ImGui::End();
+#endif
+#endif
 	}
 
 	Vector2 EditorWindowManager::ConvertScreenToMainViewportPosition(const Vector2& screenPosition) const

--- a/Project/Engine/Editor/EditorWindowManager.h
+++ b/Project/Engine/Editor/EditorWindowManager.h
@@ -18,6 +18,7 @@ namespace Ken4lowEngine
 		// WindowメニューのCommonカテゴリで切り替える標準エディタウィンドウです。
 		bool showToolbar = true;
 		bool showMainViewport = true;
+		bool showDebugViewport = true;
 		bool showContentBrowser = true;
 		bool showWorldOutliner = true;
 		bool showDetails = true;
@@ -45,6 +46,8 @@ namespace Ken4lowEngine
 		bool debugShowEnemyInfo = false;
 		bool debugShowWaveInfo = false;
 		bool debugShowFps = true;
+		bool drawDebugWireInGameView = false;
+		bool drawDebugWireInDebugView = true;
 	};
 
 	/// <summary>
@@ -87,6 +90,7 @@ namespace Ken4lowEngine
 		void DrawMenuBar();
 		void DrawToolbar();
 		void DrawMainViewport();
+		void DrawDebugViewport();
 		void DrawWorldOutliner();
 		void DrawDetails();
 		void DrawContentBrowser();

--- a/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.cpp
+++ b/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.cpp
@@ -58,6 +58,7 @@ namespace Ken4lowEngine
 		// RT0はScene/GameViewport、RT1はPostEffect出力として名前を固定し、DebugLayerで対象を特定する。
 		renderTargets_[0].debugName = L"SceneRenderTarget_GameViewportRenderTarget";
 		renderTargets_[1].debugName = L"PostEffectRenderTarget";
+		debugViewportRenderTarget_.debugName = L"DebugViewportRenderTarget";
 
 		// GameViewportRenderTargetはDebug/Editor時も既存UI/Sprite互換の1920x1080固定で開始する。
 		renderTargetWidth_ = kDefaultGameRenderTargetWidth_;
@@ -126,6 +127,7 @@ namespace Ken4lowEngine
 			rt.currentState_ = RenderTarget::kInitialState;
 			// srvIndex/uavIndex を Free できる設計ならここでFree（後述）
 		}
+		debugViewportRenderTarget_.resource.Reset();
 		renderTargets_.clear();
 
 		// 深度破棄
@@ -321,6 +323,13 @@ namespace Ken4lowEngine
 
 			rt.currentState_ = RenderTarget::kInitialState;
 		}
+		debugViewportRenderTarget_.resource.Reset();
+		debugViewportRenderTarget_.resource = CreateRenderTextureResource(width, height, DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, kRenderTextureClearColor_);
+		debugViewportRenderTarget_.resource->SetName(debugViewportRenderTarget_.debugName);
+		RTVManager::GetInstance()->CreateRTVForTexture2D(debugViewportRenderTarget_.rtvIndex, debugViewportRenderTarget_.resource.Get());
+		debugViewportRenderTarget_.rtvHandle = RTVManager::GetInstance()->GetCPUDescriptorHandle(debugViewportRenderTarget_.rtvIndex);
+		SRVManager::GetInstance()->CreateSRVForTexture2D(debugViewportRenderTarget_.srvIndex, debugViewportRenderTarget_.resource.Get(), DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, 1);
+		debugViewportRenderTarget_.currentState_ = RenderTarget::kInitialState;
 
 		// depth作り直し
 		depthResource_.Reset();
@@ -461,6 +470,35 @@ namespace Ken4lowEngine
 		auto commandList = dxCommon_->GetCommandManager()->GetCommandList();
 		auto& gameRT = renderTargets_[0];
 		CopyRenderTargetToBackBuffer(gameRT, commandList);
+	}
+
+	void PostEffectManager::BeginDebugViewportDraw()
+	{
+		auto commandList = dxCommon_->GetCommandManager()->GetCommandList();
+		TransitionTo(debugViewportRenderTarget_, commandList, D3D12_RESOURCE_STATE_RENDER_TARGET);
+		if (depthResource_ && depthState_ != D3D12_RESOURCE_STATE_DEPTH_WRITE)
+		{
+			dxCommon_->ResourceTransition(depthResource_.Get(), depthState_, D3D12_RESOURCE_STATE_DEPTH_WRITE);
+			depthState_ = D3D12_RESOURCE_STATE_DEPTH_WRITE;
+		}
+		commandList->OMSetRenderTargets(1, &debugViewportRenderTarget_.rtvHandle, false, &dsvHandle);
+		float clearColor[] = { kRenderTextureClearColor_.x, kRenderTextureClearColor_.y, kRenderTextureClearColor_.z, kRenderTextureClearColor_.w };
+		commandList->ClearRenderTargetView(debugViewportRenderTarget_.rtvHandle, clearColor, 0, nullptr);
+		commandList->ClearDepthStencilView(dsvHandle, D3D12_CLEAR_FLAG_DEPTH, 1.0f, 0, 0, nullptr);
+		commandList->RSSetViewports(1, &viewport);
+		commandList->RSSetScissorRects(1, &scissorRect);
+	}
+
+	void PostEffectManager::EndDebugViewportDraw()
+	{
+		auto commandList = dxCommon_->GetCommandManager()->GetCommandList();
+		TransitionTo(debugViewportRenderTarget_, commandList, D3D12_RESOURCE_STATE_PIXEL_SHADER_RESOURCE);
+	}
+
+	D3D12_GPU_DESCRIPTOR_HANDLE PostEffectManager::GetDebugRenderTargetSrvHandleGPU() const
+	{
+		if (debugViewportRenderTarget_.srvIndex == UINT32_MAX) { return {}; }
+		return SRVManager::GetInstance()->GetGPUDescriptorHandle(debugViewportRenderTarget_.srvIndex);
 	}
 
 
@@ -701,6 +739,15 @@ namespace Ken4lowEngine
 			UAVManager::GetInstance()->CreateSRVForTexture2DOnThisHeap(rt.srvIndexOnUavHeap, rt.resource.Get(), DXGI_FORMAT_R8G8B8A8_UNORM, 1);
 		}
 
+		debugViewportRenderTarget_.resource = CreateRenderTextureResource(renderTargetWidth_, renderTargetHeight_, DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, kRenderTextureClearColor_);
+		debugViewportRenderTarget_.resource->SetName(debugViewportRenderTarget_.debugName);
+		debugViewportRenderTarget_.currentState_ = RenderTarget::kInitialState;
+		debugViewportRenderTarget_.rtvIndex = RTVManager::GetInstance()->Allocate();
+		RTVManager::GetInstance()->CreateRTVForTexture2D(debugViewportRenderTarget_.rtvIndex, debugViewportRenderTarget_.resource.Get());
+		debugViewportRenderTarget_.rtvHandle = RTVManager::GetInstance()->GetCPUDescriptorHandle(debugViewportRenderTarget_.rtvIndex);
+		debugViewportRenderTarget_.srvIndex = SRVManager::GetInstance()->Allocate();
+		SRVManager::GetInstance()->CreateSRVForTexture2D(debugViewportRenderTarget_.srvIndex, debugViewportRenderTarget_.resource.Get(), DXGI_FORMAT_R8G8B8A8_UNORM_SRGB, 1);
+		
 		// 深度バッファの生成
 		depthResource_ = CreateDepthBufferResource(renderTargetWidth_, renderTargetHeight_);
 		depthResource_->SetName(L"PostEffectManager DepthBuffer");

--- a/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.h
+++ b/Project/Engine/Graphics/PostEffect/Manager/PostEffectManager.h
@@ -151,6 +151,7 @@ public: /// ---------- メンバ関数 ---------- ///
 	/// ImGui::Image に渡す GameRenderTarget の GPU SRV ハンドルを取得します。
 	/// </summary>
 	D3D12_GPU_DESCRIPTOR_HANDLE GetGameRenderTargetSrvHandleGPU() const;
+	D3D12_GPU_DESCRIPTOR_HANDLE GetDebugRenderTargetSrvHandleGPU() const;
 
 	uint32_t GetGameRenderTargetWidth() const { return renderTargetWidth_; }
 	uint32_t GetGameRenderTargetHeight() const { return renderTargetHeight_; }
@@ -159,6 +160,8 @@ public: /// ---------- メンバ関数 ---------- ///
 	/// Main Viewport の表示サイズ変更を受けても固定内部解像度を維持する入口です。
 	/// </summary>
 	void RequestGameRenderTargetResize(uint32_t width, uint32_t height);
+	void BeginDebugViewportDraw();
+	void EndDebugViewportDraw();
 
 private: /// ---------- メンバ関数 ---------- ///
 
@@ -253,6 +256,7 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	static constexpr int kPostRTCount = 1; // ポストエフェクト用のレンダーテクスチャ数
 	std::vector<RenderTarget> renderTargets_; // レンダーテクスチャのリスト
+	RenderTarget debugViewportRenderTarget_{}; // Debug Viewport専用RT
 	uint32_t renderTargetWidth_ = kDefaultGameRenderTargetWidth_; // Main Viewportへ表示するGameRenderTarget幅
 	uint32_t renderTargetHeight_ = kDefaultGameRenderTargetHeight_; // Main Viewportへ表示するGameRenderTarget高さ
 


### PR DESCRIPTION
### Motivation
- Allow simultaneous inspection of the game view and debug view so DebugCamera visuals (shadow frusta, frustum wire, bounds, culling) do not obscure the main game screen.
- Keep existing MainViewport behavior and game camera intact while adding a separate Debug Viewport and render target to avoid large refactors.
- Provide editor UI controls to toggle the debug viewport and where debug wireframes are drawn.

### Description
- Added a dedicated Debug Viewport RenderTarget in `PostEffectManager` (`debugViewportRenderTarget_`) and implemented `BeginDebugViewportDraw()`, `EndDebugViewportDraw()`, and `GetDebugRenderTargetSrvHandleGPU()` to manage SRV/RTV lifecycle and transitions.
- Added a debug-only second rendering path in `GameApplication`: `DrawDebugViewportWorld()` temporarily switches `CameraManager` to `DebugCamera`, sets `Wireframe::SetDebugCamera(true)`, renders the 3D pass to the debug RT via the new `PostEffectManager` begin/end helpers, then restores the previous camera state.
- Made `DrawCurrentScene3DPass` accept a `drawDebugWire` flag and wired editor toggles to control whether wireframes are drawn in Game vs Debug view.
- Extended `EditorWindowManager` with a `Debug Viewport` ImGui window and Window menu toggle, plus checkboxes for `Draw Debug Wire In Game View` and `Draw Debug Wire In Debug View`, and show the debug RT in ImGui using `ImGui::Image` with the debug SRV.
- Kept main rendering and post-effect flow unchanged: Game viewport still uses GameRenderTarget and MainCamera; Debug viewport uses the new debug RT and DebugCamera; debug-only code is guarded by `_DEBUG`/`USE_IMGUI` where appropriate.
- Minor resource management: `AllocateRTV_DSV_SRV_UAV()` and `Resize()` were extended to create and recreate the debug RT, and `Finalize()` clears the debug RT resource.
- Added an inline comment where the debug RT is drawn: `// ゲーム画面を維持したままデバッグ確認できるよう、DebugCamera用Viewportを別RenderTargetに描画する`.

### Testing
- Attempted automated Debug x64 build using `msbuild` but it failed in this environment because `msbuild` is not available (`command not found`), so compile-time verification was not performed here (failed).
- Performed repository checks and committed the changes (`git commit`) successfully (succeeded); no further automated tests or CI were run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a11424028c8832da3ca9de31ffee91c)