### PR TITLE
Separate Floor/Wall AABBs and fix MeleeEnemy obstacle push & grounding

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
@@ -70,6 +70,9 @@ void MeleeEnemy::Update(float deltaTime)
 	collisionManagerRegistered_ = true;
 	lastCollisionCount_ = 0;
 	pushedThisFrame_ = false;
+	restoredToSafePosition_ = false;
+	const auto* floorAabbs = floorAABBs_ ? floorAABBs_ : GetResolvedWorldAABBs();
+	worldAABBs_ = floorAabbs;
 	Vector3 afterPos = GetCenterPosition();
 	Vector3 push = afterPos - (beforePos + GetVelocity() * deltaTime);
 	// 押し出し補正の暴発でステージ外へ飛ばされるのを防ぐため、フレーム補正量を制限する
@@ -118,7 +121,8 @@ void MeleeEnemy::Update(float deltaTime)
 	}
 
 	isOutsideStage_ = hasStageBounds_ && !IsInsideStageBounds(GetCenterPosition());
-	if (grounded_ && !isOutsideStage_)
+	isOnFloor_ = grounded_;
+	if (grounded_ && !isOutsideStage_ && !isOverlappingWallObstacle_)
 	{
 		lastSafePosition_ = GetCenterPosition();
 	}
@@ -126,6 +130,7 @@ void MeleeEnemy::Update(float deltaTime)
 	{
 		// 押し出し補正が大きすぎる場合は安全位置へ戻し、ステージ外へ弾き出されるのを防ぐ
 		SetCenterPosition(lastSafePosition_);
+		restoredToSafePosition_ = true;
 		SetVelocity({ 0.0f, GetVelocity().y, 0.0f });
 	}
 
