### PR TITLE
MeleeEnemy: apply visualYawOffset for correct visual facing and add ImGui tuning

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
@@ -15,6 +15,7 @@ namespace
 {
 	constexpr float kEpsilon = 0.0001f;
 	constexpr float kPi = 3.1415926535f;
+	constexpr float kTwoPi = kPi * 2.0f;
 
 	float LengthXZ(const Vector3& v)
 	{
@@ -26,6 +27,13 @@ namespace
 		const float len = LengthXZ(v);
 		if (len < kEpsilon) { return { 0.0f, 0.0f, 0.0f }; }
 		return { v.x / len, 0.0f, v.z / len };
+	}
+
+	float WrapPi(float v)
+	{
+		while (v > kPi) { v -= kTwoPi; }
+		while (v < -kPi) { v += kTwoPi; }
+		return v;
 	}
 }
 
@@ -126,7 +134,8 @@ void MeleeEnemy::DrawImGui()
 		ImGui::SliderFloat("resumeChaseDistance", &resumeChaseDistance_, 0.5f, 10.0f);
 		ImGui::SliderFloat("attackLockTime", &attackLockTime_, 0.0f, 1.0f);
 		ImGui::SliderFloat("rotateSpeed", &rotateSpeed_, 0.1f, 20.0f);
-		ImGui::SliderFloat("visualYawOffset", &visualYawOffset_, -kPi, kPi);
+		ImGui::DragFloat("visualYawOffset(rad)", &visualYawOffset_, 0.01f, -kTwoPi, kTwoPi);
+		ImGui::Text("visualYawOffset(deg): %.1f", visualYawOffset_ * (180.0f / kPi));
 		ImGui::SliderFloat("walkAnimSpeed", &walkAnimSpeed_, 1.0f, 18.0f);
 		ImGui::SliderFloat("walkArmSwing", &walkArmSwing_, 0.0f, 1.5f);
 		ImGui::SliderFloat("walkLegSwing", &walkLegSwing_, 0.0f, 1.5f);
@@ -175,6 +184,12 @@ void MeleeEnemy::DrawImGui()
 		ImGui::Text("lastResolvePush: (%.2f, %.2f, %.2f)", lastResolvePush_.x, lastResolvePush_.y, lastResolvePush_.z);
 		const Vector3 tgt = GetTargetPosition();
 		ImGui::Text("Target: (%.2f, %.2f, %.2f)", tgt.x, tgt.y, tgt.z);
+		ImGui::Text("rawYaw(rad): %.3f", rawYaw_);
+		ImGui::Text("finalVisualYaw(rad): %.3f", finalVisualYaw_);
+		ImGui::Text("rawYaw(deg): %.1f", rawYaw_ * (180.0f / kPi));
+		ImGui::Text("finalVisualYaw(deg): %.1f", finalVisualYaw_ * (180.0f / kPi));
+		ImGui::Text("facingDirection: (%.2f, %.2f, %.2f)", facingDirection_.x, facingDirection_.y, facingDirection_.z);
+		ImGui::Text("targetDirection: (%.2f, %.2f, %.2f)", targetDirection_.x, targetDirection_.y, targetDirection_.z);
 		if (ImGui::Button("Force Scratch Attack")) { ForceAttack(MeleeAttackType::Scratch); }
 		ImGui::SameLine();
 		if (ImGui::Button("Force OneTwo Attack")) { ForceAttack(MeleeAttackType::OneTwo); }
@@ -265,10 +280,30 @@ bool MeleeEnemy::IsMoveResumeDistanceReached() const { return GetDistanceToTarge
 void MeleeEnemy::FaceToTarget()
 {
 	if (!target_) { return; }
-	Vector3 dir = NormalizeXZ(GetTargetPosition() - GetCenterPosition());
-	if (LengthXZ(dir) <= kEpsilon) { return; }
-	const float yaw = std::atan2(dir.x, dir.z);
-	SetOrientation({ 0.0f, yaw + visualYawOffset_, 0.0f });
+	targetDirection_ = NormalizeXZ(GetTargetPosition() - GetCenterPosition());
+	ApplyVisualYawFromDirection(targetDirection_);
+}
+
+void MeleeEnemy::FaceToMoveDirection()
+{
+	const Vector3 moveDir = NormalizeXZ(GetVelocity());
+	ApplyVisualYawFromDirection(moveDir);
+}
+
+void MeleeEnemy::ApplyVisualYawFromDirection(const Vector3& direction)
+{
+	if (LengthXZ(direction) <= kEpsilon) { return; }
+	rawYaw_ = std::atan2(direction.x, direction.z);
+	// モデルの正面が移動方向と逆のため、表示Yawだけ180度補正する
+	const float targetVisualYaw = rawYaw_ + visualYawOffset_;
+	float currentYaw = orientation_.y;
+	const float maxStep = rotateSpeed_ * (1.0f / 60.0f);
+	const float delta = WrapPi(targetVisualYaw - currentYaw);
+	currentYaw += std::clamp(delta, -maxStep, maxStep);
+	currentYaw = WrapPi(currentYaw);
+	finalVisualYaw_ = currentYaw;
+	facingDirection_ = { std::sin(rawYaw_), 0.0f, std::cos(rawYaw_) };
+	SetOrientation({ 0.0f, currentYaw, 0.0f });
 }
 
 void MeleeEnemy::DeadAction()
@@ -315,7 +350,7 @@ void MeleeEnemy::ChaseTargetAction()
 	}
 	if (pathFindEnabled_ && MoveAlongPath(1.0f / 60.0f))
 	{
-		FaceToTarget();
+		FaceToMoveDirection();
 		animState_ = AnimState::Walk;
 		currentBehaviorName_ = "ChasePathMove";
 		return;
@@ -328,7 +363,7 @@ void MeleeEnemy::ChaseTargetAction()
 		return;
 	}
 	SetVelocity({ moveDir.x * moveSpeed_, GetVelocity().y, moveDir.z * moveSpeed_ });
