### PR TITLE
Load and apply collider_rotation to stage OBBs and add debug stats

### DIFF
--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -356,8 +356,11 @@ void DebugScene::DrawImGui()
 	{
 		ImGui::Begin("Stage Debug");
 		const std::vector<AABB>& worldAABBs = stage_->GetWorldAABBs();
+		const auto& worldColliders = stage_->GetWorldColliders();
 		const LevelData* levelData = stage_->GetLevelData();
 		size_t loadedColliders = 0;
+		size_t rotatedColliderCount = 0;
+		size_t colliderRotationReadCount = 0;
 		std::unordered_map<std::string, int> colliderTypeCounts{};
 		if (levelData)
 		{
@@ -370,11 +373,24 @@ void DebugScene::DrawImGui()
 				++loadedColliders;
 				const std::string typeName = object.collider.collisionType.empty() ? "Unspecified" : object.collider.collisionType;
 				++colliderTypeCounts[typeName];
+				if (object.collider.hasRotation)
+				{
+					++colliderRotationReadCount;
+				}
+				if ((object.collider.hasRotation && Vector3::Length(object.collider.rotation) > 0.0001f) ||
+					Vector3::Length(object.rotation) > 0.0001f)
+				{
+					++rotatedColliderCount;
+				}
 			}
 		}
+		const size_t aabbFallbackCount = loadedColliders > worldColliders.size() ? loadedColliders - worldColliders.size() : 0;
 
 		ImGui::Text("WorldAABBs: %zu", worldAABBs.size());
 		ImGui::Text("Loaded Colliders: %zu", loadedColliders);
+		ImGui::Text("Rotated collider count: %zu", rotatedColliderCount);
+		ImGui::Text("AABB fallback count: %zu", aabbFallbackCount);
+		ImGui::Text("collider_rotation read count: %zu", colliderRotationReadCount);
 		ImGui::Text("Floor: %d", colliderTypeCounts["Floor"]);
 		ImGui::Text("Obstacle: %d", colliderTypeCounts["Obstacle"]);
 		ImGui::Text("Pillar: %d", colliderTypeCounts["Pillar"]);

--- a/Project/Engine/Scene/Level/LevelData.h
+++ b/Project/Engine/Scene/Level/LevelData.h
@@ -16,6 +16,9 @@ namespace Ken4lowEngine
 		int collisionTypeId = -1; // 衝突種別ID（未指定時は-1）
 		Vector3 center;			// 中心位置
 		Vector3 size;			// サイズ
+		Vector3 rotation;		// 回転（ラジアン）
+		bool hasRotation = false; // JSONの回転情報が存在したか
+		bool fromColliderRotation = false; // collider_rotation を読んだか（rotation より優先）
 		bool enabled = false;	// 有効フラグ
 	};
 

--- a/Project/Engine/Scene/Level/LevelLoader.cpp
+++ b/Project/Engine/Scene/Level/LevelLoader.cpp
@@ -3,6 +3,7 @@
 #include <json.hpp>
 #include <cassert>
 #include <iostream>
+#include <cmath>
 
 namespace Ken4lowEngine
 {
@@ -32,6 +33,12 @@ namespace Ken4lowEngine
 				result.z = -static_cast<float>(transform["rotation"][1]);
 			}
 			return result;
+		}
+
+		Vector3 DegToRad(const Vector3& deg)
+		{
+			constexpr float kDegToRad = 3.14159265358979323846f / 180.0f;
+			return { deg.x * kDegToRad, deg.y * kDegToRad, deg.z * kDegToRad };
 		}
 
 		Vector3 ReadScaleToGameAxes(const json& transform)
@@ -387,6 +394,22 @@ namespace Ken4lowEngine
 			if (jc.contains("collision_type_id") && jc["collision_type_id"].is_number_integer())
 			{
 				objectData->collider.collisionTypeId = jc["collision_type_id"].get<int>();
+			}
+
+			// JSONのcollider_rotationを保持し、回転付きステージコライダーとして生成する
+			const bool hasColliderRotation = jc.contains("collider_rotation") && jc["collider_rotation"].is_array() && jc["collider_rotation"].size() >= 3;
+			const bool hasRotation = jc.contains("rotation") && jc["rotation"].is_array() && jc["rotation"].size() >= 3;
+			if (hasColliderRotation || hasRotation)
+			{
+				const json& rotationJson = hasColliderRotation ? jc["collider_rotation"] : jc["rotation"];
+				Vector3 colliderRotationDeg{};
+				colliderRotationDeg.x = -static_cast<float>(rotationJson[0]);
+				colliderRotationDeg.y = -static_cast<float>(rotationJson[2]);
+				colliderRotationDeg.z = -static_cast<float>(rotationJson[1]);
+
+				objectData->collider.rotation = DegToRad(colliderRotationDeg);
+				objectData->collider.hasRotation = true;
+				objectData->collider.fromColliderRotation = hasColliderRotation;
 			}
 		}
 

--- a/Project/Engine/Scene/Level/StageCollisionBuilder.cpp
+++ b/Project/Engine/Scene/Level/StageCollisionBuilder.cpp
@@ -42,6 +42,12 @@ namespace Ken4lowEngine
 			collider->SetTypeID(static_cast<uint32_t>(CollisionTypeIdDef::kWorld));
 			collider->SetCenterPosition(centerW);
 			collider->SetOBBHalfSize(halfW);
+			const Vector3 colliderRotation = {
+				data.rotation.x + data.collider.rotation.x,
+				data.rotation.y + data.collider.rotation.y,
+				data.rotation.z + data.collider.rotation.z,
+			};
+			collider->SetOrientation(colliderRotation);
 
 			result.worldColliders.push_back(std::move(collider));
 		}


### PR DESCRIPTION
### Motivation
- Fix mismatch between visual rotation and debug-drawn stage colliders so rotated obstacles in `hajimarinoheigen` display correctly in the `DebugScene` without breaking existing gameplay grounding logic.
- Preserve existing `worldAABBs` behavior used by enemy grounding/penetration code while exposing rotation metadata for OBB collision/debugging.

### Description
- Added rotation metadata to `ObjectColliderData` with `rotation`, `hasRotation`, and `fromColliderRotation` fields so per-collider rotation can be preserved (`Project/Engine/Scene/Level/LevelData.h`).
- Extended `LevelLoader` to parse `collider.collider_rotation` (preferred) or fallback to `collider.rotation`, apply the existing Blender(+Z)→game(+Y) axis mapping, convert degrees to radians, and store the result (`Project/Engine/Scene/Level/LevelLoader.cpp`).
- Updated `StageCollisionBuilder` to set the world `Collider` orientation by composing `object.rotation + collider.rotation` and calling `Collider::SetOrientation`, while leaving `worldAABBs` generation unchanged to maintain existing enemy behavior (`Project/Engine/Scene/Level/StageCollisionBuilder.cpp`).
- Enhanced the `DebugScene` Stage Debug panel to show `Rotated collider count`, `AABB fallback count`, and `collider_rotation read count` alongside existing type counts to aid verification (`Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp`).
- Added a one-line comment explaining the `collider_rotation` handling and ensured changes are localized to existing files (no new source files added).

### Testing
- Committed changes and verified repository status with `git` which succeeded (commit created and workspace clean).
- Ran environment check `cmake --version` which returned success in this environment, but a full MSVC/`msbuild` build was not executed here.
- No automated unit or integration build/test was run in this environment, so full build verification (`C++20 / WarningLevel4 / TreatWarningAsError`) should be performed on CI or locally before merging.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12b8b034e4832d817f7ab53b01b20e)