### PR TITLE
Unify stage collider source->game transform and build rotated OBBs from source-space

### DIFF
--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -364,6 +364,11 @@ void DebugScene::DrawImGui()
 		std::string sampleColliderName = "(none)";
 		Vector3 sampleSourceRotationDeg{};
 		Vector3 sampleConvertedRotationDeg{};
+		Vector3 sampleRawSourceCenter{};
+		Vector3 sampleConvertedGameCenter{};
+		Vector3 sampleAxisX{1,0,0};
+		Vector3 sampleAxisY{0,1,0};
+		Vector3 sampleAxisZ{0,0,1};
 		float sampleFinalYawDeg = 0.0f;
 		std::unordered_map<std::string, int> colliderTypeCounts{};
 		if (levelData)
@@ -386,11 +391,13 @@ void DebugScene::DrawImGui()
 				{
 					++rotatedColliderCount;
 				}
-				if (sampleColliderName == "(none)" && object.collider.hasRotation)
+				if (sampleColliderName == "(none)" && (object.name.find("StoneCover_01_LargeBlock") != std::string::npos || object.collider.hasRotation))
 				{
 					sampleColliderName = object.name;
 					sampleSourceRotationDeg = object.collider.sourceRotationDeg;
 					sampleConvertedRotationDeg = object.collider.convertedRotationDeg;
+					sampleRawSourceCenter = object.collider.sourceCenter;
+					sampleConvertedGameCenter = object.position + object.collider.center;
 					constexpr float kRadToDeg = 180.0f / 3.14159265358979323846f;
 					sampleFinalYawDeg = (object.rotation.y + object.collider.rotation.y) * kRadToDeg;
 				}
@@ -408,6 +415,18 @@ void DebugScene::DrawImGui()
 			sampleSourceRotationDeg.x, sampleSourceRotationDeg.y, sampleSourceRotationDeg.z);
 		ImGui::Text("converted rotation degree: (%.2f, %.2f, %.2f)",
 			sampleConvertedRotationDeg.x, sampleConvertedRotationDeg.y, sampleConvertedRotationDeg.z);
+		ImGui::Text("raw source center: (%.2f, %.2f, %.2f)", sampleRawSourceCenter.x, sampleRawSourceCenter.y, sampleRawSourceCenter.z);
+		ImGui::Text("converted game center: (%.2f, %.2f, %.2f)", sampleConvertedGameCenter.x, sampleConvertedGameCenter.y, sampleConvertedGameCenter.z);
+		if (!worldColliders.empty() && worldColliders.front()->HasOBBBasis())
+		{
+			const OBB sampleObb = worldColliders.front()->GetOBB();
+			sampleAxisX = sampleObb.orientations[0];
+			sampleAxisY = sampleObb.orientations[1];
+			sampleAxisZ = sampleObb.orientations[2];
+		}
+		ImGui::Text("converted collider axisX: (%.2f, %.2f, %.2f)", sampleAxisX.x, sampleAxisX.y, sampleAxisX.z);
+		ImGui::Text("converted collider axisY: (%.2f, %.2f, %.2f)", sampleAxisY.x, sampleAxisY.y, sampleAxisY.z);
+		ImGui::Text("converted collider axisZ: (%.2f, %.2f, %.2f)", sampleAxisZ.x, sampleAxisZ.y, sampleAxisZ.z);
 		ImGui::Text("converted yaw sample: %.2f deg", sampleConvertedRotationDeg.y);
 		ImGui::Text("final collider yaw degree: %.2f deg", sampleFinalYawDeg);
 		ImGui::Text("Floor: %d", colliderTypeCounts["Floor"]);

--- a/Project/Engine/Scene/Level/LevelData.h
+++ b/Project/Engine/Scene/Level/LevelData.h
@@ -22,6 +22,13 @@ namespace Ken4lowEngine
 		bool hasRotation = false; // JSONの回転情報が存在したか
 		bool fromColliderRotation = false; // collider_rotation を読んだか（rotation より優先）
 		bool enabled = false;	// 有効フラグ
