### PR TITLE
Align stage obstacle AABBs with rotated OBBs

### DIFF
--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -378,9 +378,17 @@ void DebugScene::DrawImGui()
 		size_t rotatedColliderCount = 0;
 		size_t colliderRotationReadCount = 0;
 		std::string sampleColliderName = "(none)";
+		Vector3 sampleRawCenter{};
+		Vector3 sampleConvertedCenter{};
 		Vector3 sampleSourceRotationDeg{};
 		Vector3 sampleConvertedRotationDeg{};
+		Vector3 sampleOBBCenter{};
+		Vector3 sampleAABBMin{};
+		Vector3 sampleAABBMax{};
 		float sampleFinalYawDeg = 0.0f;
+		bool sampleUsedByNavigationObstacle = false;
+		bool sampleUsedByWallObstacle = false;
+		bool sampleUsedByCollisionObstacle = false;
 		std::unordered_map<std::string, int> colliderTypeCounts{};
 		if (levelData)
 		{
@@ -405,10 +413,29 @@ void DebugScene::DrawImGui()
 				if (sampleColliderName == "(none)" && object.collider.hasRotation)
 				{
 					sampleColliderName = object.name;
+					sampleRawCenter = object.collider.center;
+					sampleConvertedCenter = {
+						object.position.x + object.collider.center.x * object.scale.x,
+						object.position.y + object.collider.center.y * object.scale.y,
+						object.position.z + object.collider.center.z * object.scale.z,
+					};
 					sampleSourceRotationDeg = object.collider.sourceRotationDeg;
 					sampleConvertedRotationDeg = object.collider.convertedRotationDeg;
 					constexpr float kRadToDeg = 180.0f / 3.14159265358979323846f;
 					sampleFinalYawDeg = (object.rotation.y + object.collider.rotation.y) * kRadToDeg;
+					sampleOBBCenter = sampleConvertedCenter;
+					const Vector3 half = {
+						0.5f * object.collider.size.x * object.scale.x,
+						0.5f * object.collider.size.y * object.scale.y,
+						0.5f * object.collider.size.z * object.scale.z
+					};
+					sampleAABBMin = sampleConvertedCenter - half;
+					sampleAABBMax = sampleConvertedCenter + half;
+					sampleUsedByNavigationObstacle =
+						(object.collider.collisionType == "Obstacle" || object.collider.collisionType == "Pillar" ||
+							object.collider.collisionType == "Fence" || object.collider.collisionType == "Tree");
+					sampleUsedByWallObstacle = sampleUsedByNavigationObstacle;
+					sampleUsedByCollisionObstacle = sampleUsedByNavigationObstacle;
 				}
 			}
 		}
@@ -423,12 +450,20 @@ void DebugScene::DrawImGui()
 		ImGui::Text("AABB fallback count: %zu", aabbFallbackCount);
 		ImGui::Text("collider_rotation read count: %zu", colliderRotationReadCount);
 		ImGui::Text("sample collider name: %s", sampleColliderName.c_str());
+		ImGui::Text("raw center: (%.2f, %.2f, %.2f)", sampleRawCenter.x, sampleRawCenter.y, sampleRawCenter.z);
+		ImGui::Text("converted center: (%.2f, %.2f, %.2f)", sampleConvertedCenter.x, sampleConvertedCenter.y, sampleConvertedCenter.z);
 		ImGui::Text("source rotation degree: (%.2f, %.2f, %.2f)",
 			sampleSourceRotationDeg.x, sampleSourceRotationDeg.y, sampleSourceRotationDeg.z);
 		ImGui::Text("converted rotation degree: (%.2f, %.2f, %.2f)",
 			sampleConvertedRotationDeg.x, sampleConvertedRotationDeg.y, sampleConvertedRotationDeg.z);
 		ImGui::Text("converted yaw sample: %.2f deg", sampleConvertedRotationDeg.y);
 		ImGui::Text("final collider yaw degree: %.2f deg", sampleFinalYawDeg);
+		ImGui::Text("OBB center: (%.2f, %.2f, %.2f)", sampleOBBCenter.x, sampleOBBCenter.y, sampleOBBCenter.z);
+		ImGui::Text("AABB min: (%.2f, %.2f, %.2f)", sampleAABBMin.x, sampleAABBMin.y, sampleAABBMin.z);
+		ImGui::Text("AABB max: (%.2f, %.2f, %.2f)", sampleAABBMax.x, sampleAABBMax.y, sampleAABBMax.z);
+		ImGui::Text("used by NavigationObstacle: %s", sampleUsedByNavigationObstacle ? "true" : "false");
+		ImGui::Text("used by WallObstacle: %s", sampleUsedByWallObstacle ? "true" : "false");
+		ImGui::Text("used by CollisionObstacle: %s", sampleUsedByCollisionObstacle ? "true" : "false");
 		const int floorCount = colliderTypeCounts["Floor"];
 		const int wallObstacleCount = colliderTypeCounts["Obstacle"] + colliderTypeCounts["Pillar"] + colliderTypeCounts["Fence"] + colliderTypeCounts["Tree"];
 		ImGui::Text("Floor AABB count: %d", floorCount);

--- a/Project/Engine/Scene/Level/StageCollisionBuilder.cpp
+++ b/Project/Engine/Scene/Level/StageCollisionBuilder.cpp
@@ -1,8 +1,44 @@
 #include "StageCollisionBuilder.h"
 #include "CollisionTypeIdDef.h"
