### PR TITLE
Separate Game/Debug viewport camera responsibilities and add per-viewport HUD/wire toggles

### DIFF
--- a/Project/Engine/Core/Application/GameApplication.cpp
+++ b/Project/Engine/Core/Application/GameApplication.cpp
@@ -160,7 +160,7 @@ namespace Ken4lowEngine
 		//--------------------------------------------
 		PostEffectManager::GetInstance()->BeginGameRenderTargetOverlay(); // 2DをMain Viewportに含めるためGameRenderTargetをRTVへ戻す
 		// Debug/ReleaseでGamePlaySceneのHUD/UI/Sprite/Font描画を必ず同じ入口から呼ぶ。
-		DrawCurrentScene2DOverlay();
+		DrawCurrentScene2DOverlay(EditorWindowManager::GetInstance()->GetWindowState().drawHudInGameView);
 		PostEffectManager::GetInstance()->EndGameRenderTargetOverlay(); // ImGui::Imageで読むためGameRenderTargetをSRVへ戻す
 
 #ifdef _DEBUG
@@ -225,8 +225,12 @@ namespace Ken4lowEngine
 	/// -------------------------------------------------------------
 	///						HUD/UI/Sprite描画の共通処理
 	/// -------------------------------------------------------------
-	void GameApplication::DrawCurrentScene2DOverlay()
+	void GameApplication::DrawCurrentScene2DOverlay(bool drawHud)
 	{
+		if (!drawHud)
+		{
+			return;
+		}
 		// GamePlayScene::Draw2DSprites() 内で HUDManager/Reticle/Ammo/HP/Fade まで描画する。
 		SceneManager::GetInstance()->Draw2DSprites();
 	}
@@ -256,8 +260,10 @@ namespace Ken4lowEngine
 
 		auto* cameraManager = CameraManager::GetInstance();
 		const bool useDebugBefore = cameraManager->IsUsingDebugCamera();
-		// ゲーム画面を維持したままデバッグ確認できるよう、DebugCamera用Viewportを別RenderTargetに描画する。
+		Camera* previousRenderCamera = cameraManager->GetRenderCamera();
+		// Game ViewとDebug Viewで使用カメラとデバッグ描画を分離する
 		cameraManager->SetUseDebugCamera(true);
+		cameraManager->SetRenderCamera(cameraManager->GetGameCamera());
 		Wireframe::GetInstance()->SetDebugCamera(true);
 
 		PostEffectManager::GetInstance()->BeginDebugViewportDraw();
@@ -266,10 +272,15 @@ namespace Ken4lowEngine
 		drawDebugWire = EditorWindowManager::GetInstance()->GetWindowState().drawDebugWireInDebugView;
 #endif
 		DrawCurrentScene3DPass(drawDebugWire);
+		if (editorWindowState.drawHudInDebugView)
+		{
+			DrawCurrentScene2DOverlay(true);
+		}
 		PostEffectManager::GetInstance()->EndDebugViewportDraw();
 
 		Wireframe::GetInstance()->SetDebugCamera(useDebugBefore);
 		cameraManager->SetUseDebugCamera(useDebugBefore);
+		cameraManager->SetRenderCamera(previousRenderCamera ? previousRenderCamera : cameraManager->GetGameCamera());
 	}
 
 	void GameApplication::ApplyPostEffectToBackBuffer()
@@ -281,7 +292,7 @@ namespace Ken4lowEngine
 	void GameApplication::DrawGameUIToBackBuffer()
 	{
 		// HUD/UI/Sprite/FontはPostEffect後のBackBufferへ直接描画する。
-		DrawCurrentScene2DOverlay();
+		DrawCurrentScene2DOverlay(EditorWindowManager::GetInstance()->GetWindowState().drawHudInGameView);
 	}
 
 

--- a/Project/Engine/Core/Application/GameApplication.h
+++ b/Project/Engine/Core/Application/GameApplication.h
@@ -56,7 +56,7 @@ private:
 	void DrawCurrentScene3DPass(bool drawDebugWire = true);
 
 	// Debug/ReleaseでHUD/UI/Sprite/Fontを必ず重ねるための共通ルート。
-	void DrawCurrentScene2DOverlay();
+	void DrawCurrentScene2DOverlay(bool drawHud = true);
 
 	// ReleaseでもSceneRenderTarget起点の描画順に揃えるためのフェーズ分割。
 	void DrawGameWorldToSceneTarget();

