### PR TITLE
DataAsset基盤追加とLightPresetの初期接続

### DIFF
--- a/Project/Engine/Graphics/Lighting/LightManager.cpp
+++ b/Project/Engine/Graphics/Lighting/LightManager.cpp
@@ -6,6 +6,8 @@
 #include "ParameterManager.h"
 #include <SRVManager.h>
 #include "Wireframe.h"
+#include "JsonDataManager.h"
+#include "DataAssetPresets.h"
 
 #include <numbers>    // 円周率（C++20）
 #include <algorithm>  // std::clamp
@@ -721,6 +723,10 @@ namespace Ken4lowEngine
 			{
 				DrawPunctualLightsInspector();
 			}
+			static char presetId[64] = "default_light";
+			ImGui::InputText("LightPreset Id", presetId, IM_ARRAYSIZE(presetId));
+			if (ImGui::Button("Save Current LightPreset")) { SaveLightPreset(presetId); }
+			if (ImGui::Button("Apply Selected LightPreset")) { ApplyLightPresetByPath(std::string("Resources/DataAssets/LightPresets/") + presetId + ".json"); }
 		}
 		ImGui::End();
 #else
@@ -773,4 +779,65 @@ namespace Ken4lowEngine
 		punctualLights_.push_back(light);
 	}
 
+
+	bool LightManager::SaveLightPreset(const std::string& assetId)
+	{
+		JsonAssetEntry entry{};
+		entry.type = "LightPreset";
+		entry.id = assetId;
+		entry.displayName = assetId;
+		entry.path = "Resources/DataAssets/LightPresets/" + assetId + ".json";
+		LightPreset preset{};
+		if (!punctualLights_.empty())
+		{
+			const auto& light = punctualLights_.front();
+			preset.directionalDirection = light.direction;
+			preset.color = light.color;
+			preset.intensity = light.intensity;
+		}
+		preset.enableShadow = enableShadow_;
+		preset.shadowBias = shadowBias_;
+		preset.normalBias = normalBias_;
+		preset.shadowStrength = shadowStrength_;
+		preset.shadowMapSize = shadowMapSize_;
+		preset.shadowWidth = directionalShadowWidth_;
+		preset.shadowHeight = directionalShadowHeight_;
+		preset.shadowNearZ = directionalShadowNearZ_;
+		preset.shadowFarZ = directionalShadowFarZ_;
+		preset.shadowFocusMode = static_cast<uint32_t>(shadowFocusMode_);
+		preset.ToJson(entry.data);
+		return JsonDataManager::SafeSave(entry);
+	}
+
+	bool LightManager::ApplyLightPresetByPath(const std::string& filePath)
+	{
+		JsonAssetEntry entry{};
+		if (!JsonDataManager::SafeLoad(filePath, entry))
+		{
+			return false;
+		}
+		LightPreset preset{};
+		preset.FromJson(entry.data);
+		if (punctualLights_.empty())
+		{
+			AddDefaultDirectionalLight();
+		}
+		auto& light = punctualLights_.front();
+		light.lightType = 1;
+		light.enabled = 1;
+		light.direction = preset.directionalDirection;
+		light.color = preset.color;
+		light.intensity = preset.intensity;
+		enableShadow_ = preset.enableShadow;
+		shadowBias_ = preset.shadowBias;
+		normalBias_ = preset.normalBias;
+		shadowStrength_ = preset.shadowStrength;
+		shadowMapSize_ = preset.shadowMapSize;
+		directionalShadowWidth_ = preset.shadowWidth;
+		directionalShadowHeight_ = preset.shadowHeight;
+		directionalShadowNearZ_ = preset.shadowNearZ;
+		directionalShadowFarZ_ = preset.shadowFarZ;
+		shadowFocusMode_ = static_cast<ShadowFocusMode>(preset.shadowFocusMode);
+		return true;
+	}
 } // namespace Ken4lowEngine

--- a/Project/Engine/Graphics/Lighting/LightManager.h
+++ b/Project/Engine/Graphics/Lighting/LightManager.h
@@ -3,6 +3,7 @@
 #include "Vector3.h" 
 #include "Vector4.h"
 #include "Matrix4x4.h"
