### PR TITLE
Connect MeleeEnemy chase to obstacle-aware A* pathfinding

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.cpp
@@ -17,6 +17,7 @@
 using namespace Ken4lowEngine;
 
 const std::vector<Ken4lowEngine::AABB>* EnemyBase::g_worldAABBs_ = nullptr;
+const std::vector<Ken4lowEngine::AABB>* EnemyBase::g_navigationObstacleAABBs_ = nullptr;
 
 namespace
 {
@@ -390,6 +391,11 @@ void EnemyBase::TakeDamage(int amount, const Vector3& hitDir, float hitPower)
 void EnemyBase::SetGlobalStageWorldAABBs(const std::vector<K4E::AABB>* aabbs)
 {
 	g_worldAABBs_ = aabbs;
+}
+
+void EnemyBase::SetGlobalStageNavigationObstacleAABBs(const std::vector<K4E::AABB>* aabbs)
+{
+	g_navigationObstacleAABBs_ = aabbs;
 }
 
 void EnemyBase::SpawnHitEffectAt(const K4E::Vector3& worldPos)

--- a/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.h
@@ -123,6 +123,7 @@ public:
 	void OnCollisionExit(K4E::Collider* other) override { (void)other; }
 
 	static void SetGlobalStageWorldAABBs(const std::vector<K4E::AABB>* aabbs);
+	static void SetGlobalStageNavigationObstacleAABBs(const std::vector<K4E::AABB>* aabbs);
 
 	// 参照用
 	BodyPart& GetBody() { return body_; }
@@ -134,6 +135,7 @@ public:
 	void SpawnHitEffectAt(const K4E::Vector3& worldPos);
 
 	const std::vector<K4E::AABB>* GetResolvedWorldAABBs() const { return worldAABBs_ ? worldAABBs_ : g_worldAABBs_; }
+	const std::vector<K4E::AABB>* GetResolvedNavigationObstacleAABBs() const { return g_navigationObstacleAABBs_ ? g_navigationObstacleAABBs_ : GetResolvedWorldAABBs(); }
 
 protected:
 	// 派生で差し替え可（デフォルトはバラバラ崩壊開始）
@@ -225,4 +227,5 @@ protected:
 
 private:
 	static const std::vector<K4E::AABB>* g_worldAABBs_;
+	static const std::vector<K4E::AABB>* g_navigationObstacleAABBs_;
 };

--- a/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
@@ -126,6 +126,16 @@ void MeleeEnemy::Draw()
 	Wireframe::GetInstance()->DrawLine(origin, origin + targetDirection_ * 2.0f, { 1.0f, 1.0f, 0.2f, 1.0f });
 	Wireframe::GetInstance()->DrawLine(origin, origin + visualForward_ * 2.2f, { 1.0f, 0.4f, 1.0f, 1.0f });
 	Wireframe::GetInstance()->DrawLine(origin, origin + attackForward_ * 2.4f, { 1.0f, 0.2f, 0.2f, 1.0f });
+	const auto& path = navigator_.GetCurrentPath();
+	for (size_t i = 1; i < path.size(); ++i)
+	{
+		Wireframe::GetInstance()->DrawLine(path[i - 1] + Vector3{ 0.0f, 0.15f, 0.0f }, path[i] + Vector3{ 0.0f, 0.15f, 0.0f }, { 0.1f, 1.0f, 0.6f, 1.0f });
+	}
+	for (size_t i = 0; i < path.size(); ++i)
+	{
+		const Vector4 c = (static_cast<int>(i) == navigator_.GetCurrentPathIndex()) ? Vector4{ 1.0f, 0.3f, 0.1f, 1.0f } : Vector4{ 0.1f, 0.9f, 1.0f, 1.0f };
+		Wireframe::GetInstance()->DrawSphere(path[i] + Vector3{ 0.0f, 0.2f, 0.0f }, (static_cast<int>(i) == navigator_.GetCurrentPathIndex()) ? 0.26f : 0.16f, c);
+	}
 }
 
 void MeleeEnemy::DrawImGui()
@@ -180,10 +190,15 @@ void MeleeEnemy::DrawImGui()
 		ImGui::Text("Attack Active: %s", attackController_.IsCurrentStepActive() ? "true" : "false");
 		ImGui::Text("Last Hit: %s", attackController_.WasLastHitSuccess() ? "Hit" : "Miss");
 		ImGui::Text("Path Found: %s", pathFound_ ? "true" : "false");