--- a/Project/Engine/Editor/EditorWindowManager.cpp
+++ b/Project/Engine/Editor/EditorWindowManager.cpp
@@ -494,6 +494,8 @@ namespace Ken4lowEngine
 		if (ImGui::Begin("Main Viewport", &windowState_.showMainViewport, ImGuiWindowFlags_NoScrollbar))
 		{
 			ImGui::Checkbox("Draw Debug Wire In Game View", &windowState_.drawDebugWireInGameView);
+			ImGui::Checkbox("Draw HUD In Game View", &windowState_.drawHudInGameView);
+			ImGui::TextUnformatted("Game Viewport Camera: MainCamera / PlayerCamera");
 			const ImVec2 availableSize = ImGui::GetContentRegionAvail();
 			auto* postEffectManager = PostEffectManager::GetInstance();
 			const float renderTargetWidth = static_cast<float>(GameViewportConstants::Width);
@@ -624,6 +626,8 @@ namespace Ken4lowEngine
 		if (ImGui::Begin("Debug Viewport", &windowState_.showDebugViewport, ImGuiWindowFlags_NoScrollbar))
 		{
 			ImGui::Checkbox("Draw Debug Wire In Debug View", &windowState_.drawDebugWireInDebugView);
+			ImGui::Checkbox("Draw HUD In Debug View", &windowState_.drawHudInDebugView);
+			ImGui::TextUnformatted("Debug Viewport Camera: DebugCamera");
 			const ImVec2 availableSize = ImGui::GetContentRegionAvail();
 			const ImVec2 imageSize = FitImageSize(GameViewportConstants::Width, GameViewportConstants::Height, availableSize);
 			const ImVec2 cursor = ImGui::GetCursorScreenPos();

--- a/Project/Engine/Editor/EditorWindowManager.h
+++ b/Project/Engine/Editor/EditorWindowManager.h
@@ -48,6 +48,8 @@ namespace Ken4lowEngine
 		bool debugShowFps = true;
 		bool drawDebugWireInGameView = false;
 		bool drawDebugWireInDebugView = true;
+		bool drawHudInGameView = true;
+		bool drawHudInDebugView = false;
 	};
 
 	/// <summary>

--- a/Project/Engine/Graphics/Camera/Manager/CameraManager.cpp
+++ b/Project/Engine/Graphics/Camera/Manager/CameraManager.cpp
@@ -13,12 +13,16 @@ namespace Ken4lowEngine
 	void CameraManager::Initialize()
 	{
 		debugCamera_ = DebugCamera::GetInstance();
+		gameCamera_ = nullptr;
+		renderCamera_ = nullptr;
 		useDebugCamera_ = false;
 	}
 
 	void CameraManager::Finalize()
 	{
 		mainCamera_ = nullptr;
+		gameCamera_ = nullptr;
+		renderCamera_ = nullptr;
 		debugCamera_ = nullptr;
 		useDebugCamera_ = false;
 	}
@@ -36,6 +40,23 @@ namespace Ken4lowEngine
 	void CameraManager::SetMainCamera(Camera* camera)
 	{
 		mainCamera_ = camera;
+		if (!gameCamera_) { gameCamera_ = camera; }
+		if (!renderCamera_) { renderCamera_ = camera; }
+	}
+
+	void CameraManager::SetRenderCamera(Camera* camera)
+	{
+		renderCamera_ = camera;
+	}
+
+	void CameraManager::SetGameCamera(Camera* camera)
+	{
+		gameCamera_ = camera;
+	}
+
+	void CameraManager::SetDebugCamera(DebugCamera* camera)
+	{
+		debugCamera_ = camera;
 	}
 
 	void CameraManager::SetUseDebugCamera(bool useDebugCamera)
@@ -51,9 +72,9 @@ namespace Ken4lowEngine
 			return debugCamera_->GetViewMatrix();
 		}
 #endif
-		if (mainCamera_)
+		if (GetRenderCamera())
 		{
-			return mainCamera_->GetViewMatrix();
+			return GetRenderCamera()->GetViewMatrix();
 		}
 		return Matrix4x4::MakeIdentity();
 	}
@@ -66,9 +87,9 @@ namespace Ken4lowEngine
 			return debugCamera_->GetProjectionMatrix();
 		}
 #endif
-		if (mainCamera_)
+		if (GetRenderCamera())
 		{
-			return mainCamera_->GetProjectionMatrix();
+			return GetRenderCamera()->GetProjectionMatrix();
 		}
 		return Matrix4x4::MakeIdentity();
 	}
@@ -81,9 +102,9 @@ namespace Ken4lowEngine
 			return debugCamera_->GetViewProjectionMatrix();
 		}
 #endif
-		if (mainCamera_)
+		if (GetRenderCamera())
 		{
-			return mainCamera_->GetViewProjectionMatrix();
+			return GetRenderCamera()->GetViewProjectionMatrix();
 		}
 		return Matrix4x4::MakeIdentity();
 	}
@@ -96,9 +117,9 @@ namespace Ken4lowEngine
 			return debugCamera_->GetTranslate();
 		}
 #endif