@@ -137,13 +142,15 @@ void MeleeEnemy::Update(float deltaTime)
 bool MeleeEnemy::ResolveObstaclePenetrationXZ(float deltaTime)
 {
 	(void)deltaTime;
-	const auto* obstacleAabbs = GetResolvedNavigationObstacleAABBs();
+	const auto* obstacleAabbs = wallObstacleAABBs_ ? wallObstacleAABBs_ : GetResolvedNavigationObstacleAABBs();
 	usingObstacleAABBCount_ = obstacleAabbs ? static_cast<int>(obstacleAabbs->size()) : 0;
 	isCollidingWithStage_ = false;
 	blockedByObstacle_ = false;
 	lastStageCollisionType_ = "None";
 	lastStageCollisionName_ = "None";
 	lastBlockedObstacleName_ = "None";
+	isOverlappingWallObstacle_ = false;
+	lastWallResolvePush_ = { 0.0f, 0.0f, 0.0f };
 	if (!obstacleAabbs || obstacleAabbs->empty()) { return false; }
 
 	Vector3 pos = GetCenterPosition();
@@ -158,9 +165,11 @@ bool MeleeEnemy::ResolveObstaclePenetrationXZ(float deltaTime)
 		const float overlapZ = std::min(pos.z + half.z, o.max.z) - std::max(pos.z - half.z, o.min.z);
 		if (overlapX <= 0.0f || overlapZ <= 0.0f) { continue; }
 		isCollidingWithStage_ = true;
+		isOverlappingWallObstacle_ = true;
 		blockedByObstacle_ = true;
 		lastStageCollisionType_ = "Obstacle";
 		lastStageCollisionName_ = "Obstacle[" + std::to_string(i) + "]";
+		lastWallObstacleName_ = lastStageCollisionName_;
 		lastBlockedObstacleName_ = lastStageCollisionName_;
 		float pushX = 0.0f, pushZ = 0.0f;
 		if (overlapX < overlapZ) { pushX = (pos.x < (o.min.x + o.max.x) * 0.5f ? -overlapX : overlapX); }
@@ -169,6 +178,8 @@ bool MeleeEnemy::ResolveObstaclePenetrationXZ(float deltaTime)
 		pushZ = std::clamp(pushZ, -maxPush, maxPush);
 		pos.x += pushX;
 		pos.z += pushZ;
+		lastWallResolvePush_.x += pushX;
+		lastWallResolvePush_.z += pushZ;
 		auto vel = GetVelocity();
 		if ((pushX < 0.0f && vel.x > 0.0f) || (pushX > 0.0f && vel.x < 0.0f)) vel.x = 0.0f;
 		if ((pushZ < 0.0f && vel.z > 0.0f) || (pushZ > 0.0f && vel.z < 0.0f)) vel.z = 0.0f;
@@ -194,6 +205,7 @@ void MeleeEnemy::OnCollisionEnter(K4E::Collider* other)
 	if (other->GetTypeID() == static_cast<uint32_t>(CollisionTypeIdDef::kWorld))
 	{
 		isCollidingWithStage_ = true;
+		isOverlappingWallObstacle_ = true;
 		lastStageCollisionType_ = "World";
 		lastStageCollisionName_ = "StageCollider";
 		++lastCollisionCount_;
@@ -291,10 +303,16 @@ void MeleeEnemy::DrawImGui()
 		ImGui::Text("lastStageCollisionType: %s", lastStageCollisionType_.c_str());
 		ImGui::Text("lastStageCollisionName: %s", lastStageCollisionName_.c_str());
 		ImGui::Text("usingWorldAABBCount: %d", usingWorldAABBCount_);
+		ImGui::Text("floorAABBCount: %d", floorAABBs_ ? static_cast<int>(floorAABBs_->size()) : usingWorldAABBCount_);
+		ImGui::Text("wallObstacleAABBCount: %d", wallObstacleAABBs_ ? static_cast<int>(wallObstacleAABBs_->size()) : usingObstacleAABBCount_);
 		ImGui::Text("usingObstacleAABBCount: %d", usingObstacleAABBCount_);
 		ImGui::Text("collisionManagerRegistered: %s", collisionManagerRegistered_ ? "true" : "false");
 		ImGui::Text("lastCollisionCount: %d", lastCollisionCount_);
 		ImGui::Text("blockedByObstacle: %s", blockedByObstacle_ ? "true" : "false");
+		ImGui::Text("isOnFloor: %s", isOnFloor_ ? "true" : "false");
+		ImGui::Text("isOverlappingWallObstacle: %s", isOverlappingWallObstacle_ ? "true" : "false");
+		ImGui::Text("lastWallObstacleName: %s", lastWallObstacleName_.c_str());
+		ImGui::Text("lastWallResolvePush: (%.2f, %.2f, %.2f)", lastWallResolvePush_.x, lastWallResolvePush_.y, lastWallResolvePush_.z);
 		ImGui::Text("lastBlockedObstacleName: %s", lastBlockedObstacleName_.c_str());
 		ImGui::Text("Path Node Count: %d", static_cast<int>(navigator_.GetCurrentPath().size()));
 		ImGui::Text("Current Waypoint Index: %d", navigator_.GetCurrentPathIndex());
@@ -314,7 +332,8 @@ void MeleeEnemy::DrawImGui()
 		ImGui::Text("lastSafePosition: (%.2f, %.2f, %.2f)", lastSafePosition_.x, lastSafePosition_.y, lastSafePosition_.z);
 		ImGui::Text("isOutsideStage: %s", isOutsideStage_ ? "true" : "false");
 		ImGui::Text("lastResolvePush: (%.2f, %.2f, %.2f)", lastResolvePush_.x, lastResolvePush_.y, lastResolvePush_.z);
-		ImGui::Text("pushedThisFrame: %s", pushedThisFrame_ ? "true" : "false");
+		ImGui::Text("pushedByWallThisFrame: %s", pushedThisFrame_ ? "true" : "false");
+		ImGui::Text("restoredToSafePosition: %s", restoredToSafePosition_ ? "true" : "false");
 		const Vector3 tgt = GetTargetPosition();
 		ImGui::Text("Target: (%.2f, %.2f, %.2f)", tgt.x, tgt.y, tgt.z);
 		ImGui::Text("rawYaw(rad): %.3f", rawYaw_);

--- a/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.h
@@ -18,6 +18,8 @@ public:
 	void OnCollisionStay(K4E::Collider* other) override;
 
 	void SetTarget(K4E::Collider* target) { target_ = target; }
+	void SetFloorAABBs(const std::vector<K4E::AABB>* aabbs) { floorAABBs_ = aabbs; }
+	void SetWallObstacleAABBs(const std::vector<K4E::AABB>* aabbs) { wallObstacleAABBs_ = aabbs; }
 
 	K4E::Collider* GetTargetCollider() const { return target_; }
 	K4E::Vector3 GetTargetPositionForAttack() const;
@@ -106,6 +108,11 @@ private:
 	bool collisionManagerRegistered_ = false;
 	int lastCollisionCount_ = 0;
 	bool pushedThisFrame_ = false;
+	bool restoredToSafePosition_ = false;
+	bool isOverlappingWallObstacle_ = false;
+	bool isOnFloor_ = false;
+	std::string lastWallObstacleName_ = "None";
+	K4E::Vector3 lastWallResolvePush_{};
 	float maxResolvePushPerFrame_ = 0.75f;
 	float maxHorizontalPushPerFrame_ = 0.45f;
 	float stuckCheckTime_ = 0.8f;
@@ -159,5 +166,7 @@ private:
 	K4E::Vector3 attackForward_{ 0.0f, 0.0f, 1.0f };
 
 	AnimState animState_ = AnimState::Idle;
+	const std::vector<K4E::AABB>* floorAABBs_ = nullptr;
+	const std::vector<K4E::AABB>* wallObstacleAABBs_ = nullptr;
 	const char* currentBehaviorName_ = "None";
 };

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -158,6 +158,8 @@ void DebugScene::Initialize()
 	// DebugSceneでもステージAABBを共有し、EnemyBase系の敵が床と障害物に衝突できるようにする。
 	EnemyBase::SetGlobalStageWorldAABBs(&stage_->GetWorldAABBs());
 	EnemyBase::SetGlobalStageNavigationObstacleAABBs(&stage_->GetNavigationObstacleAABBs());
+	debugMeleeEnemy_->SetFloorAABBs(&stage_->GetFloorAABBs());
+	debugMeleeEnemy_->SetWallObstacleAABBs(&stage_->GetWallObstacleAABBs());
 }
 
 void DebugScene::Update()
