### PR TITLE
Stage collision: add StageCollisionType and stop casting JSON IDs to CollisionTypeIdDef

### DIFF
--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -418,6 +418,28 @@ void DebugScene::DrawImGui()
 		ImGui::Separator();
 		ImGui::Text("True Collider Source: StageCollisionBuilder(LevelData collider.center/size/rotation)");
 		ImGui::Text("True Collider Count: %zu", stage_->GetWorldColliders().size());
+		size_t floorCount = 0;
+		size_t obstacleCount = 0;
+		size_t pillarCount = 0;
+		size_t fenceCount = 0;
+		size_t treeCount = 0;
+		for (const auto& box : stage_->GetObstacleBoxes())
+		{
+			switch (box.stageCollisionType)
+			{
+			case Ken4lowEngine::StageCollisionType::Floor: ++floorCount; break;
+			case Ken4lowEngine::StageCollisionType::Obstacle: ++obstacleCount; break;
+			case Ken4lowEngine::StageCollisionType::Pillar: ++pillarCount; break;
+			case Ken4lowEngine::StageCollisionType::Fence: ++fenceCount; break;
+			case Ken4lowEngine::StageCollisionType::Tree: ++treeCount; break;
+			default: break;
+			}
+		}
+		ImGui::Text("Stage Type Count - Floor: %zu", floorCount);
+		ImGui::Text("Stage Type Count - Obstacle: %zu", obstacleCount);
+		ImGui::Text("Stage Type Count - Pillar: %zu", pillarCount);
+		ImGui::Text("Stage Type Count - Fence: %zu", fenceCount);
+		ImGui::Text("Stage Type Count - Tree: %zu", treeCount);
 		if (!stage_->GetObstacleBoxes().empty())
 		{
 			const auto& sample = stage_->GetObstacleBoxes().front();
@@ -431,7 +453,10 @@ void DebugScene::DrawImGui()
 			ImGui::Separator();
 			ImGui::Text("Sample Obstacle Compare");
 			ImGui::Text("object name: %s", sample.name.c_str());
-			ImGui::Text("collision type: %s", sample.collisionTypeName.c_str());
+			ImGui::Text("raw collision_type: %s", sample.collisionTypeName.c_str());
+			ImGui::Text("raw collision_type_id: %d", sample.rawCollisionTypeId);
+			ImGui::Text("parsed StageCollisionType: %d", static_cast<int>(sample.stageCollisionType));
+			ImGui::Text("CollisionTypeIdDef direct cast used: NO");
 			ImGui::Text("true collider center: (%.3f, %.3f, %.3f)", sample.center.x, sample.center.y, sample.center.z);
 			ImGui::Text("nav/wall center: (%.3f, %.3f, %.3f)", sample.center.x, sample.center.y, sample.center.z);
 			ImGui::Text("center delta: (0.000, 0.000, 0.000)");

--- a/Project/Engine/Scene/Level/LevelData.h
+++ b/Project/Engine/Scene/Level/LevelData.h
@@ -5,6 +5,15 @@
 
 namespace Ken4lowEngine
 {
+	enum class StageCollisionType : uint32_t
+	{
+		Unknown = 0,
+		Floor,
+		Obstacle,
+		Pillar,
+		Fence,
+		Tree,
+	};
 
 	/// -------------------------------------------------------------
 	///				　	ボックスコライダーデータ構造体
@@ -14,6 +23,7 @@ namespace Ken4lowEngine
 		std::string type;		// コライダーの名前
 		std::string collisionType; // 衝突種別名（Floor / Obstacle など）
 		int collisionTypeId = -1; // 衝突種別ID（未指定時は-1）
+		StageCollisionType stageCollisionType = StageCollisionType::Unknown; // ステージ衝突分類
 		Vector3 center;			// 中心位置
 		Vector3 size;			// サイズ
 		Vector3 rotation;		// 回転（ラジアン）

--- a/Project/Engine/Scene/Level/LevelLoader.cpp
+++ b/Project/Engine/Scene/Level/LevelLoader.cpp
@@ -103,6 +103,16 @@ namespace Ken4lowEngine
 				type == "EscapePoint" ||
 				type == "BossPhaseTrigger";
 		}
+
+		StageCollisionType ParseStageCollisionType(const std::string& collisionTypeName)
+		{
+			if (collisionTypeName == "Floor") { return StageCollisionType::Floor; }
+			if (collisionTypeName == "Obstacle") { return StageCollisionType::Obstacle; }
+			if (collisionTypeName == "Pillar") { return StageCollisionType::Pillar; }
+			if (collisionTypeName == "Fence") { return StageCollisionType::Fence; }
+			if (collisionTypeName == "Tree") { return StageCollisionType::Tree; }
+			return StageCollisionType::Unknown;
+		}
 	}
 
 	std::unique_ptr<LevelData> LevelLoader::LoadLevel(const std::string& filePath)
