### PR TITLE
Debug: Toggle brown wireframe between OBB/AABB and add OBB inspection controls

### DIFF
--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -240,10 +240,57 @@ void DebugScene::Draw3DObjects()
 	if (stage_)
 	{
 		stage_->Draw();
-		// Stage Debugの茶色ワイヤーはNavigation/Wall用AABBではなくCollider由来OBBで描画する。
-		for (const auto& obstacleObb : stage_->GetWallObstacleOBBs())
+		// Stage Debugの茶色ワイヤーはAABB/OBB切り替え可能にし、既定はOBB優先表示にする。
+		const std::vector<OBB>& wallObstacleOBBs = stage_->GetWallObstacleOBBs();
+		const std::vector<OBB>& navObstacleOBBs = stage_->GetNavigationObstacleOBBs();
+		const std::vector<AABB>& wallObstacleAABBs = stage_->GetWallObstacleAABBs();
+		const std::vector<AABB>& navObstacleAABBs = stage_->GetNavigationObstacleAABBs();
+		if (showWallObstacleObbWire_)
 		{
-			Wireframe::GetInstance()->DrawOBB(obstacleObb, { 0.60f, 0.35f, 0.12f, 0.90f });
+			if (showOnlySelectedObstacleObb_ && !wallObstacleOBBs.empty())
+			{
+				const int clampedIndex = std::clamp(selectedWallObstacleObbIndex_, 0, static_cast<int>(wallObstacleOBBs.size()) - 1);
+				Wireframe::GetInstance()->DrawOBB(wallObstacleOBBs[clampedIndex], { 0.60f, 0.35f, 0.12f, 0.90f });
+			}
+			else
+			{
+				for (const auto& obstacleObb : wallObstacleOBBs)
+				{
+					Wireframe::GetInstance()->DrawOBB(obstacleObb, { 0.60f, 0.35f, 0.12f, 0.90f });
+				}
+			}
+		}
+		if (showNavigationObstacleObbWire_)
+		{
+			if (showOnlySelectedObstacleObb_ && !navObstacleOBBs.empty())
+			{
+				const int clampedIndex = std::clamp(selectedNavigationObstacleObbIndex_, 0, static_cast<int>(navObstacleOBBs.size()) - 1);
+				Wireframe::GetInstance()->DrawOBB(navObstacleOBBs[clampedIndex], { 0.50f, 0.28f, 0.08f, 0.90f });
+			}
+			else
+			{
+				for (const auto& obstacleObb : navObstacleOBBs)
+				{
+					Wireframe::GetInstance()->DrawOBB(obstacleObb, { 0.50f, 0.28f, 0.08f, 0.90f });
+				}
+			}
+		}
+		if (showWallNavigationAabbWire_)
+		{
+			for (const auto& wallAabb : wallObstacleAABBs)
+			{
+				Wireframe::GetInstance()->DrawAABB(wallAabb, { 0.95f, 0.75f, 0.20f, 0.90f });
+			}
+			for (const auto& navAabb : navObstacleAABBs)
+			{
+				Wireframe::GetInstance()->DrawAABB(navAabb, { 1.00f, 0.55f, 0.10f, 0.90f });
+			}
+		}
+		// StageChunk/ObjectBounds AABBの茶色系ワイヤーは比較用に個別切り替え可能にする。
+		stage_->SetStageChunkObjectBoundsVisible(showStageChunkObjectBoundsAabbWire_);
+		if (showStageChunkObjectBoundsAabbWire_)
+		{
+			stage_->DrawChunkDebug();
 		}
 	}
 
@@ -454,7 +501,46 @@ void DebugScene::DrawImGui()
 		ImGui::Text("NavigationObstacleAABB count: %zu", navObstacles.size());
 		ImGui::Text("WallObstacleOBB count: %zu", wallObstacleOBBs.size());
 		ImGui::Text("NavigationObstacleOBB count: %zu", navObstacleOBBs.size());