@@ -367,6 +369,8 @@ void DebugScene::DrawImGui()
 	{
 		ImGui::Begin("Stage Debug");
 		const std::vector<AABB>& worldAABBs = stage_->GetWorldAABBs();
+		const std::vector<AABB>& floorAABBs = stage_->GetFloorAABBs();
+		const std::vector<AABB>& wallObstacles = stage_->GetWallObstacleAABBs();
 		const std::vector<AABB>& navObstacles = stage_->GetNavigationObstacleAABBs();
 		const auto& worldColliders = stage_->GetWorldColliders();
 		const LevelData* levelData = stage_->GetLevelData();
@@ -411,7 +415,9 @@ void DebugScene::DrawImGui()
 		const size_t aabbFallbackCount = loadedColliders > worldColliders.size() ? loadedColliders - worldColliders.size() : 0;
 
 		ImGui::Text("WorldAABBs: %zu", worldAABBs.size());
-		ImGui::Text("Navigation Obstacles: %zu", navObstacles.size());
+		ImGui::Text("FloorAABB count: %zu", floorAABBs.size());
+		ImGui::Text("WallObstacleAABB count: %zu", wallObstacles.size());
+		ImGui::Text("NavigationObstacleAABB count: %zu", navObstacles.size());
 		ImGui::Text("Loaded Colliders: %zu", loadedColliders);
 		ImGui::Text("Rotated collider count: %zu", rotatedColliderCount);
 		ImGui::Text("AABB fallback count: %zu", aabbFallbackCount);

--- a/Project/Engine/Scene/Level/Stage.cpp
+++ b/Project/Engine/Scene/Level/Stage.cpp
@@ -26,6 +26,8 @@ namespace Ken4lowEngine
 			StageCollisionBuilder::Build(*levelData_, offset_);
 
 		worldAABBs_ = std::move(collisionResult.worldAABBs);
+		floorAABBs_ = std::move(collisionResult.floorAABBs);
+		wallObstacleAABBs_ = std::move(collisionResult.wallObstacleAABBs);
 		navigationObstacleAABBs_ = std::move(collisionResult.navigationObstacleAABBs);
 		worldColliders_ = std::move(collisionResult.worldColliders);
 		occlusionCullingSystem_.BuildAutoOccludersFromWorldAABBs(worldAABBs_);
@@ -38,6 +40,8 @@ namespace Ken4lowEngine
 		stageChunkManager_.Clear();
 		occlusionCullingSystem_.ClearOccluders();
 		worldAABBs_.clear();
+		floorAABBs_.clear();
+		wallObstacleAABBs_.clear();
 		navigationObstacleAABBs_.clear();
 		worldColliders_.clear();
 	}

--- a/Project/Engine/Scene/Level/Stage.h
+++ b/Project/Engine/Scene/Level/Stage.h
@@ -87,6 +87,8 @@ namespace Ken4lowEngine
 	public: /// ---------- アクセサ ---------- ///
 
 		const std::vector<AABB>& GetWorldAABBs() const { return worldAABBs_; }
+		const std::vector<AABB>& GetFloorAABBs() const { return floorAABBs_; }
+		const std::vector<AABB>& GetWallObstacleAABBs() const { return wallObstacleAABBs_; }
 		const std::vector<AABB>& GetNavigationObstacleAABBs() const { return navigationObstacleAABBs_; }
 		const std::vector<std::unique_ptr<Collider>>& GetWorldColliders() const { return worldColliders_; }
 
@@ -104,6 +106,8 @@ namespace Ken4lowEngine
 		StageChunkManager stageChunkManager_;                 // 静的ステージを Chunk 単位で Draw スキップする管理クラス
 		OcclusionCullingSystem occlusionCullingSystem_;          // Lv4: 遮蔽物裏の StageChunk Draw を安全側で止める管理クラス
 		std::vector<AABB> worldAABBs_;                         // ワールド衝突AABB