-	FaceToTarget();
+	FaceToMoveDirection();
 	animState_ = AnimState::Walk;
 	currentBehaviorName_ = "ChaseTargetAction";
 }
@@ -386,6 +421,7 @@ void MeleeEnemy::WanderAction(float deltaTime)
 		wanderDirection_ = { std::sin(angle), 0.0f, std::cos(angle) };
 	}
 	SetVelocity({ wanderDirection_.x * (moveSpeed_ * 0.45f), GetVelocity().y, wanderDirection_.z * (moveSpeed_ * 0.45f) });
+	FaceToMoveDirection();
 	currentBehaviorName_ = "WanderAction";
 	animState_ = AnimState::Walk;
 }

--- a/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.h
@@ -49,6 +49,8 @@ private:
 	float GetDistanceToTarget() const;
 	K4E::Vector3 GetTargetPosition() const;
 	void FaceToTarget();
+	void FaceToMoveDirection();
+	void ApplyVisualYawFromDirection(const K4E::Vector3& direction);
 	void StopMove();
 	bool IsMoveResumeDistanceReached() const;
 	bool MoveAlongPath(float deltaTime);
@@ -115,6 +117,10 @@ private:
 	EnemyAStarNavigator navigator_{};
 	float wanderTimer_ = 0.0f;
 	K4E::Vector3 wanderDirection_{ 1.0f, 0.0f, 0.0f };
+	float rawYaw_ = 0.0f;
+	float finalVisualYaw_ = 0.0f;
+	K4E::Vector3 facingDirection_{ 0.0f, 0.0f, 1.0f };
+	K4E::Vector3 targetDirection_{ 0.0f, 0.0f, 1.0f };
 
 	AnimState animState_ = AnimState::Idle;
 	const char* currentBehaviorName_ = "None";


### PR DESCRIPTION
### Motivation
- Fix MeleeEnemy model visually facing the opposite direction from its movement/target while keeping movement vectors and gameplay logic unchanged. 
- Provide an in-game tweakable debug parameter so the visual yaw correction can be tuned quickly during testing.

### Description
- Introduced `FaceToMoveDirection()`, `ApplyVisualYawFromDirection()` and members `rawYaw_`, `finalVisualYaw_`, `facingDirection_`, and `targetDirection_` to separate raw movement/target yaw from the visual yaw with offset. 
- Apply `visualYawOffset_` (default `3.141592f` = 180°) only to the displayed yaw and perform smooth interpolation using `rotateSpeed_` with angle wrap (`WrapPi`) to preserve existing rotation smoothing. 
- Updated chase/path/wander/attack flows to call the unified visual-facing helpers (`FaceToTarget()` or `FaceToMoveDirection()`) without inverting any movement vectors or pathfinding directions. 
- Added ImGui controls and readouts: `visualYawOffset` as `DragFloat` (rad) with degree display, and debug displays for `rawYaw`, `finalVisualYaw`, `facingDirection`, and `targetDirection`, and included a one-line comment documenting the intent of the correction.

### Testing
- `git commit` of the changes completed successfully (files changed: `MeleeEnemy.h`, `MeleeEnemy.cpp`).
- No automated build or engine runtime tests were executed in this environment, so a full project build and in-editor verification are required (C++20 / WarningLevel4 / TreatWarningAsError).
- Manual/visual verification steps expected: verify in DebugScene that the MeleeEnemy visually faces the DummyTarget and during Scratch/OneTwo attacks, movement direction remains unchanged and attack hit forward remains consistent.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12e9a67638832d90524298b2eaf476)