-		if (mainCamera_)
+		if (GetRenderCamera())
 		{
-			return mainCamera_->GetTranslate();
+			return GetRenderCamera()->GetTranslate();
 		}
 		return { 0.0f, 0.0f, 0.0f };
 	}

--- a/Project/Engine/Graphics/Camera/Manager/CameraManager.h
+++ b/Project/Engine/Graphics/Camera/Manager/CameraManager.h
@@ -25,11 +25,16 @@ namespace Ken4lowEngine
 
 		// 登録
 		void SetMainCamera(Camera* camera);
+		void SetRenderCamera(Camera* camera);
+		void SetGameCamera(Camera* camera);
+		void SetDebugCamera(DebugCamera* camera);
 		void SetUseDebugCamera(bool useDebugCamera);
 
 	public: /// ---------- ゲッタ ---------- ///
 
 		Camera* GetMainCamera() const { return mainCamera_; }
+		Camera* GetRenderCamera() const { return renderCamera_ ? renderCamera_ : gameCamera_; }
+		Camera* GetGameCamera() const { return gameCamera_; }
 		DebugCamera* GetDebugCamera() const { return debugCamera_; }
 
 		bool IsUsingDebugCamera() const { return useDebugCamera_; }
@@ -39,10 +44,7 @@ namespace Ken4lowEngine
 		Matrix4x4 GetActiveViewProjectionMatrix() const;
 		Vector3 GetActiveCameraPosition() const;
 
-		// Object3D や FPS など「Camera* が欲しい側」用
-		// DebugCamera は型が違うので、通常カメラが必要な場所では main を返す
-		Camera* GetRenderCamera() const { return mainCamera_; }
-
+		
 	private: /// ---------- コピー禁止 ---------- ///
 
 		CameraManager() = default;
@@ -53,6 +55,8 @@ namespace Ken4lowEngine
 	private: /// ---------- メンバ変数 ---------- ///
 
 		Camera* mainCamera_ = nullptr;
+		Camera* gameCamera_ = nullptr;
+		Camera* renderCamera_ = nullptr;
 		DebugCamera* debugCamera_ = nullptr;
 		bool useDebugCamera_ = false;
 	};


### PR DESCRIPTION
### Motivation

- Separate the visual responsibilities of the Main (game) and Debug viewports so the Debug viewport can be used for independent inspection (shadow frustums, culling, bounds, wires) without affecting gameplay cameras. 
- Provide per-viewport controls so debug overlays (wires/frustums/bounds) and HUD/UI can be toggled independently. 
- Keep changes minimal and localized to avoid broad refactors and preserve existing render target flow and scene logic.

### Description

- Added camera role APIs to `CameraManager` including `SetRenderCamera`, `SetGameCamera`, `SetDebugCamera`, `GetRenderCamera`, and `GetGameCamera`, and added `gameCamera_` / `renderCamera_` members so rendering can use a dedicated camera while preserving `DebugCamera` override behavior. (`Project/Engine/Graphics/Camera/Manager/CameraManager.h` / `.cpp`)
- Updated active-camera accessors (`GetActiveViewMatrix`, `GetActiveProjectionMatrix`, `GetActiveViewProjectionMatrix`, `GetActiveCameraPosition`) to use `GetRenderCamera()` when not using `DebugCamera`. (`CameraManager.cpp`)
- Exposed per-viewport HUD toggles in `EditorWindowState` as `drawHudInGameView` and `drawHudInDebugView` and added ImGui controls and camera labels to `EditorWindowManager` for clarity. (`Project/Engine/Editor/EditorWindowManager.h` / `.cpp`)
- Extended `DrawCurrentScene2DOverlay` to `DrawCurrentScene2DOverlay(bool drawHud)` and updated `GameApplication` to: use `EditorWindowManager` flags to conditionally draw HUD in Main View; switch to a DebugCamera render path for the Debug Viewport (via `SetUseDebugCamera(true)` and `SetRenderCamera(...)`), enable debug wire/HUD per the new flags, and restore the previous render camera after the debug pass; also added the comment `// Game ViewとDebug Viewで使用カメラとデバッグ描画を分離する`. (`Project/Engine/Core/Application/GameApplication.h` / `.cpp`)
- Ensured `Wireframe::GetInstance()->SetDebugCamera(true)` is used for debug viewport drawing and restored afterwards so moving `DebugCamera` does not affect the gameplay cameras.

### Testing

- Attempted an automated build with `msbuild Project/Ken4lowEngine.vcxproj /p:Configuration=Debug /p:Platform=x64` but the environment reports `msbuild: command not found`, so a Debug x64 build could not be verified here. 
- Performed code-level validation via repository search/diff to ensure all call sites were updated and to verify the added API usage and UI flags; no automated unit/integration tests were present or run in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a114623d3e0832d84a68353ddf1f6a8)