### PR TITLE
DebugSceneでStageクラスを使った衝突読み込みを追加

### DIFF
--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -29,6 +29,7 @@
 #include <cstdio>
 #include <array>
 #include <numbers>
+#include <unordered_map>
 
 using namespace Ken4lowEngine;
 
@@ -134,7 +135,8 @@ void DebugScene::Initialize()
 
 	debugMeleeEnemy_ = std::make_unique<MeleeEnemy>();
 	debugMeleeEnemy_->Initialize();
-	debugMeleeEnemy_->SetCenterPosition({ -8.0f, 2.0f, 18.0f });
+	// ステージ床に確実に着地できるよう、初期位置は少し高めから開始する。
+	debugMeleeEnemy_->SetCenterPosition({ -8.0f, 4.0f, 18.0f });
 
 	meleeDummyTarget_.SetCenterPosition({ 0.0f, 2.0f, 18.0f });
 	meleeDummyTarget_.SetOBBHalfSize({ 0.8f, 1.0f, 0.8f });
@@ -149,8 +151,12 @@ void DebugScene::Initialize()
 	frustumCullingDebug_->Initialize(true);
 	InitializeCullingTestObjects();
 
-	stageObject_ = std::make_unique<Object3D>();
-	stageObject_->Initialize("Stages/hajimarinoheigen.gltf");
+	stage_ = std::make_unique<K4E::Stage>();
+	stage_->Initialize("Stages/hajimarinoheigen.json", "Stages/hajimarinoheigen.gltf");
+	stage_->RegisterColliders(collisionManager_.get());
+	stage_->Update();
+	// DebugSceneでもステージAABBを共有し、EnemyBase系の敵が床と障害物に衝突できるようにする。
+	EnemyBase::SetGlobalStageWorldAABBs(&stage_->GetWorldAABBs());
 }
 
 void DebugScene::Update()
@@ -199,7 +205,10 @@ void DebugScene::Update()
 	collisionManager_->Update();
 	collisionManager_->CheckAllCollisions();
 
-	stageObject_->Update();
+	if (stage_)
+	{
+		stage_->Update();
+	}
 
 }
 
@@ -225,7 +234,10 @@ void DebugScene::Draw3DObjects()
 		debugMeleeEnemy_->Draw();
 	}
 
-	stageObject_->Draw();
+	if (stage_)
+	{
+		stage_->Draw();
+	}
 
 #ifdef _DEBUG
 	// ワイヤーフレームの描画
@@ -254,9 +266,9 @@ void DebugScene::DrawShadowObjects()
 	{
 		debugMeleeEnemy_->DrawShadow();
 	}
-	if (stageObject_)
+	if (stage_)
 	{
-		stageObject_->DrawShadow();
+		stage_->DrawShadow();
 	}
 }
 
@@ -288,10 +300,11 @@ void DebugScene::Finalize()
 	cullingTestObjects_.clear();
 	frustumCullingDebug_.reset();
 	disintegrationDebug_.reset();
+	EnemyBase::SetGlobalStageWorldAABBs(nullptr);
 	debugBoss_.reset();
 	debugMeleeEnemy_.reset();
 	collisionManager_.reset();
-	stageObject_.reset();
+	stage_.reset();
 
 	input_ = nullptr;
 	dxCommon_ = nullptr;
@@ -338,6 +351,45 @@ void DebugScene::DrawImGui()
 	}
 	ImGui::Text("MeleeEnemy and dummy target are for BT behavior verification.");
 	ImGui::End();
+
+	if (stage_)
+	{
+		ImGui::Begin("Stage Debug");
+		const std::vector<AABB>& worldAABBs = stage_->GetWorldAABBs();
+		const LevelData* levelData = stage_->GetLevelData();
+		size_t loadedColliders = 0;
+		std::unordered_map<std::string, int> colliderTypeCounts{};
+		if (levelData)
+		{
+			for (const auto& object : levelData->objects)
+			{
+				if (!object.collider.enabled)
+				{
+					continue;
+				}
+				++loadedColliders;
+				const std::string typeName = object.collider.collisionType.empty() ? "Unspecified" : object.collider.collisionType;
+				++colliderTypeCounts[typeName];
+			}
+		}
+
+		ImGui::Text("WorldAABBs: %zu", worldAABBs.size());
+		ImGui::Text("Loaded Colliders: %zu", loadedColliders);
+		ImGui::Text("Floor: %d", colliderTypeCounts["Floor"]);
+		ImGui::Text("Obstacle: %d", colliderTypeCounts["Obstacle"]);
+		ImGui::Text("Pillar: %d", colliderTypeCounts["Pillar"]);
+		ImGui::Text("Fence: %d", colliderTypeCounts["Fence"]);
+		ImGui::Text("Tree: %d", colliderTypeCounts["Tree"]);
+
+		if (debugMeleeEnemy_)
+		{
+			const Vector3 enemyPos = debugMeleeEnemy_->GetCenterPosition();
+			ImGui::Text("MeleeEnemy Pos: (%.2f, %.2f, %.2f)", enemyPos.x, enemyPos.y, enemyPos.z);
+			ImGui::Text("Grounded: %s", debugMeleeEnemy_->GetVelocity().y == 0.0f ? "Likely grounded" : "Falling/Moving");
+		}
+
+		ImGui::End();
+	}
 
 	/// ---------- GPUパーティクルデバッグ ---------- ///
 	GpuParticleManager::GetInstance()->DrawImGui();

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
@@ -10,8 +10,7 @@
 #include "ApplicationLayer/DebugTools/FrustumCulling/FrustumCullingDebugController.h"
 #include "Vector3.h"
 #include "Vector4.h"
