### PR TITLE
Refactor MeleeEnemy state into structs and improve jump velocity calculation

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
@@ -44,35 +44,35 @@ void MeleeEnemy::Initialize()
 	EnemyBase::Initialize();
 	SetMaxHp(160);
 	SetCenterPosition({ 0.0f, 2.0f, 10.0f });
-	wanderTimer_ = 0.0f;
+	wander_.timer = 0.0f;
 	currentBehaviorName_ = "Wander";
-	animState_ = AnimState::Idle;
+	animationState_.animState = AnimState::Idle;
 	attackController_.Initialize();
 	spawnPosition_ = GetCenterPosition();
-	lastStuckCheckPosition_ = spawnPosition_;
-	lastSafePosition_ = spawnPosition_;
-	visualYawOffset_ = 0.0f;
-	visualYawOffsetDeg_ = 0.0f;
+	pathState_.lastStuckCheckPosition = spawnPosition_;
+	collision_.lastSafePosition = spawnPosition_;
+	animation_.visualYawOffset = 0.0f;
+	animationState_.visualYawOffsetDeg = 0.0f;
 }
 
 void MeleeEnemy::Update(float deltaTime)
 {
 	const Vector3 beforePos = GetCenterPosition();
 	attackController_.Update(*this, deltaTime);
-	attackLockTimer_ = std::max(0.0f, attackLockTimer_ - deltaTime);
+	attackState_.lockTimer = std::max(0.0f, attackState_.lockTimer - deltaTime);
 	// 連続ジャンプを防ぐため、追跡ジャンプのクールダウンタイマーを更新する
-	jumpCooldownTimer_ = std::max(0.0f, jumpCooldownTimer_ - deltaTime);
+	jumpState_.cooldownTimer = std::max(0.0f, jumpState_.cooldownTimer - deltaTime);
 
 	// 優先度の高い行動から順に評価して近接敵の行動を決定する
 	EvaluateBehavior(deltaTime);
 	EnemyBase::Update(deltaTime);
 
-	usingWorldAABBCount_ = GetResolvedWorldAABBs() ? static_cast<int>(GetResolvedWorldAABBs()->size()) : 0;
-	usingObstacleAABBCount_ = GetResolvedNavigationObstacleAABBs() ? static_cast<int>(GetResolvedNavigationObstacleAABBs()->size()) : 0;
-	collisionManagerRegistered_ = true;
-	lastCollisionCount_ = 0;
-	pushedThisFrame_ = false;
-	restoredToSafePosition_ = false;
+	collision_.usingWorldAABBCount = GetResolvedWorldAABBs() ? static_cast<int>(GetResolvedWorldAABBs()->size()) : 0;
+	collision_.usingObstacleAABBCount = GetResolvedNavigationObstacleAABBs() ? static_cast<int>(GetResolvedNavigationObstacleAABBs()->size()) : 0;
+	collision_.collisionManagerRegistered = true;
+	collision_.lastCollisionCount = 0;
+	collision_.pushedThisFrame = false;
+	collision_.restoredToSafePosition = false;
 	const auto* floorAabbs = floorAABBs_ ? floorAABBs_ : GetResolvedWorldAABBs();
 	worldAABBs_ = floorAabbs;
 	Vector3 afterPos = GetCenterPosition();
@@ -80,19 +80,19 @@ void MeleeEnemy::Update(float deltaTime)
 	// 押し出し補正の暴発でステージ外へ飛ばされるのを防ぐため、フレーム補正量を制限する
 	const float pushLen = std::sqrt(push.x * push.x + push.y * push.y + push.z * push.z);
 	const float horizontalPushLen = LengthXZ(push);
-	if (pushLen > maxResolvePushPerFrame_ || horizontalPushLen > maxHorizontalPushPerFrame_)
+	if (pushLen > move_.maxResolvePushPerFrame || horizontalPushLen > move_.maxHorizontalPushPerFrame)
 	{
-		const float clampScale = std::min(maxResolvePushPerFrame_ / std::max(pushLen, kEpsilon), maxHorizontalPushPerFrame_ / std::max(horizontalPushLen, kEpsilon));
+		const float clampScale = std::min(move_.maxResolvePushPerFrame / std::max(pushLen, kEpsilon), move_.maxHorizontalPushPerFrame / std::max(horizontalPushLen, kEpsilon));
 		afterPos = beforePos + (afterPos - beforePos) * std::max(0.0f, std::min(1.0f, clampScale));
 		SetCenterPosition(afterPos);
 	}
-	lastResolvePush_ = afterPos - beforePos;
+	collision_.lastResolvePush = afterPos - beforePos;
 	if (ResolveObstaclePenetrationXZ(deltaTime))
 	{
 		afterPos = GetCenterPosition();
-		lineBlocked_ = true;
-		blockedObstacleName_ = lastBlockedObstacleName_;
-		pushedThisFrame_ = true;
+		pathState_.lineBlocked = true;
+		pathState_.blockedObstacleName = collision_.lastBlockedObstacleName;
+		collision_.pushedThisFrame = true;
 	}
 
 
@@ -105,34 +105,34 @@ void MeleeEnemy::Update(float deltaTime)
 			const float sizeY = aabb.max.y - aabb.min.y;
 			if (sizeX > 2.0f && sizeZ > 2.0f && sizeY <= 3.5f)
 			{
-				if (!hasStageBounds_)
+				if (!collision_.hasStageBounds)
 				{
-					stageBoundsMin_ = aabb.min;
-					stageBoundsMax_ = aabb.max;
-					hasStageBounds_ = true;
+					collision_.stageBoundsMin = aabb.min;
+					collision_.stageBoundsMax = aabb.max;
+					collision_.hasStageBounds = true;
 				}
 				else
 				{
-					stageBoundsMin_.x = std::min(stageBoundsMin_.x, aabb.min.x);
-					stageBoundsMin_.z = std::min(stageBoundsMin_.z, aabb.min.z);
-					stageBoundsMax_.x = std::max(stageBoundsMax_.x, aabb.max.x);
-					stageBoundsMax_.z = std::max(stageBoundsMax_.z, aabb.max.z);
+					collision_.stageBoundsMin.x = std::min(collision_.stageBoundsMin.x, aabb.min.x);
+					collision_.stageBoundsMin.z = std::min(collision_.stageBoundsMin.z, aabb.min.z);
+					collision_.stageBoundsMax.x = std::max(collision_.stageBoundsMax.x, aabb.max.x);
+					collision_.stageBoundsMax.z = std::max(collision_.stageBoundsMax.z, aabb.max.z);
 				}
 			}
 		}
 	}
 
-	isOutsideStage_ = hasStageBounds_ && !IsInsideStageBounds(GetCenterPosition());
-	isOnFloor_ = grounded_;
-	if (grounded_ && !isOutsideStage_ && !isOverlappingWallObstacle_)
+	collision_.isOutsideStage = collision_.hasStageBounds && !IsInsideStageBounds(GetCenterPosition());
+	collision_.isOnFloor = grounded_;
+	if (grounded_ && !collision_.isOutsideStage && !collision_.isOverlappingWallObstacle)
 	{
-		lastSafePosition_ = GetCenterPosition();
+		collision_.lastSafePosition = GetCenterPosition();
 	}
-	else if (isOutsideStage_)
+	else if (collision_.isOutsideStage)
 	{
 		// 押し出し補正が大きすぎる場合は安全位置へ戻し、ステージ外へ弾き出されるのを防ぐ
-		SetCenterPosition(lastSafePosition_);
-		restoredToSafePosition_ = true;
+		SetCenterPosition(collision_.lastSafePosition);
+		collision_.restoredToSafePosition = true;
 		SetVelocity({ 0.0f, GetVelocity().y, 0.0f });
 	}
 
@@ -145,19 +145,19 @@ bool MeleeEnemy::ResolveObstaclePenetrationXZ(float deltaTime)
 {
 	(void)deltaTime;
 	const auto* obstacleAabbs = wallObstacleAABBs_ ? wallObstacleAABBs_ : GetResolvedNavigationObstacleAABBs();
-	usingObstacleAABBCount_ = obstacleAabbs ? static_cast<int>(obstacleAabbs->size()) : 0;
-	isCollidingWithStage_ = false;
-	blockedByObstacle_ = false;
-	lastStageCollisionType_ = "None";
-	lastStageCollisionName_ = "None";
-	lastBlockedObstacleName_ = "None";
-	isOverlappingWallObstacle_ = false;
-	lastWallResolvePush_ = { 0.0f, 0.0f, 0.0f };
+	collision_.usingObstacleAABBCount = obstacleAabbs ? static_cast<int>(obstacleAabbs->size()) : 0;
+	collision_.isCollidingWithStage = false;
+	collision_.blockedByObstacle = false;
+	collision_.lastStageCollisionType = "None";
+	collision_.lastStageCollisionName = "None";
+	collision_.lastBlockedObstacleName = "None";
+	collision_.isOverlappingWallObstacle = false;
+	collision_.lastWallResolvePush = { 0.0f, 0.0f, 0.0f };
 	if (!obstacleAabbs || obstacleAabbs->empty()) { return false; }
 
 	Vector3 pos = GetCenterPosition();
 	const Vector3 half = { 1.0f, 2.0f, 1.0f };
-	const float maxPush = std::max(0.05f, maxHorizontalPushPerFrame_);
+	const float maxPush = std::max(0.05f, move_.maxHorizontalPushPerFrame);
 	bool resolved = false;
 	for (size_t i = 0; i < obstacleAabbs->size(); ++i)
 	{
@@ -166,13 +166,13 @@ bool MeleeEnemy::ResolveObstaclePenetrationXZ(float deltaTime)
 		const float overlapX = std::min(pos.x + half.x, o.max.x) - std::max(pos.x - half.x, o.min.x);
 		const float overlapZ = std::min(pos.z + half.z, o.max.z) - std::max(pos.z - half.z, o.min.z);
 		if (overlapX <= 0.0f || overlapZ <= 0.0f) { continue; }
-		isCollidingWithStage_ = true;
-		isOverlappingWallObstacle_ = true;
-		blockedByObstacle_ = true;
-		lastStageCollisionType_ = "Obstacle";
-		lastStageCollisionName_ = "Obstacle[" + std::to_string(i) + "]";
-		lastWallObstacleName_ = lastStageCollisionName_;
-		lastBlockedObstacleName_ = lastStageCollisionName_;
+		collision_.isCollidingWithStage = true;
+		collision_.isOverlappingWallObstacle = true;
+		collision_.blockedByObstacle = true;
+		collision_.lastStageCollisionType = "Obstacle";
+		collision_.lastStageCollisionName = "Obstacle[" + std::to_string(i) + "]";
+		collision_.lastWallObstacleName = collision_.lastStageCollisionName;
+		collision_.lastBlockedObstacleName = collision_.lastStageCollisionName;
 		float pushX = 0.0f, pushZ = 0.0f;
 		if (overlapX < overlapZ) { pushX = (pos.x < (o.min.x + o.max.x) * 0.5f ? -overlapX : overlapX); }
 		else { pushZ = (pos.z < (o.min.z + o.max.z) * 0.5f ? -overlapZ : overlapZ); }
@@ -180,8 +180,8 @@ bool MeleeEnemy::ResolveObstaclePenetrationXZ(float deltaTime)
 		pushZ = std::clamp(pushZ, -maxPush, maxPush);
 		pos.x += pushX;
 		pos.z += pushZ;
-		lastWallResolvePush_.x += pushX;
-		lastWallResolvePush_.z += pushZ;
+		collision_.lastWallResolvePush.x += pushX;
+		collision_.lastWallResolvePush.z += pushZ;
 		auto vel = GetVelocity();
 		if ((pushX < 0.0f && vel.x > 0.0f) || (pushX > 0.0f && vel.x < 0.0f)) vel.x = 0.0f;
 		if ((pushZ < 0.0f && vel.z > 0.0f) || (pushZ > 0.0f && vel.z < 0.0f)) vel.z = 0.0f;
@@ -193,7 +193,7 @@ bool MeleeEnemy::ResolveObstaclePenetrationXZ(float deltaTime)
 		// Floorは接地用、Obstacle系は横押し出し用として分け、MeleeEnemyが壁へ埋まらないようにする
 		SetCenterPosition(pos);
 		navigator_.Reset();
-		lastRepathReason_ = "ObstaclePushResolve";
+		pathState_.lastRepathReason = "ObstaclePushResolve";
 	}
 	return resolved;
 }