-		ImGui::Text("Path Node Count: %d", pathFound_ ? 1 : 0);
-		ImGui::Text("Current Waypoint Index: %d", pathFound_ ? 0 : -1);
+		ImGui::Text("Obstacle Count: %zu", GetResolvedWorldAABBs() ? GetResolvedWorldAABBs()->size() : 0);
+		ImGui::Text("Path Node Count: %d", static_cast<int>(navigator_.GetCurrentPath().size()));
+		ImGui::Text("Current Waypoint Index: %d", navigator_.GetCurrentPathIndex());
+		ImGui::Text("Current Waypoint: (%.2f, %.2f, %.2f)", currentPathWaypoint_.x, currentPathWaypoint_.y, currentPathWaypoint_.z);
 		ImGui::Text("Last Repath Timer: %.2f", lastRepathTimer_);
+		ImGui::Text("Repath Timer: %.2f", navigator_.GetRepathTimer());
+		ImGui::Text("TargetMovedDistanceForRepath: %.2f", targetMovedDistanceForRepath_);
 		ImGui::Text("Path Failure Reason: %s", pathFailureReason_.c_str());
+		ImGui::Text("Last Repath Reason: %s", lastRepathReason_.c_str());
 		ImGui::Text("Grounded: %s", grounded_ ? "true" : "false");
 		ImGui::Text("AnimState: %s", GetAnimStateName());
 		ImGui::Text("lastSafePosition: (%.2f, %.2f, %.2f)", lastSafePosition_.x, lastSafePosition_.y, lastSafePosition_.z);
@@ -375,11 +390,17 @@ void MeleeEnemy::ChaseTargetAction()
 		currentBehaviorName_ = "ChaseStopNearTarget";
 		return;
 	}
-	if (pathFindEnabled_ && MoveAlongPath(1.0f / 60.0f))
+	if (pathFindEnabled_ && !attackController_.IsAttacking() && distance > attackStartRange_ && MoveAlongPath(1.0f / 60.0f))
 	{
 		FaceToMoveDirection(1.0f / 60.0f);
 		animState_ = AnimState::Walk;
 		currentBehaviorName_ = "ChasePathMove";
+		return;
+	}
+	if (pathFindEnabled_)
+	{
+		StopMove();
+		currentBehaviorName_ = "PathFailed";
 		return;
 	}
 	const Vector3 moveDir = NormalizeXZ(GetTargetPosition() - GetCenterPosition());
@@ -404,19 +425,37 @@ bool MeleeEnemy::MoveAlongPath(float deltaTime)
 	s.repathIntervalSec = repathInterval_;
 	s.waypointReachDistance = waypointReachDistance_;
 	navigator_.SetSettings(s);
-	navigator_.SetWorldAABBs(GetResolvedWorldAABBs());
+	// 障害物AABBを避ける経路を使い、近接敵がプレイヤーへ最短経路で詰めるようにする
+	navigator_.SetWorldAABBs(GetResolvedNavigationObstacleAABBs());
 	lastRepathTimer_ += deltaTime;
+	const Vector3 targetPos = GetTargetPosition();
+	targetMovedDistanceForRepath_ = LengthXZ(targetPos - lastPathTargetPos_);
+	if (targetMovedDistanceForRepath_ >= targetRepathThreshold_ || isStuck_)
+	{
+		navigator_.Reset();
+		lastRepathReason_ = isStuck_ ? "StuckForceRepath" : "TargetMoved";
+	}
 	// 障害物を考慮した経路を使い、MeleeEnemyが直線移動で引っかからないようにする
-	if (navigator_.GetNextWaypoint(GetCenterPosition(), GetTargetPosition(), GetCenterPosition().y, deltaTime, currentPathWaypoint_))
+	if (navigator_.GetNextWaypoint(GetCenterPosition(), targetPos, GetCenterPosition().y, deltaTime, currentPathWaypoint_))
 	{
 		pathFound_ = true;
 		pathFailureReason_ = "None";
+		lastRepathReason_ = "Periodic";
+		lastPathTargetPos_ = targetPos;
+		pathRetryTimer_ = 0.0f;
 		const Vector3 dir = NormalizeXZ(currentPathWaypoint_ - GetCenterPosition());
 		SetVelocity({ dir.x * moveSpeed_, GetVelocity().y, dir.z * moveSpeed_ });
 		return true;
 	}
 	pathFound_ = false;
 	pathFailureReason_ = "PathNotFound";
+	pathRetryTimer_ += deltaTime;
+	if (pathRetryTimer_ >= repathInterval_)
+	{
+		navigator_.Reset();
+		pathRetryTimer_ = 0.0f;
+		lastRepathReason_ = "RetryAfterFailure";
+	}
 	StopMove();
 	return false;
 }

