### PR TITLE
Fix brown stage wireframe to use Collider OBBs

### DIFF
--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -240,6 +240,11 @@ void DebugScene::Draw3DObjects()
 	if (stage_)
 	{
 		stage_->Draw();
+		// Stage Debugの茶色ワイヤーはNavigation/Wall用AABBではなくCollider由来OBBで描画する。
+		for (const auto& obstacleObb : stage_->GetWallObstacleOBBs())
+		{
+			Wireframe::GetInstance()->DrawOBB(obstacleObb, { 0.60f, 0.35f, 0.12f, 0.90f });
+		}
 	}
 
 #ifdef _DEBUG
@@ -372,6 +377,8 @@ void DebugScene::DrawImGui()
 		const std::vector<AABB>& floorAABBs = stage_->GetFloorAABBs();
 		const std::vector<AABB>& wallObstacles = stage_->GetWallObstacleAABBs();
 		const std::vector<AABB>& navObstacles = stage_->GetNavigationObstacleAABBs();
+		const std::vector<OBB>& wallObstacleOBBs = stage_->GetWallObstacleOBBs();
+		const std::vector<OBB>& navObstacleOBBs = stage_->GetNavigationObstacleOBBs();
 		const auto& worldColliders = stage_->GetWorldColliders();
 		const LevelData* levelData = stage_->GetLevelData();
 		size_t loadedColliders = 0;
@@ -445,6 +452,9 @@ void DebugScene::DrawImGui()
 		ImGui::Text("FloorAABB count: %zu", floorAABBs.size());
 		ImGui::Text("WallObstacleAABB count: %zu", wallObstacles.size());
 		ImGui::Text("NavigationObstacleAABB count: %zu", navObstacles.size());
+		ImGui::Text("WallObstacleOBB count: %zu", wallObstacleOBBs.size());
+		ImGui::Text("NavigationObstacleOBB count: %zu", navObstacleOBBs.size());
+		ImGui::Text("Brown wire source: OBB");
 		ImGui::Text("Loaded Colliders: %zu", loadedColliders);
 		ImGui::Text("Rotated collider count: %zu", rotatedColliderCount);
 		ImGui::Text("AABB fallback count: %zu", aabbFallbackCount);

--- a/Project/Engine/Scene/Level/Stage.cpp
+++ b/Project/Engine/Scene/Level/Stage.cpp
@@ -30,6 +30,8 @@ namespace Ken4lowEngine
 		wallObstacleAABBs_ = std::move(collisionResult.wallObstacleAABBs);
 		navigationObstacleAABBs_ = std::move(collisionResult.navigationObstacleAABBs);
 		worldColliders_ = std::move(collisionResult.worldColliders);
+		wallObstacleOBBs_ = std::move(collisionResult.wallObstacleOBBs);
+		navigationObstacleOBBs_ = std::move(collisionResult.navigationObstacleOBBs);
 		occlusionCullingSystem_.BuildAutoOccludersFromWorldAABBs(worldAABBs_);
 	}
 
@@ -44,6 +46,8 @@ namespace Ken4lowEngine
 		wallObstacleAABBs_.clear();
 		navigationObstacleAABBs_.clear();
 		worldColliders_.clear();
+		wallObstacleOBBs_.clear();
+		navigationObstacleOBBs_.clear();
 	}
 
 	void Stage::Update()

--- a/Project/Engine/Scene/Level/Stage.h
+++ b/Project/Engine/Scene/Level/Stage.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "AABB.h"
 #include "Collider.h"
+#include "OBB.h"
 #include "Object3D.h"
 #include "LevelData.h"
 #include "OcclusionCullingSystem.h"
@@ -91,6 +92,8 @@ namespace Ken4lowEngine
 		const std::vector<AABB>& GetWallObstacleAABBs() const { return wallObstacleAABBs_; }
 		const std::vector<AABB>& GetNavigationObstacleAABBs() const { return navigationObstacleAABBs_; }
 		const std::vector<std::unique_ptr<Collider>>& GetWorldColliders() const { return worldColliders_; }
+		const std::vector<OBB>& GetWallObstacleOBBs() const { return wallObstacleOBBs_; }
+		const std::vector<OBB>& GetNavigationObstacleOBBs() const { return navigationObstacleOBBs_; }
 
 		/// <summary>
 		/// 保持しているワールドコライダーを CollisionManager に登録する
@@ -110,6 +113,8 @@ namespace Ken4lowEngine
 		std::vector<AABB> wallObstacleAABBs_;                  // 横押し出し用Obstacle AABB
 		std::vector<AABB> navigationObstacleAABBs_;            // Navigation向け障害物AABB(Floor除外)
 		std::vector<std::unique_ptr<Collider>> worldColliders_; // ワールド衝突Collider