-
-#include <Object3D.h>
+#include "Stage.h"
 
 #include <memory>
 #include <string>
@@ -87,8 +86,8 @@ private: /// ---------- メンバ変数 ---------- ///
 	std::unique_ptr<GuardianBoss> debugBoss_;
 	std::unique_ptr<MeleeEnemy> debugMeleeEnemy_;
 
-	// ステージ確認用
-	std::unique_ptr<K4E::Object3D> stageObject_;
+	// ステージ確認用（見た目＋衝突）
+	std::unique_ptr<K4E::Stage> stage_;
 
 	// --- 仮ヒット確認用パラメータ ---
 	bool debugBossHitTestEnabled_ = true; // 仮ヒット確認ON/OFF
@@ -110,4 +109,3 @@ private: /// ---------- メンバ変数 ---------- ///
 	K4E::Collider meleeDummyTarget_{};
 
 };
-

--- a/Project/Engine/Scene/Level/LevelData.h
+++ b/Project/Engine/Scene/Level/LevelData.h
@@ -12,6 +12,8 @@ namespace Ken4lowEngine
 	struct ObjectColliderData
 	{
 		std::string type;		// コライダーの名前
+		std::string collisionType; // 衝突種別名（Floor / Obstacle など）
+		int collisionTypeId = -1; // 衝突種別ID（未指定時は-1）
 		Vector3 center;			// 中心位置
 		Vector3 size;			// サイズ
 		bool enabled = false;	// 有効フラグ

--- a/Project/Engine/Scene/Level/LevelLoader.cpp
+++ b/Project/Engine/Scene/Level/LevelLoader.cpp
@@ -378,6 +378,16 @@ namespace Ken4lowEngine
 				objectData->collider.size.y = static_cast<float>(jc["size"][2]);
 				objectData->collider.size.z = static_cast<float>(jc["size"][1]);
 			}
+
+			if (jc.contains("collision_type") && jc["collision_type"].is_string())
+			{
+				objectData->collider.collisionType = jc["collision_type"].get<std::string>();
+			}
+
+			if (jc.contains("collision_type_id") && jc["collision_type_id"].is_number_integer())
+			{
+				objectData->collider.collisionTypeId = jc["collision_type_id"].get<int>();
+			}
 		}
 
 		if (object.contains("children") && object["children"].is_array())


### PR DESCRIPTION
### Motivation
- DebugSceneでステージは見た目のみ読み込まれており衝突判定が無かったため、`MeleeEnemy` が永遠に落下していた問題を解消するため。 
- GamePlayWorldと同じ流れ（JSON/modelの読み込み、`RegisterColliders`、WorldAABB共有）をDebugSceneにも導入して挙動を一致させる目的。 
- デバッグ時に読み込まれたコライダ情報や `collision_type` を確認できるようにして検証を容易にするため。 

### Description
- `LevelData::ObjectColliderData` に `collisionType` と `collisionTypeId` を追加し、`LevelLoader` が `collision_type` / `collision_type_id` をパースして格納するようにした（`Project/Engine/Scene/Level/LevelData.h`、`LevelLoader.cpp`）。
- `DebugScene` のステージ管理を `Object3D` から `Stage` クラスへ切り替え、`stage_->Initialize("Stages/hajimarinoheigen.json", "Stages/hajimarinoheigen.gltf")` の流れで初期化し `stage_->RegisterColliders(collisionManager_.get())` と `EnemyBase::SetGlobalStageWorldAABBs(&stage_->GetWorldAABBs())` を呼ぶようにした（`Project/ApplicationLayer/Scene/DebugScene/DebugScene.h`、`DebugScene.cpp`）。
- `DebugScene` の `Update` / `Draw3DObjects` / `DrawShadowObjects` / `Finalize` を `stage_` 対応に変更し、`Finalize` で `EnemyBase::SetGlobalStageWorldAABBs(nullptr)` を呼んで参照を解除するようにした。 
- `MeleeEnemy` のデバッグ初期位置を少し上げて着地しやすくし、ImGuiに `Stage Debug` ウィンドウを追加して `WorldAABBs` 件数、読み込みcollider数、`Floor/Obstacle/Pillar/Fence/Tree` の件数、`MeleeEnemy` 座標と接地目安が確認できるようにした（ImGui表示は `DebugScene.cpp` に実装）。

### Testing
- 自動チェックとして `git diff --check` を実行して差分の基本的な問題は検出されず通過しています。 
- フルビルドやランタイム確認（Visual Studio/MSBuildでのビルド、ゲーム起動による `stage_->GetWorldAABBs()` の実測確認）はこの環境では未実行のため、ローカルでのビルドと実行確認をお願いします。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12b38deab8832da807a042fc309556)