+#include <string>
 
 namespace Ken4lowEngine
 {
@@ -140,6 +141,9 @@ namespace Ken4lowEngine
 		/// デフォルトの指向性ライトを追加します。
 		/// </summary>
 		void AddDefaultDirectionalLight();
+		bool SaveLightPreset(const std::string& assetId);
+		bool ApplyLightPresetByPath(const std::string& filePath);
+
 
 	public: /// ---------- ゲッター ---------- ///
 

--- a/Project/Engine/System/JsonAssets/DataAssetPresets.cpp
+++ b/Project/Engine/System/JsonAssets/DataAssetPresets.cpp
@@ -1,0 +1,25 @@
+#include "DataAssetPresets.h"
+
+namespace Ken4lowEngine
+{
+	namespace
+	{
+		nlohmann::json ToJ(const Vector2& v) { return { v.x, v.y }; }
+		nlohmann::json ToJ(const Vector3& v) { return { v.x, v.y, v.z }; }
+		nlohmann::json ToJ(const Vector4& v) { return { v.x, v.y, v.z, v.w }; }
+		void FromJ(const nlohmann::json& j, Vector2& v) { if (j.is_array() && j.size() >= 2) { v.x = j[0].get<float>(); v.y = j[1].get<float>(); } }
+		void FromJ(const nlohmann::json& j, Vector3& v) { if (j.is_array() && j.size() >= 3) { v.x = j[0].get<float>(); v.y = j[1].get<float>(); v.z = j[2].get<float>(); } }
+		void FromJ(const nlohmann::json& j, Vector4& v) { if (j.is_array() && j.size() >= 4) { v.x = j[0].get<float>(); v.y = j[1].get<float>(); v.z = j[2].get<float>(); v.w = j[3].get<float>(); } }
+	}
+#define READ_NUM(name) if(inJson.contains(#name)){ name = inJson[#name].get<decltype(name)>(); }
+	void LightPreset::ToJson(nlohmann::json& outJson) const { outJson = {{"directionalDirection",ToJ(directionalDirection)},{"color",ToJ(color)},{"intensity",intensity},{"enableShadow",enableShadow},{"shadowBias",shadowBias},{"normalBias",normalBias},{"shadowStrength",shadowStrength},{"shadowMapSize",shadowMapSize},{"shadowWidth",shadowWidth},{"shadowHeight",shadowHeight},{"shadowNearZ",shadowNearZ},{"shadowFarZ",shadowFarZ},{"shadowFocusMode",shadowFocusMode}}; }
+	void LightPreset::FromJson(const nlohmann::json& inJson) { FromJ(inJson.value("directionalDirection", nlohmann::json::array()), directionalDirection); FromJ(inJson.value("color", nlohmann::json::array()), color); READ_NUM(intensity); READ_NUM(enableShadow); READ_NUM(shadowBias); READ_NUM(normalBias); READ_NUM(shadowStrength); READ_NUM(shadowMapSize); READ_NUM(shadowWidth); READ_NUM(shadowHeight); READ_NUM(shadowNearZ); READ_NUM(shadowFarZ); READ_NUM(shadowFocusMode); }
+	void PostEffectPreset::ToJson(nlohmann::json& outJson) const { outJson = {{"enabled",enabled},{"activeEffect",activeEffect},{"bloomIntensity",bloomIntensity},{"vignetteIntensity",vignetteIntensity},{"grayscale",grayscale},{"sepia",sepia},{"fade",fade}}; }
+	void PostEffectPreset::FromJson(const nlohmann::json& inJson) { READ_NUM(enabled); if(inJson.contains("activeEffect")) activeEffect=inJson["activeEffect"].get<std::string>(); READ_NUM(bloomIntensity); READ_NUM(vignetteIntensity); READ_NUM(grayscale); READ_NUM(sepia); READ_NUM(fade); }
+	void Object3DPreset::ToJson(nlohmann::json& outJson) const { outJson={{"modelPath",modelPath},{"texturePath",texturePath},{"position",ToJ(position)},{"rotation",ToJ(rotation)},{"scale",ToJ(scale)},{"visible",visible},{"castShadow",castShadow},{"receiveShadow",receiveShadow}}; }
+	void Object3DPreset::FromJson(const nlohmann::json& inJson) { if(inJson.contains("modelPath"))modelPath=inJson["modelPath"].get<std::string>(); if(inJson.contains("texturePath"))texturePath=inJson["texturePath"].get<std::string>(); FromJ(inJson.value("position",nlohmann::json::array()),position); FromJ(inJson.value("rotation",nlohmann::json::array()),rotation); FromJ(inJson.value("scale",nlohmann::json::array()),scale); READ_NUM(visible); READ_NUM(castShadow); READ_NUM(receiveShadow); }
+	void SpritePreset::ToJson(nlohmann::json& outJson) const { outJson={{"texturePath",texturePath},{"position",ToJ(position)},{"size",ToJ(size)},{"color",ToJ(color)},{"anchor",ToJ(anchor)},{"visible",visible}}; }
+	void SpritePreset::FromJson(const nlohmann::json& inJson) { if(inJson.contains("texturePath"))texturePath=inJson["texturePath"].get<std::string>(); FromJ(inJson.value("position",nlohmann::json::array()),position); FromJ(inJson.value("size",nlohmann::json::array()),size); FromJ(inJson.value("color",nlohmann::json::array()),color); FromJ(inJson.value("anchor",nlohmann::json::array()),anchor); READ_NUM(visible); }
+	void ParticlePreset::ToJson(nlohmann::json& outJson) const { outJson={{"emitterType",emitterType},{"position",ToJ(position)},{"spawnRate",spawnRate},{"lifetime",lifetime},{"speed",speed},{"color",ToJ(color)},{"size",size},{"loop",loop}}; }
+	void ParticlePreset::FromJson(const nlohmann::json& inJson) { if(inJson.contains("emitterType"))emitterType=inJson["emitterType"].get<std::string>(); FromJ(inJson.value("position",nlohmann::json::array()),position); READ_NUM(spawnRate); READ_NUM(lifetime); READ_NUM(speed); FromJ(inJson.value("color",nlohmann::json::array()),color); READ_NUM(size); READ_NUM(loop); }
+}

--- a/Project/Engine/System/JsonAssets/DataAssetPresets.h
+++ b/Project/Engine/System/JsonAssets/DataAssetPresets.h
@@ -1,0 +1,84 @@
+#pragma once
+
+#include "JsonSerializable.h"
+#include "Vector2.h"
+#include "Vector3.h"
+#include "Vector4.h"
+
+#include <string>
+
+namespace Ken4lowEngine
+{
+	struct LightPreset : public JsonSerializable
+	{
+		Vector3 directionalDirection = { 0.3f, -1.0f, 0.2f };
+		Vector4 color = { 1.0f, 1.0f, 1.0f, 1.0f };
+		float intensity = 1.0f;
+		bool enableShadow = true;
+		float shadowBias = 0.0f;
+		float normalBias = 0.025f;
+		float shadowStrength = 0.6f;
+		uint32_t shadowMapSize = 2048;
+		float shadowWidth = 35.0f;
+		float shadowHeight = 35.0f;
+		float shadowNearZ = 0.1f;
+		float shadowFarZ = 120.0f;
+		uint32_t shadowFocusMode = 0;
+
+		void ToJson(nlohmann::json& outJson) const override;
+		void FromJson(const nlohmann::json& inJson) override;
+	};
+
+	struct PostEffectPreset : public JsonSerializable
+	{
+		bool enabled = true;
+		std::string activeEffect = "None";
+		float bloomIntensity = 0.0f;
+		float vignetteIntensity = 0.0f;
+		float grayscale = 0.0f;
+		float sepia = 0.0f;
+		float fade = 0.0f;
+		void ToJson(nlohmann::json& outJson) const override;
+		void FromJson(const nlohmann::json& inJson) override;
+	};
+
+	struct Object3DPreset : public JsonSerializable
+	{
+		std::string modelPath;
+		std::string texturePath;
+		Vector3 position{};
+		Vector3 rotation{};
+		Vector3 scale = { 1.0f, 1.0f, 1.0f };
+		bool visible = true;
+		bool castShadow = true;
+		bool receiveShadow = true;
+		void ToJson(nlohmann::json& outJson) const override;
+		void FromJson(const nlohmann::json& inJson) override;
+	};
+
+	struct SpritePreset : public JsonSerializable
+	{
+		std::string texturePath;
+		Vector2 position{};
+		Vector2 size = { 128.0f, 128.0f };
+		Vector4 color = { 1,1,1,1 };
+		Vector2 anchor = { 0.5f, 0.5f };
+		bool visible = true;
+		void ToJson(nlohmann::json& outJson) const override;
+		void FromJson(const nlohmann::json& inJson) override;
+	};
+
+	struct ParticlePreset : public JsonSerializable
+	{
+		std::string emitterType = "Default";
+		Vector3 position{};
+		float spawnRate = 10.0f;
+		float lifetime = 1.0f;
+		float speed = 1.0f;
+		Vector4 color = { 1,1,1,1 };
+		float size = 1.0f;
+		bool loop = true;
+		void ToJson(nlohmann::json& outJson) const override;
+		void FromJson(const nlohmann::json& inJson) override;
+	};
+}

--- a/Project/Engine/System/JsonAssets/JsonEditorWindow.cpp
+++ b/Project/Engine/System/JsonAssets/JsonEditorWindow.cpp
@@ -1,6 +1,7 @@
 #include "JsonEditorWindow.h"
 #include "JsonDataManager.h"
 #include "ExampleJsonAsset.h"
+#include "DataAssetPresets.h"
 
 #ifdef USE_IMGUI
 #include <imgui.h>
@@ -56,11 +57,23 @@ namespace Ken4lowEngine
 	void JsonEditorWindow::CreateNewAsset()
 	{
 		JsonAssetEntry entry;
-		entry.type = newType_;
+		const char* kTypes[] = { "ExampleType", "LightPreset", "PostEffectPreset", "Object3DPreset", "SpritePreset", "ParticlePreset", "ModelPreset" };
+		entry.type = kTypes[newTypeIndex_];
 		entry.id = registry_.MakeUniqueId(newId_);
 		entry.displayName = newDisplayName_;
-		entry.path = std::string(basePath_) + "/" + entry.id + ".json";
-		entry.data = nlohmann::json::object();
+		std::string folder = std::string(basePath_) + "/";
+		if (entry.type == "LightPreset") { folder += "LightPresets/"; }
+		else if (entry.type == "PostEffectPreset") { folder += "PostEffectPresets/"; }
+		else if (entry.type == "Object3DPreset") { folder += "Object3DPresets/"; }
+		else if (entry.type == "SpritePreset") { folder += "SpritePresets/"; }
+		else if (entry.type == "ParticlePreset") { folder += "ParticlePresets/"; }
+		entry.path = folder + entry.id + ".json";
+				if (entry.type == "LightPreset") { LightPreset preset; preset.ToJson(entry.data); }
+		else if (entry.type == "PostEffectPreset") { PostEffectPreset preset; preset.ToJson(entry.data); }
+		else if (entry.type == "Object3DPreset") { Object3DPreset preset; preset.ToJson(entry.data); }
+		else if (entry.type == "SpritePreset") { SpritePreset preset; preset.ToJson(entry.data); }
+		else if (entry.type == "ParticlePreset") { ParticlePreset preset; preset.ToJson(entry.data); }
+		else { entry.data = nlohmann::json::object(); }
 		entry.dirty = true;
 		registry_.Register(entry);
 	}
@@ -112,7 +125,8 @@ namespace Ken4lowEngine
 			}
 		}
 