+		std::vector<OBB> wallObstacleOBBs_;                  // デバッグ表示用の壁/障害物OBB
+		std::vector<OBB> navigationObstacleOBBs_;            // デバッグ表示用のNavigation障害物OBB
 		Vector3 offset_ = { 0.0f, 0.0f, 0.0f };               // ステージ全体オフセット
 	};
 } // namespace Ken4lowEngine

--- a/Project/Engine/Scene/Level/StageCollisionBuilder.cpp
+++ b/Project/Engine/Scene/Level/StageCollisionBuilder.cpp
@@ -47,6 +47,8 @@ namespace Ken4lowEngine
 		result.wallObstacleAABBs.reserve(levelData.objects.size());
 		result.navigationObstacleAABBs.reserve(levelData.objects.size());
 		result.worldColliders.reserve(levelData.objects.size());
+		result.wallObstacleOBBs.reserve(levelData.objects.size());
+		result.navigationObstacleOBBs.reserve(levelData.objects.size());
 
 		for (const ObjectData& data : levelData.objects)
 		{
@@ -85,6 +87,7 @@ namespace Ken4lowEngine
 			// OBB表示とNavigation/Wall用AABBの生成元を揃え、見た目と判定の向き不一致を解消する
 			const AABB aabb = BuildAABBFromRotatedOBB(centerW, halfW, colliderRotation);
 			result.worldAABBs.push_back(aabb);
+			const OBB colliderObb = collider->GetOBB();
 			const std::string& collisionType = data.collider.collisionType;
 			if (collisionType == "Floor")
 			{
@@ -94,6 +97,9 @@ namespace Ken4lowEngine
 			{
 				result.wallObstacleAABBs.push_back(aabb);
 				result.navigationObstacleAABBs.push_back(aabb);
+				// 表示用ワイヤーはAABBではなくCollider::GetOBB()由来の姿勢をそのまま使う。
+				result.wallObstacleOBBs.push_back(colliderObb);
+				result.navigationObstacleOBBs.push_back(colliderObb);
 			}
 
 			result.worldColliders.push_back(std::move(collider));

--- a/Project/Engine/Scene/Level/StageCollisionBuilder.h
+++ b/Project/Engine/Scene/Level/StageCollisionBuilder.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "AABB.h"
 #include "Collider.h"
+#include "OBB.h"
 #include "LevelData.h"
 
 #include <memory>
@@ -15,6 +16,8 @@ namespace Ken4lowEngine
 		std::vector<AABB> wallObstacleAABBs;
 		std::vector<AABB> navigationObstacleAABBs;
 		std::vector<std::unique_ptr<Collider>> worldColliders;
+		std::vector<OBB> wallObstacleOBBs;
+		std::vector<OBB> navigationObstacleOBBs;
 	};
 
 	/// -------------------------------------------------------------


### PR DESCRIPTION
### Motivation
- Brown stage wireframe shown in Stage Debug was drawn from AABBs and did not match rotated colliders, causing visual/logic mismatch for rotated walls/obstacles.
- Intend to keep existing AABB datasets used for navigation/collision, but make debug visualization use the real OBB orientation from colliders so the brown wireframe matches collider rotation.

### Description
- `StageCollisionBuilder` now collects `OBB` objects for wall/navigation obstacles in addition to the existing AABB outputs, using `Collider::GetOBB()` as the source for display OBBs.
- `Stage` was extended to store and expose `wallObstacleOBBs` and `navigationObstacleOBBs`, and sync them during initialization/clear without changing existing AABB members or runtime logic.
- `DebugScene` Draw path now draws brown obstacle wireframes by calling `Wireframe::DrawOBB()` for `stage_->GetWallObstacleOBBs()`, and the ImGui Stage Debug panel shows `WallObstacleOBB`/`NavigationObstacleOBB` counts and a `Brown wire source: OBB` indicator; a one-line code comment was added at the draw site.
- Existing floor/wall/obstacle classification, `StageCollisionType`, `NavigationObstacleAABB`, and `WallObstacleAABB` handling were preserved so runtime collision and navigation remain unchanged.

### Testing
- Created and switched to branch `fix/brown-wireframe` (`git checkout -b fix/brown-wireframe`) and committed the changes (`git commit`), which succeeded.
- Verified repository status with `git status --short` and produced the PR body with the `make_pr` helper; these operations succeeded.
- No full build or runtime visual tests were executed in this environment (`Visual Studio / runtime tests not run`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13a0faef14832daee24a7728f78634)