### PR TITLE
SpritePreset の JSON DataAsset とエディタ対応を追加

### DIFF
--- a/Project/Engine/System/JsonAssets/DataAssetPresets.cpp
+++ b/Project/Engine/System/JsonAssets/DataAssetPresets.cpp
@@ -1,5 +1,7 @@
 #include "DataAssetPresets.h"
 
+#include "Sprite.h"
+
 namespace Ken4lowEngine
 {
 	namespace
@@ -18,8 +20,26 @@ namespace Ken4lowEngine
 	void PostEffectPreset::FromJson(const nlohmann::json& inJson) { READ_NUM(enabled); if(inJson.contains("activeEffect")) activeEffect=inJson["activeEffect"].get<std::string>(); READ_NUM(bloomIntensity); READ_NUM(vignetteIntensity); READ_NUM(grayscale); READ_NUM(sepia); READ_NUM(fade); }
 	void Object3DPreset::ToJson(nlohmann::json& outJson) const { outJson={{"modelPath",modelPath},{"texturePath",texturePath},{"position",ToJ(position)},{"rotation",ToJ(rotation)},{"scale",ToJ(scale)},{"visible",visible},{"castShadow",castShadow},{"receiveShadow",receiveShadow}}; }
 	void Object3DPreset::FromJson(const nlohmann::json& inJson) { if(inJson.contains("modelPath"))modelPath=inJson["modelPath"].get<std::string>(); if(inJson.contains("texturePath"))texturePath=inJson["texturePath"].get<std::string>(); FromJ(inJson.value("position",nlohmann::json::array()),position); FromJ(inJson.value("rotation",nlohmann::json::array()),rotation); FromJ(inJson.value("scale",nlohmann::json::array()),scale); READ_NUM(visible); READ_NUM(castShadow); READ_NUM(receiveShadow); }
-	void SpritePreset::ToJson(nlohmann::json& outJson) const { outJson={{"texturePath",texturePath},{"position",ToJ(position)},{"size",ToJ(size)},{"color",ToJ(color)},{"anchor",ToJ(anchor)},{"visible",visible}}; }
-	void SpritePreset::FromJson(const nlohmann::json& inJson) { if(inJson.contains("texturePath"))texturePath=inJson["texturePath"].get<std::string>(); FromJ(inJson.value("position",nlohmann::json::array()),position); FromJ(inJson.value("size",nlohmann::json::array()),size); FromJ(inJson.value("color",nlohmann::json::array()),color); FromJ(inJson.value("anchor",nlohmann::json::array()),anchor); READ_NUM(visible); }
+	void SpritePreset::ToJson(nlohmann::json& outJson) const { outJson={{"texturePath",texturePath},{"position",ToJ(position)},{"size",ToJ(size)},{"rotation",rotation},{"anchor",ToJ(anchor)},{"color",ToJ(color)},{"visible",visible},{"layer",layer},{"pivot",ToJ(pivot)},{"uvPosition",ToJ(uvPosition)},{"uvSize",ToJ(uvSize)},{"enableAlpha",enableAlpha},{"drawOrder",drawOrder}}; }
+	void SpritePreset::FromJson(const nlohmann::json& inJson) { if(inJson.contains("texturePath"))texturePath=inJson["texturePath"].get<std::string>(); FromJ(inJson.value("position",nlohmann::json::array()),position); FromJ(inJson.value("size",nlohmann::json::array()),size); READ_NUM(rotation); FromJ(inJson.value("anchor",nlohmann::json::array()),anchor); FromJ(inJson.value("color",nlohmann::json::array()),color); READ_NUM(visible); READ_NUM(layer); FromJ(inJson.value("pivot",nlohmann::json::array()),pivot); FromJ(inJson.value("uvPosition",nlohmann::json::array()),uvPosition); FromJ(inJson.value("uvSize",nlohmann::json::array()),uvSize); READ_NUM(enableAlpha); READ_NUM(drawOrder); }
+
+	void ApplySpritePreset(Sprite& sprite, const SpritePreset& preset)
+	{
+		if (!preset.texturePath.empty()) { sprite.SetTexture(preset.texturePath); }
+		sprite.SetPosition(preset.position);
+		sprite.SetSize(preset.size);
+		sprite.SetRotation(preset.rotation);
+		sprite.SetAnchorPoint(preset.anchor);
+		sprite.SetColor(preset.color);
+		// SpritePresetから2D表示設定を復元できるようにする
+		sprite.SetUVRect(preset.uvPosition, preset.uvSize);
+		if (!preset.visible)
+		{
+			Vector4 hidden = preset.color;
+			hidden.w = 0.0f;
+			sprite.SetColor(hidden);
+		}
+	}
 	void ParticlePreset::ToJson(nlohmann::json& outJson) const { outJson={{"emitterType",emitterType},{"position",ToJ(position)},{"spawnRate",spawnRate},{"lifetime",lifetime},{"speed",speed},{"color",ToJ(color)},{"size",size},{"loop",loop}}; }
 	void ParticlePreset::FromJson(const nlohmann::json& inJson) { if(inJson.contains("emitterType"))emitterType=inJson["emitterType"].get<std::string>(); FromJ(inJson.value("position",nlohmann::json::array()),position); READ_NUM(spawnRate); READ_NUM(lifetime); READ_NUM(speed); FromJ(inJson.value("color",nlohmann::json::array()),color); READ_NUM(size); READ_NUM(loop); }
 }