-		ImGui::InputText("New Type", newType_, IM_ARRAYSIZE(newType_));
+		const char* kTypes[] = { "ExampleType", "LightPreset", "PostEffectPreset", "Object3DPreset", "SpritePreset", "ParticlePreset", "ModelPreset" };
+		ImGui::Combo("New Type", &newTypeIndex_, kTypes, IM_ARRAYSIZE(kTypes));
 		ImGui::InputText("New Id", newId_, IM_ARRAYSIZE(newId_));
 		ImGui::InputText("New DisplayName", newDisplayName_, IM_ARRAYSIZE(newDisplayName_));
 

--- a/Project/Engine/System/JsonAssets/JsonEditorWindow.h
+++ b/Project/Engine/System/JsonAssets/JsonEditorWindow.h
@@ -22,9 +22,9 @@ namespace Ken4lowEngine
 		float autoSaveIntervalSec_ = 2.0f;
 		float autoSaveElapsedSec_ = 0.0f;
 		char typeFilter_[64] = "All";
-		char newType_[64] = "ExampleType";
+		int newTypeIndex_ = 0;
 		char newId_[64] = "example_asset";
 		char newDisplayName_[64] = "Example Asset";
-		char basePath_[256] = "Resources/JSON/JsonAssets";
+		char basePath_[256] = "Resources/DataAssets";
 	};
 }

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -1130,12 +1130,14 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     </ProjectReference>
   </ItemGroup>
   <ItemGroup>