--- a/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.h
@@ -112,7 +112,12 @@ private:
 	std::string pathFailureReason_ = "None";
 	float stuckTimer_ = 0.0f;
 	float lastRepathTimer_ = 0.0f;
+	float pathRetryTimer_ = 0.0f;
+	float targetMovedDistanceForRepath_ = 0.0f;
+	float targetRepathThreshold_ = 1.2f;
+	std::string lastRepathReason_ = "None";
 	K4E::Vector3 lastStuckCheckPosition_{};
+	K4E::Vector3 lastPathTargetPos_{};
 	K4E::Vector3 spawnPosition_{};
 	K4E::Vector3 currentPathWaypoint_{};
 	EnemyAStarNavigator navigator_{};

--- a/Project/ApplicationLayer/Character/Enemy/Navigation/EnemyAStarNavigator.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Navigation/EnemyAStarNavigator.cpp
@@ -63,8 +63,7 @@ bool EnemyAStarNavigator::GetNextWaypoint(
 	{
 		if (!RebuildPath(current, goal, sampleY))
 		{
-			// パスが引けないときは直進フォールバック
-			outWaypoint = goal;
+			outWaypoint = current;
 			repathTimer_ = settings_.repathIntervalSec;
 			return false;
 		}
@@ -77,7 +76,7 @@ bool EnemyAStarNavigator::GetNextWaypoint(
 
 	if (path_.empty())
 	{
-		outWaypoint = goal;
+		outWaypoint = current;
 		return false;
 	}
 

--- a/Project/ApplicationLayer/Character/Enemy/Navigation/EnemyAStarNavigator.h
+++ b/Project/ApplicationLayer/Character/Enemy/Navigation/EnemyAStarNavigator.h
@@ -33,6 +33,9 @@ public:
 		float sampleY,
 		float deltaTime,
 		K4E::Vector3& outWaypoint);
+	const std::vector<K4E::Vector3>& GetCurrentPath() const { return path_; }
+	int GetCurrentPathIndex() const { return currentPathIndex_; }
+	float GetRepathTimer() const { return repathTimer_; }
 
 private:
 	struct GridNode

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -157,6 +157,7 @@ void DebugScene::Initialize()
 	stage_->Update();
 	// DebugSceneでもステージAABBを共有し、EnemyBase系の敵が床と障害物に衝突できるようにする。
 	EnemyBase::SetGlobalStageWorldAABBs(&stage_->GetWorldAABBs());
+	EnemyBase::SetGlobalStageNavigationObstacleAABBs(&stage_->GetNavigationObstacleAABBs());
 }
 
 void DebugScene::Update()
@@ -366,6 +367,7 @@ void DebugScene::DrawImGui()
 	{
 		ImGui::Begin("Stage Debug");
 		const std::vector<AABB>& worldAABBs = stage_->GetWorldAABBs();
+		const std::vector<AABB>& navObstacles = stage_->GetNavigationObstacleAABBs();
 		const auto& worldColliders = stage_->GetWorldColliders();
 		const LevelData* levelData = stage_->GetLevelData();
 		size_t loadedColliders = 0;
@@ -409,6 +411,7 @@ void DebugScene::DrawImGui()
 		const size_t aabbFallbackCount = loadedColliders > worldColliders.size() ? loadedColliders - worldColliders.size() : 0;
 
 		ImGui::Text("WorldAABBs: %zu", worldAABBs.size());
+		ImGui::Text("Navigation Obstacles: %zu", navObstacles.size());
 		ImGui::Text("Loaded Colliders: %zu", loadedColliders);
 		ImGui::Text("Rotated collider count: %zu", rotatedColliderCount);
 		ImGui::Text("AABB fallback count: %zu", aabbFallbackCount);

--- a/Project/Engine/Scene/Level/Stage.cpp
+++ b/Project/Engine/Scene/Level/Stage.cpp
@@ -26,6 +26,7 @@ namespace Ken4lowEngine
 			StageCollisionBuilder::Build(*levelData_, offset_);
 
 		worldAABBs_ = std::move(collisionResult.worldAABBs);
+		navigationObstacleAABBs_ = std::move(collisionResult.navigationObstacleAABBs);
 		worldColliders_ = std::move(collisionResult.worldColliders);
 		occlusionCullingSystem_.BuildAutoOccludersFromWorldAABBs(worldAABBs_);
 	}
@@ -37,6 +38,7 @@ namespace Ken4lowEngine
 		stageChunkManager_.Clear();
 		occlusionCullingSystem_.ClearOccluders();
 		worldAABBs_.clear();
+		navigationObstacleAABBs_.clear();
 		worldColliders_.clear();
 	}
 

