### PR TITLE
Define StageObstacleBox in namespace and fix vector/type mismatches in Stage

### DIFF
--- a/Project/Engine/Scene/Level/Stage.h
+++ b/Project/Engine/Scene/Level/Stage.h
@@ -5,6 +5,7 @@
 #include "LevelData.h"
 #include "OcclusionCullingSystem.h"
 #include "StageChunkManager.h"
+#include "StageCollisionBuilder.h"
 
 #include <memory>
 #include <string>
@@ -91,7 +92,7 @@ namespace Ken4lowEngine
 		const std::vector<AABB>& GetFloorAABBs() const { return floorAABBs_; }
 		const std::vector<AABB>& GetWallObstacleAABBs() const { return wallObstacleAABBs_; }
 		const std::vector<AABB>& GetNavigationObstacleAABBs() const { return navigationObstacleAABBs_; }
-		const std::vector<StageCollisionBuildResult::StageObstacleBox>& GetObstacleBoxes() const { return obstacleBoxes_; }
+		const std::vector<StageObstacleBox>& GetObstacleBoxes() const { return obstacleBoxes_; }
 		const std::vector<std::unique_ptr<Collider>>& GetWorldColliders() const { return worldColliders_; }
 
 		/// <summary>
@@ -112,7 +113,8 @@ namespace Ken4lowEngine
 		std::vector<AABB> floorAABBs_;                         // 接地用Floor AABB
 		std::vector<AABB> wallObstacleAABBs_;                  // 横押し出し用Obstacle AABB
 		std::vector<AABB> navigationObstacleAABBs_;            // Navigation向け障害物AABB(Floor除外)
-		std::vector<StageCollisionBuildResult::StageObstacleBox> obstacleBoxes_; // 回転付き障害物OBB情報
+		std::vector<StageObstacleBox> obstacleBoxes_; // 回転付き障害物OBB情報
+		// 回転付き障害物BoxとAABBリストを分けて保持し、型不一致を防ぐ
 		std::vector<std::unique_ptr<Collider>> worldColliders_; // ワールド衝突Collider
 		Vector3 offset_ = { 0.0f, 0.0f, 0.0f };               // ステージ全体オフセット
 	};

--- a/Project/Engine/Scene/Level/StageCollisionBuilder.h
+++ b/Project/Engine/Scene/Level/StageCollisionBuilder.h
@@ -9,10 +9,8 @@
 
 namespace Ken4lowEngine
 {
-	struct StageCollisionBuildResult
+	struct StageObstacleBox
 	{
-		struct StageObstacleBox
-		{
 			std::string name;
 			std::string collisionTypeName;
 			int collisionTypeId = -1;
@@ -23,8 +21,10 @@ namespace Ken4lowEngine
 			Vector3 axisZ{ 0.0f, 0.0f, 1.0f };
 			std::array<Vector3, 8> corners{};
 			AABB enclosingAABB{};
-		};
+	};
 
+	struct StageCollisionBuildResult
+	{
 		std::vector<AABB> worldAABBs;
 		std::vector<AABB> worldAABBsLegacy;
 		std::vector<AABB> floorAABBs;


### PR DESCRIPTION
### Motivation
- Fix compile errors where `StageObstacleBox` was not a visible/complete type when used in `Stage.h`, causing undefined `StageCollisionBuildResult` and `std::vector` assignment/type mismatches.
- Ensure `std::vector<AABB>` and obstacle-box lists are kept as distinct, consistent types to avoid `operator=` type errors.

### Description
- Move `StageObstacleBox` to namespace scope in `Project/Engine/Scene/Level/StageCollisionBuilder.h` so it is fully defined before any `std::vector` usage.
- Rework `StageCollisionBuildResult` to use `std::vector<StageObstacleBox>` and keep `obstacleBoxes` consistent with the new top-level `StageObstacleBox` type.
- Add `#include "StageCollisionBuilder.h"` to `Project/Engine/Scene/Level/Stage.h` and change the `Stage` member/accessor types from `StageCollisionBuildResult::StageObstacleBox` to `StageObstacleBox` to unify types across headers.
- Add a one-line comment in `Stage.h` clarifying that rotated obstacle boxes and AABB lists are stored separately to prevent type mismatches.

### Testing
- Ran `rg` searches to verify `StageCollisionBuildResult`, `StageObstacleBox`, and `std::vector<StageObstacleBox>` references are consistent across `Stage.h`, `Stage.cpp`, and `StageCollisionBuilder.h`, and the searches returned the expected matches (success).
- Attempted to run a project build with `cmake --build .` but no top-level `CMakeLists.txt` was present in this environment, so a full compile was not executed (no build).
- Committed the changes successfully with `git commit` (success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a130b934414832dbeff8b187b9d6569)