@@ -399,6 +409,7 @@ namespace Ken4lowEngine
 			if (jc.contains("collision_type") && jc["collision_type"].is_string())
 			{
 				objectData->collider.collisionType = jc["collision_type"].get<std::string>();
+				objectData->collider.stageCollisionType = ParseStageCollisionType(objectData->collider.collisionType);
 			}
 
 			if (jc.contains("collision_type_id") && jc["collision_type_id"].is_number_integer())

--- a/Project/Engine/Scene/Level/StageCollisionBuilder.cpp
+++ b/Project/Engine/Scene/Level/StageCollisionBuilder.cpp
@@ -7,6 +7,16 @@ namespace Ken4lowEngine
 {
 	namespace
 	{
+		StageCollisionType ParseStageCollisionType(const std::string& collisionTypeName)
+		{
+			if (collisionTypeName == "Floor") { return StageCollisionType::Floor; }
+			if (collisionTypeName == "Obstacle") { return StageCollisionType::Obstacle; }
+			if (collisionTypeName == "Pillar") { return StageCollisionType::Pillar; }
+			if (collisionTypeName == "Fence") { return StageCollisionType::Fence; }
+			if (collisionTypeName == "Tree") { return StageCollisionType::Tree; }
+			return StageCollisionType::Unknown;
+		}
+
 		Vector3 TransformDirection(const Vector3& v, const Matrix4x4& m)
 		{
 			// 回転方向だけを変換するため、平行移動成分は使わない
@@ -95,6 +105,7 @@ namespace Ken4lowEngine
 			};
 
 			auto collider = std::make_unique<Collider>();
+			// JSONのcollision_type_idはステージ分類IDなので、CollisionTypeIdDefへ直接変換せずStageCollisionTypeとして扱う
 			collider->SetTypeID(static_cast<uint32_t>(CollisionTypeIdDef::kWorld));
 			collider->SetCenterPosition(centerW);
 			collider->SetOBBHalfSize(halfW);
@@ -116,7 +127,8 @@ namespace Ken4lowEngine
 			StageObstacleBox box{};
 			box.name = data.name;
 			box.collisionTypeName = data.collider.collisionType;
-			box.collisionTypeId = data.collider.collisionTypeId;
+			box.rawCollisionTypeId = data.collider.collisionTypeId;
+			box.stageCollisionType = data.collider.stageCollisionType;
 			box.corners = corners;
 			box.enclosingAABB = aabb;
 			box.center = centerW;
@@ -127,15 +139,23 @@ namespace Ken4lowEngine
 			box.axisY = Vector3::Normalize(TransformDirection({ 0.0f, 1.0f, 0.0f }, rotationM));
 			box.axisZ = Vector3::Normalize(TransformDirection({ 0.0f, 0.0f, 1.0f }, rotationM));
 			result.obstacleBoxes.push_back(box);
-			const std::string& collisionType = data.collider.collisionType;
-			if (collisionType == "Floor")
+			const StageCollisionType stageCollisionType = data.collider.stageCollisionType;
+			if (stageCollisionType == StageCollisionType::Floor)
 			{
 				result.floorAABBs.push_back(aabb);
+				++result.floorCount;
 			}
-			else if (collisionType == "Obstacle" || collisionType == "Pillar" || collisionType == "Fence" || collisionType == "Tree")
+			else if (stageCollisionType == StageCollisionType::Obstacle ||
+				stageCollisionType == StageCollisionType::Pillar ||
+				stageCollisionType == StageCollisionType::Fence ||
+				stageCollisionType == StageCollisionType::Tree)
 			{
 				result.wallObstacleAABBs.push_back(aabb);
 				result.navigationObstacleAABBs.push_back(aabb);
+				if (stageCollisionType == StageCollisionType::Obstacle) { ++result.obstacleCount; }
+				else if (stageCollisionType == StageCollisionType::Pillar) { ++result.pillarCount; }
+				else if (stageCollisionType == StageCollisionType::Fence) { ++result.fenceCount; }
+				else if (stageCollisionType == StageCollisionType::Tree) { ++result.treeCount; }
 			}
 
 			result.worldColliders.push_back(std::move(collider));

--- a/Project/Engine/Scene/Level/StageCollisionBuilder.h
+++ b/Project/Engine/Scene/Level/StageCollisionBuilder.h
@@ -13,7 +13,8 @@ namespace Ken4lowEngine
 	{
 			std::string name;
 			std::string collisionTypeName;
-			int collisionTypeId = -1;
+			int rawCollisionTypeId = -1;
+			StageCollisionType stageCollisionType = StageCollisionType::Unknown;
 			Vector3 center{};
 			Vector3 halfSize{};
 			Vector3 axisX{ 1.0f, 0.0f, 0.0f };
@@ -31,6 +32,11 @@ namespace Ken4lowEngine
 		std::vector<Ken4lowEngine::AABB> wallObstacleAABBs;
 		std::vector<Ken4lowEngine::AABB> navigationObstacleAABBs;
 		std::vector<StageObstacleBox> obstacleBoxes;
+		uint32_t floorCount = 0;
+		uint32_t obstacleCount = 0;
+		uint32_t pillarCount = 0;
+		uint32_t fenceCount = 0;
+		uint32_t treeCount = 0;
 		std::vector<std::unique_ptr<Collider>> worldColliders;
 	};
 


### PR DESCRIPTION
### Motivation
- JSON `collision_type`/`collision_type_id` used stage-specific IDs which were being (mis)interpreted as `CollisionTypeIdDef` gameplay IDs, causing Floor/Obstacle/Pillar/Tree to be misclassified.
- The goal is to separate stage classification from game object collision IDs and ensure Navigation/Wall/Floor sources are generated from stage semantics.

### Description
- Added `enum class StageCollisionType` and stored it in `ObjectColliderData` as `stageCollisionType` so stage classification is kept separate from `collision_type_id` (`Project/Engine/Scene/Level/LevelData.h`).
- Updated JSON loading in `LevelLoader` to parse `collision_type` string-first into `StageCollisionType` while retaining `collision_type_id` as a raw value (`Project/Engine/Scene/Level/LevelLoader.cpp`).
- Modified `StageCollisionBuilder` to classify colliders using `StageCollisionType` (Floor → `floorAABBs` only; Obstacle/Pillar/Fence/Tree → `wallObstacleAABBs` + `navigationObstacleAABBs`) and kept stage colliders registered with `CollisionTypeIdDef::kWorld` while adding a clarifying comment (`Project/Engine/Scene/Level/StageCollisionBuilder.h` / `.cpp`).
- Added `rawCollisionTypeId` and `stageCollisionType` to `StageObstacleBox`, added per-type counters to `StageCollisionBuildResult`, and extended debug UI to show raw `collision_type`, raw `collision_type_id`, parsed `StageCollisionType`, and per-type counts (`Project/Engine/Scene/Level/StageCollisionBuilder.h` / `.cpp`, `Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp`).
- Files changed: `LevelData.h`, `LevelLoader.cpp`, `StageCollisionBuilder.h`, `StageCollisionBuilder.cpp`, and `DebugScene.cpp`.

### Testing
- Ran repository searches to confirm there were no direct `collision_type_id -> CollisionTypeIdDef` casts in the touched paths and validated the updated code areas with `rg` which returned expected references (success).
- Ran `git diff --check` and `git status` to ensure the patch is clean and staged changes are consistent (success).
- Did not run a full Visual Studio / MSBuild C++ build in this environment, so `C++20 / W4 / TreatWarningAsError` compliance remains to be verified in CI or a developer machine (not executed here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1323b2e128832d9b036f25ead334a1)