@@ -206,11 +206,11 @@ void MeleeEnemy::OnCollisionEnter(K4E::Collider* other)
 	if (!other) { return; }
 	if (other->GetTypeID() == static_cast<uint32_t>(CollisionTypeIdDef::kWorld))
 	{
-		isCollidingWithStage_ = true;
-		isOverlappingWallObstacle_ = true;
-		lastStageCollisionType_ = "World";
-		lastStageCollisionName_ = "StageCollider";
-		++lastCollisionCount_;
+		collision_.isCollidingWithStage = true;
+		collision_.isOverlappingWallObstacle = true;
+		collision_.lastStageCollisionType = "World";
+		collision_.lastStageCollisionName = "StageCollider";
+		++collision_.lastCollisionCount;
 	}
 }
 
@@ -222,10 +222,10 @@ void MeleeEnemy::Draw()
 {
 	EnemyBase::Draw();
 	const Vector3 origin = GetCenterPosition() + Vector3{ 0.0f, 1.0f, 0.0f };
-	Wireframe::GetInstance()->DrawLine(origin, origin + movementDirection_ * 1.8f, { 0.2f, 0.8f, 1.0f, 1.0f });
-	Wireframe::GetInstance()->DrawLine(origin, origin + targetDirection_ * 2.0f, { 1.0f, 1.0f, 0.2f, 1.0f });
-	Wireframe::GetInstance()->DrawLine(origin, origin + visualForward_ * 2.2f, { 1.0f, 0.4f, 1.0f, 1.0f });
-	Wireframe::GetInstance()->DrawLine(origin, origin + attackForward_ * 2.4f, { 1.0f, 0.2f, 0.2f, 1.0f });
+	Wireframe::GetInstance()->DrawLine(origin, origin + animationState_.movementDirection * 1.8f, { 0.2f, 0.8f, 1.0f, 1.0f });
+	Wireframe::GetInstance()->DrawLine(origin, origin + animationState_.targetDirection * 2.0f, { 1.0f, 1.0f, 0.2f, 1.0f });
+	Wireframe::GetInstance()->DrawLine(origin, origin + animationState_.visualForward * 2.2f, { 1.0f, 0.4f, 1.0f, 1.0f });
+	Wireframe::GetInstance()->DrawLine(origin, origin + animationState_.attackForward * 2.4f, { 1.0f, 0.2f, 0.2f, 1.0f });
 	const auto& path = navigator_.GetCurrentPath();
 	for (size_t i = 1; i < path.size(); ++i)
 	{
@@ -236,9 +236,9 @@ void MeleeEnemy::Draw()
 		const Vector4 c = (static_cast<int>(i) == navigator_.GetCurrentPathIndex()) ? Vector4{ 1.0f, 0.3f, 0.1f, 1.0f } : Vector4{ 0.1f, 0.9f, 1.0f, 1.0f };
 		Wireframe::GetInstance()->DrawSphere(path[i] + Vector3{ 0.0f, 0.2f, 0.0f }, (static_cast<int>(i) == navigator_.GetCurrentPathIndex()) ? 0.26f : 0.16f, c);
 	}
-	if (lineBlocked_)
+	if (pathState_.lineBlocked)
 	{
-		Wireframe::GetInstance()->DrawLine(blockedSegmentFrom_ + Vector3{ 0.0f, 0.2f, 0.0f }, blockedSegmentTo_ + Vector3{ 0.0f, 0.2f, 0.0f }, { 1.0f, 0.15f, 0.1f, 1.0f });
+		Wireframe::GetInstance()->DrawLine(pathState_.blockedSegmentFrom + Vector3{ 0.0f, 0.2f, 0.0f }, pathState_.blockedSegmentTo + Vector3{ 0.0f, 0.2f, 0.0f }, { 1.0f, 0.15f, 0.1f, 1.0f });
 	}
 	if (HasTarget())
 	{
@@ -261,119 +261,125 @@ void MeleeEnemy::DrawImGui()
 	if (ImGui::Begin("MeleeEnemy Debug"))
 	{
 		EnemyBase::DrawImGui();
-		ImGui::SliderFloat("detectRange", &detectRange_, 1.0f, 50.0f);
-		ImGui::SliderFloat("meleeAttackRange", &meleeAttackRange_, 0.5f, 10.0f);
-		ImGui::SliderFloat("moveSpeed", &moveSpeed_, 0.1f, 10.0f);
-		ImGui::SliderFloat("stopDistance", &stopDistance_, 0.5f, 6.0f);
-		ImGui::SliderFloat("attackStartRange", &attackStartRange_, 0.5f, 8.0f);
-		ImGui::SliderFloat("resumeChaseDistance", &resumeChaseDistance_, 0.5f, 10.0f);
-		ImGui::SliderFloat("attackLockTime", &attackLockTime_, 0.0f, 1.0f);
-		ImGui::SliderFloat("rotateSpeed", &rotateSpeed_, 0.1f, 20.0f);
-		ImGui::Text("visualYawOffset(rad): %.3f (fixed)", visualYawOffset_);
-		ImGui::SliderFloat("walkAnimSpeed", &walkAnimSpeed_, 1.0f, 18.0f);
-		ImGui::SliderFloat("walkArmSwing", &walkArmSwing_, 0.0f, 1.5f);
-		ImGui::SliderFloat("walkLegSwing", &walkLegSwing_, 0.0f, 1.5f);
-		ImGui::SliderFloat("attackArmSwing", &attackArmSwing_, 0.0f, 2.0f);
-		ImGui::SliderFloat("attackReturnSpeed", &attackReturnSpeed_, 1.0f, 24.0f);
-		ImGui::SliderFloat("attackBodyLean", &attackBodyLean_, 0.0f, 0.4f);
-		ImGui::SliderFloat("maxResolvePushPerFrame", &maxResolvePushPerFrame_, 0.05f, 2.0f);
-		ImGui::SliderFloat("stuckCheckTime", &stuckCheckTime_, 0.1f, 3.0f);
-		ImGui::SliderFloat("stuckDistance", &stuckDistance_, 0.01f, 2.0f);
-		ImGui::SliderFloat("stuckMoveThreshold", &stuckMoveThreshold_, 0.03f, 1.2f);
-		ImGui::SliderFloat("repathInterval", &repathInterval_, 0.05f, 2.0f);
-		ImGui::SliderFloat("waypointReachDistance", &waypointReachDistance_, 0.5f, 1.5f);
-		ImGui::Checkbox("pathFindEnabled", &pathFindEnabled_);
-		ImGui::Checkbox("jumpEnabled", &jumpEnabled_);
-		ImGui::SliderFloat("jumpVelocity", &jumpVelocity_, 2.0f, 18.0f);
-		ImGui::SliderFloat("jumpTargetHeightThreshold", &jumpTargetHeightThreshold_, 0.1f, 5.0f);
-		ImGui::SliderFloat("jumpHorizontalDistanceMax", &jumpHorizontalDistanceMax_, 0.5f, 20.0f);
-		ImGui::SliderFloat("jumpCooldown", &jumpCooldown_, 0.0f, 3.0f);
-		const float prevGridSize = pathGridSize_;
-		ImGui::SliderFloat("pathGridSize", &pathGridSize_, 0.5f, 1.0f);
-		if (std::abs(prevGridSize - pathGridSize_) > kEpsilon) { navigator_.Reset(); lastRepathReason_ = "GridSizeChanged"; }
-		ImGui::SliderFloat("pathSearchRadius", &pathSearchRadius_, 6.0f, 80.0f);
-		ImGui::SliderFloat("obstacleExpandRadius", &obstacleExpandRadius_, 0.7f, 1.6f);
-		ImGui::SliderFloat("temporaryBlockDuration", &temporaryBlockDuration_, 0.3f, 4.0f);
-		ImGui::SliderFloat("temporaryBlockRadius", &temporaryBlockRadius_, 0.4f, 2.2f);
-		ImGui::Checkbox("cornerCuttingDisabled", &cornerCuttingDisabled_);
+		ImGui::SliderFloat("detectRange", &detection_.detectRange, 1.0f, 50.0f);
+		ImGui::SliderFloat("meleeAttackRange", &detection_.meleeAttackRange, 0.5f, 10.0f);
+		ImGui::SliderFloat("moveSpeed", &move_.moveSpeed, 0.1f, 10.0f);
+		ImGui::SliderFloat("stopDistance", &detection_.stopDistance, 0.5f, 6.0f);
+		ImGui::SliderFloat("attackStartRange", &detection_.attackStartRange, 0.5f, 8.0f);
+		ImGui::SliderFloat("resumeChaseDistance", &detection_.resumeChaseDistance, 0.5f, 10.0f);
+		ImGui::SliderFloat("attackLockTime", &attackSettings_.lockTime, 0.0f, 1.0f);
+		ImGui::SliderFloat("rotateSpeed", &move_.rotateSpeed, 0.1f, 20.0f);
+		ImGui::Text("visualYawOffset(rad): %.3f (fixed)", animation_.visualYawOffset);
+		ImGui::SliderFloat("walkAnimSpeed", &animation_.walkAnimSpeed, 1.0f, 18.0f);
+		ImGui::SliderFloat("walkArmSwing", &animation_.walkArmSwing, 0.0f, 1.5f);
+		ImGui::SliderFloat("walkLegSwing", &animation_.walkLegSwing, 0.0f, 1.5f);
+		ImGui::SliderFloat("attackArmSwing", &animation_.attackArmSwing, 0.0f, 2.0f);
+		ImGui::SliderFloat("attackReturnSpeed", &animation_.attackReturnSpeed, 1.0f, 24.0f);
+		ImGui::SliderFloat("attackBodyLean", &animation_.attackBodyLean, 0.0f, 0.4f);
+		ImGui::SliderFloat("maxResolvePushPerFrame", &move_.maxResolvePushPerFrame, 0.05f, 2.0f);
+		ImGui::SliderFloat("stuckCheckTime", &stuckSettings_.checkTime, 0.1f, 3.0f);
+		ImGui::SliderFloat("stuckDistance", &stuckSettings_.distance, 0.01f, 2.0f);
+		ImGui::SliderFloat("stuckMoveThreshold", &stuckSettings_.moveThreshold, 0.03f, 1.2f);
+		ImGui::SliderFloat("repathInterval", &pathSettings_.repathInterval, 0.05f, 2.0f);
+		ImGui::SliderFloat("waypointReachDistance", &pathSettings_.waypointReachDistance, 0.5f, 1.5f);
+		ImGui::Checkbox("pathFindEnabled", &pathSettings_.enabled);
+		ImGui::Checkbox("jumpEnabled", &jump_.enabled);
+		ImGui::SliderFloat("baseJumpVelocity", &jump_.baseVelocity, 2.0f, 18.0f);
+		ImGui::SliderFloat("jumpExtraBoost", &jump_.extraBoost, 0.0f, 8.0f);
+		ImGui::SliderFloat("jumpGravityEstimate", &jump_.gravityEstimate, 1.0f, 40.0f);
+		ImGui::SliderFloat("maxJumpVelocity", &jump_.maxVelocity, 1.0f, 30.0f);
+		ImGui::SliderFloat("jumpTargetHeightThreshold", &jump_.targetHeightThreshold, 0.1f, 5.0f);
+		ImGui::SliderFloat("jumpHorizontalDistanceMax", &jump_.horizontalDistanceMax, 0.5f, 20.0f);
+		ImGui::SliderFloat("jumpCooldown", &jump_.cooldown, 0.0f, 3.0f);
+		const float prevGridSize = pathSettings_.gridSize;
+		ImGui::SliderFloat("pathGridSize", &pathSettings_.gridSize, 0.5f, 1.0f);
+		if (std::abs(prevGridSize - pathSettings_.gridSize) > kEpsilon) { navigator_.Reset(); pathState_.lastRepathReason = "GridSizeChanged"; }
+		ImGui::SliderFloat("pathSearchRadius", &pathSettings_.searchRadius, 6.0f, 80.0f);
+		ImGui::SliderFloat("obstacleExpandRadius", &pathSettings_.obstacleExpandRadius, 0.7f, 1.6f);
+		ImGui::SliderFloat("temporaryBlockDuration", &pathSettings_.temporaryBlockDuration, 0.3f, 4.0f);
+		ImGui::SliderFloat("temporaryBlockRadius", &pathSettings_.temporaryBlockRadius, 0.4f, 2.2f);
+		ImGui::Checkbox("cornerCuttingDisabled", &pathSettings_.cornerCuttingDisabled);
 
-		int attackSelect = static_cast<int>(selectedAttackType_);
+		int attackSelect = static_cast<int>(attackSettings_.selectedAttackType);
 		const char* attackItems[] = { "Scratch", "OneTwo" };
 		if (ImGui::Combo("AttackPattern", &attackSelect, attackItems, IM_ARRAYSIZE(attackItems)))
 		{
-			selectedAttackType_ = static_cast<MeleeAttackType>(attackSelect);
+			attackSettings_.selectedAttackType = static_cast<MeleeAttackType>(attackSelect);
 		}
 		ImGui::Text("Selected Attack: %s", attackItems[attackSelect]);
 		ImGui::Text("Current BT: %s", currentBehaviorName_);
 		ImGui::Text("Current Attack Name: %s", attackController_.GetCurrentAttackName());
 		ImGui::Text("Distance To Target: %.2f", GetDistanceToTarget());
 		ImGui::Text("Is Attacking: %s", attackController_.IsAttacking() ? "true" : "false");
-		ImGui::Text("Stuck: %s", isStuck_ ? "true" : "false");
+		ImGui::Text("Stuck: %s", stuck_.isStuck ? "true" : "false");
 		ImGui::Text("Position: (%.2f, %.2f, %.2f)", GetCenterPosition().x, GetCenterPosition().y, GetCenterPosition().z);
 		ImGui::Text("Velocity: (%.2f, %.2f, %.2f)", GetVelocity().x, GetVelocity().y, GetVelocity().z);
 		ImGui::Text("Attack Elapsed: %.2f", attackController_.GetAttackElapsed());
 		ImGui::Text("Attack Step Index: %d", attackController_.GetCurrentStepIndex());
 		ImGui::Text("Cooldown Remaining: %.2f", attackController_.GetCooldownRemaining());
-		ImGui::Text("attackLockTimer: %.2f", attackLockTimer_);
+		ImGui::Text("attackLockTimer: %.2f", attackState_.lockTimer);
 		ImGui::Text("Attack Active: %s", attackController_.IsCurrentStepActive() ? "true" : "false");
 		ImGui::Text("Last Hit: %s", attackController_.WasLastHitSuccess() ? "Hit" : "Miss");
-		ImGui::Text("Path Found: %s", pathFound_ ? "true" : "false");
+		ImGui::Text("Path Found: %s", pathState_.found ? "true" : "false");
 		ImGui::Text("Obstacle Count: %zu", GetResolvedWorldAABBs() ? GetResolvedWorldAABBs()->size() : 0);
-		ImGui::Text("isCollidingWithStage: %s", isCollidingWithStage_ ? "true" : "false");
-		ImGui::Text("lastStageCollisionType: %s", lastStageCollisionType_.c_str());
-		ImGui::Text("lastStageCollisionName: %s", lastStageCollisionName_.c_str());
-		ImGui::Text("usingWorldAABBCount: %d", usingWorldAABBCount_);
-		ImGui::Text("floorAABBCount: %d", floorAABBs_ ? static_cast<int>(floorAABBs_->size()) : usingWorldAABBCount_);
-		ImGui::Text("wallObstacleAABBCount: %d", wallObstacleAABBs_ ? static_cast<int>(wallObstacleAABBs_->size()) : usingObstacleAABBCount_);
-		ImGui::Text("usingObstacleAABBCount: %d", usingObstacleAABBCount_);
-		ImGui::Text("collisionManagerRegistered: %s", collisionManagerRegistered_ ? "true" : "false");
-		ImGui::Text("lastCollisionCount: %d", lastCollisionCount_);
-		ImGui::Text("blockedByObstacle: %s", blockedByObstacle_ ? "true" : "false");
-		ImGui::Text("isOnFloor: %s", isOnFloor_ ? "true" : "false");
-		ImGui::Text("isOverlappingWallObstacle: %s", isOverlappingWallObstacle_ ? "true" : "false");
-		ImGui::Text("lastWallObstacleName: %s", lastWallObstacleName_.c_str());
-		ImGui::Text("lastWallResolvePush: (%.2f, %.2f, %.2f)", lastWallResolvePush_.x, lastWallResolvePush_.y, lastWallResolvePush_.z);
-		ImGui::Text("lastBlockedObstacleName: %s", lastBlockedObstacleName_.c_str());
+		ImGui::Text("isCollidingWithStage: %s", collision_.isCollidingWithStage ? "true" : "false");
+		ImGui::Text("lastStageCollisionType: %s", collision_.lastStageCollisionType.c_str());
+		ImGui::Text("lastStageCollisionName: %s", collision_.lastStageCollisionName.c_str());
+		ImGui::Text("usingWorldAABBCount: %d", collision_.usingWorldAABBCount);
+		ImGui::Text("floorAABBCount: %d", floorAABBs_ ? static_cast<int>(floorAABBs_->size()) : collision_.usingWorldAABBCount);
+		ImGui::Text("wallObstacleAABBCount: %d", wallObstacleAABBs_ ? static_cast<int>(wallObstacleAABBs_->size()) : collision_.usingObstacleAABBCount);
+		ImGui::Text("usingObstacleAABBCount: %d", collision_.usingObstacleAABBCount);
+		ImGui::Text("collisionManagerRegistered: %s", collision_.collisionManagerRegistered ? "true" : "false");
+		ImGui::Text("lastCollisionCount: %d", collision_.lastCollisionCount);
+		ImGui::Text("blockedByObstacle: %s", collision_.blockedByObstacle ? "true" : "false");
+		ImGui::Text("isOnFloor: %s", collision_.isOnFloor ? "true" : "false");
+		ImGui::Text("isOverlappingWallObstacle: %s", collision_.isOverlappingWallObstacle ? "true" : "false");
+		ImGui::Text("lastWallObstacleName: %s", collision_.lastWallObstacleName.c_str());
+		ImGui::Text("lastWallResolvePush: (%.2f, %.2f, %.2f)", collision_.lastWallResolvePush.x, collision_.lastWallResolvePush.y, collision_.lastWallResolvePush.z);
+		ImGui::Text("lastBlockedObstacleName: %s", collision_.lastBlockedObstacleName.c_str());
 		ImGui::Text("Path Node Count: %d", static_cast<int>(navigator_.GetCurrentPath().size()));
 		ImGui::Text("Current Waypoint Index: %d", navigator_.GetCurrentPathIndex());
-		ImGui::Text("Current Waypoint: (%.2f, %.2f, %.2f)", currentPathWaypoint_.x, currentPathWaypoint_.y, currentPathWaypoint_.z);
-		ImGui::Text("Last Repath Timer: %.2f", lastRepathTimer_);
+		ImGui::Text("Current Waypoint: (%.2f, %.2f, %.2f)", pathState_.currentWaypoint.x, pathState_.currentWaypoint.y, pathState_.currentWaypoint.z);
+		ImGui::Text("Last Repath Timer: %.2f", pathState_.lastRepathTimer);
 		ImGui::Text("Repath Timer: %.2f", navigator_.GetRepathTimer());
-		ImGui::Text("TargetMovedDistanceForRepath: %.2f", targetMovedDistanceForRepath_);
-		ImGui::Text("Path Failure Reason: %s", pathFailureReason_.c_str());
-		ImGui::Text("Last Repath Reason: %s", lastRepathReason_.c_str());
-		ImGui::Text("lineBlocked: %s", lineBlocked_ ? "true" : "false");
-		ImGui::Text("blockedObstacleName: %s", blockedObstacleName_.c_str());
-		ImGui::Text("blockedWaypointIndex: %d", blockedWaypointIndex_);
-		ImGui::Text("stuckTimer: %.2f", stuckTimer_);
-		ImGui::Text("lastMovedDistance: %.3f", lastMovedDistance_);
+		ImGui::Text("TargetMovedDistanceForRepath: %.2f", pathState_.targetMovedDistanceForRepath);
+		ImGui::Text("Path Failure Reason: %s", pathState_.failureReason.c_str());
+		ImGui::Text("Last Repath Reason: %s", pathState_.lastRepathReason.c_str());
+		ImGui::Text("lineBlocked: %s", pathState_.lineBlocked ? "true" : "false");
+		ImGui::Text("blockedObstacleName: %s", pathState_.blockedObstacleName.c_str());
+		ImGui::Text("blockedWaypointIndex: %d", pathState_.blockedWaypointIndex);
+		ImGui::Text("stuckTimer: %.2f", stuck_.timer);
+		ImGui::Text("lastMovedDistance: %.3f", pathState_.lastMovedDistance);
 		ImGui::Text("temporaryBlockedCellCount: %d", static_cast<int>(navigator_.GetTemporaryBlockedAreas().size()));
-		ImGui::Text("cornerCuttingDisabled: %s", cornerCuttingDisabled_ ? "true" : "false");
+		ImGui::Text("cornerCuttingDisabled: %s", pathSettings_.cornerCuttingDisabled ? "true" : "false");
 		ImGui::Text("Grounded: %s", grounded_ ? "true" : "false");
-		ImGui::Text("jumpCooldownTimer: %.2f", jumpCooldownTimer_);
-		ImGui::Text("lastJumpReason: %s", lastJumpReason_.c_str());
+		ImGui::Text("jumpCooldownTimer: %.2f", jumpState_.cooldownTimer);
+		ImGui::Text("targetHeightDelta: %.2f", jumpState_.targetHeightDelta);
+		ImGui::Text("calculatedJumpVelocity: %.2f", jumpState_.calculatedVelocity);
+		ImGui::Text("appliedJumpVelocity: %.2f", jumpState_.appliedVelocity);
+		ImGui::Text("lastJumpReason: %s", jumpState_.lastReason.c_str());
 		ImGui::Text("AnimState: %s", GetAnimStateName());
-		ImGui::Text("lastSafePosition: (%.2f, %.2f, %.2f)", lastSafePosition_.x, lastSafePosition_.y, lastSafePosition_.z);
-		ImGui::Text("isOutsideStage: %s", isOutsideStage_ ? "true" : "false");
-		ImGui::Text("lastResolvePush: (%.2f, %.2f, %.2f)", lastResolvePush_.x, lastResolvePush_.y, lastResolvePush_.z);
-		ImGui::Text("pushedByWallThisFrame: %s", pushedThisFrame_ ? "true" : "false");
-		ImGui::Text("restoredToSafePosition: %s", restoredToSafePosition_ ? "true" : "false");
+		ImGui::Text("lastSafePosition: (%.2f, %.2f, %.2f)", collision_.lastSafePosition.x, collision_.lastSafePosition.y, collision_.lastSafePosition.z);
+		ImGui::Text("isOutsideStage: %s", collision_.isOutsideStage ? "true" : "false");
+		ImGui::Text("lastResolvePush: (%.2f, %.2f, %.2f)", collision_.lastResolvePush.x, collision_.lastResolvePush.y, collision_.lastResolvePush.z);
+		ImGui::Text("pushedByWallThisFrame: %s", collision_.pushedThisFrame ? "true" : "false");
+		ImGui::Text("restoredToSafePosition: %s", collision_.restoredToSafePosition ? "true" : "false");
 		const Vector3 tgt = GetTargetPosition();
 		ImGui::Text("Target: (%.2f, %.2f, %.2f)", tgt.x, tgt.y, tgt.z);
-		ImGui::Text("rawYaw(rad): %.3f", rawYaw_);
-		ImGui::Text("finalVisualYaw(rad): %.3f", finalVisualYaw_);
-		ImGui::Text("rawYaw(deg): %.1f", rawYaw_ * (180.0f / kPi));
-		ImGui::Text("finalVisualYaw(deg): %.1f", finalVisualYaw_ * (180.0f / kPi));
-		ImGui::Text("currentYaw(deg): %.1f", debugCurrentYaw_ * (180.0f / kPi));
-		ImGui::Text("targetYaw(deg): %.1f", debugTargetYaw_ * (180.0f / kPi));
-		ImGui::Text("deltaYaw(deg): %.1f", debugDeltaYaw_ * (180.0f / kPi));
-		ImGui::Text("normalizedDeltaYaw(deg): %.1f", debugNormalizedDeltaYaw_ * (180.0f / kPi));
-		ImGui::Text("rotateSpeed: %.2f", rotateSpeed_);
-		ImGui::Text("facingDirection: (%.2f, %.2f, %.2f)", facingDirection_.x, facingDirection_.y, facingDirection_.z);
-		ImGui::Text("movementDir: (%.2f, %.2f, %.2f)", movementDirection_.x, movementDirection_.y, movementDirection_.z);
-		ImGui::Text("targetDirection: (%.2f, %.2f, %.2f)", targetDirection_.x, targetDirection_.y, targetDirection_.z);
-		ImGui::Text("visualForward: (%.2f, %.2f, %.2f)", visualForward_.x, visualForward_.y, visualForward_.z);
-		ImGui::Text("attackForward: (%.2f, %.2f, %.2f)", attackForward_.x, attackForward_.y, attackForward_.z);
+		ImGui::Text("rawYaw(rad): %.3f", animationState_.rawYaw);
+		ImGui::Text("finalVisualYaw(rad): %.3f", animationState_.finalVisualYaw);
+		ImGui::Text("rawYaw(deg): %.1f", animationState_.rawYaw * (180.0f / kPi));
+		ImGui::Text("finalVisualYaw(deg): %.1f", animationState_.finalVisualYaw * (180.0f / kPi));
+		ImGui::Text("currentYaw(deg): %.1f", animationState_.debugCurrentYaw * (180.0f / kPi));
+		ImGui::Text("targetYaw(deg): %.1f", animationState_.debugTargetYaw * (180.0f / kPi));
+		ImGui::Text("deltaYaw(deg): %.1f", animationState_.debugDeltaYaw * (180.0f / kPi));
+		ImGui::Text("normalizedDeltaYaw(deg): %.1f", animationState_.debugNormalizedDeltaYaw * (180.0f / kPi));
+		ImGui::Text("rotateSpeed: %.2f", move_.rotateSpeed);
+		ImGui::Text("facingDirection: (%.2f, %.2f, %.2f)", animationState_.facingDirection.x, animationState_.facingDirection.y, animationState_.facingDirection.z);
+		ImGui::Text("movementDir: (%.2f, %.2f, %.2f)", animationState_.movementDirection.x, animationState_.movementDirection.y, animationState_.movementDirection.z);
+		ImGui::Text("targetDirection: (%.2f, %.2f, %.2f)", animationState_.targetDirection.x, animationState_.targetDirection.y, animationState_.targetDirection.z);
+		ImGui::Text("visualForward: (%.2f, %.2f, %.2f)", animationState_.visualForward.x, animationState_.visualForward.y, animationState_.visualForward.z);
+		ImGui::Text("attackForward: (%.2f, %.2f, %.2f)", animationState_.attackForward.x, animationState_.attackForward.y, animationState_.attackForward.z);
 		if (ImGui::Button("Force Scratch Attack")) { ForceAttack(MeleeAttackType::Scratch); }
 		ImGui::SameLine();
 		if (ImGui::Button("Force OneTwo Attack")) { ForceAttack(MeleeAttackType::OneTwo); }
@@ -423,7 +429,7 @@ void MeleeEnemy::DrawImGui()
 				ImGui::SliderFloat("OneTwo Right Radius", &right.radius, 0.1f, 3.0f);
 				ImGui::SliderFloat("OneTwo Forward Speed", &oneTwo->forwardMoveSpeed, 0.0f, 5.0f);
 				ImGui::SliderFloat("OneTwo Forward Duration", &oneTwo->forwardMoveDuration, 0.0f, 2.0f);
-				ImGui::SliderFloat("OneTwo MinForwardDistance", &minOneTwoForwardDistance_, 0.1f, 5.0f);
+				ImGui::SliderFloat("OneTwo MinForwardDistance", &detection_.minOneTwoForwardDistance, 0.1f, 5.0f);
 				ImGui::SliderFloat("OneTwo Recovery", &oneTwo->recoveryTime, 0.01f, 2.0f);
 				ImGui::SliderFloat("OneTwo Cooldown", &oneTwo->cooldown, 0.01f, 3.0f);
 				ImGui::TreePop();
@@ -454,34 +460,34 @@ Vector3 MeleeEnemy::GetTargetPositionForAttack() const
 	return GetTargetPosition();
 }
 
-bool MeleeEnemy::IsTargetInDetectRange() const { return GetDistanceToTarget() <= detectRange_; }
-bool MeleeEnemy::IsTargetInMeleeRange() const { return GetDistanceToTarget() <= meleeAttackRange_; }
-bool MeleeEnemy::IsTargetInAttackStartRange() const { return GetDistanceToTarget() <= attackStartRange_; }
-bool MeleeEnemy::IsTargetInAttackHoldRange() const { return GetDistanceToTarget() <= resumeChaseDistance_; }
+bool MeleeEnemy::IsTargetInDetectRange() const { return GetDistanceToTarget() <= detection_.detectRange; }
+bool MeleeEnemy::IsTargetInMeleeRange() const { return GetDistanceToTarget() <= detection_.meleeAttackRange; }
+bool MeleeEnemy::IsTargetInAttackStartRange() const { return GetDistanceToTarget() <= detection_.attackStartRange; }
+bool MeleeEnemy::IsTargetInAttackHoldRange() const { return GetDistanceToTarget() <= detection_.resumeChaseDistance; }
 bool MeleeEnemy::IsAttackCooldownReady() const { return attackController_.CanStartAttack(); }
-bool MeleeEnemy::IsMoveResumeDistanceReached() const { return GetDistanceToTarget() >= resumeChaseDistance_; }
+bool MeleeEnemy::IsMoveResumeDistanceReached() const { return GetDistanceToTarget() >= detection_.resumeChaseDistance; }
 
 void MeleeEnemy::FaceToTarget(float deltaTime)
 {
 	if (!target_) { return; }
-	targetDirection_ = NormalizeXZ(GetTargetPosition() - GetCenterPosition());
-	ApplyVisualYawFromDirection(targetDirection_, deltaTime);
+	animationState_.targetDirection = NormalizeXZ(GetTargetPosition() - GetCenterPosition());
+	ApplyVisualYawFromDirection(animationState_.targetDirection, deltaTime);
 }
 
 void MeleeEnemy::FaceToMoveDirection(float deltaTime)
 {
 	const Vector3 moveDir = NormalizeXZ(GetVelocity());
-	movementDirection_ = moveDir;
+	animationState_.movementDirection = moveDir;
 	ApplyVisualYawFromDirection(moveDir, deltaTime);
 }
 
 void MeleeEnemy::ApplyVisualYawFromDirection(const Vector3& direction, float deltaTime)
 {
 	if (LengthXZ(direction) <= kEpsilon) { return; }
-	rawYaw_ = std::atan2(-direction.x, direction.z);
-	const float targetVisualYaw = rawYaw_;
+	animationState_.rawYaw = std::atan2(-direction.x, direction.z);
+	const float targetVisualYaw = animationState_.rawYaw;
 	float currentYaw = NormalizeAngleRad(orientation_.y);
-	const float maxStep = rotateSpeed_ * std::max(deltaTime, 0.0f);
+	const float maxStep = move_.rotateSpeed * std::max(deltaTime, 0.0f);
 	float deltaYaw = NormalizeAngleRad(targetVisualYaw - currentYaw);
 	if (std::abs(deltaYaw) > (kPi - 0.001f))
 	{
@@ -490,14 +496,14 @@ void MeleeEnemy::ApplyVisualYawFromDirection(const Vector3& direction, float del
 	// Yaw差分を-π～+πに正規化し、左右ターゲット移動時の逆回転を防ぐ
 	deltaYaw = std::clamp(deltaYaw, -maxStep, maxStep);
 	currentYaw = NormalizeAngleRad(currentYaw + deltaYaw);
-	debugCurrentYaw_ = currentYaw;
-	debugTargetYaw_ = targetVisualYaw;
-	debugDeltaYaw_ = targetVisualYaw - orientation_.y;
-	debugNormalizedDeltaYaw_ = NormalizeAngleRad(targetVisualYaw - orientation_.y);
-	finalVisualYaw_ = currentYaw;
-	facingDirection_ = { -std::sin(rawYaw_), 0.0f, std::cos(rawYaw_) };
-	visualForward_ = NormalizeXZ({ -std::sin(finalVisualYaw_), 0.0f, std::cos(finalVisualYaw_) });
-	attackForward_ = visualForward_;
+	animationState_.debugCurrentYaw = currentYaw;
+	animationState_.debugTargetYaw = targetVisualYaw;
+	animationState_.debugDeltaYaw = targetVisualYaw - orientation_.y;
+	animationState_.debugNormalizedDeltaYaw = NormalizeAngleRad(targetVisualYaw - orientation_.y);
+	animationState_.finalVisualYaw = currentYaw;
+	animationState_.facingDirection = { -std::sin(animationState_.rawYaw), 0.0f, std::cos(animationState_.rawYaw) };
+	animationState_.visualForward = NormalizeXZ({ -std::sin(animationState_.finalVisualYaw), 0.0f, std::cos(animationState_.finalVisualYaw) });
+	animationState_.attackForward = animationState_.visualForward;
 	// 最終的な人型パーツのYawへ正面補正を加え、移動方向と見た目の向きを一致させる
 	SetOrientation({ 0.0f, currentYaw, 0.0f });
 }
@@ -505,7 +511,7 @@ void MeleeEnemy::ApplyVisualYawFromDirection(const Vector3& direction, float del
 void MeleeEnemy::DeadAction()
 {
 	StopMove();
-	animState_ = AnimState::Dead;
+	animationState_.animState = AnimState::Dead;
 	currentBehaviorName_ = "DeadAction";
 }
 
@@ -516,11 +522,11 @@ void MeleeEnemy::MeleeAttackAction()
 	if (!attackController_.IsAttacking() && attackController_.CanStartAttack())
 	{
 		// 攻撃パターンをデータとして扱い、ScratchとOneTwoを同じ制御経路で実行する
-		attackController_.StartAttack(selectedAttackType_);
-		attackLockTimer_ = attackLockTime_;
-	animState_ = (selectedAttackType_ == MeleeAttackType::OneTwo) ? AnimState::OneTwo : AnimState::Scratch;
+		attackController_.StartAttack(attackSettings_.selectedAttackType);
+		attackState_.lockTimer = attackSettings_.lockTime;
+	animationState_.animState = (attackSettings_.selectedAttackType == MeleeAttackType::OneTwo) ? AnimState::OneTwo : AnimState::Scratch;
 	}
-	currentBehaviorName_ = (selectedAttackType_ == MeleeAttackType::OneTwo) ? "OneTwoAttack" : "ScratchAttack";
+	currentBehaviorName_ = (attackSettings_.selectedAttackType == MeleeAttackType::OneTwo) ? "OneTwoAttack" : "ScratchAttack";
 }
 
 void MeleeEnemy::CombatIdleAction()
@@ -528,7 +534,7 @@ void MeleeEnemy::CombatIdleAction()
 	// 攻撃範囲内では追跡を止め、AttackとChaseの細かい切り替わりによる震えを防ぐ
 	StopMove();
 	FaceToTarget(1.0f / 60.0f);
-	animState_ = AnimState::Idle;
+	animationState_.animState = AnimState::Idle;
 	currentBehaviorName_ = "CombatIdle";
 }
 
@@ -537,24 +543,24 @@ void MeleeEnemy::ChaseTargetAction()
 	UpdateStuckState(1.0f / 60.0f);
 	TryJumpToTarget(1.0f / 60.0f);
 	const float distance = GetDistanceToTarget();
-	if (distance <= stopDistance_)
+	if (distance <= detection_.stopDistance)
 	{
 		StopMove();
 		FaceToTarget(1.0f / 60.0f);
-		animState_ = AnimState::Idle;
+		animationState_.animState = AnimState::Idle;
 		currentBehaviorName_ = "ChaseStopNearTarget";
 		return;
 	}
-	if (pathFindEnabled_ && !attackController_.IsAttacking() && distance > attackStartRange_ && MoveAlongPath(1.0f / 60.0f))
+	if (pathSettings_.enabled && !attackController_.IsAttacking() && distance > detection_.attackStartRange && MoveAlongPath(1.0f / 60.0f))
 	{
 		FaceToMoveDirection(1.0f / 60.0f);
-		animState_ = AnimState::Walk;
+		animationState_.animState = AnimState::Walk;
 		currentBehaviorName_ = "ChasePathMove";
 		return;
 	}
-	if (pathFindEnabled_)
+	if (pathSettings_.enabled)
 	{
-		pathFailedWaitTimer_ = std::max(pathFailedWaitTimer_, repathInterval_);
+		pathState_.failedWaitTimer = std::max(pathState_.failedWaitTimer, pathSettings_.repathInterval);
 		StopMove();
 		currentBehaviorName_ = "PathFailedWait";
 		return;
@@ -566,137 +572,148 @@ void MeleeEnemy::ChaseTargetAction()
 		currentBehaviorName_ = "ChaseNoMove";
 		return;
 	}
-	SetVelocity({ moveDir.x * moveSpeed_, GetVelocity().y, moveDir.z * moveSpeed_ });
+	SetVelocity({ moveDir.x * move_.moveSpeed, GetVelocity().y, moveDir.z * move_.moveSpeed });
 	FaceToMoveDirection(1.0f / 60.0f);
-	animState_ = AnimState::Walk;
+	animationState_.animState = AnimState::Walk;
 	currentBehaviorName_ = "ChaseTargetAction";
 }
 
 bool MeleeEnemy::MoveAlongPath(float deltaTime)
 {
 	EnemyAStarNavigator::Settings s = navigator_.GetSettings();
-	s.cellSize = pathGridSize_;
-	s.agentRadius = obstacleExpandRadius_ + stuckRepathExpandBonus_;
-	s.searchRangeCells = static_cast<int>(pathSearchRadius_);
-	s.repathIntervalSec = repathInterval_;
-	s.waypointReachDistance = waypointReachDistance_;
-	s.disableCornerCutting = cornerCuttingDisabled_;
+	s.cellSize = pathSettings_.gridSize;
+	s.agentRadius = pathSettings_.obstacleExpandRadius + pathSettings_.stuckRepathExpandBonus;
+	s.searchRangeCells = static_cast<int>(pathSettings_.searchRadius);
+	s.repathIntervalSec = pathSettings_.repathInterval;
+	s.waypointReachDistance = pathSettings_.waypointReachDistance;
+	s.disableCornerCutting = pathSettings_.cornerCuttingDisabled;
 	navigator_.SetSettings(s);
 	// 敵半径ぶん障害物を膨張して経路探索し、見た目上通れない隙間へ進まないようにする
 	navigator_.SetWorldAABBs(GetResolvedNavigationObstacleAABBs());
-	lastRepathTimer_ += deltaTime;
+	pathState_.lastRepathTimer += deltaTime;
 	navigator_.TickTemporaryBlocks(deltaTime);
 	const Vector3 targetPos = GetTargetPosition();
-	targetMovedDistanceForRepath_ = LengthXZ(targetPos - lastPathTargetPos_);
-	if (targetMovedDistanceForRepath_ >= targetRepathThreshold_ || isStuck_)
+	pathState_.targetMovedDistanceForRepath = LengthXZ(targetPos - pathState_.lastPathTargetPos);
+	if (pathState_.targetMovedDistanceForRepath >= pathSettings_.targetRepathThreshold || stuck_.isStuck)
 	{
 		navigator_.Reset();
-		lastRepathReason_ = isStuck_ ? "StuckForceRepath" : "TargetMoved";
+		pathState_.lastRepathReason = stuck_.isStuck ? "StuckForceRepath" : "TargetMoved";
 	}
 	// 障害物を考慮した経路を使い、MeleeEnemyが直線移動で引っかからないようにする
-	if (navigator_.GetNextWaypoint(GetCenterPosition(), targetPos, GetCenterPosition().y, deltaTime, currentPathWaypoint_))
+	if (navigator_.GetNextWaypoint(GetCenterPosition(), targetPos, GetCenterPosition().y, deltaTime, pathState_.currentWaypoint))
 	{
-		pathFound_ = true;
-		pathFailureReason_ = "None";
-		lastRepathReason_ = "Periodic";
-		lastPathTargetPos_ = targetPos;
-		pathRetryTimer_ = 0.0f;
-		lineBlocked_ = false;
-		blockedWaypointIndex_ = navigator_.GetCurrentPathIndex();
-		blockedObstacleName_ = "None";
+		pathState_.found = true;
+		pathState_.failureReason = "None";
+		pathState_.lastRepathReason = "Periodic";
+		pathState_.lastPathTargetPos = targetPos;
+		pathState_.retryTimer = 0.0f;
+		pathState_.lineBlocked = false;
+		pathState_.blockedWaypointIndex = navigator_.GetCurrentPathIndex();
+		pathState_.blockedObstacleName = "None";
 		int blockedIdx = -1;
-		if (navigator_.IsSegmentBlockedByObstacle(GetCenterPosition(), currentPathWaypoint_, GetCenterPosition().y, &blockedIdx))
+		if (navigator_.IsSegmentBlockedByObstacle(GetCenterPosition(), pathState_.currentWaypoint, GetCenterPosition().y, &blockedIdx))
 		{
-			lineBlocked_ = true;
-			blockedWaypointIndex_ = navigator_.GetCurrentPathIndex();
-			blockedObstacleName_ = (blockedIdx >= 0) ? ("Obstacle[" + std::to_string(blockedIdx) + "]") : "Unknown";
-			blockedSegmentFrom_ = GetCenterPosition();
-			blockedSegmentTo_ = currentPathWaypoint_;
+			pathState_.lineBlocked = true;
+			pathState_.blockedWaypointIndex = navigator_.GetCurrentPathIndex();
+			pathState_.blockedObstacleName = (blockedIdx >= 0) ? ("Obstacle[" + std::to_string(blockedIdx) + "]") : "Unknown";
+			pathState_.blockedSegmentFrom = GetCenterPosition();
+			pathState_.blockedSegmentTo = pathState_.currentWaypoint;
 			navigator_.Reset();
-			navigator_.AddTemporaryBlockedArea(currentPathWaypoint_, temporaryBlockRadius_, temporaryBlockDuration_, "WaypointSegmentBlocked");
-			lastRepathReason_ = "WaypointSegmentBlocked";
+			navigator_.AddTemporaryBlockedArea(pathState_.currentWaypoint, pathSettings_.temporaryBlockRadius, pathSettings_.temporaryBlockDuration, "WaypointSegmentBlocked");
+			pathState_.lastRepathReason = "WaypointSegmentBlocked";
 			StopMove();
 			return false;
 		}
-		const Vector3 dir = NormalizeXZ(currentPathWaypoint_ - GetCenterPosition());
-		SetVelocity({ dir.x * moveSpeed_, GetVelocity().y, dir.z * moveSpeed_ });
+		const Vector3 dir = NormalizeXZ(pathState_.currentWaypoint - GetCenterPosition());
+		SetVelocity({ dir.x * move_.moveSpeed, GetVelocity().y, dir.z * move_.moveSpeed });
 		// 経路追跡中でも段差追従のためにジャンプ可否を判定する
 		TryJumpToTarget(deltaTime);
 		return true;
 	}
-	pathFound_ = false;
-	pathFailureReason_ = "PathNotFound";
-	pathRetryTimer_ += deltaTime;
-	pathFailedWaitTimer_ = std::max(0.0f, pathFailedWaitTimer_ - deltaTime);
-	if (pathFailedWaitTimer_ > 0.0f)
+	pathState_.found = false;
+	pathState_.failureReason = "PathNotFound";
+	pathState_.retryTimer += deltaTime;
+	pathState_.failedWaitTimer = std::max(0.0f, pathState_.failedWaitTimer - deltaTime);
+	if (pathState_.failedWaitTimer > 0.0f)
 	{
-		lastRepathReason_ = "PathFailedWait";
+		pathState_.lastRepathReason = "PathFailedWait";
 		StopMove();
 		return false;
 	}
-	if (pathRetryTimer_ >= repathInterval_)
+	if (pathState_.retryTimer >= pathSettings_.repathInterval)
 	{
 		navigator_.Reset();
-		pathRetryTimer_ = 0.0f;
-		lastRepathReason_ = "RetryAfterFailure";
+		pathState_.retryTimer = 0.0f;
+		pathState_.lastRepathReason = "RetryAfterFailure";
 	}
 	StopMove();
 	return false;
 }
 
+float MeleeEnemy::CalculateJumpVelocityForHeight(float heightDelta) const
+{
+	// 高さ差に必要な初速を重力推定値から算出し、段差追従ジャンプの不足を防ぐ
+	const float clampedHeight = std::max(0.0f, heightDelta);
+	return std::sqrt(2.0f * std::max(jump_.gravityEstimate, 0.0f) * clampedHeight);
+}
+
 void MeleeEnemy::TryJumpToTarget(float)
 {
-	if (!jumpEnabled_) { lastJumpReason_ = "Disabled"; return; }
-	if (!HasTarget()) { lastJumpReason_ = "NoTarget"; return; }
-	if (IsDeadCondition()) { lastJumpReason_ = "Dead"; return; }
-	if (attackController_.IsAttacking() || attackLockTimer_ > 0.0f) { lastJumpReason_ = "Attack"; return; }
-	if (!grounded_) { lastJumpReason_ = "Airborne"; return; }
-	if (jumpCooldownTimer_ > 0.0f) { lastJumpReason_ = "Cooldown"; return; }
+	if (!jump_.enabled) { jumpState_.lastReason = "Disabled"; return; }
+	if (!HasTarget()) { jumpState_.lastReason = "NoTarget"; return; }
+	if (IsDeadCondition()) { jumpState_.lastReason = "Dead"; return; }
+	if (attackController_.IsAttacking() || attackState_.lockTimer > 0.0f) { jumpState_.lastReason = "Attack"; return; }
+	if (!grounded_) { jumpState_.lastReason = "Airborne"; return; }
+	if (jumpState_.cooldownTimer > 0.0f) { jumpState_.lastReason = "Cooldown"; return; }
 
 	const Vector3 selfPos = GetCenterPosition();
 	const Vector3 targetPos = GetTargetPosition();
 	const Vector3 toTarget = targetPos - selfPos;
 	const float heightDelta = toTarget.y;
 	const float horizontalDistance = LengthXZ(toTarget);
+	jumpState_.targetHeightDelta = heightDelta;
+	jumpState_.calculatedVelocity = CalculateJumpVelocityForHeight(heightDelta);
 
-	if (heightDelta < jumpTargetHeightThreshold_) { lastJumpReason_ = "TargetNotHigher"; return; }
-	if (horizontalDistance > jumpHorizontalDistanceMax_) { lastJumpReason_ = "TooFar"; return; }
+	if (heightDelta < jump_.targetHeightThreshold) { jumpState_.lastReason = "TargetNotHigher"; jumpState_.appliedVelocity = 0.0f; return; }
+	if (horizontalDistance > jump_.horizontalDistanceMax) { jumpState_.lastReason = "TooFar"; return; }
 
-	const bool obstacleJumpCandidate = blockedByObstacle_ || lineBlocked_ || isStuck_ || isOverlappingWallObstacle_;
+	const bool obstacleJumpCandidate = collision_.blockedByObstacle || pathState_.lineBlocked || stuck_.isStuck || collision_.isOverlappingWallObstacle;
 	if (obstacleJumpCandidate)
 	{
-		lastJumpReason_ = "TargetHigherBlocked";
+		jumpState_.lastReason = "TargetHigherBlocked";
 	}
 	else
 	{
-		lastJumpReason_ = "TargetHigher";
+		jumpState_.lastReason = "TargetHigher";
 	}
 	// 水平速度は維持しつつY速度だけを上書きし、段差追跡ジャンプを行う
 	Vector3 v = GetVelocity();
-	v.y = jumpVelocity_;
+	const float requested = std::max(jump_.baseVelocity, jumpState_.calculatedVelocity + jump_.extraBoost);
+	jumpState_.appliedVelocity = std::clamp(requested, 0.0f, jump_.maxVelocity);
+	v.y = jumpState_.appliedVelocity;
 	SetVelocity(v);
-	jumpCooldownTimer_ = jumpCooldown_;
+	jumpState_.cooldownTimer = jump_.cooldown;
 }
 
 void MeleeEnemy::UpdateStuckState(float deltaTime)
 {
-	stuckTimer_ += deltaTime;
-	if (stuckTimer_ < stuckCheckTime_) { return; }
-	const float moved = LengthXZ(GetCenterPosition() - lastStuckCheckPosition_);
-	const bool attackingOrInRange = attackController_.IsAttacking() || GetDistanceToTarget() <= attackStartRange_;
+	stuck_.timer += deltaTime;
+	if (stuck_.timer < stuckSettings_.checkTime) { return; }
+	const float moved = LengthXZ(GetCenterPosition() - pathState_.lastStuckCheckPosition);
+	const bool attackingOrInRange = attackController_.IsAttacking() || GetDistanceToTarget() <= detection_.attackStartRange;
 	const bool tryingToMove = LengthXZ(GetVelocity()) > 0.05f || std::string(currentBehaviorName_).find("Chase") != std::string::npos;
-	isStuck_ = !attackingOrInRange && tryingToMove && moved <= stuckMoveThreshold_ && GetDistanceToTarget() > stopDistance_;
-	lastMovedDistance_ = moved;
-	if (isStuck_)
+	stuck_.isStuck = !attackingOrInRange && tryingToMove && moved <= stuckSettings_.moveThreshold && GetDistanceToTarget() > detection_.stopDistance;
+	pathState_.lastMovedDistance = moved;
+	if (stuck_.isStuck)
 	{
 		// 詰まった地点を一時的に通行不可へ追加し、再探索時に同じ障害物へ押し込み続けないようにする
-		navigator_.AddTemporaryBlockedArea(GetCenterPosition(), temporaryBlockRadius_, temporaryBlockDuration_, "StuckPosition");
+		navigator_.AddTemporaryBlockedArea(GetCenterPosition(), pathSettings_.temporaryBlockRadius, pathSettings_.temporaryBlockDuration, "StuckPosition");
 		navigator_.Reset();
-		stuckRepathExpandBonus_ = std::min(stuckRepathExpandBonus_ + 0.1f, maxStuckRepathExpandBonus_);
-		lastRepathReason_ = "RepathFromStuck";
-		if (blockedByObstacle_ || lineBlocked_)
+		pathSettings_.stuckRepathExpandBonus = std::min(pathSettings_.stuckRepathExpandBonus + 0.1f, pathSettings_.maxStuckRepathExpandBonus);
+		pathState_.lastRepathReason = "RepathFromStuck";
+		if (collision_.blockedByObstacle || pathState_.lineBlocked)
 		{
-			const Vector3 tangent = NormalizeXZ(Vector3{ -lastWallResolvePush_.z, 0.0f, lastWallResolvePush_.x });
+			const Vector3 tangent = NormalizeXZ(Vector3{ -collision_.lastWallResolvePush.z, 0.0f, collision_.lastWallResolvePush.x });
 			if (LengthXZ(tangent) > kEpsilon)
 			{
 				const Vector3 toTarget = NormalizeXZ(GetTargetPosition() - GetCenterPosition());
@@ -704,7 +721,7 @@ void MeleeEnemy::UpdateStuckState(float deltaTime)
 				const float dotA = tangent.x * toTarget.x + tangent.z * toTarget.z;
 				const float dotB = invTangent.x * toTarget.x + invTangent.z * toTarget.z;
 				const Vector3 sideEscape = (dotA >= dotB) ? tangent : invTangent;
-				SetVelocity({ sideEscape.x * (moveSpeed_ * 0.45f), GetVelocity().y, sideEscape.z * (moveSpeed_ * 0.45f) });
+				SetVelocity({ sideEscape.x * (move_.moveSpeed * 0.45f), GetVelocity().y, sideEscape.z * (move_.moveSpeed * 0.45f) });
 			}
 		}
 		else
@@ -714,30 +731,30 @@ void MeleeEnemy::UpdateStuckState(float deltaTime)
 	}
 	else
 	{
-		stuckRepathExpandBonus_ = std::max(0.0f, stuckRepathExpandBonus_ - 0.05f);
+		pathSettings_.stuckRepathExpandBonus = std::max(0.0f, pathSettings_.stuckRepathExpandBonus - 0.05f);
 	}
-	lastStuckCheckPosition_ = GetCenterPosition();
-	stuckTimer_ = 0.0f;
+	pathState_.lastStuckCheckPosition = GetCenterPosition();
+	stuck_.timer = 0.0f;
 }
 
 void MeleeEnemy::WanderAction(float deltaTime)
 {
-	wanderTimer_ -= deltaTime;
-	if (wanderTimer_ <= 0.0f)
+	wander_.timer -= deltaTime;
+	if (wander_.timer <= 0.0f)
 	{
-		wanderTimer_ = 1.4f;
+		wander_.timer = 1.4f;
 		const float angle = static_cast<float>((std::rand() % 360) * (kPi / 180.0f));
-		wanderDirection_ = { std::sin(angle), 0.0f, std::cos(angle) };
+		wander_.direction = { std::sin(angle), 0.0f, std::cos(angle) };
 	}
-	SetVelocity({ wanderDirection_.x * (moveSpeed_ * 0.45f), GetVelocity().y, wanderDirection_.z * (moveSpeed_ * 0.45f) });
+	SetVelocity({ wander_.direction.x * (move_.moveSpeed * 0.45f), GetVelocity().y, wander_.direction.z * (move_.moveSpeed * 0.45f) });
 	FaceToMoveDirection(1.0f / 60.0f);
 	currentBehaviorName_ = "WanderAction";
-	animState_ = AnimState::Walk;
+	animationState_.animState = AnimState::Walk;
 }
 
 void MeleeEnemy::ApplyAttackMove(const Vector3& horizontalVelocity)
 {
-	if (selectedAttackType_ == MeleeAttackType::OneTwo && GetDistanceToTarget() > minOneTwoForwardDistance_)
+	if (attackSettings_.selectedAttackType == MeleeAttackType::OneTwo && GetDistanceToTarget() > detection_.minOneTwoForwardDistance)
 	{
 		SetVelocity({ horizontalVelocity.x, GetVelocity().y, horizontalVelocity.z });
 	}
@@ -757,16 +774,16 @@ void MeleeEnemy::EvaluateBehavior(float deltaTime)
 	if (IsDeadCondition()) { DeadAction(); return; }
 	if (!HasTarget()) { WanderAction(deltaTime); return; }
 
-	if (attackController_.IsAttacking() || attackLockTimer_ > 0.0f)
+	if (attackController_.IsAttacking() || attackState_.lockTimer > 0.0f)
 	{
 		MeleeAttackAction();
 		return;
 	}
 
 	const float distance = GetDistanceToTarget();
-	isStuck_ = (distance <= stopDistance_ && LengthXZ(GetVelocity()) < 0.05f);
+	stuck_.isStuck = (distance <= detection_.stopDistance && LengthXZ(GetVelocity()) < 0.05f);
 
-	if (distance <= attackStartRange_)
+	if (distance <= detection_.attackStartRange)
 	{
 		if (IsAttackCooldownReady()) { MeleeAttackAction(); return; }
 		CombatIdleAction();
@@ -779,15 +796,15 @@ void MeleeEnemy::EvaluateBehavior(float deltaTime)
 		return;
 	}
 
-	if (distance <= meleeAttackRange_)
+	if (distance <= detection_.meleeAttackRange)
 	{
 		// 攻撃射程内では押し込みを止める
 		CombatIdleAction();
 		return;
 	}
 
-	shouldChase_ = shouldChase_ ? !IsTargetInAttackHoldRange() : IsMoveResumeDistanceReached();
-	if (HasTarget() && IsTargetInDetectRange() && (shouldChase_ || distance > resumeChaseDistance_))
+	attackState_.shouldChase = attackState_.shouldChase ? !IsTargetInAttackHoldRange() : IsMoveResumeDistanceReached();
+	if (HasTarget() && IsTargetInDetectRange() && (attackState_.shouldChase || distance > detection_.resumeChaseDistance))
 	{
 		ChaseTargetAction();
 		return;
@@ -802,17 +819,17 @@ void MeleeEnemy::StopMove()
 
 void MeleeEnemy::ForceAttack(MeleeAttackType type)
 {
-	selectedAttackType_ = type;
+	attackSettings_.selectedAttackType = type;
 	attackController_.ResetCooldown();
 	attackController_.StopAttack();
 	attackController_.StartAttack(type);
-	attackLockTimer_ = attackLockTime_;
+	attackState_.lockTimer = attackSettings_.lockTime;
 }
 
 void MeleeEnemy::StopAttack()
 {
 	attackController_.StopAttack();
-	attackLockTimer_ = 0.0f;
+	attackState_.lockTimer = 0.0f;
 }
 
 void MeleeEnemy::ResetAttackCooldown()
@@ -827,40 +844,40 @@ void MeleeEnemy::UpdateVisualAnimation(float deltaTime)
 	const uint32_t rArm = partIndices_.rightArm;
 	const uint32_t lLeg = partIndices_.leftLeg;
 	const uint32_t rLeg = partIndices_.rightLeg;
-	const float speedRate = std::min(1.5f, LengthXZ(GetVelocity()) / std::max(moveSpeed_, kEpsilon));
-	walkAnimTime_ += deltaTime * (walkAnimSpeed_ * std::max(0.2f, speedRate));
+	const float speedRate = std::min(1.5f, LengthXZ(GetVelocity()) / std::max(move_.moveSpeed, kEpsilon));
+	animationState_.walkAnimTime += deltaTime * (animation_.walkAnimSpeed * std::max(0.2f, speedRate));
 	float armTarget = 0.0f;
 	float legTarget = 0.0f;
 	float lAttack = 0.0f;
 	float rAttack = 0.0f;
 	if (attackController_.IsAttacking())
 	{
-		if (attackController_.GetCurrentAttackType() == MeleeAttackType::Scratch || attackController_.GetCurrentStepIndex() == 0) { lAttack = attackArmSwing_; }
-		if (attackController_.GetCurrentAttackType() == MeleeAttackType::OneTwo && attackController_.GetCurrentStepIndex() == 1) { rAttack = attackArmSwing_; }
+		if (attackController_.GetCurrentAttackType() == MeleeAttackType::Scratch || attackController_.GetCurrentStepIndex() == 0) { lAttack = animation_.attackArmSwing; }
+		if (attackController_.GetCurrentAttackType() == MeleeAttackType::OneTwo && attackController_.GetCurrentStepIndex() == 1) { rAttack = animation_.attackArmSwing; }
 	}
-	else if (animState_ == AnimState::Walk)
+	else if (animationState_.animState == AnimState::Walk)
 	{
-		armTarget = std::sin(walkAnimTime_) * walkArmSwing_ * speedRate;
-		legTarget = std::sin(walkAnimTime_) * walkLegSwing_ * speedRate;
+		armTarget = std::sin(animationState_.walkAnimTime) * animation_.walkArmSwing * speedRate;
+		legTarget = std::sin(animationState_.walkAnimTime) * animation_.walkLegSwing * speedRate;
 	}
-	const float ret = std::min(1.0f, attackReturnSpeed_ * deltaTime);
+	const float ret = std::min(1.0f, animation_.attackReturnSpeed * deltaTime);
 	parts_[lArm].transform.rotate_.x += ((armTarget - lAttack) - parts_[lArm].transform.rotate_.x) * ret;
 	parts_[rArm].transform.rotate_.x += ((-armTarget - rAttack) - parts_[rArm].transform.rotate_.x) * ret;
 	parts_[lLeg].transform.rotate_.x += ((-legTarget) - parts_[lLeg].transform.rotate_.x) * ret;
 	parts_[rLeg].transform.rotate_.x += ((legTarget) - parts_[rLeg].transform.rotate_.x) * ret;
-	body_.transform.rotate_.x = (lAttack + rAttack) * attackBodyLean_;
+	body_.transform.rotate_.x = (lAttack + rAttack) * animation_.attackBodyLean;
 	UpdateVisualHierarchy();
 }
 
 bool MeleeEnemy::IsInsideStageBounds(const Vector3& position) const
 {
-	if (!hasStageBounds_) { return true; }
-	return position.x >= stageBoundsMin_.x && position.x <= stageBoundsMax_.x && position.z >= stageBoundsMin_.z && position.z <= stageBoundsMax_.z;
+	if (!collision_.hasStageBounds) { return true; }
+	return position.x >= collision_.stageBoundsMin.x && position.x <= collision_.stageBoundsMax.x && position.z >= collision_.stageBoundsMin.z && position.z <= collision_.stageBoundsMax.z;
 }
 
 const char* MeleeEnemy::GetAnimStateName() const
 {
-	switch (animState_)
+	switch (animationState_.animState)
 	{
 	case AnimState::Idle: return "Idle";
 	case AnimState::Walk: return "Walk";

--- a/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.h
@@ -23,14 +23,14 @@ public:
 
 	K4E::Collider* GetTargetCollider() const { return target_; }
 	K4E::Vector3 GetTargetPositionForAttack() const;
-	K4E::Vector3 GetAttackForward() const { return attackForward_; }
+	K4E::Vector3 GetAttackForward() const { return animationState_.attackForward; }
 	void ApplyAttackMove(const K4E::Vector3& horizontalVelocity);
 	void NotifyAttackHit(int damage, const K4E::Vector3& forward);
 	void ForceAttack(MeleeAttackType type);
 	void StopAttack();
 	void ResetAttackCooldown();
-	void SetSelectedAttackType(MeleeAttackType type) { selectedAttackType_ = type; }
-	MeleeAttackType GetSelectedAttackType() const { return selectedAttackType_; }
+	void SetSelectedAttackType(MeleeAttackType type) { attackSettings_.selectedAttackType = type; }
+	MeleeAttackType GetSelectedAttackType() const { return attackSettings_.selectedAttackType; }
 	bool IsAttacking() const { return attackController_.IsAttacking(); }
 	const char* GetCurrentAttackName() const { return attackController_.GetCurrentAttackName(); }
 
@@ -60,6 +60,7 @@ private:
 	bool IsMoveResumeDistanceReached() const;
 	bool MoveAlongPath(float deltaTime);
 	void TryJumpToTarget(float deltaTime);
+	float CalculateJumpVelocityForHeight(float heightDelta) const;
 
 	bool ResolveObstaclePenetrationXZ(float deltaTime);
 	void UpdateStuckState(float deltaTime);
@@ -75,110 +76,48 @@ private:
 	const char* GetAnimStateName() const;
 
 private:
+	struct DetectionSettings
+	{
+		float detectRange = 18.0f;
+		float meleeAttackRange = 2.8f;
+		float stopDistance = 1.8f;
+		float attackStartRange = 2.4f;
+		float resumeChaseDistance = 2.8f;
+		float minOneTwoForwardDistance = 1.6f;
+	};
+
+	struct MoveSettings { float moveSpeed = 3.2f; float rotateSpeed = 8.0f; float maxResolvePushPerFrame = 0.75f; float maxHorizontalPushPerFrame = 0.45f; };
+	struct JumpSettings { bool enabled = true; float baseVelocity = 12.0f; float extraBoost = 0.8f; float gravityEstimate = 20.0f; float maxVelocity = 18.0f; float targetHeightThreshold = 1.0f; float horizontalDistanceMax = 8.0f; float cooldown = 0.9f; };
+	struct JumpState { float cooldownTimer = 0.0f; float targetHeightDelta = 0.0f; float calculatedVelocity = 0.0f; float appliedVelocity = 0.0f; std::string lastReason = "None"; };
+	struct PathSettings { bool enabled = true; float repathInterval = 0.25f; float waypointReachDistance = 0.85f; float gridSize = 1.5f; float searchRadius = 28.0f; float obstacleExpandRadius = 0.9f; float temporaryBlockDuration = 1.5f; float temporaryBlockRadius = 1.0f; bool cornerCuttingDisabled = true; float targetRepathThreshold = 1.2f; float stuckRepathExpandBonus = 0.25f; float maxStuckRepathExpandBonus = 1.0f; };
+	struct PathState { bool found = false; std::string failureReason = "None"; float failedWaitTimer = 0.0f; float lastRepathTimer = 0.0f; float retryTimer = 0.0f; float targetMovedDistanceForRepath = 0.0f; float lastMovedDistance = 0.0f; std::string lastRepathReason = "None"; std::string blockedObstacleName = "None"; K4E::Vector3 lastStuckCheckPosition{}; K4E::Vector3 lastPathTargetPos{}; K4E::Vector3 currentWaypoint{}; K4E::Vector3 blockedSegmentFrom{}; K4E::Vector3 blockedSegmentTo{}; int blockedWaypointIndex = -1; bool lineBlocked = false; };
+	struct StuckSettings { float checkTime = 0.8f; float distance = 0.2f; float moveThreshold = 0.18f; };
+	struct StuckState { bool isStuck = false; float timer = 0.0f; };
+	struct AttackSettings { MeleeAttackType selectedAttackType = MeleeAttackType::Scratch; float lockTime = 0.18f; };
+	struct AttackState { float lockTimer = 0.0f; bool shouldChase = true; };
+	struct AnimationSettings { float visualYawOffset = 0.0f; float walkAnimSpeed = 8.0f; float walkArmSwing = 0.55f; float walkLegSwing = 0.45f; float attackArmSwing = 1.25f; float attackReturnSpeed = 12.0f; float attackBodyLean = 0.15f; };
+	struct AnimationStateData { float walkAnimTime = 0.0f; float rawYaw = 0.0f; float finalVisualYaw = 0.0f; float visualYawOffsetDeg = 0.0f; float debugCurrentYaw = 0.0f; float debugTargetYaw = 0.0f; float debugDeltaYaw = 0.0f; float debugNormalizedDeltaYaw = 0.0f; K4E::Vector3 facingDirection{0.0f,0.0f,1.0f}; K4E::Vector3 movementDirection{0.0f,0.0f,1.0f}; K4E::Vector3 targetDirection{0.0f,0.0f,1.0f}; K4E::Vector3 visualForward{0.0f,0.0f,1.0f}; K4E::Vector3 attackForward{0.0f,0.0f,1.0f}; AnimState animState = AnimState::Idle; };
+	struct CollisionState { K4E::Vector3 lastSafePosition{}; K4E::Vector3 stageBoundsMin{-1000.0f,-1000.0f,-1000.0f}; K4E::Vector3 stageBoundsMax{1000.0f,1000.0f,1000.0f}; bool hasStageBounds = false; bool isOutsideStage = false; K4E::Vector3 lastResolvePush{}; bool isCollidingWithStage = false; std::string lastStageCollisionType = "None"; std::string lastStageCollisionName = "None"; bool blockedByObstacle = false; std::string lastBlockedObstacleName = "None"; int usingWorldAABBCount = 0; int usingObstacleAABBCount = 0; bool collisionManagerRegistered = false; int lastCollisionCount = 0; bool pushedThisFrame = false; bool restoredToSafePosition = false; bool isOverlappingWallObstacle = false; bool isOnFloor = false; std::string lastWallObstacleName = "None"; K4E::Vector3 lastWallResolvePush{}; };
+	struct WanderState { float timer = 0.0f; K4E::Vector3 direction{1.0f,0.0f,0.0f}; };
+
 	K4E::Collider* target_ = nullptr;
-
-	float detectRange_ = 18.0f;
-	float meleeAttackRange_ = 2.8f;
-	float moveSpeed_ = 3.2f;
-	float stopDistance_ = 1.8f;
-	float attackStartRange_ = 2.4f;
-	float resumeChaseDistance_ = 2.8f;
-	float minOneTwoForwardDistance_ = 1.6f;
-	float rotateSpeed_ = 8.0f;
-	float visualYawOffset_ = 0.0f;
-	float walkAnimSpeed_ = 8.0f;
-	float walkArmSwing_ = 0.55f;
-	float walkLegSwing_ = 0.45f;
-	float attackArmSwing_ = 1.25f;
-	float attackReturnSpeed_ = 12.0f;
-	float attackBodyLean_ = 0.15f;
-	float walkAnimTime_ = 0.0f;
-	K4E::Vector3 lastSafePosition_{};
-	K4E::Vector3 stageBoundsMin_{ -1000.0f, -1000.0f, -1000.0f };
-	K4E::Vector3 stageBoundsMax_{ 1000.0f, 1000.0f, 1000.0f };
-	bool hasStageBounds_ = false;
-	bool isOutsideStage_ = false;
-	K4E::Vector3 lastResolvePush_{};
-	bool isCollidingWithStage_ = false;
-	std::string lastStageCollisionType_ = "None";
-	std::string lastStageCollisionName_ = "None";
-	bool blockedByObstacle_ = false;
-	std::string lastBlockedObstacleName_ = "None";
-	int usingWorldAABBCount_ = 0;
-	int usingObstacleAABBCount_ = 0;
-	bool collisionManagerRegistered_ = false;
-	int lastCollisionCount_ = 0;
-	bool pushedThisFrame_ = false;
-	bool restoredToSafePosition_ = false;
-	bool isOverlappingWallObstacle_ = false;
-	bool isOnFloor_ = false;
-	std::string lastWallObstacleName_ = "None";
-	K4E::Vector3 lastWallResolvePush_{};
-	float maxResolvePushPerFrame_ = 0.75f;
-	float maxHorizontalPushPerFrame_ = 0.45f;
-	float stuckCheckTime_ = 0.8f;
-	float stuckDistance_ = 0.2f;
-	float stuckMoveThreshold_ = 0.18f;
-	bool pathFindEnabled_ = true;
-	bool jumpEnabled_ = true;
-	float jumpVelocity_ = 8.2f;
-	float jumpTargetHeightThreshold_ = 1.0f;
-	float jumpHorizontalDistanceMax_ = 8.0f;
-	float jumpCooldown_ = 0.9f;
-	float jumpCooldownTimer_ = 0.0f;
-	std::string lastJumpReason_ = "None";
-	float repathInterval_ = 0.25f;
-	float waypointReachDistance_ = 0.85f;
-	float pathGridSize_ = 1.5f;
-	float pathSearchRadius_ = 28.0f;
-	float obstacleExpandRadius_ = 0.9f;
-	float temporaryBlockDuration_ = 1.5f;
-	float temporaryBlockRadius_ = 1.0f;
-	bool cornerCuttingDisabled_ = true;
-	float pathFailedWaitTimer_ = 0.0f;
-	MeleeAttackType selectedAttackType_ = MeleeAttackType::Scratch;
+	DetectionSettings detection_{};
+	MoveSettings move_{};
+	JumpSettings jump_{};
+	JumpState jumpState_{};
+	PathSettings pathSettings_{};
+	PathState pathState_{};
+	StuckSettings stuckSettings_{};
+	StuckState stuck_{};
+	AttackSettings attackSettings_{};
+	AttackState attackState_{};
+	AnimationSettings animation_{};
+	AnimationStateData animationState_{};
+	CollisionState collision_{};
+	WanderState wander_{};
 	MeleeAttackController attackController_{};
-	float attackLockTimer_ = 0.0f;
-	float attackLockTime_ = 0.18f;
-	bool isStuck_ = false;
-	bool shouldChase_ = true;
-	bool pathFound_ = false;
-	std::string pathFailureReason_ = "None";
-	float stuckTimer_ = 0.0f;
-	float lastRepathTimer_ = 0.0f;
-	float pathRetryTimer_ = 0.0f;
-	float targetMovedDistanceForRepath_ = 0.0f;
-	float lastMovedDistance_ = 0.0f;
-	float targetRepathThreshold_ = 1.2f;
-	float stuckRepathExpandBonus_ = 0.25f;
-	float maxStuckRepathExpandBonus_ = 1.0f;
-	std::string lastRepathReason_ = "None";
-	std::string blockedObstacleName_ = "None";
-	K4E::Vector3 lastStuckCheckPosition_{};
-	K4E::Vector3 lastPathTargetPos_{};
-	K4E::Vector3 spawnPosition_{};
-	K4E::Vector3 currentPathWaypoint_{};
-	K4E::Vector3 blockedSegmentFrom_{};
-	K4E::Vector3 blockedSegmentTo_{};
-	int blockedWaypointIndex_ = -1;
-	bool lineBlocked_ = false;
 	EnemyAStarNavigator navigator_{};
-	float wanderTimer_ = 0.0f;
-	K4E::Vector3 wanderDirection_{ 1.0f, 0.0f, 0.0f };
-	float rawYaw_ = 0.0f;
-	float finalVisualYaw_ = 0.0f;
-	float visualYawOffsetDeg_ = 0.0f;
-	float debugCurrentYaw_ = 0.0f;
-	float debugTargetYaw_ = 0.0f;
-	float debugDeltaYaw_ = 0.0f;
-	float debugNormalizedDeltaYaw_ = 0.0f;
-	K4E::Vector3 facingDirection_{ 0.0f, 0.0f, 1.0f };
-	K4E::Vector3 movementDirection_{ 0.0f, 0.0f, 1.0f };
-	K4E::Vector3 targetDirection_{ 0.0f, 0.0f, 1.0f };
-	K4E::Vector3 visualForward_{ 0.0f, 0.0f, 1.0f };
-	K4E::Vector3 attackForward_{ 0.0f, 0.0f, 1.0f };
-
-	AnimState animState_ = AnimState::Idle;
+	K4E::Vector3 spawnPosition_{};
 	const std::vector<K4E::AABB>* floorAABBs_ = nullptr;
 	const std::vector<K4E::AABB>* wallObstacleAABBs_ = nullptr;
 	const char* currentBehaviorName_ = "None";


### PR DESCRIPTION
### Motivation
- Reduce clutter in `MeleeEnemy` by grouping many private variables into purpose-specific structs to improve maintainability and readability.
- Fix insufficient jump power when pursuing targets on higher ledges by computing jump velocity from height difference instead of using a fixed low value.
- Keep existing attack, navigation, wall-push resolution, animation, and gravity behaviors intact while only changing MeleeEnemy internals.

### Description
- Reorganized private members into the requested structs and instance fields: `DetectionSettings detection_`, `MoveSettings move_`, `JumpSettings jump_`, `JumpState jumpState_`, `PathSettings pathSettings_`, `PathState pathState_`, `StuckSettings stuckSettings_`, `StuckState stuck_`, `AttackSettings attackSettings_`, `AttackState attackState_`, `AnimationSettings animation_`, `AnimationStateData animationState_`, `CollisionState collision_`, and `WanderState wander_` in `MeleeEnemy.h` and updated all internal references in `MeleeEnemy.cpp` to use these structs.
- Added `float CalculateJumpVelocityForHeight(float heightDelta) const` which computes `sqrt(2.0f * gravityEstimate * heightDelta)` and used it inside `TryJumpToTarget()` to compute a height-dependent jump velocity.
- Increased default `jump_.baseVelocity` to `12.0f` and added configurable jump tuning fields `jump_.extraBoost`, `jump_.gravityEstimate`, and `jump_.maxVelocity`, then apply `applied = clamp(max(baseVelocity, calculated + extraBoost), 0.0f, maxVelocity)` to `velocity.y` while preserving `velocity.x`/`velocity.z` during jumps.
- Exposed the new jump settings and state values in ImGui (`baseJumpVelocity`, `jumpExtraBoost`, `jumpGravityEstimate`, `maxJumpVelocity`, `jumpTargetHeightThreshold`, `jumpHorizontalDistanceMax`, `jumpCooldown`, `jumpCooldownTimer`, `targetHeightDelta`, `calculatedJumpVelocity`, `appliedJumpVelocity`, `lastJumpReason`) and updated ImGui labels to the new struct-backed fields.
- Changes are limited to the two target files: `Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.h` and `Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp` and preserve public API behavior where possible (e.g. `GetAttackForward`, attack selection accessors, and attack controller logic).

### Testing
- Performed automated code modifications and repository-wide updates, and validated via search that `MeleeEnemy` references were migrated to the new struct fields (file-level refactoring completed successfully).
- Attempted to build the solution with `msbuild`, but the container environment does not have `msbuild` available so a full build could not be performed in this environment (build attempt failed due to missing `msbuild`).
- Committed the changes locally and verified the modified files are only the intended `MeleeEnemy.h` and `MeleeEnemy.cpp` files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13ad630074832d89790237c0edce76)