### PR TITLE
整理: DebugScene / MeleeEnemy のデバッグ項目を最小構成へ削減

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
@@ -253,129 +253,31 @@ void MeleeEnemy::DrawImGui()
 #ifdef USE_IMGUI
 	if (ImGui::Begin("MeleeEnemy Debug"))
 	{
-		EnemyBase::DrawImGui();
 		ImGui::SliderFloat("detectRange", &detectRange_, 1.0f, 50.0f);
 		ImGui::SliderFloat("meleeAttackRange", &meleeAttackRange_, 0.5f, 10.0f);
 		ImGui::SliderFloat("moveSpeed", &moveSpeed_, 0.1f, 10.0f);
 		ImGui::SliderFloat("stopDistance", &stopDistance_, 0.5f, 6.0f);
 		ImGui::SliderFloat("attackStartRange", &attackStartRange_, 0.5f, 8.0f);
 		ImGui::SliderFloat("resumeChaseDistance", &resumeChaseDistance_, 0.5f, 10.0f);
-		ImGui::SliderFloat("attackLockTime", &attackLockTime_, 0.0f, 1.0f);
-		ImGui::SliderFloat("rotateSpeed", &rotateSpeed_, 0.1f, 20.0f);
-		ImGui::Text("visualYawOffset(rad): %.3f (fixed)", visualYawOffset_);
-		ImGui::SliderFloat("walkAnimSpeed", &walkAnimSpeed_, 1.0f, 18.0f);
-		ImGui::SliderFloat("walkArmSwing", &walkArmSwing_, 0.0f, 1.5f);
-		ImGui::SliderFloat("walkLegSwing", &walkLegSwing_, 0.0f, 1.5f);
-		ImGui::SliderFloat("attackArmSwing", &attackArmSwing_, 0.0f, 2.0f);
-		ImGui::SliderFloat("attackReturnSpeed", &attackReturnSpeed_, 1.0f, 24.0f);
-		ImGui::SliderFloat("attackBodyLean", &attackBodyLean_, 0.0f, 0.4f);
-		ImGui::SliderFloat("maxResolvePushPerFrame", &maxResolvePushPerFrame_, 0.05f, 2.0f);
-		ImGui::SliderFloat("stuckCheckTime", &stuckCheckTime_, 0.1f, 3.0f);
-		ImGui::SliderFloat("stuckDistance", &stuckDistance_, 0.01f, 2.0f);
-		ImGui::SliderFloat("stuckMoveThreshold", &stuckMoveThreshold_, 0.03f, 1.2f);
-		ImGui::SliderFloat("repathInterval", &repathInterval_, 0.05f, 2.0f);
-		ImGui::SliderFloat("waypointReachDistance", &waypointReachDistance_, 0.5f, 1.5f);
 		ImGui::Checkbox("pathFindEnabled", &pathFindEnabled_);
-		const float prevGridSize = pathGridSize_;
-		ImGui::SliderFloat("pathGridSize", &pathGridSize_, 0.5f, 1.0f);
-		if (std::abs(prevGridSize - pathGridSize_) > kEpsilon) { navigator_.Reset(); lastRepathReason_ = "GridSizeChanged"; }
-		ImGui::SliderFloat("pathSearchRadius", &pathSearchRadius_, 6.0f, 80.0f);
-		ImGui::SliderFloat("obstacleExpandRadius", &obstacleExpandRadius_, 0.7f, 1.6f);
-		ImGui::SliderFloat("temporaryBlockDuration", &temporaryBlockDuration_, 0.3f, 4.0f);
-		ImGui::SliderFloat("temporaryBlockRadius", &temporaryBlockRadius_, 0.4f, 2.2f);
-		ImGui::Checkbox("cornerCuttingDisabled", &cornerCuttingDisabled_);
-
 		int attackSelect = static_cast<int>(selectedAttackType_);
 		const char* attackItems[] = { "Scratch", "OneTwo" };
-		if (ImGui::Combo("AttackPattern", &attackSelect, attackItems, IM_ARRAYSIZE(attackItems)))
-		{
-			selectedAttackType_ = static_cast<MeleeAttackType>(attackSelect);
-		}
-		ImGui::Text("Selected Attack: %s", attackItems[attackSelect]);
-		ImGui::Text("Current BT: %s", currentBehaviorName_);
-		ImGui::Text("Current Attack Name: %s", attackController_.GetCurrentAttackName());
-		ImGui::Text("Distance To Target: %.2f", GetDistanceToTarget());
-		ImGui::Text("Is Attacking: %s", attackController_.IsAttacking() ? "true" : "false");
-		ImGui::Text("Stuck: %s", isStuck_ ? "true" : "false");
-		ImGui::Text("Position: (%.2f, %.2f, %.2f)", GetCenterPosition().x, GetCenterPosition().y, GetCenterPosition().z);
-		ImGui::Text("Velocity: (%.2f, %.2f, %.2f)", GetVelocity().x, GetVelocity().y, GetVelocity().z);
-		ImGui::Text("Attack Elapsed: %.2f", attackController_.GetAttackElapsed());
-		ImGui::Text("Attack Step Index: %d", attackController_.GetCurrentStepIndex());
-		ImGui::Text("Cooldown Remaining: %.2f", attackController_.GetCooldownRemaining());
-		ImGui::Text("attackLockTimer: %.2f", attackLockTimer_);
-		ImGui::Text("Attack Active: %s", attackController_.IsCurrentStepActive() ? "true" : "false");
-		ImGui::Text("Last Hit: %s", attackController_.WasLastHitSuccess() ? "Hit" : "Miss");
-		ImGui::Text("Path Found: %s", pathFound_ ? "true" : "false");
-		ImGui::Text("Obstacle Count: %zu", GetResolvedWorldAABBs() ? GetResolvedWorldAABBs()->size() : 0);
-		ImGui::Text("isCollidingWithStage: %s", isCollidingWithStage_ ? "true" : "false");
-		ImGui::Text("lastStageCollisionType: %s", lastStageCollisionType_.c_str());
-		ImGui::Text("lastStageCollisionName: %s", lastStageCollisionName_.c_str());
-		ImGui::Text("usingWorldAABBCount: %d", usingWorldAABBCount_);
-		ImGui::Text("floorAABBCount: %d", floorAABBs_ ? static_cast<int>(floorAABBs_->size()) : usingWorldAABBCount_);
-		ImGui::Text("wallObstacleAABBCount: %d", wallObstacleAABBs_ ? static_cast<int>(wallObstacleAABBs_->size()) : usingObstacleAABBCount_);
-		ImGui::Text("usingObstacleAABBCount: %d", usingObstacleAABBCount_);
-		ImGui::Text("collisionManagerRegistered: %s", collisionManagerRegistered_ ? "true" : "false");
-		ImGui::Text("lastCollisionCount: %d", lastCollisionCount_);
-		ImGui::Text("blockedByObstacle: %s", blockedByObstacle_ ? "true" : "false");
-		ImGui::Text("isOnFloor: %s", isOnFloor_ ? "true" : "false");
-		ImGui::Text("isOverlappingWallObstacle: %s", isOverlappingWallObstacle_ ? "true" : "false");
-		ImGui::Text("lastWallObstacleName: %s", lastWallObstacleName_.c_str());
-		ImGui::Text("lastWallResolvePush: (%.2f, %.2f, %.2f)", lastWallResolvePush_.x, lastWallResolvePush_.y, lastWallResolvePush_.z);
-		ImGui::Text("lastBlockedObstacleName: %s", lastBlockedObstacleName_.c_str());
-		ImGui::Text("Path Node Count: %d", static_cast<int>(navigator_.GetCurrentPath().size()));
-		ImGui::Text("Current Waypoint Index: %d", navigator_.GetCurrentPathIndex());
-		ImGui::Text("Current Waypoint: (%.2f, %.2f, %.2f)", currentPathWaypoint_.x, currentPathWaypoint_.y, currentPathWaypoint_.z);
-		ImGui::Text("Last Repath Timer: %.2f", lastRepathTimer_);
-		ImGui::Text("Repath Timer: %.2f", navigator_.GetRepathTimer());
-		ImGui::Text("TargetMovedDistanceForRepath: %.2f", targetMovedDistanceForRepath_);
-		ImGui::Text("Path Failure Reason: %s", pathFailureReason_.c_str());
-		ImGui::Text("Last Repath Reason: %s", lastRepathReason_.c_str());
-		ImGui::Text("lineBlocked: %s", lineBlocked_ ? "true" : "false");
-		ImGui::Text("blockedObstacleName: %s", blockedObstacleName_.c_str());
-		ImGui::Text("blockedWaypointIndex: %d", blockedWaypointIndex_);
-		ImGui::Text("stuckTimer: %.2f", stuckTimer_);
-		ImGui::Text("lastMovedDistance: %.3f", lastMovedDistance_);
-		ImGui::Text("temporaryBlockedCellCount: %d", static_cast<int>(navigator_.GetTemporaryBlockedAreas().size()));
-		ImGui::Text("cornerCuttingDisabled: %s", cornerCuttingDisabled_ ? "true" : "false");
-		ImGui::Text("Grounded: %s", grounded_ ? "true" : "false");
-		ImGui::Text("AnimState: %s", GetAnimStateName());
-		ImGui::Text("lastSafePosition: (%.2f, %.2f, %.2f)", lastSafePosition_.x, lastSafePosition_.y, lastSafePosition_.z);
-		ImGui::Text("isOutsideStage: %s", isOutsideStage_ ? "true" : "false");
-		ImGui::Text("lastResolvePush: (%.2f, %.2f, %.2f)", lastResolvePush_.x, lastResolvePush_.y, lastResolvePush_.z);
-		ImGui::Text("pushedByWallThisFrame: %s", pushedThisFrame_ ? "true" : "false");
-		ImGui::Text("restoredToSafePosition: %s", restoredToSafePosition_ ? "true" : "false");
-		const Vector3 tgt = GetTargetPosition();
-		ImGui::Text("Target: (%.2f, %.2f, %.2f)", tgt.x, tgt.y, tgt.z);
-		ImGui::Text("rawYaw(rad): %.3f", rawYaw_);
-		ImGui::Text("finalVisualYaw(rad): %.3f", finalVisualYaw_);
-		ImGui::Text("rawYaw(deg): %.1f", rawYaw_ * (180.0f / kPi));
-		ImGui::Text("finalVisualYaw(deg): %.1f", finalVisualYaw_ * (180.0f / kPi));
-		ImGui::Text("currentYaw(deg): %.1f", debugCurrentYaw_ * (180.0f / kPi));
-		ImGui::Text("targetYaw(deg): %.1f", debugTargetYaw_ * (180.0f / kPi));
-		ImGui::Text("deltaYaw(deg): %.1f", debugDeltaYaw_ * (180.0f / kPi));
-		ImGui::Text("normalizedDeltaYaw(deg): %.1f", debugNormalizedDeltaYaw_ * (180.0f / kPi));
-		ImGui::Text("rotateSpeed: %.2f", rotateSpeed_);
-		ImGui::Text("facingDirection: (%.2f, %.2f, %.2f)", facingDirection_.x, facingDirection_.y, facingDirection_.z);
-		ImGui::Text("movementDir: (%.2f, %.2f, %.2f)", movementDirection_.x, movementDirection_.y, movementDirection_.z);
-		ImGui::Text("targetDirection: (%.2f, %.2f, %.2f)", targetDirection_.x, targetDirection_.y, targetDirection_.z);
-		ImGui::Text("visualForward: (%.2f, %.2f, %.2f)", visualForward_.x, visualForward_.y, visualForward_.z);
-		ImGui::Text("attackForward: (%.2f, %.2f, %.2f)", attackForward_.x, attackForward_.y, attackForward_.z);
+		if (ImGui::Combo("selectedAttackType", &attackSelect, attackItems, IM_ARRAYSIZE(attackItems))) { selectedAttackType_ = static_cast<MeleeAttackType>(attackSelect); }
 		if (ImGui::Button("Force Scratch Attack")) { ForceAttack(MeleeAttackType::Scratch); }
 		ImGui::SameLine();
 		if (ImGui::Button("Force OneTwo Attack")) { ForceAttack(MeleeAttackType::OneTwo); }
 		if (ImGui::Button("Stop Attack")) { StopAttack(); }
 		ImGui::SameLine();
 		if (ImGui::Button("Reset Cooldown")) { ResetAttackCooldown(); }
-		if (ImGui::Button("Teleport Near Target"))
-		{
-			Vector3 p = GetTargetPosition();
-			p.z -= 1.2f;
-			SetCenterPosition(p);
-		}
-		ImGui::SameLine();
-		if (ImGui::Button("Reset Position")) { SetCenterPosition(spawnPosition_); }
-
-		if (MeleeAttackPattern* scratch = attackController_.FindPattern(MeleeAttackType::Scratch))
+		ImGui::Text("currentBTActionName: %s", currentBehaviorName_);
+		ImGui::Text("currentAttackName: %s", attackController_.GetCurrentAttackName());
+		ImGui::Text("isAttacking: %s", attackController_.IsAttacking() ? "true" : "false");
+		ImGui::Text("distanceToTarget: %.2f", GetDistanceToTarget());
+		ImGui::Text("pathFound: %s", pathFound_ ? "true" : "false");
+		ImGui::Text("currentWaypointIndex: %d", navigator_.GetCurrentPathIndex());
+		ImGui::Text("stuck: %s", isStuck_ ? "true" : "false");
+		ImGui::Text("lastRepathReason: %s", lastRepathReason_.c_str());
+if (MeleeAttackPattern* scratch = attackController_.FindPattern(MeleeAttackType::Scratch))
 		{
 			if (ImGui::TreeNode("Scratch Params"))
 			{

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -27,77 +27,11 @@
 #include <algorithm>
 #include <filesystem>
 #include <cstdio>
-#include <array>
-#include <numbers>
-#include <unordered_map>
-#include <format>
 
 using namespace Ken4lowEngine;
 
 namespace
 {
-	std::string BuildBrownWireSourceLabel(
-		bool showStageChunkBounds,
-		bool showObjectBounds,
-		bool showOldBounds,
-		bool showColliderObb)
-	{
-		std::vector<std::string> sources{};
-		if (showStageChunkBounds) { sources.emplace_back("StageChunkBounds"); }
-		if (showObjectBounds) { sources.emplace_back("ObjectBounds"); }
-		if (showOldBounds) { sources.emplace_back("Old AABB"); }
-		if (showColliderObb) { sources.emplace_back("Collider OBB"); }
-		if (sources.empty()) { return "None"; }
-
-		std::string label{};
-		for (size_t i = 0; i < sources.size(); ++i)
-		{
-			if (i > 0) { label += " + "; }
-			label += sources[i];
-		}
-		return label;
-	}
-
-	void DrawObbCornersWire(const std::array<Vector3, 8>& corners, const Vector4& color)
-	{
-		static constexpr int kEdges[12][2] = {
-			{0,1},{1,2},{2,3},{3,0}, // bottom 4
-			{4,5},{5,6},{6,7},{7,4}, // top 4
-			{0,4},{1,5},{2,6},{3,7}, // vertical 4
-		};
-		for (const auto& e : kEdges)
-		{
-			Wireframe::GetInstance()->DrawLine(corners[static_cast<size_t>(e[0])], corners[static_cast<size_t>(e[1])], color);
-		}
-	}
-
-	std::array<Vector3, 8> ApplyColliderAdjustToCorners(
-		const std::array<Vector3, 8>& sourceCorners,
-		const Vector3& center,
-		const DebugScene::ColliderDebugAdjust& adjust)
-	{
-		if (!adjust.enabled)
-		{
-			return sourceCorners;
-		}
-		std::array<Vector3, 8> adjusted = sourceCorners;
-		const Matrix4x4 rotation = Matrix4x4::MakeRotateMatrix(adjust.rotationOffsetRad);
-		for (Vector3& c : adjusted)
-		{
-			Vector3 local = c - center;
-			local.x *= adjust.scaleMultiplier.x;
-			local.y *= adjust.scaleMultiplier.y;
-			local.z *= adjust.scaleMultiplier.z;
-			local = Vector3::Transform(local, rotation);
-			c = center + local + adjust.positionOffset;
-		}
-		return adjusted;
-	}
-
-	/// -------------------------------------------------------------
-	/// Visual Studio の「出力」ウィンドウへ文字列を出す
-	/// 改行付きで送るための簡易ヘルパー
-	/// -------------------------------------------------------------
 	void DebugLog(const std::string& message)
 	{
 		std::string line = message + "\n";
@@ -299,55 +233,13 @@ void DebugScene::Draw3DObjects()
 	if (stage_)
 	{
 		stage_->Draw();
-		if (showColliderObbWire_)
+		if (showStageColliderWire_)
 		{
-			const Vector4 colliderObbColor = { 0.15f, 0.95f, 0.95f, 1.0f };
-			// Collider OBBの位置・回転・スケールをImGuiから補正し、水色コライダーとのズレを手動で確認できるようにする
-			const auto& boxes = stage_->GetObstacleBoxes();
-			for (size_t i = 0; i < boxes.size(); ++i)
+			for (const AABB& aabb : stage_->GetWorldAABBs())
 			{
-				if (drawSelectedColliderOnly_ && i != selectedColliderIndex_) { continue; }
-				const StageObstacleBox& box = boxes[i];
-				auto corners = ApplyColliderAdjustToCorners(box.corners, box.center, commonColliderAdjust_);
-				if (i == selectedColliderIndex_ && selectedColliderAdjust_.enabled)
-				{
-					corners = ApplyColliderAdjustToCorners(corners, box.center + commonColliderAdjust_.positionOffset, selectedColliderAdjust_);
-				}
-				DrawObbCornersWire(corners, colliderObbColor);
-				if (showEnclosingAabbWire_)
-				{
-					Wireframe::GetInstance()->DrawAABB(BuildAABBFromCorners(corners), { 0.95f, 0.85f, 0.20f, 1.0f });
-				}
+				Wireframe::GetInstance()->DrawAABB(aabb, { 0.15f, 0.95f, 0.95f, 1.0f });
 			}
 		}
-		if (showNavigationAabbWire_)
-		{
-			for (const AABB& aabb : stage_->GetNavigationObstacleAABBs())
-			{
-				Wireframe::GetInstance()->DrawAABB(aabb, { 0.90f, 0.45f, 0.12f, 1.0f });
-			}
-		}
-		if (showWallAabbWire_)
-		{
-			for (const AABB& aabb : stage_->GetWallObstacleAABBs())
-			{
-				Wireframe::GetInstance()->DrawAABB(aabb, { 0.70f, 0.25f, 0.12f, 1.0f });
-			}
-		}
-		if (showOldBoundsWire_)
-		{
-			for (const AABB& aabb : stage_->GetWorldAABBsLegacy())
-			{
-				Wireframe::GetInstance()->DrawAABB(aabb, { 0.55f, 0.35f, 0.20f, 1.0f });
-			}
-		}
-		stage_->SetStageChunkBoundsVisible(showStageChunkBoundsWire_);
-		stage_->SetStageChunkObjectBoundsVisible(showStageChunkObjectBoundsWire_);
-		brownWireframeSource_ = BuildBrownWireSourceLabel(
-			showStageChunkBoundsWire_,
-			showStageChunkObjectBoundsWire_,
-			showOldBoundsWire_,
-			showColliderObbWire_);
 	}
 
 #ifdef _DEBUG
@@ -475,250 +367,18 @@ void DebugScene::DrawImGui()
 
 	if (stage_)
 	{
-		selectedColliderIndex_ = std::min(selectedColliderIndex_, stage_->GetObstacleBoxes().empty() ? size_t{ 0 } : stage_->GetObstacleBoxes().size() - 1);
-		debugAdjustedNavigationAABBs_.clear();
-		debugAdjustedWallAABBs_.clear();
-		debugAdjustedWorldAABBs_.clear();
-		for (size_t i = 0; i < stage_->GetObstacleBoxes().size(); ++i)
-		{
-			const auto& box = stage_->GetObstacleBoxes()[i];
-			auto corners = ApplyColliderAdjustToCorners(box.corners, box.center, commonColliderAdjust_);
-			if (i == selectedColliderIndex_ && selectedColliderAdjust_.enabled)
-			{
-				corners = ApplyColliderAdjustToCorners(corners, box.center + commonColliderAdjust_.positionOffset, selectedColliderAdjust_);
-			}
-			const AABB aabb = BuildAABBFromCorners(corners);
-			debugAdjustedWorldAABBs_.push_back(aabb);
-			const std::string& t = box.collisionTypeName;
-			if (t == "Obstacle" || t == "Pillar" || t == "Fence" || t == "Tree")
-			{
-				debugAdjustedNavigationAABBs_.push_back(aabb);
-				debugAdjustedWallAABBs_.push_back(aabb);
-			}
-		}
-		EnemyBase::SetGlobalStageWorldAABBs((commonColliderAdjust_.enabled || selectedColliderAdjust_.enabled) ? &debugAdjustedWorldAABBs_ : &stage_->GetWorldAABBs());
-		EnemyBase::SetGlobalStageNavigationObstacleAABBs(applyDebugAdjustToNavigation_ ? &debugAdjustedNavigationAABBs_ : &stage_->GetNavigationObstacleAABBs());
-		if (debugMeleeEnemy_)
-		{
-			debugMeleeEnemy_->SetWallObstacleAABBs(applyDebugAdjustToWallCollision_ ? &debugAdjustedWallAABBs_ : &stage_->GetWallObstacleAABBs());
-		}
 		ImGui::Begin("Stage Debug");
-		const std::vector<AABB>& worldAABBs = stage_->GetWorldAABBs();
-		const std::vector<AABB>& floorAABBs = stage_->GetFloorAABBs();
-		const std::vector<AABB>& wallObstacles = stage_->GetWallObstacleAABBs();
-		const std::vector<AABB>& navObstacles = stage_->GetNavigationObstacleAABBs();
-		const std::vector<AABB>& legacyWorldAABBs = stage_->GetWorldAABBsLegacy();
-		const auto& obstacleBoxes = stage_->GetObstacleBoxes();
-		const auto& worldColliders = stage_->GetWorldColliders();
-		const LevelData* levelData = stage_->GetLevelData();
-		size_t loadedColliders = 0;
-		size_t rotatedColliderCount = 0;
-		size_t colliderRotationReadCount = 0;
-		std::string sampleColliderName = "(none)";
-		Vector3 sampleRawCenter{};
-		Vector3 sampleConvertedCenter{};
-		Vector3 sampleSourceRotationDeg{};
-		Vector3 sampleConvertedRotationDeg{};
-		Vector3 sampleOBBCenter{};
-		Vector3 sampleOBBHalfSize{};
-		Vector3 sampleOBBAxisX{ 1.0f, 0.0f, 0.0f };
-		Vector3 sampleOBBAxisY{ 0.0f, 1.0f, 0.0f };
-		Vector3 sampleOBBAxisZ{ 0.0f, 0.0f, 1.0f };
-		Vector3 sampleRawSize{};
-		Vector3 sampleRawColliderRotation{};
-		Vector3 sampleAABBMin{};
-		Vector3 sampleAABBMax{};
-		float sampleFinalYawDeg = 0.0f;
-		bool sampleUsedByNavigationObstacle = false;
-		bool sampleUsedByWallObstacle = false;
-		bool sampleUsedByCollisionObstacle = false;
-		std::unordered_map<std::string, int> colliderTypeCounts{};
-		if (levelData)
-		{
-			for (const auto& object : levelData->objects)
-			{
-				if (!object.collider.enabled)
-				{
-					continue;
-				}
-				++loadedColliders;
-				const std::string typeName = object.collider.collisionType.empty() ? "Unspecified" : object.collider.collisionType;
-				++colliderTypeCounts[typeName];
-				if (object.collider.hasRotation)
-				{
-					++colliderRotationReadCount;
-				}
-				if ((object.collider.hasRotation && Vector3::Length(object.collider.rotation) > 0.0001f) ||
-					Vector3::Length(object.rotation) > 0.0001f)
-				{
-					++rotatedColliderCount;
-				}
-				if (sampleColliderName == "(none)" && object.collider.hasRotation)
-				{
-					sampleColliderName = object.name;
-					sampleRawCenter = object.collider.center;
-					sampleConvertedCenter = {
-						object.position.x + object.collider.center.x * object.scale.x,
-						object.position.y + object.collider.center.y * object.scale.y,
-						object.position.z + object.collider.center.z * object.scale.z,
-					};
-					sampleRawSize = object.collider.size;
-					sampleRawColliderRotation = object.collider.rotation;
-					sampleSourceRotationDeg = object.collider.sourceRotationDeg;
-					sampleConvertedRotationDeg = object.collider.convertedRotationDeg;
-					constexpr float kRadToDeg = 180.0f / 3.14159265358979323846f;
-					sampleFinalYawDeg = (object.rotation.y + object.collider.rotation.y) * kRadToDeg;
-					sampleOBBCenter = sampleConvertedCenter;
-					const Vector3 half = {
-						0.5f * object.collider.size.x * object.scale.x,
-						0.5f * object.collider.size.y * object.scale.y,
-						0.5f * object.collider.size.z * object.scale.z
-					};
-					sampleAABBMin = sampleConvertedCenter - half;
-					sampleAABBMax = sampleConvertedCenter + half;
-					sampleUsedByNavigationObstacle =
-						(object.collider.collisionType == "Obstacle" || object.collider.collisionType == "Pillar" ||
-							object.collider.collisionType == "Fence" || object.collider.collisionType == "Tree");
-					sampleUsedByWallObstacle = sampleUsedByNavigationObstacle;
-					sampleUsedByCollisionObstacle = sampleUsedByNavigationObstacle;
-				}
-			}
-		}
-		if (!obstacleBoxes.empty())
-		{
-			const StageObstacleBox& sampleObb = obstacleBoxes.front();
-			sampleColliderName = sampleObb.name.empty() ? sampleColliderName : sampleObb.name;
-			sampleOBBCenter = sampleObb.center;
-			sampleOBBHalfSize = sampleObb.halfSize;
-			sampleOBBAxisX = sampleObb.axisX;
-			sampleOBBAxisY = sampleObb.axisY;
-			sampleOBBAxisZ = sampleObb.axisZ;
-			sampleAABBMin = sampleObb.enclosingAABB.min;
-			sampleAABBMax = sampleObb.enclosingAABB.max;
-		}
-		const size_t aabbFallbackCount = loadedColliders > worldColliders.size() ? loadedColliders - worldColliders.size() : 0;
-
-		ImGui::Text("WorldAABBs: %zu", worldAABBs.size());
-		ImGui::Text("FloorAABB count: %zu", floorAABBs.size());
-		ImGui::Text("WallObstacleAABB count: %zu", wallObstacles.size());
-		ImGui::Text("NavigationObstacleAABB count: %zu", navObstacles.size());
-		ImGui::Text("Collider OBB count: %zu", obstacleBoxes.size());
-		ImGui::Text("CollisionObstacle count: %zu", obstacleBoxes.size());
-		ImGui::Text("Loaded Colliders: %zu", loadedColliders);
-		ImGui::Text("Rotated collider count: %zu", rotatedColliderCount);
-		ImGui::Text("AABB fallback count: %zu", aabbFallbackCount);
-		ImGui::Text("collider_rotation read count: %zu", colliderRotationReadCount);
-		ImGui::Text("sample collider name: %s", sampleColliderName.c_str());
-		ImGui::Text("raw center: (%.2f, %.2f, %.2f)", sampleRawCenter.x, sampleRawCenter.y, sampleRawCenter.z);
-		ImGui::Text("raw size: (%.2f, %.2f, %.2f)", sampleRawSize.x, sampleRawSize.y, sampleRawSize.z);
-		ImGui::Text("raw collider_rotation(rad): (%.3f, %.3f, %.3f)",
-			sampleRawColliderRotation.x, sampleRawColliderRotation.y, sampleRawColliderRotation.z);
-		ImGui::Text("converted center: (%.2f, %.2f, %.2f)", sampleConvertedCenter.x, sampleConvertedCenter.y, sampleConvertedCenter.z);
-		ImGui::Text("source rotation degree: (%.2f, %.2f, %.2f)",
-			sampleSourceRotationDeg.x, sampleSourceRotationDeg.y, sampleSourceRotationDeg.z);
-		ImGui::Text("converted rotation degree: (%.2f, %.2f, %.2f)",
-			sampleConvertedRotationDeg.x, sampleConvertedRotationDeg.y, sampleConvertedRotationDeg.z);
-		ImGui::Text("converted yaw sample: %.2f deg", sampleConvertedRotationDeg.y);
-		ImGui::Text("final collider yaw degree: %.2f deg", sampleFinalYawDeg);
-		ImGui::Text("OBB center: (%.2f, %.2f, %.2f)", sampleOBBCenter.x, sampleOBBCenter.y, sampleOBBCenter.z);
-		ImGui::Text("OBB halfSize: (%.2f, %.2f, %.2f)", sampleOBBHalfSize.x, sampleOBBHalfSize.y, sampleOBBHalfSize.z);
-		ImGui::Text("OBB axisX: (%.3f, %.3f, %.3f)", sampleOBBAxisX.x, sampleOBBAxisX.y, sampleOBBAxisX.z);
-		ImGui::Text("OBB axisY: (%.3f, %.3f, %.3f)", sampleOBBAxisY.x, sampleOBBAxisY.y, sampleOBBAxisY.z);
-		ImGui::Text("OBB axisZ: (%.3f, %.3f, %.3f)", sampleOBBAxisZ.x, sampleOBBAxisZ.y, sampleOBBAxisZ.z);
-		ImGui::Text("AABB min: (%.2f, %.2f, %.2f)", sampleAABBMin.x, sampleAABBMin.y, sampleAABBMin.z);
-		ImGui::Text("AABB max: (%.2f, %.2f, %.2f)", sampleAABBMax.x, sampleAABBMax.y, sampleAABBMax.z);
-		ImGui::Text("used by NavigationObstacle: %s", sampleUsedByNavigationObstacle ? "true" : "false");
-		ImGui::Text("used by WallObstacle: %s", sampleUsedByWallObstacle ? "true" : "false");
-		ImGui::Text("used by CollisionObstacle: %s", sampleUsedByCollisionObstacle ? "true" : "false");
-		const int floorCount = colliderTypeCounts["Floor"];
-		const int wallObstacleCount = colliderTypeCounts["Obstacle"] + colliderTypeCounts["Pillar"] + colliderTypeCounts["Fence"] + colliderTypeCounts["Tree"];
-		ImGui::Text("Floor AABB count: %d", floorCount);
-		ImGui::Text("Wall/Obstacle AABB count: %d", wallObstacleCount);
-		ImGui::Text("Navigation obstacle count: %zu", navObstacles.size());
-		ImGui::Text("Collision obstacle count: %d", wallObstacleCount);
-		const bool usingObbDerivedAabb = worldAABBs.size() == obstacleBoxes.size();
-		ImGui::Text("Brown Wire Source: %s", brownWireframeSource_.c_str());
-		ImGui::Text("Draw Source: StageObstacleBox OBB");
-		ImGui::Text("Old Bounds source: StageChunkBounds/ObjectBounds/worldAABBsLegacy");
-		ImGui::Text("Using OBB-derived AABB: %s", usingObbDerivedAabb ? "true" : "false");
-		ImGui::Checkbox("Show Collider OBB Wire", &showColliderObbWire_);
-		ImGui::Checkbox("Show Enclosing AABB Wire", &showEnclosingAabbWire_);
-		ImGui::Checkbox("Show Navigation AABB Wire", &showNavigationAabbWire_);
-		ImGui::Checkbox("Show Wall AABB Wire", &showWallAabbWire_);
-		ImGui::Checkbox("Show Old Bounds Wire", &showOldBoundsWire_);
-		ImGui::Checkbox("Show StageChunk Bounds", &showStageChunkBoundsWire_);
-		ImGui::Checkbox("Show Object Bounds", &showStageChunkObjectBoundsWire_);
-		ImGui::Text("Legacy WorldAABB count: %zu", legacyWorldAABBs.size());
-		if (!obstacleBoxes.empty())
-		{
-			ImGui::Text("corners[0]: (%.2f, %.2f, %.2f)", obstacleBoxes.front().corners[0].x, obstacleBoxes.front().corners[0].y, obstacleBoxes.front().corners[0].z);
-			ImGui::Text("corners[1]: (%.2f, %.2f, %.2f)", obstacleBoxes.front().corners[1].x, obstacleBoxes.front().corners[1].y, obstacleBoxes.front().corners[1].z);
-			ImGui::Text("corners[2]: (%.2f, %.2f, %.2f)", obstacleBoxes.front().corners[2].x, obstacleBoxes.front().corners[2].y, obstacleBoxes.front().corners[2].z);
-			ImGui::Text("corners[3]: (%.2f, %.2f, %.2f)", obstacleBoxes.front().corners[3].x, obstacleBoxes.front().corners[3].y, obstacleBoxes.front().corners[3].z);
-		}
-		ImGui::Text("Floor: %d", colliderTypeCounts["Floor"]);
-		ImGui::Text("Obstacle: %d", colliderTypeCounts["Obstacle"]);
-		ImGui::Text("Pillar: %d", colliderTypeCounts["Pillar"]);
-		ImGui::Text("Fence: %d", colliderTypeCounts["Fence"]);
-		ImGui::Text("Tree: %d", colliderTypeCounts["Tree"]);
-		ImGui::SeparatorText("Collider Debug Adjust");
-		ImGui::Checkbox("Enable Collider Debug Adjust", &commonColliderAdjust_.enabled);
-		ImGui::DragFloat3("Collider Position Offset", &commonColliderAdjust_.positionOffset.x, 0.01f);
-		float commonDeg[3] = { commonColliderAdjust_.rotationOffsetRad.x * 180.0f / std::numbers::pi_v<float>, commonColliderAdjust_.rotationOffsetRad.y * 180.0f / std::numbers::pi_v<float>, commonColliderAdjust_.rotationOffsetRad.z * 180.0f / std::numbers::pi_v<float> };
-		if (ImGui::DragFloat3("Collider Rotation Offset Deg", commonDeg, 0.1f)) { commonColliderAdjust_.rotationOffsetRad = { commonDeg[0] * std::numbers::pi_v<float> / 180.0f, commonDeg[1] * std::numbers::pi_v<float> / 180.0f, commonDeg[2] * std::numbers::pi_v<float> / 180.0f }; }
-		ImGui::DragFloat3("Collider Scale Multiplier", &commonColliderAdjust_.scaleMultiplier.x, 0.01f);
-		if (!obstacleBoxes.empty())
-		{
-			ImGui::Text("Collider index: %zu / %zu", selectedColliderIndex_, obstacleBoxes.size() - 1);
-			ImGui::Text("Collider name: %s", obstacleBoxes[selectedColliderIndex_].name.c_str());
-			ImGui::Text("Collision type: %s", obstacleBoxes[selectedColliderIndex_].collisionTypeName.c_str());
-		}
-		if (ImGui::Button("Previous Collider") && selectedColliderIndex_ > 0) { --selectedColliderIndex_; }
-		ImGui::SameLine();
-		if (ImGui::Button("Next Collider") && (selectedColliderIndex_ + 1) < obstacleBoxes.size()) { ++selectedColliderIndex_; }
-		ImGui::Checkbox("Draw Selected Collider Only", &drawSelectedColliderOnly_);
-		ImGui::Checkbox("Enable Selected Collider Adjust", &selectedColliderAdjust_.enabled);
-		ImGui::DragFloat3("Selected Position Offset", &selectedColliderAdjust_.positionOffset.x, 0.01f);
-		float selectedDeg[3] = { selectedColliderAdjust_.rotationOffsetRad.x * 180.0f / std::numbers::pi_v<float>, selectedColliderAdjust_.rotationOffsetRad.y * 180.0f / std::numbers::pi_v<float>, selectedColliderAdjust_.rotationOffsetRad.z * 180.0f / std::numbers::pi_v<float> };
-		if (ImGui::DragFloat3("Selected Rotation Offset Deg", selectedDeg, 0.1f)) { selectedColliderAdjust_.rotationOffsetRad = { selectedDeg[0] * std::numbers::pi_v<float> / 180.0f, selectedDeg[1] * std::numbers::pi_v<float> / 180.0f, selectedDeg[2] * std::numbers::pi_v<float> / 180.0f }; }
-		ImGui::DragFloat3("Selected Scale Multiplier", &selectedColliderAdjust_.scaleMultiplier.x, 0.01f);
-		ImGui::Checkbox("Apply Debug Adjust To Navigation", &applyDebugAdjustToNavigation_);
-		ImGui::Checkbox("Apply Debug Adjust To WallCollision", &applyDebugAdjustToWallCollision_);
-		if (ImGui::Button("Reset Common Adjust")) { commonColliderAdjust_ = {}; }
-		ImGui::SameLine();
-		if (ImGui::Button("Reset Selected Adjust")) { selectedColliderAdjust_.positionOffset = {}; selectedColliderAdjust_.rotationOffsetRad = {}; selectedColliderAdjust_.scaleMultiplier = { 1.0f,1.0f,1.0f }; selectedColliderAdjust_.enabled = false; }
-		if (ImGui::Button("Reset All Collider Adjust")) { commonColliderAdjust_ = {}; selectedColliderAdjust_.positionOffset = {}; selectedColliderAdjust_.rotationOffsetRad = {}; selectedColliderAdjust_.scaleMultiplier = { 1.0f,1.0f,1.0f }; selectedColliderAdjust_.enabled = false; }
-		ImGui::SameLine();
-		if (ImGui::Button("Apply Common To Selected")) { selectedColliderAdjust_ = commonColliderAdjust_; selectedColliderAdjust_.enabled = true; }
-		if (ImGui::Button("Rotation X +90")) { commonColliderAdjust_.rotationOffsetRad.x += std::numbers::pi_v<float> * 0.5f; lastAdjustPresetAction_ = "Rotation X +90"; } ImGui::SameLine();
-		if (ImGui::Button("Rotation X -90")) { commonColliderAdjust_.rotationOffsetRad.x -= std::numbers::pi_v<float> * 0.5f; lastAdjustPresetAction_ = "Rotation X -90"; }
-		if (ImGui::Button("Rotation Y +90")) { commonColliderAdjust_.rotationOffsetRad.y += std::numbers::pi_v<float> * 0.5f; lastAdjustPresetAction_ = "Rotation Y +90"; } ImGui::SameLine();
-		if (ImGui::Button("Rotation Y -90")) { commonColliderAdjust_.rotationOffsetRad.y -= std::numbers::pi_v<float> * 0.5f; lastAdjustPresetAction_ = "Rotation Y -90"; }
-		if (ImGui::Button("Rotation Z +90")) { commonColliderAdjust_.rotationOffsetRad.z += std::numbers::pi_v<float> * 0.5f; lastAdjustPresetAction_ = "Rotation Z +90"; } ImGui::SameLine();
-		if (ImGui::Button("Rotation Z -90")) { commonColliderAdjust_.rotationOffsetRad.z -= std::numbers::pi_v<float> * 0.5f; lastAdjustPresetAction_ = "Rotation Z -90"; }
-		if (ImGui::Button("Flip X Scale")) { commonColliderAdjust_.scaleMultiplier.x *= -1.0f; lastAdjustPresetAction_ = "Flip X Scale"; } ImGui::SameLine();
-		if (ImGui::Button("Flip Y Scale")) { commonColliderAdjust_.scaleMultiplier.y *= -1.0f; lastAdjustPresetAction_ = "Flip Y Scale"; } ImGui::SameLine();
-		if (ImGui::Button("Flip Z Scale")) { commonColliderAdjust_.scaleMultiplier.z *= -1.0f; lastAdjustPresetAction_ = "Flip Z Scale"; }
-		if (ImGui::Button("Swap X/Z Size")) { std::swap(commonColliderAdjust_.scaleMultiplier.x, commonColliderAdjust_.scaleMultiplier.z); lastAdjustPresetAction_ = "Swap X/Z Size"; } ImGui::SameLine();
-		if (ImGui::Button("Swap Y/Z Size")) { std::swap(commonColliderAdjust_.scaleMultiplier.y, commonColliderAdjust_.scaleMultiplier.z); lastAdjustPresetAction_ = "Swap Y/Z Size"; } ImGui::SameLine();
-		if (ImGui::Button("Swap X/Y Size")) { std::swap(commonColliderAdjust_.scaleMultiplier.x, commonColliderAdjust_.scaleMultiplier.y); lastAdjustPresetAction_ = "Swap X/Y Size"; }
-		ImGui::Text("Last preset action: %s", lastAdjustPresetAction_.c_str());
-		const std::string copyText = std::format("ColliderDebugAdjust:\npositionOffset = {{ {:.3f}, {:.3f}, {:.3f} }}\nrotationOffsetDeg = {{ {:.3f}, {:.3f}, {:.3f} }}\nscaleMultiplier = {{ {:.3f}, {:.3f}, {:.3f} }}",
-			commonColliderAdjust_.positionOffset.x, commonColliderAdjust_.positionOffset.y, commonColliderAdjust_.positionOffset.z,
-			commonDeg[0], commonDeg[1], commonDeg[2],
-			commonColliderAdjust_.scaleMultiplier.x, commonColliderAdjust_.scaleMultiplier.y, commonColliderAdjust_.scaleMultiplier.z);
-		ImGui::TextUnformatted(copyText.c_str());
-		if (ImGui::Button("Print Current Adjust To OutputLog")) { DebugLog(copyText); }
-
-		if (debugMeleeEnemy_)
-		{
-			const Vector3 enemyPos = debugMeleeEnemy_->GetCenterPosition();
-			ImGui::Text("MeleeEnemy Pos: (%.2f, %.2f, %.2f)", enemyPos.x, enemyPos.y, enemyPos.z);
-			ImGui::Text("Grounded: %s", debugMeleeEnemy_->GetVelocity().y == 0.0f ? "Likely grounded" : "Falling/Moving");
-		}
-
+		ImGui::Text("WorldAABBs count: %zu", stage_->GetWorldAABBs().size());
+		ImGui::Text("FloorAABB count: %zu", stage_->GetFloorAABBs().size());
+		ImGui::Text("WallObstacleAABB count: %zu", stage_->GetWallObstacleAABBs().size());
+		ImGui::Text("NavigationObstacleAABB count: %zu", stage_->GetNavigationObstacleAABBs().size());
+		ImGui::Text("Loaded Colliders count: %zu", stage_->GetWorldColliders().size());
+		ImGui::Checkbox("Show Stage Collider Wire", &showStageColliderWire_);
+		ImGui::Checkbox("Show Navigation Path", &showNavigationPath_);
+		ImGui::Checkbox("Show DummyTarget Wire", &meleeDummyWireVisible_);
 		ImGui::End();
 	}
+
 
 	/// ---------- GPUパーティクルデバッグ ---------- ///
 	GpuParticleManager::GetInstance()->DrawImGui();

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
@@ -27,14 +27,6 @@ namespace K4E = ::Ken4lowEngine;
 class DebugScene : public BaseScene
 {
 public: /// ---------- メンバ関数 ---------- ///
-	struct ColliderDebugAdjust
-	{
-		Vector3 positionOffset{ 0.0f, 0.0f, 0.0f };
-		Vector3 rotationOffsetRad{ 0.0f, 0.0f, 0.0f };
-		Vector3 scaleMultiplier{ 1.0f, 1.0f, 1.0f };
-		bool enabled = true;
-	};
-
 	~DebugScene() override;
 
 	// 仮想初期化処理
@@ -116,23 +108,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	K4E::Collider meleeDummyTarget_{};
 	bool meleeDummyWireVisible_ = true;
 	float meleeDummyWireRadius_ = 0.5f;
-	bool showColliderObbWire_ = true;
-	bool showEnclosingAabbWire_ = false;
-	bool showNavigationAabbWire_ = false;
-	bool showWallAabbWire_ = false;
-	bool showOldBoundsWire_ = false;
-	bool showStageChunkBoundsWire_ = false;
-	bool showStageChunkObjectBoundsWire_ = false;
-	std::string brownWireframeSource_ = "StageObstacleBox OBB";
-	ColliderDebugAdjust commonColliderAdjust_{};
-	ColliderDebugAdjust selectedColliderAdjust_{ {0.0f,0.0f,0.0f}, {0.0f,0.0f,0.0f}, {1.0f,1.0f,1.0f}, false };
-	bool drawSelectedColliderOnly_ = false;
-	bool applyDebugAdjustToNavigation_ = false;
-	bool applyDebugAdjustToWallCollision_ = false;
-	size_t selectedColliderIndex_ = 0;
-	std::string lastAdjustPresetAction_ = "None";
-	std::vector<K4E::AABB> debugAdjustedNavigationAABBs_{};
-	std::vector<K4E::AABB> debugAdjustedWallAABBs_{};
-	std::vector<K4E::AABB> debugAdjustedWorldAABBs_{};
+	bool showStageColliderWire_ = true;
+	bool showNavigationPath_ = true;
 
 };


### PR DESCRIPTION
### Motivation
- Debug UI とワイヤーフレーム表示が肥大化して可読性と保守性が落ちていたため、Stage/Navigation/MeleeEnemy 周りを最小限の確認に整理して将来の改修をしやすくする。 
- ビルドが通る状態を維持しつつ不要なデバッグコード・未使用調整機能を削除する。 

### Description
- DebugScene 側の冗長な Collider 補正・OBB/AABB の詳細表示・旧ワイヤー切替ロジックを削除し、`Show Stage Collider Wire` で `worldAABBs` を描画する単純構成へ統一した。 
- Stage Debug の ImGui を最小化し、`WorldAABBs count` / `FloorAABB count` / `WallObstacleAABB count` / `NavigationObstacleAABB count` / `Loaded Colliders count` と `Show Stage Collider Wire` / `Show Navigation Path` / `Show DummyTarget Wire` のトグルのみを残した。 
- MeleeEnemy の ImGui を整理し、要求どおり主要パラメータと操作（`detectRange` / `meleeAttackRange` / `moveSpeed` / `stopDistance` / `attackStartRange` / `resumeChaseDistance` / `selectedAttackType` / 強制攻撃ボタン等）と状態表示（`currentBTActionName` / `currentAttackName` / `isAttacking` / `distanceToTarget` / `pathFound` / `currentWaypointIndex` / `stuck` / `lastRepathReason`）のみを残した。 
- 不要になったヘルパー関数・配列インクルードと大量の ImGui 行を削除してコードを簡素化した。 
- 変更ファイル: `Project/ApplicationLayer/Scene/DebugScene/DebugScene.h`, `Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp`, `Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp`（削除中心、約486行削除／約24行追加）。

### Testing
- 自動化チェックとして `rg` によるソース検索で主要 UI ラベル・トグル（例: `WorldAABBs count`, `Show Stage Collider Wire`, `currentBTActionName`, `selectedAttackType`）の存在を確認し、期待どおり最小項目が残っていることを検証した（検索は成功）。
- 変更は主にデバッグ表示の削除に限定しており、ゲームロジック（攻撃/経路探索本体）は保持しているため回帰リスクは低いと想定するが、本 PR の実行環境ではフルビルド／ランタイムの統合テストは未実施であるため、マージ前に `DebugScene` と `MeleeEnemy` の実行を伴うローカルビルドと動作確認（ステージ読み込み・DummyTarget 操作・Scratch/OneTwo の検証）を推奨する。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a131d3dc884832da00ecb2e17a6ddb6)