+
+		// Debug/変換検証用
+		Vector3 sourceCenter{};
+		Vector3 sourceSize{};
+		Vector3 finalAxisX{1.0f,0.0f,0.0f};
+		Vector3 finalAxisY{0.0f,1.0f,0.0f};
+		Vector3 finalAxisZ{0.0f,0.0f,1.0f};
 	};
 
 	/// -------------------------------------------------------------
@@ -91,6 +98,10 @@ namespace Ken4lowEngine
 		Vector3 position;                 // 位置
 		Vector3 rotation;                 // 回転
 		Vector3 scale{ 1.0f,1.0f,1.0f };  // スケール
+
+		Vector3 sourcePosition{};
+		Vector3 sourceRotationDeg{};
+		Vector3 sourceScale{ 1.0f,1.0f,1.0f };
 		ObjectColliderData collider;      // コライダーデータ
 
 		// SpawnPoint用

--- a/Project/Engine/Scene/Level/LevelLoader.cpp
+++ b/Project/Engine/Scene/Level/LevelLoader.cpp
@@ -185,6 +185,26 @@ namespace Ken4lowEngine
 			parentPosition.z + localPosition.z,
 		};
 
+		Vector3 localSourcePosition{};
+		Vector3 localSourceRotationDeg{};
+		Vector3 localSourceScale{ 1.0f, 1.0f, 1.0f };
+		if (object.contains("transform") && object["transform"].is_object())
+		{
+			const json& transform = object["transform"];
+			if (transform.contains("translation") && transform["translation"].is_array() && transform["translation"].size() >= 3)
+			{
+				localSourcePosition = { static_cast<float>(transform["translation"][0]), static_cast<float>(transform["translation"][1]), static_cast<float>(transform["translation"][2]) };
+			}
+			if (transform.contains("rotation") && transform["rotation"].is_array() && transform["rotation"].size() >= 3)
+			{
+				localSourceRotationDeg = { static_cast<float>(transform["rotation"][0]), static_cast<float>(transform["rotation"][1]), static_cast<float>(transform["rotation"][2]) };
+			}
+			if (transform.contains("scaling") && transform["scaling"].is_array() && transform["scaling"].size() >= 3)
+			{
+				localSourceScale = { static_cast<float>(transform["scaling"][0]), static_cast<float>(transform["scaling"][1]), static_cast<float>(transform["scaling"][2]) };
+			}
+		}
+
 		const Vector3 combinedRotation = {
 			parentRotation.x + localRotation.x,
 			parentRotation.y + localRotation.y,
@@ -226,6 +246,9 @@ namespace Ken4lowEngine
 			objectData->position = combinedPosition;
 			objectData->rotation = combinedRotation;
 			objectData->scale = combinedScale;
+			objectData->sourcePosition = localSourcePosition;
+			objectData->sourceRotationDeg = localSourceRotationDeg;
+			objectData->sourceScale = localSourceScale;
 
 			if (HasSpawnProps(object))
 			{
@@ -384,13 +407,15 @@ namespace Ken4lowEngine
 
 			if (jc.contains("center") && jc["center"].is_array() && jc["center"].size() >= 3)
 			{
-				objectData->collider.center.x = -static_cast<float>(jc["center"][0]);
+				objectData->collider.sourceCenter = { static_cast<float>(jc["center"][0]), static_cast<float>(jc["center"][1]), static_cast<float>(jc["center"][2]) };
+				objectData->collider.center.x = static_cast<float>(jc["center"][0]);
 				objectData->collider.center.y = static_cast<float>(jc["center"][2]);
-				objectData->collider.center.z = -static_cast<float>(jc["center"][1]);
+				objectData->collider.center.z = static_cast<float>(jc["center"][1]);
 			}
 
 			if (jc.contains("size") && jc["size"].is_array() && jc["size"].size() >= 3)
 			{
+				objectData->collider.sourceSize = { static_cast<float>(jc["size"][0]), static_cast<float>(jc["size"][1]), static_cast<float>(jc["size"][2]) };
 				objectData->collider.size.x = static_cast<float>(jc["size"][0]);
 				objectData->collider.size.y = static_cast<float>(jc["size"][2]);
 				objectData->collider.size.z = static_cast<float>(jc["size"][1]);

--- a/Project/Engine/Scene/Level/StageCollisionBuilder.cpp
+++ b/Project/Engine/Scene/Level/StageCollisionBuilder.cpp
@@ -1,8 +1,30 @@
 #include "StageCollisionBuilder.h"
 #include "CollisionTypeIdDef.h"
+#include <array>
+#include <algorithm>
 
 namespace Ken4lowEngine
 {
+	namespace
+	{
+		constexpr float kDegToRad = 3.14159265358979323846f / 180.0f;
+
+		Vector3 ConvertSourcePointToGamePoint(const Vector3& source)
+		{
+			return { -source.x, source.z, source.y };
+		}
+
+		void ConvertSourceRotationToGameBasis(const Matrix4x4& sourceRotation, Vector3& outX, Vector3& outY, Vector3& outZ)
+		{
+			const Vector3 sx = { sourceRotation.m[0][0], sourceRotation.m[0][1], sourceRotation.m[0][2] };
+			const Vector3 sy = { sourceRotation.m[1][0], sourceRotation.m[1][1], sourceRotation.m[1][2] };
+			const Vector3 sz = { sourceRotation.m[2][0], sourceRotation.m[2][1], sourceRotation.m[2][2] };
+			outX = Vector3::Normalize(ConvertSourcePointToGamePoint(sx));
+			outY = Vector3::Normalize(ConvertSourcePointToGamePoint(sy));
+			outZ = Vector3::Normalize(ConvertSourcePointToGamePoint(sz));
+		}
+	}
+
 	StageCollisionBuildResult StageCollisionBuilder::Build(const LevelData& levelData, const Vector3& offset)
 	{
 		StageCollisionBuildResult result{};
@@ -11,47 +33,45 @@ namespace Ken4lowEngine
 
 		for (const ObjectData& data : levelData.objects)
 		{
-			if (!data.collider.enabled)
-			{
-				continue;
-			}
+			if (!data.collider.enabled || data.collider.type != "BOX") { continue; }
 
-			if (data.collider.type != "BOX")
-			{
-				continue;
-			}
+			const Vector3 sourceObjectRotationRad = data.sourceRotationDeg * kDegToRad;
+			const Matrix4x4 sourceObjectRotation = Matrix4x4::MakeRotateMatrix(sourceObjectRotationRad);
+			const Matrix4x4 sourceColliderRotation = Matrix4x4::MakeRotateMatrix(data.collider.sourceRotationDeg * kDegToRad);
+			const Matrix4x4 sourceLocalRotation = Matrix4x4::Multiply(sourceColliderRotation, sourceObjectRotation);
 
-			const Vector3 centerW = {
-				data.position.x + data.collider.center.x * data.scale.x + offset.x,
-				data.position.y + data.collider.center.y * data.scale.y + offset.y,
-				data.position.z + data.collider.center.z * data.scale.z + offset.z
-			};
+			Vector3 axisX{}, axisY{}, axisZ{};
+			// モデルと同じsource→game変換をコライダーにも適用し、見た目と当たり判定の向きを一致させる
+			ConvertSourceRotationToGameBasis(sourceLocalRotation, axisX, axisY, axisZ);
 
-			const Vector3 halfW = {
-				0.5f * data.collider.size.x * data.scale.x,
-				0.5f * data.collider.size.y * data.scale.y,
-				0.5f * data.collider.size.z * data.scale.z,
-			};
+			const Vector3 localCenterScaled = Vector3::Multiply(data.collider.sourceCenter, data.sourceScale);
+			const Vector3 sourceCenter = data.sourcePosition + localCenterScaled;
+			const Vector3 centerW = ConvertSourcePointToGamePoint(sourceCenter) + offset;
 
-			AABB aabb{};
-			aabb.min = centerW - halfW;
-			aabb.max = centerW + halfW;
-			result.worldAABBs.push_back(aabb);
-
+			const Vector3 halfSource = data.collider.sourceSize * 0.5f;
+			const Vector3 halfScaled = Vector3::Multiply(halfSource, data.sourceScale);
 			auto collider = std::make_unique<Collider>();
 			collider->SetTypeID(static_cast<uint32_t>(CollisionTypeIdDef::kWorld));
 			collider->SetCenterPosition(centerW);
-			collider->SetOBBHalfSize(halfW);
-			const Vector3 colliderRotation = {
-				data.rotation.x + data.collider.rotation.x,
-				data.rotation.y + data.collider.rotation.y,
-				data.rotation.z + data.collider.rotation.z,
-			};
-			collider->SetOrientation(colliderRotation);
+			collider->SetOBBHalfSize(halfScaled);
+			collider->SetOBBBasis(axisX, axisY, axisZ);
 
+			std::array<Vector3, 8> corners{};
+			int i = 0;
+			for (int sx : { -1, 1 }) for (int sy : { -1, 1 }) for (int sz : { -1, 1 })
+			{
+				corners[i++] = centerW + axisX * (halfScaled.x * static_cast<float>(sx)) + axisY * (halfScaled.y * static_cast<float>(sy)) + axisZ * (halfScaled.z * static_cast<float>(sz));
+			}
+			AABB aabb{};
+			aabb.min = aabb.max = corners[0];
+			for (const auto& p : corners)
+			{
+				aabb.min.x = std::min(aabb.min.x, p.x); aabb.min.y = std::min(aabb.min.y, p.y); aabb.min.z = std::min(aabb.min.z, p.z);
+				aabb.max.x = std::max(aabb.max.x, p.x); aabb.max.y = std::max(aabb.max.y, p.y); aabb.max.z = std::max(aabb.max.z, p.z);
+			}
+			result.worldAABBs.push_back(aabb);
 			result.worldColliders.push_back(std::move(collider));
 		}
-
 		return result;
 	}
-} // namespace Ken4lowEngine
+}


### PR DESCRIPTION
### Motivation
- The stage colliders were misaligned with visual meshes because center/size/rotation were transformed via inconsistent code paths instead of using the same source->game conversion as the model loader.
- Previous ad-hoc fixes only converted `collider_rotation`, leaving remaining offsets from center and axis basis mismatches.
- We need deterministic conversion from the source (glTF/Blender) coordinates to game coordinates so mesh and collider agree without sign/90° hacks.

### Description
- Add source-space fields to `LevelData` (`sourcePosition`, `sourceRotationDeg`, `sourceScale`, `ObjectColliderData::sourceCenter`, `sourceSize`) and populate them in `LevelLoader` so raw JSON values are preserved for unified conversion.
- Replace the prior per-field ad-hoc collider conversion with a unified conversion in `StageCollisionBuilder`: compute source-space rotation matrices, convert source basis to game basis, convert source center->game point, build an OBB via `SetOBBBasis` and half-sizes, and generate `WorldAABBs` from the 8 transformed OBB corners.
- Keep AABB fallback behavior for gameplay (fall prevention) while moving accurate rotated colliders into `worldColliders_`, and add diagnostic fields and ImGui output in `DebugScene` for raw source center, converted game center, converted axes, and sample yaw (preferring `StoneCover_01_LargeBlock` for verification).
- Files changed: `Project/Engine/Scene/Level/StageCollisionBuilder.cpp`, `Project/Engine/Scene/Level/LevelData.h`, `Project/Engine/Scene/Level/LevelLoader.cpp`, `Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp`.

### Testing
- Ran repository status checks with `git status --short` and committed the changes (`git commit`) to record the patch.
- No full Visual Studio / MSBuild C++20 build with WarningLevel4/TreatWarningAsError was executed in this environment, so runtime verification and visual validation in DebugScene (StoneCover_01_LargeBlock, StoneCover_02/03, WoodenCrate, Fence) remain required.
- ImGui diagnostics were added so in-engine visual checks can be performed to confirm collider axes/centers and that `MeleeEnemy` falling behavior remains unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12bc121d50832d82a48a502ff14d26)