+    <ClCompile Include="Engine\System\JsonAssets\DataAssetPresets.cpp" />
     <ClCompile Include="Engine\System\JsonAssets\ExampleJsonAsset.cpp" />
     <ClCompile Include="Engine\System\JsonAssets\JsonAssetRegistry.cpp" />
     <ClCompile Include="Engine\System\JsonAssets\JsonDataManager.cpp" />
     <ClCompile Include="Engine\System\JsonAssets\JsonEditorWindow.cpp" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="Engine\System\JsonAssets\DataAssetPresets.h" />
     <ClInclude Include="Engine\System\JsonAssets\ExampleJsonAsset.h" />
     <ClInclude Include="Engine\System\JsonAssets\JsonAssetEntry.h" />
     <ClInclude Include="Engine\System\JsonAssets\JsonAssetRegistry.h" />


### PR DESCRIPTION
### Motivation
- エンジン機能をJSON DataAssetから設定できる共通基盤を作り、まずはLight設定をDataAsset化して適用/保存ができるようにするため。 
- エディタ側でDataAssetの作成・保存・複製・削除・読み込みを行えるようにして、保存先を新規の `Resources/DataAssets/` 配下に整理するため。 
- 将来的なObject3D/Sprite/Particle/PostEffectへの接続を見据え、共通のPreset構造体とJSON化手段（JsonSerializable）を先に整備するため。 