+#include "Matrix4x4.h"
+#include <limits>
 
 namespace Ken4lowEngine
 {
+	namespace
+	{
+		AABB BuildAABBFromRotatedOBB(const Vector3& center, const Vector3& half, const Vector3& rotationRad)
+		{
+			const Matrix4x4 rotation = Matrix4x4::MakeRotateMatrix(rotationRad);
+			AABB aabb{};
+			aabb.min = { std::numeric_limits<float>::max(), std::numeric_limits<float>::max(), std::numeric_limits<float>::max() };
+			aabb.max = { std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest(), std::numeric_limits<float>::lowest() };
+
+			for (int ix = -1; ix <= 1; ix += 2)
+			{
+				for (int iy = -1; iy <= 1; iy += 2)
+				{
+					for (int iz = -1; iz <= 1; iz += 2)
+					{
+						Vector3 cornerLocal = {
+							half.x * static_cast<float>(ix),
+							half.y * static_cast<float>(iy),
+							half.z * static_cast<float>(iz),
+						};
+						const Vector3 cornerWorld = Vector3::Transform(cornerLocal, rotation) + center;
+						aabb.min.x = (std::min)(aabb.min.x, cornerWorld.x);
+						aabb.min.y = (std::min)(aabb.min.y, cornerWorld.y);
+						aabb.min.z = (std::min)(aabb.min.z, cornerWorld.z);
+						aabb.max.x = (std::max)(aabb.max.x, cornerWorld.x);
+						aabb.max.y = (std::max)(aabb.max.y, cornerWorld.y);
+						aabb.max.z = (std::max)(aabb.max.z, cornerWorld.z);
+					}
+				}
+			}
+			return aabb;
+		}
+	}
+
 	StageCollisionBuildResult StageCollisionBuilder::Build(const LevelData& levelData, const Vector3& offset)
 	{
 		StageCollisionBuildResult result{};
@@ -36,9 +72,18 @@ namespace Ken4lowEngine
 				0.5f * data.collider.size.z * data.scale.z,
 			};
 
-			AABB aabb{};
-			aabb.min = centerW - halfW;
-			aabb.max = centerW + halfW;
+			auto collider = std::make_unique<Collider>();
+			collider->SetTypeID(static_cast<uint32_t>(CollisionTypeIdDef::kWorld));
+			collider->SetCenterPosition(centerW);
+			collider->SetOBBHalfSize(halfW);
+			const Vector3 colliderRotation = {
+				data.rotation.x + data.collider.rotation.x,
+				data.rotation.y + data.collider.rotation.y,
+				data.rotation.z + data.collider.rotation.z,
+			};
+			collider->SetOrientation(colliderRotation);
+			// OBB表示とNavigation/Wall用AABBの生成元を揃え、見た目と判定の向き不一致を解消する
+			const AABB aabb = BuildAABBFromRotatedOBB(centerW, halfW, colliderRotation);
 			result.worldAABBs.push_back(aabb);
 			const std::string& collisionType = data.collider.collisionType;
 			if (collisionType == "Floor")
@@ -50,17 +95,6 @@ namespace Ken4lowEngine
 				result.wallObstacleAABBs.push_back(aabb);
 				result.navigationObstacleAABBs.push_back(aabb);
 			}
-
-			auto collider = std::make_unique<Collider>();
-			collider->SetTypeID(static_cast<uint32_t>(CollisionTypeIdDef::kWorld));
-			collider->SetCenterPosition(centerW);
-			collider->SetOBBHalfSize(halfW);
-			const Vector3 colliderRotation = {
-				data.rotation.x + data.collider.rotation.x,
-				data.rotation.y + data.collider.rotation.y,
-				data.rotation.z + data.collider.rotation.z,
-			};
-			collider->SetOrientation(colliderRotation);
 
 			result.worldColliders.push_back(std::move(collider));
 		}


### PR DESCRIPTION
### Motivation
- The brown wireframe AABBs used for navigation/wall obstacles were generated from unrotated center/size while the cyan collider OBBs respected rotation, causing visible bounds and runtime collision/navigation to disagree and producing enemy clipping/tunneling/embedding issues.
- The goal is to make NavigationObstacle/WallObstacle/CollisionObstacle and the debug wireframe derive from the same rotated OBB basis so pathfinding and collision resolution reference the same visible obstacle shape.

### Description
- Add `BuildAABBFromRotatedOBB` to `StageCollisionBuilder` and use it to reconstruct AABB by transforming all 8 OBB corners with the collider rotation and taking their envelope, ensuring rotation is included when creating `worldAABBs`, `floorAABBs`, `wallObstacleAABBs`, and `navigationObstacleAABBs`.
- Set up the `Collider` orientation first and compute the rotated-source AABB from `centerW`, `halfW`, and `colliderRotation`, and include `Matrix4x4.h` and `<limits>` to support the implementation, with a clarifying one-line comment added.
- Extend the Stage Debug panel (`DebugScene.cpp`) to show a sample collider's raw/converted center, source/converted rotation degrees, OBB center, AABB min/max, and flags indicating whether the sample is used by Navigation/Wall/Collision obstacles to aid verification.
- Files changed: `Project/Engine/Scene/Level/StageCollisionBuilder.cpp` and `Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp`.

### Testing
- Verified source changes and diffs locally and confirmed the AABB-from-OBB logic and additional debug fields are present in modified files.
- Attempted a full solution build but the environment lacks `msbuild` so the build could not be executed here (`/bin/bash: line 1: msbuild: command not found`).
- No automated unit tests were present for these specific changes in this environment, so runtime verification should be performed in the normal development build (expected to reduce enemy clipping and align wireframe with colliders).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1307e44170832d8a7a9a9dc92b3bb8)