-		ImGui::Text("Brown wire source: OBB");
+		ImGui::Separator();
+		ImGui::Checkbox("Show Wall Obstacle OBB Wire", &showWallObstacleObbWire_);
+		ImGui::Checkbox("Show Navigation Obstacle OBB Wire", &showNavigationObstacleObbWire_);
+		ImGui::Checkbox("Show Wall/Navigation AABB Wire", &showWallNavigationAabbWire_);
+		ImGui::Checkbox("Show StageChunk/ObjectBounds AABB Wire", &showStageChunkObjectBoundsAabbWire_);
+		ImGui::Checkbox("Show Only Selected OBB", &showOnlySelectedObstacleObb_);
+		if (!wallObstacleOBBs.empty())
+		{
+			ImGui::SliderInt("Selected Wall OBB", &selectedWallObstacleObbIndex_, 0, static_cast<int>(wallObstacleOBBs.size()) - 1);
+		}
+		if (!navObstacleOBBs.empty())
+		{
+			ImGui::SliderInt("Selected Navigation OBB", &selectedNavigationObstacleObbIndex_, 0, static_cast<int>(navObstacleOBBs.size()) - 1);
+		}
+		const bool obbWireEnabled = showWallObstacleObbWire_ || showNavigationObstacleObbWire_;
+		const bool aabbWireEnabled = showWallNavigationAabbWire_ || showStageChunkObjectBoundsAabbWire_;
+		const char* brownWireSourceLabel = obbWireEnabled && !aabbWireEnabled ? "OBB"
+			: (!obbWireEnabled && aabbWireEnabled ? "AABB" : (obbWireEnabled && aabbWireEnabled ? "OBB + AABB" : "OFF"));
+		ImGui::Text("Brown wire source: %s", brownWireSourceLabel);
+		if (!wallObstacleOBBs.empty())
+		{
+			const int clampedIndex = std::clamp(selectedWallObstacleObbIndex_, 0, static_cast<int>(wallObstacleOBBs.size()) - 1);
+			const OBB& selected = wallObstacleOBBs[clampedIndex];
+			// 選択中OBBの軸情報をImGui表示して回転追従を確認しやすくする。
+			ImGui::Text("Selected Wall OBB[%d] center: (%.2f, %.2f, %.2f)", clampedIndex, selected.center.x, selected.center.y, selected.center.z);
+			ImGui::Text("Selected Wall OBB[%d] size: (%.2f, %.2f, %.2f)", clampedIndex, selected.size.x, selected.size.y, selected.size.z);
+			ImGui::Text("Selected Wall OBB[%d] axisX: (%.2f, %.2f, %.2f)", clampedIndex, selected.orientations[0].x, selected.orientations[0].y, selected.orientations[0].z);
+			ImGui::Text("Selected Wall OBB[%d] axisY: (%.2f, %.2f, %.2f)", clampedIndex, selected.orientations[1].x, selected.orientations[1].y, selected.orientations[1].z);
+			ImGui::Text("Selected Wall OBB[%d] axisZ: (%.2f, %.2f, %.2f)", clampedIndex, selected.orientations[2].x, selected.orientations[2].y, selected.orientations[2].z);
+		}
+		if (!navObstacleOBBs.empty())
+		{
+			const int clampedIndex = std::clamp(selectedNavigationObstacleObbIndex_, 0, static_cast<int>(navObstacleOBBs.size()) - 1);
+			const OBB& selected = navObstacleOBBs[clampedIndex];
+			ImGui::Text("Selected Navigation OBB[%d] center: (%.2f, %.2f, %.2f)", clampedIndex, selected.center.x, selected.center.y, selected.center.z);
+			ImGui::Text("Selected Navigation OBB[%d] size: (%.2f, %.2f, %.2f)", clampedIndex, selected.size.x, selected.size.y, selected.size.z);
+			ImGui::Text("Selected Navigation OBB[%d] axisX: (%.2f, %.2f, %.2f)", clampedIndex, selected.orientations[0].x, selected.orientations[0].y, selected.orientations[0].z);
+			ImGui::Text("Selected Navigation OBB[%d] axisY: (%.2f, %.2f, %.2f)", clampedIndex, selected.orientations[1].x, selected.orientations[1].y, selected.orientations[1].z);
+			ImGui::Text("Selected Navigation OBB[%d] axisZ: (%.2f, %.2f, %.2f)", clampedIndex, selected.orientations[2].x, selected.orientations[2].y, selected.orientations[2].z);
+		}
 		ImGui::Text("Loaded Colliders: %zu", loadedColliders);
 		ImGui::Text("Rotated collider count: %zu", rotatedColliderCount);
 		ImGui::Text("AABB fallback count: %zu", aabbFallbackCount);

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
@@ -109,5 +109,12 @@ private: /// ---------- メンバ変数 ---------- ///
 	K4E::Collider meleeDummyTarget_{};
 	bool meleeDummyWireVisible_ = true;
 	float meleeDummyWireRadius_ = 0.5f;