### Description
- `Project/Engine/System/JsonAssets/DataAssetPresets.h/.cpp` を新規追加し、`LightPreset / PostEffectPreset / Object3DPreset / SpritePreset / ParticlePreset` を `JsonSerializable` 継承で実装して `ToJson`/`FromJson` を提供しました。 
- `JsonEditorWindow` を修正して `basePath` を `Resources/DataAssets` に変更し、`New Type` をComboBox化して型別デフォルトJSONを生成・型別フォルダ（例: `LightPresets/`）へ保存するようにしました（複製時の型別フォルダ保持は要改善の余地あり）。 
- `LightManager` に `SaveLightPreset(const std::string&)` と `ApplyLightPresetByPath(const std::string&)` を追加し、Light Editorに `Save Current LightPreset` / `Apply Selected LightPreset` のUIを組み込み、プリセットとマネージャ間で主要フィールドの読み書きを行う初期連携を実装しました。 
- 新規ファイルを `Project/Ken4lowEngine.vcxproj` の `ClCompile/ClInclude` に追加し、既存 `Resources/JSON/` 等の既存データは変更していません。 

### Testing
- レポジトリ内検索・ファイル列挙で変更箇所を確認するコマンド `rg --files` および `rg` によるパターン検索を実行して期待ファイルとインクルードが存在することを確認し成功しました。 
- 変更後のソースを `sed -n` / `nl -ba` で表示して、`JsonEditorWindow` の `basePath` / ComboBox 変更と `LightManager` の新関数・UI追加を目視検証し成功しました。 
- 自動ビルド（Debug x64 / MSBuild or Visual Studio）はこの実行環境にWindowsビルドツールが無いため実行できず、実機ビルド・ランタイム検証（Json Asset Manager起動、LightPresetの保存/読み込み/適用、各シーン描画確認）は未実施です。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a115387e358832d84d3e00f49b3384a)