### PR TITLE
Align stage brown wireframe to collider OBB corners

### DIFF
--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -38,8 +38,8 @@ namespace
 	void DrawObbCornersWire(const std::array<Vector3, 8>& corners, const Vector4& color)
 	{
 		static constexpr int kEdges[12][2] = {
-			{0,1},{1,3},{3,2},{2,0}, // bottom 4
-			{4,5},{5,7},{7,6},{6,4}, // top 4
+			{0,1},{1,2},{2,3},{3,0}, // bottom 4
+			{4,5},{5,6},{6,7},{7,4}, // top 4
 			{0,4},{1,5},{2,6},{3,7}, // vertical 4
 		};
 		for (const auto& e : kEdges)
@@ -284,6 +284,7 @@ void DebugScene::Draw3DObjects()
 			}
 		}
 		stage_->SetStageChunkBoundsVisible(showStageChunkBoundsWire_);
+		stage_->SetStageChunkObjectBoundsVisible(showStageChunkObjectBoundsWire_);
 	}
 
 #ifdef _DEBUG
@@ -545,14 +546,17 @@ void DebugScene::DrawImGui()
 		ImGui::Text("Wall/Obstacle AABB count: %d", wallObstacleCount);
 		ImGui::Text("Navigation obstacle count: %zu", navObstacles.size());
 		ImGui::Text("Collision obstacle count: %d", wallObstacleCount);
-		ImGui::Text("brown wireframe source: %s", brownWireframeSource_.c_str());
+		const bool usingObbDerivedAabb = worldAABBs.size() == obstacleBoxes.size();
+		ImGui::Text("Brown Wire Source: %s", brownWireframeSource_.c_str());
 		ImGui::Text("Draw Source: StageObstacleBox OBB");
 		ImGui::Text("Old Bounds source: StageChunkBounds/ObjectBounds/worldAABBsLegacy");
+		ImGui::Text("Using OBB-derived AABB: %s", usingObbDerivedAabb ? "true" : "false");
 		ImGui::Checkbox("Show Collider OBB Wire", &showColliderObbWire_);
 		ImGui::Checkbox("Show Navigation AABB Wire", &showNavigationAabbWire_);
 		ImGui::Checkbox("Show Wall AABB Wire", &showWallAabbWire_);
 		ImGui::Checkbox("Show Old Bounds Wire", &showOldBoundsWire_);
 		ImGui::Checkbox("Show StageChunk Bounds", &showStageChunkBoundsWire_);
+		ImGui::Checkbox("Show Object Bounds", &showStageChunkObjectBoundsWire_);
 		ImGui::Text("Legacy WorldAABB count: %zu", legacyWorldAABBs.size());
 		ImGui::Text("Floor: %d", colliderTypeCounts["Floor"]);
 		ImGui::Text("Obstacle: %d", colliderTypeCounts["Obstacle"]);

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
@@ -114,6 +114,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	bool showWallAabbWire_ = false;
 	bool showOldBoundsWire_ = false;
 	bool showStageChunkBoundsWire_ = false;
+	bool showStageChunkObjectBoundsWire_ = false;
 	std::string brownWireframeSource_ = "StageObstacleBox OBB";
 
 };

--- a/Project/Engine/Scene/Level/StageCollisionBuilder.cpp
+++ b/Project/Engine/Scene/Level/StageCollisionBuilder.cpp
@@ -34,28 +34,29 @@ namespace Ken4lowEngine
 			return aabb;
 		}
 
-		std::array<Vector3, 8> BuildObbCorners(const Vector3& center, const Vector3& half, const Vector3& rotationRad)
+		std::array<Vector3, 8> BuildColliderObbCorners(const Vector3& center, const Vector3& half, const Vector3& rotationRad)
 		{
 			const Matrix4x4 rotation = Matrix4x4::MakeRotateMatrix(rotationRad);
-			std::array<Vector3, 8> corners{};
-			int index = 0;
-			for (int ix = -1; ix <= 1; ix += 2)
+			std::array<Vector3, 8> corners = {
+				Vector3{ -half.x, -half.y, -half.z }, // 0 bottom
+				Vector3{  half.x, -half.y, -half.z }, // 1
+				Vector3{  half.x, -half.y,  half.z }, // 2
+				Vector3{ -half.x, -half.y,  half.z }, // 3
+				Vector3{ -half.x,  half.y, -half.z }, // 4 top
+				Vector3{  half.x,  half.y, -half.z }, // 5
+				Vector3{  half.x,  half.y,  half.z }, // 6
+				Vector3{ -half.x,  half.y,  half.z }, // 7
+			};
+			for (Vector3& cornerLocal : corners)
 			{
-				for (int iy = -1; iy <= 1; iy += 2)
-				{
-					for (int iz = -1; iz <= 1; iz += 2)
-					{
-						Vector3 cornerLocal = { half.x * static_cast<float>(ix), half.y * static_cast<float>(iy), half.z * static_cast<float>(iz) };
-						corners[static_cast<size_t>(index++)] = Vector3::Transform(cornerLocal, rotation) + center;
-					}
-				}
+				cornerLocal = Vector3::Transform(cornerLocal, rotation) + center;
 			}
 			return corners;
 		}
 
 		AABB BuildAABBFromRotatedOBB(const Vector3& center, const Vector3& half, const Vector3& rotationRad)
 		{
-			return BuildAABBFromCorners(BuildObbCorners(center, half, rotationRad));
+			return BuildAABBFromCorners(BuildColliderObbCorners(center, half, rotationRad));
 		}
 	}
 
@@ -108,7 +109,7 @@ namespace Ken4lowEngine
 				centerW - halfW,
 				centerW + halfW,
 			};
-			const std::array<Vector3, 8> corners = BuildObbCorners(centerW, halfW, colliderRotation);
+			const std::array<Vector3, 8> corners = BuildColliderObbCorners(centerW, halfW, colliderRotation);
 			const AABB aabb = BuildAABBFromCorners(corners);
 			result.worldAABBsLegacy.push_back(legacyAabb);
 			result.worldAABBs.push_back(aabb);


### PR DESCRIPTION
### Motivation
- The brown wireframe used for stage obstacles must exactly match the blue collider OBB (same center/size/rotation) instead of drawing enclosing AABBs or object-level bounds.

### Description
- Generate collider OBB corners from the collider `center`/`size`/`rotation` with a fixed corner index layout by adding `BuildColliderObbCorners(...)` and use those corners to compute enclosing AABBs in `StageCollisionBuilder` (`Project/Engine/Scene/Level/StageCollisionBuilder.cpp`).
- Draw the brown wireframe by connecting the 8 `StageObstacleBox::corners` with the 12 edges `0-1,1-2,2-3,3-0 / 4-5,5-6,6-7,7-4 / 0-4,1-5,2-6,3-7` in `DrawObbCornersWire(...)` so the wireframe is the collider OBB rather than an AABB (`Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp`).
- Add an ImGui debug UI and state to make sources and toggles explicit: show `Brown Wire Source`, `Using OBB-derived AABB`, `Show Collider OBB Wire`, `Show Navigation AABB Wire`, `Show Wall AABB Wire`, and `Show Object Bounds` which is hooked to `StageChunkObjectBoundsVisible` (`Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp` and `.h`).

### Testing
- Ran `git diff --check` which completed with no issues prior to committing. 
- Committed changes successfully (local commit created). 
- No full project build or runtime image overlap test was performed in this environment, so runtime verification should be done locally to confirm the brown wireframe now perfectly overlaps the blue collider in the running application.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a131620e2e4832d8318cd06a5c8ad1f)