+	bool showWallObstacleObbWire_ = true;             // Stage Debug茶色ワイヤーのWall OBB表示切り替え
+	bool showNavigationObstacleObbWire_ = true;       // Stage Debug茶色ワイヤーのNavigation OBB表示切り替え
+	bool showWallNavigationAabbWire_ = false;         // Stage DebugのWall/Navigation AABB比較表示切り替え
+	bool showStageChunkObjectBoundsAabbWire_ = false; // StageChunk/ObjectBounds AABB表示切り替え
+	bool showOnlySelectedObstacleObb_ = false;        // 選択中OBBのみ表示する切り替え
+	int selectedWallObstacleObbIndex_ = 0;            // 表示/詳細確認するWall OBBインデックス
+	int selectedNavigationObstacleObbIndex_ = 0;      // 表示/詳細確認するNavigation OBBインデックス
 
 };


### PR DESCRIPTION
### Motivation
- The brown Stage debug wireframe was visually mismatched with rotated obstacles because it was effectively showing axis-aligned AABBs rather than collider-derived OBBs. 
- Provide an easy way to compare AABB vs OBB rendering and inspect OBB axes/parameters to verify rotation/offset conversion without changing collision logic.

### Description
- Added debug state variables to `DebugScene` (`showWallObstacleObbWire_`, `showNavigationObstacleObbWire_`, `showWallNavigationAabbWire_`, `showStageChunkObjectBoundsAabbWire_`, `showOnlySelectedObstacleObb_`, `selectedWallObstacleObbIndex_`, `selectedNavigationObstacleObbIndex_`) in `Project/ApplicationLayer/Scene/DebugScene/DebugScene.h` to control display modes. 
- Updated `DebugScene::Draw3DObjects()` to draw `Stage::GetWallObstacleOBBs()` / `Stage::GetNavigationObstacleOBBs()` when OBB rendering is enabled, and to draw the existing `GetWallObstacleAABBs()` / `GetNavigationObstacleAABBs()` only when AABB rendering is enabled; added "only selected OBB" support to isolate a single OBB. 
- Added ImGui controls in `DebugScene::DrawImGui()` to toggle OBB/AABB displays, select indices for wall/navigation OBBs, show a `Brown wire source` status, and display selected OBB `center`, `size`, and `axisX/axisY/axisZ` for rotation/axis inspection. 
- Preserved internal AABB arrays and StageChunk/ObjectBounds AABB code paths (no changes to collision logic), and added short one-line comments explaining the debug intent in modified locations.

### Testing
- Ran repository checks `git status --short` to confirm only the intended files changed and it returned normally. 
- Ran `git diff --check` to verify there are no whitespace/format issues and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13a68d33d4832d9f9b7854956e32b7)