### PR TITLE
Fix MeleeEnemy passing through stage obstacles in DebugScene

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
@@ -5,6 +5,7 @@
 #include <algorithm>
 #include <cstdlib>
 #include "Wireframe.h"
+#include "CollisionTypeIdDef.h"
 
 #ifdef USE_IMGUI
 #include <imgui.h>
@@ -67,6 +68,8 @@ void MeleeEnemy::Update(float deltaTime)
 	usingWorldAABBCount_ = GetResolvedWorldAABBs() ? static_cast<int>(GetResolvedWorldAABBs()->size()) : 0;
 	usingObstacleAABBCount_ = GetResolvedNavigationObstacleAABBs() ? static_cast<int>(GetResolvedNavigationObstacleAABBs()->size()) : 0;
 	collisionManagerRegistered_ = true;
+	lastCollisionCount_ = 0;
+	pushedThisFrame_ = false;
 	Vector3 afterPos = GetCenterPosition();
 	Vector3 push = afterPos - (beforePos + GetVelocity() * deltaTime);
 	// 押し出し補正の暴発でステージ外へ飛ばされるのを防ぐため、フレーム補正量を制限する
@@ -84,6 +87,7 @@ void MeleeEnemy::Update(float deltaTime)
 		afterPos = GetCenterPosition();
 		lineBlocked_ = true;
 		blockedObstacleName_ = lastBlockedObstacleName_;
+		pushedThisFrame_ = true;
 	}
 
 
@@ -181,6 +185,25 @@ bool MeleeEnemy::ResolveObstaclePenetrationXZ(float deltaTime)
 	return resolved;
 }
 
+
+
+void MeleeEnemy::OnCollisionEnter(K4E::Collider* other)
+{
+	EnemyBase::OnCollisionEnter(other);
+	if (!other) { return; }
+	if (other->GetTypeID() == static_cast<uint32_t>(CollisionTypeIdDef::kWorld))
+	{
+		isCollidingWithStage_ = true;
+		lastStageCollisionType_ = "World";
+		lastStageCollisionName_ = "StageCollider";
+		++lastCollisionCount_;
+	}
+}
+
+void MeleeEnemy::OnCollisionStay(K4E::Collider* other)
+{
+	OnCollisionEnter(other);
+}
 void MeleeEnemy::Draw()
 {
 	EnemyBase::Draw();
@@ -270,6 +293,7 @@ void MeleeEnemy::DrawImGui()
 		ImGui::Text("usingWorldAABBCount: %d", usingWorldAABBCount_);
 		ImGui::Text("usingObstacleAABBCount: %d", usingObstacleAABBCount_);
 		ImGui::Text("collisionManagerRegistered: %s", collisionManagerRegistered_ ? "true" : "false");
+		ImGui::Text("lastCollisionCount: %d", lastCollisionCount_);
 		ImGui::Text("blockedByObstacle: %s", blockedByObstacle_ ? "true" : "false");
 		ImGui::Text("lastBlockedObstacleName: %s", lastBlockedObstacleName_.c_str());
 		ImGui::Text("Path Node Count: %d", static_cast<int>(navigator_.GetCurrentPath().size()));
@@ -290,6 +314,7 @@ void MeleeEnemy::DrawImGui()
 		ImGui::Text("lastSafePosition: (%.2f, %.2f, %.2f)", lastSafePosition_.x, lastSafePosition_.y, lastSafePosition_.z);
 		ImGui::Text("isOutsideStage: %s", isOutsideStage_ ? "true" : "false");
 		ImGui::Text("lastResolvePush: (%.2f, %.2f, %.2f)", lastResolvePush_.x, lastResolvePush_.y, lastResolvePush_.z);
+		ImGui::Text("pushedThisFrame: %s", pushedThisFrame_ ? "true" : "false");
 		const Vector3 tgt = GetTargetPosition();
 		ImGui::Text("Target: (%.2f, %.2f, %.2f)", tgt.x, tgt.y, tgt.z);
 		ImGui::Text("rawYaw(rad): %.3f", rawYaw_);

--- a/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.h
@@ -14,6 +14,8 @@ public:
 	void Update(float deltaTime) override;
 	void Draw() override;
 	void DrawImGui() override;
+	void OnCollisionEnter(K4E::Collider* other) override;
+	void OnCollisionStay(K4E::Collider* other) override;
 
 	void SetTarget(K4E::Collider* target) { target_ = target; }
 
@@ -102,6 +104,8 @@ private:
 	int usingWorldAABBCount_ = 0;
 	int usingObstacleAABBCount_ = 0;
 	bool collisionManagerRegistered_ = false;
+	int lastCollisionCount_ = 0;
+	bool pushedThisFrame_ = false;
 	float maxResolvePushPerFrame_ = 0.75f;
 	float maxHorizontalPushPerFrame_ = 0.45f;
 	float stuckCheckTime_ = 0.8f;

--- a/Project/ApplicationLayer/Colliders/CollisionManager.cpp
+++ b/Project/ApplicationLayer/Colliders/CollisionManager.cpp
@@ -144,6 +144,8 @@ void CollisionManager::CheckAllCollisions()
 	pairLoop(kPlayer, kBossBullet);
 	pairLoop(kPlayer, kItem);
 	pairLoop(kPlayer, kWorld);
+	pairLoop(kEnemy, kWorld);
+	pairLoop(kBoss, kWorld);
 	// Bullet vs World（壁に当てて消す）
 	pairLoop(kBullet, kWorld);
 	pairLoop(kEnemyBullet, kWorld);


### PR DESCRIPTION
### Motivation
- Melee enemies were not receiving collision events from stage colliders despite navigation AABBs being present, causing visual navigation to work but physical collisions to be ignored.
- The collision pair matrix in `CollisionManager::CheckAllCollisions()` omitted `Enemy vs World` (and `Boss vs World`), preventing `OnCollisionEnter/Stay` from firing for world colliders.
- Provide clear debug visibility into whether MeleeEnemy receives stage collisions and whether obstacle push-out is applied each frame.

### Description
- Enabled world collision checks by adding `pairLoop(kEnemy, kWorld)` and `pairLoop(kBoss, kWorld)` in `CollisionManager::CheckAllCollisions()` so enemies are tested against stage colliders.
- Added `OnCollisionEnter` and `OnCollisionStay` overrides to `MeleeEnemy` that update `isCollidingWithStage_`, `lastStageCollisionType_`, `lastStageCollisionName_` and increment `lastCollisionCount_` when colliding with `CollisionTypeIdDef::kWorld`.
- Introduced per-frame debug fields `lastCollisionCount_` and `pushedThisFrame_` to `MeleeEnemy`, reset them at start of `Update()`, set `pushedThisFrame_ = true` when `ResolveObstaclePenetrationXZ` performs a push, and exposed both values in MeleeEnemy ImGui output.
- Kept existing post-move AABB obstacle push-out logic in `MeleeEnemy::ResolveObstaclePenetrationXZ()` unchanged and included `#include "CollisionTypeIdDef.h"` where needed.

### Testing
- Static code inspection via `rg`/file reads and targeted file views was performed to verify changes and cross-references and completed successfully.
- Verified diffs with `git diff` and recorded the change set, then committed the patch successfully; commit message: `Fix melee enemy stage obstacle collision resolution`.
- No automated build or unit test was executed in this environment, so a full build (`C++20 / W4 / TreatWarningAsError`) and runtime test in `DebugScene` should be performed on CI or locally to confirm runtime collision behavior and that nothing else regressed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a12fa358a48832db5603ccd20e76485)