### PR TITLE
Fix StageCollisionBuilder: use StageObstacleBox and add TransformDirection for OBB axes

### DIFF
--- a/Project/Engine/Scene/Level/StageCollisionBuilder.cpp
+++ b/Project/Engine/Scene/Level/StageCollisionBuilder.cpp
@@ -7,6 +7,16 @@ namespace Ken4lowEngine
 {
 	namespace
 	{
+		Vector3 TransformDirection(const Vector3& v, const Matrix4x4& m)
+		{
+			// 回転方向だけを変換するため、平行移動成分は使わない
+			return {
+				v.x * m.m[0][0] + v.y * m.m[1][0] + v.z * m.m[2][0],
+				v.x * m.m[0][1] + v.y * m.m[1][1] + v.z * m.m[2][1],
+				v.x * m.m[0][2] + v.y * m.m[1][2] + v.z * m.m[2][2],
+			};
+		}
+
 		AABB BuildAABBFromCorners(const std::array<Vector3, 8>& corners)
 		{
 			AABB aabb{};
@@ -102,7 +112,7 @@ namespace Ken4lowEngine
 			const AABB aabb = BuildAABBFromCorners(corners);
 			result.worldAABBsLegacy.push_back(legacyAabb);
 			result.worldAABBs.push_back(aabb);
-			StageCollisionBuildResult::StageObstacleBox box{};
+			StageObstacleBox box{};
 			box.name = data.name;
 			box.collisionTypeName = data.collider.collisionType;
 			box.collisionTypeId = data.collider.collisionTypeId;
@@ -111,9 +121,10 @@ namespace Ken4lowEngine
 			box.center = centerW;
 			box.halfSize = halfW;
 			const Matrix4x4 rotationM = Matrix4x4::MakeRotateMatrix(colliderRotation);
-			box.axisX = Vector3::Normalize(Vector3::TransformNormal({ 1.0f, 0.0f, 0.0f }, rotationM));
-			box.axisY = Vector3::Normalize(Vector3::TransformNormal({ 0.0f, 1.0f, 0.0f }, rotationM));
-			box.axisZ = Vector3::Normalize(Vector3::TransformNormal({ 0.0f, 0.0f, 1.0f }, rotationM));
+			// 回転行列でローカル軸を変換し、StageObstacleBoxのOBB軸として保持する
+			box.axisX = Vector3::Normalize(TransformDirection({ 1.0f, 0.0f, 0.0f }, rotationM));
+			box.axisY = Vector3::Normalize(TransformDirection({ 0.0f, 1.0f, 0.0f }, rotationM));
+			box.axisZ = Vector3::Normalize(TransformDirection({ 0.0f, 0.0f, 1.0f }, rotationM));
 			result.obstacleBoxes.push_back(box);
 			const std::string& collisionType = data.collider.collisionType;
 			if (collisionType == "Floor")


### PR DESCRIPTION
### Motivation
- Fix compilation errors in `StageCollisionBuilder.cpp` caused by an incorrect type qualification and a call to a nonexistent `Vector3::TransformNormal` function.
- Ensure OBB axis vectors are computed using rotation-only transformation (ignore translation) so direction vectors are transformed correctly.

### Description
- Added a local helper `TransformDirection(const Vector3&, const Matrix4x4&)` in the anonymous namespace of `StageCollisionBuilder.cpp` that multiplies only the rotation 3x3 part of `Matrix4x4` into a direction vector.
- Replaced the incorrect `StageCollisionBuildResult::StageObstacleBox box{}` with the correct `StageObstacleBox box{}`.
- Replaced `Vector3::TransformNormal(...)` calls with `TransformDirection(...)` and kept axis normalization via `Vector3::Normalize(...)`, and added a comment explaining the rotation-only conversion.

### Testing
- Ran `rg` to verify occurrences of `TransformNormal`, `StageCollisionBuildResult::StageObstacleBox`, and presence of `TransformDirection` and found expected replacements (succeeded).
- Ran `git status` and committed the change with `git commit` to ensure the patch is staged and recorded (succeeded).
- Printed the updated file with line numbers to confirm modifications are in place (succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a130d1a7c3c832d94d7c0c96793dfd5)