+		std::vector<AABB> floorAABBs_;                         // 接地用Floor AABB
+		std::vector<AABB> wallObstacleAABBs_;                  // 横押し出し用Obstacle AABB
 		std::vector<AABB> navigationObstacleAABBs_;            // Navigation向け障害物AABB(Floor除外)
 		std::vector<std::unique_ptr<Collider>> worldColliders_; // ワールド衝突Collider
 		Vector3 offset_ = { 0.0f, 0.0f, 0.0f };               // ステージ全体オフセット

--- a/Project/Engine/Scene/Level/StageCollisionBuilder.cpp
+++ b/Project/Engine/Scene/Level/StageCollisionBuilder.cpp
@@ -7,6 +7,8 @@ namespace Ken4lowEngine
 	{
 		StageCollisionBuildResult result{};
 		result.worldAABBs.reserve(levelData.objects.size());
+		result.floorAABBs.reserve(levelData.objects.size());
+		result.wallObstacleAABBs.reserve(levelData.objects.size());
 		result.navigationObstacleAABBs.reserve(levelData.objects.size());
 		result.worldColliders.reserve(levelData.objects.size());
 
@@ -39,8 +41,13 @@ namespace Ken4lowEngine
 			aabb.max = centerW + halfW;
 			result.worldAABBs.push_back(aabb);
 			const std::string& collisionType = data.collider.collisionType;
-			if (collisionType == "Obstacle" || collisionType == "Pillar" || collisionType == "Fence" || collisionType == "Tree")
+			if (collisionType == "Floor")
 			{
+				result.floorAABBs.push_back(aabb);
+			}
+			else if (collisionType == "Obstacle" || collisionType == "Pillar" || collisionType == "Fence" || collisionType == "Tree")
+			{
+				result.wallObstacleAABBs.push_back(aabb);
 				result.navigationObstacleAABBs.push_back(aabb);
 			}
 

--- a/Project/Engine/Scene/Level/StageCollisionBuilder.h
+++ b/Project/Engine/Scene/Level/StageCollisionBuilder.h
@@ -11,6 +11,8 @@ namespace Ken4lowEngine
 	struct StageCollisionBuildResult
 	{
 		std::vector<AABB> worldAABBs;
+		std::vector<AABB> floorAABBs;
+		std::vector<AABB> wallObstacleAABBs;
 		std::vector<AABB> navigationObstacleAABBs;
 		std::vector<std::unique_ptr<Collider>> worldColliders;
 	};


### PR DESCRIPTION
### Motivation
- Floor and obstacle AABBs were mixed, causing MeleeEnemy to snap onto obstacle tops or pass through obstacle walls during movement/attacks. 
- The goal is to make grounding use only Floor AABBs and make obstacle interaction use horizontal (XZ) push-out so pathfinding and runtime collision match.

### Description
- Split stage collision outputs into three lists in `StageCollisionBuildResult` and `Stage`: `floorAABBs`, `wallObstacleAABBs`, and `navigationObstacleAABBs`, and updated `Stage::Initialize`/`Clear` to populate/clear them.
- Updated `StageCollisionBuilder` to classify collider types so `Floor` goes into `floorAABBs` and `Obstacle/Pillar/Fence/Tree` go into `wallObstacleAABBs` and `navigationObstacleAABBs` (floor is excluded from navigation obstacles).
- Wired `DebugScene` to pass `floorAABBs` and `wallObstacleAABBs` into `MeleeEnemy` and added Stage debug counts for floor/wall/navigation AABBs.
- Modified `MeleeEnemy` to accept `SetFloorAABBs`/`SetWallObstacleAABBs`, use Floor AABBs for grounding/world resolve and WallObstacle AABBs for XZ push-out in `ResolveObstaclePenetrationXZ`, and added debug/state fields and ImGui displays (e.g., `isOnFloor`, `isOverlappingWallObstacle`, `lastWallResolvePush`, `restoredToSafePosition`).
- Key changed files: `StageCollisionBuilder.{h,cpp}`, `Stage.h/cpp`, `MeleeEnemy.{h,cpp}`, and `DebugScene.cpp`.

### Testing
- Attempted an automated build with `msbuild Ken4lowEngine.vcxproj` but the environment lacks `msbuild` so the build could not be executed (`msbuild: command not found`).
- No other automated tests were run in this environment; runtime verification (in-editor/playtest) is recommended to confirm enemies no longer ride on or pass through obstacles.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a130144dd98832dacd2b7c8719f5cf7)