--- a/Project/Engine/System/JsonAssets/DataAssetPresets.h
+++ b/Project/Engine/System/JsonAssets/DataAssetPresets.h
@@ -9,6 +9,8 @@
 
 namespace Ken4lowEngine
 {
+	class Sprite;
+
 	struct LightPreset : public JsonSerializable
 	{
 		Vector3 directionalDirection = { 0.3f, -1.0f, 0.2f };
@@ -61,12 +63,21 @@ namespace Ken4lowEngine
 		std::string texturePath;
 		Vector2 position{};
 		Vector2 size = { 128.0f, 128.0f };
-		Vector4 color = { 1,1,1,1 };
+		float rotation = 0.0f;
 		Vector2 anchor = { 0.5f, 0.5f };
+		Vector4 color = { 1,1,1,1 };
 		bool visible = true;
+		int layer = 0;
+		Vector2 pivot = { 0.5f, 0.5f };
+		Vector2 uvPosition = { 0.0f, 0.0f };
+		Vector2 uvSize = { 1.0f, 1.0f };
+		bool enableAlpha = true;
+		int drawOrder = 0;
 		void ToJson(nlohmann::json& outJson) const override;
 		void FromJson(const nlohmann::json& inJson) override;
 	};
+
+	void ApplySpritePreset(Sprite& sprite, const SpritePreset& preset);
 
 	struct ParticlePreset : public JsonSerializable
 	{

--- a/Project/Engine/System/JsonAssets/JsonEditorWindow.cpp
+++ b/Project/Engine/System/JsonAssets/JsonEditorWindow.cpp
@@ -9,6 +9,20 @@
 
 #include <algorithm>
 
+namespace
+{
+	std::string GetDataAssetFolder(const std::string& basePath, const std::string& type)
+	{
+		std::string folder = basePath + "/";
+		if (type == "LightPreset") { folder += "LightPresets/"; }
+		else if (type == "PostEffectPreset") { folder += "PostEffectPresets/"; }
+		else if (type == "Object3DPreset") { folder += "Object3DPresets/"; }
+		else if (type == "SpritePreset") { folder += "SpritePresets/"; }
+		else if (type == "ParticlePreset") { folder += "ParticlePresets/"; }
+		return folder;
+	}
+}
+
 namespace Ken4lowEngine
 {
 	JsonEditorWindow* JsonEditorWindow::GetInstance()
@@ -61,12 +75,7 @@ namespace Ken4lowEngine
 		entry.type = kTypes[newTypeIndex_];
 		entry.id = registry_.MakeUniqueId(newId_);
 		entry.displayName = newDisplayName_;
-		std::string folder = std::string(basePath_) + "/";
-		if (entry.type == "LightPreset") { folder += "LightPresets/"; }
-		else if (entry.type == "PostEffectPreset") { folder += "PostEffectPresets/"; }
-		else if (entry.type == "Object3DPreset") { folder += "Object3DPresets/"; }
-		else if (entry.type == "SpritePreset") { folder += "SpritePresets/"; }
-		else if (entry.type == "ParticlePreset") { folder += "ParticlePresets/"; }
+		std::string folder = GetDataAssetFolder(basePath_, entry.type);
 		entry.path = folder + entry.id + ".json";
 				if (entry.type == "LightPreset") { LightPreset preset; preset.ToJson(entry.data); }
 		else if (entry.type == "PostEffectPreset") { PostEffectPreset preset; preset.ToJson(entry.data); }
@@ -111,7 +120,7 @@ namespace Ken4lowEngine
 			auto& src = const_cast<std::vector<JsonAssetEntry>&>(registry_.GetAssets())[selectedIndex_];
 			JsonAssetEntry dup;
 			const std::string newId = registry_.MakeUniqueId(src.id + "_copy");
-			const std::string dstPath = std::string(basePath_) + "/" + newId + ".json";
+			const std::string dstPath = GetDataAssetFolder(basePath_, src.type) + newId + ".json";
 			if (JsonDataManager::Duplicate(src, dstPath, newId, dup)) { registry_.Register(dup); }
 		}
 		ImGui::SameLine();
@@ -154,6 +163,30 @@ namespace Ken4lowEngine
 			{
 				asset.displayName = displayNameBuffer;
 				asset.dirty = true;
+			}
+
+			if (asset.type == "SpritePreset")
+			{
+				SpritePreset preset{};
+				preset.FromJson(asset.data);
+
+				char texturePathBuffer[256]{};
+				std::snprintf(texturePathBuffer, sizeof(texturePathBuffer), "%s", preset.texturePath.c_str());
+				if (ImGui::InputText("Texture Path", texturePathBuffer, IM_ARRAYSIZE(texturePathBuffer))) { preset.texturePath = texturePathBuffer; asset.dirty = true; }
+				if (ImGui::InputFloat2("Position", &preset.position.x)) { asset.dirty = true; }
+				if (ImGui::InputFloat2("Size", &preset.size.x)) { asset.dirty = true; }
+				if (ImGui::InputFloat("Rotation", &preset.rotation)) { asset.dirty = true; }
+				if (ImGui::InputFloat2("Anchor", &preset.anchor.x)) { asset.dirty = true; }
+				if (ImGui::ColorEdit4("Color", &preset.color.x)) { asset.dirty = true; }
+				if (ImGui::Checkbox("Visible", &preset.visible)) { asset.dirty = true; }
+				if (ImGui::InputInt("DrawOrder", &preset.drawOrder)) { asset.dirty = true; }
+				if (ImGui::InputFloat2("UV Position", &preset.uvPosition.x)) { asset.dirty = true; }
+				if (ImGui::InputFloat2("UV Size", &preset.uvSize.x)) { asset.dirty = true; }
+
+				if (asset.dirty)
+				{
+					preset.ToJson(asset.data);
+				}
 			}
 		}
 

--- a/Resources/DataAssets/SpritePresets/hp_heart_icon.json
+++ b/Resources/DataAssets/SpritePresets/hp_heart_icon.json
@@ -1,0 +1,18 @@
+{
+  "version": 1,
+  "id": "hp_heart_icon",
+  "displayName": "HP Heart Icon",
+  "type": "SpritePreset",
+  "data": {
+    "texturePath": "UI/hp_heart.dds",
+    "position": [100.0, 100.0],
+    "size": [32.0, 32.0],
+    "rotation": 0.0,
+    "anchor": [0.5, 0.5],
+    "color": [1.0, 1.0, 1.0, 1.0],
+    "visible": true,
+    "drawOrder": 0,
+    "uvPosition": [0.0, 0.0],
+    "uvSize": [1.0, 1.0]
+  }
+}


### PR DESCRIPTION
### Motivation
- Sprite の表示設定を既存の DataAsset 基盤 (`Resources/DataAssets/`) で管理できるようにし、UI画像やHUDなどを将来 DataAsset 化できる土台を作るため。 
- 既にある `LightPreset` と同様に `SpritePreset` を JSON シリアライズ/デシリアライズ可能にしてエディタから作成・保存・複製・削除できるようにするため。 
- 読み込んだプリセットをランタイムの `Sprite` に反映する適用 API を用意して運用面の最低限の接続を確保するため。 

### Description
- `Project/Engine/System/JsonAssets/DataAssetPresets.h` に `SpritePreset` のフィールドを拡張して `rotation`, `anchor`, `layer`, `pivot`, `uvPosition`, `uvSize`, `enableAlpha`, `drawOrder` を追加し、`ApplySpritePreset(Sprite&, const SpritePreset&)` を宣言しました。 
- `Project/Engine/System/JsonAssets/DataAssetPresets.cpp` に `SpritePreset::ToJson` / `FromJson` を更新して新項目を扱うようにし、`ApplySpritePreset` 実装を追加してプリセットから `Sprite` に設定を反映する処理を実装しました（`texturePath`, `position`, `size`, `rotation`, `anchor`, `color`, `uv` を反映、`visible=false` はアルファ0で反映）。 
- `Project/Engine/System/JsonAssets/JsonEditorWindow.cpp` に型別フォルダ決定の共通関数 `GetDataAssetFolder` を追加して `New` / `Duplicate` の出力先を `Resources/DataAssets/SpritePresets/` に統一し、`SpritePreset` 選択時の編集 UI を追加して `texturePath`, `position`, `size`, `rotation`, `anchor`, `color`, `visible`, `drawOrder`, `uvPosition`, `uvSize` を編集・反映できるようにしました。 
- サンプル JSON を `Resources/DataAssets/SpritePresets/hp_heart_icon.json` に追加してフォーマット例を配置しました。 
- 実装中に `// SpritePresetから2D表示設定を復元できるようにする` のコメントを追加しています。 

### Testing
- `git commit` による変更コミットは正常に実行できました (差分をコミット済み)。 
- サンプルファイル `Resources/DataAssets/SpritePresets/hp_heart_icon.json` を作成・確認しました。 
- Debug x64 ビルドはこの環境で `msbuild Project/Ken4lowEngine.sln /p:Configuration=Debug /p:Platform=x64` を実行しましたが、実行環境に `msbuild` が無くビルドは失敗しました（`msbuild: command not found`）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a115a05b924832da85d93caf92b6d25)