--- a/Project/Engine/Scene/Level/Stage.h
+++ b/Project/Engine/Scene/Level/Stage.h
@@ -87,6 +87,7 @@ namespace Ken4lowEngine
 	public: /// ---------- アクセサ ---------- ///
 
 		const std::vector<AABB>& GetWorldAABBs() const { return worldAABBs_; }
+		const std::vector<AABB>& GetNavigationObstacleAABBs() const { return navigationObstacleAABBs_; }
 		const std::vector<std::unique_ptr<Collider>>& GetWorldColliders() const { return worldColliders_; }
 
 		/// <summary>
@@ -103,6 +104,7 @@ namespace Ken4lowEngine
 		StageChunkManager stageChunkManager_;                 // 静的ステージを Chunk 単位で Draw スキップする管理クラス
 		OcclusionCullingSystem occlusionCullingSystem_;          // Lv4: 遮蔽物裏の StageChunk Draw を安全側で止める管理クラス
 		std::vector<AABB> worldAABBs_;                         // ワールド衝突AABB
+		std::vector<AABB> navigationObstacleAABBs_;            // Navigation向け障害物AABB(Floor除外)
 		std::vector<std::unique_ptr<Collider>> worldColliders_; // ワールド衝突Collider
 		Vector3 offset_ = { 0.0f, 0.0f, 0.0f };               // ステージ全体オフセット
 	};

--- a/Project/Engine/Scene/Level/StageCollisionBuilder.cpp
+++ b/Project/Engine/Scene/Level/StageCollisionBuilder.cpp
@@ -7,6 +7,7 @@ namespace Ken4lowEngine
 	{
 		StageCollisionBuildResult result{};
 		result.worldAABBs.reserve(levelData.objects.size());
+		result.navigationObstacleAABBs.reserve(levelData.objects.size());
 		result.worldColliders.reserve(levelData.objects.size());
 
 		for (const ObjectData& data : levelData.objects)
@@ -37,6 +38,11 @@ namespace Ken4lowEngine
 			aabb.min = centerW - halfW;
 			aabb.max = centerW + halfW;
 			result.worldAABBs.push_back(aabb);
+			const std::string& collisionType = data.collider.collisionType;
+			if (collisionType == "Obstacle" || collisionType == "Pillar" || collisionType == "Fence" || collisionType == "Tree")
+			{
+				result.navigationObstacleAABBs.push_back(aabb);
+			}
 
 			auto collider = std::make_unique<Collider>();
 			collider->SetTypeID(static_cast<uint32_t>(CollisionTypeIdDef::kWorld));

--- a/Project/Engine/Scene/Level/StageCollisionBuilder.h
+++ b/Project/Engine/Scene/Level/StageCollisionBuilder.h
@@ -11,6 +11,7 @@ namespace Ken4lowEngine
 	struct StageCollisionBuildResult
 	{
 		std::vector<AABB> worldAABBs;
+		std::vector<AABB> navigationObstacleAABBs;
 		std::vector<std::unique_ptr<Collider>> worldColliders;
 	};
 


### PR DESCRIPTION
### Motivation
- Prevent MeleeEnemy from running straight into level geometry by using navigation-only obstacle data and making chase follow A* waypoints. 
- Ensure MeleeEnemy stops/repaths cleanly when no viable path exists or when stuck, while keeping existing melee attack behaviors intact.

### Description
- Extract navigation obstacle AABBs (Obstacle/Pillar/Fence/Tree) in `StageCollisionBuilder` and expose them via `Stage::GetNavigationObstacleAABBs()` so floors are not treated as navigation blockers. 
- Add global navigation-obstacle wiring in `EnemyBase` (`SetGlobalStageNavigationObstacleAABBs`) and connect it from `DebugScene` so enemies can access obstacle-only AABBs. 
- Make `MeleeEnemy` use `EnemyAStarNavigator` waypoint output as primary chase movement when `pathFindEnabled_` is true, including repath triggers on target movement or stuck detection and stop/retry behavior on path failure. 
- Improve debug visibility: wireframe path lines and waypoint spheres in `MeleeEnemy::Draw()`, and add ImGui debug fields for obstacle/path counts, waypoint index/position, repath timers and last replan reason. 
- Adjust `EnemyAStarNavigator` to avoid forcing a straight-line fallback when path rebuild fails (return current position/false instead), enabling MeleeEnemy to refrain from blind linear movement into obstacles.

### Testing
- Ran `git diff --check` to validate whitespace/patch issues and it reported no problems. (succeeded)
- No automated solution build or unit test run was executed in this environment due to missing MSVC/CI build execution here; integration/build should be run in a Windows MSVC environment before merging. (not executed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12f2981334832d850c4e2109dbb736)