### PR TITLE
Allow MeleeEnemy to land on obstacle tops (skip wall push-out when landing)

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
@@ -73,6 +73,8 @@ void MeleeEnemy::Update(float deltaTime)
 	collision_.lastCollisionCount = 0;
 	collision_.pushedThisFrame = false;
 	collision_.restoredToSafePosition = false;
+	collision_.landedOnObstacleTop = false;
+	collision_.lastObstacleTopLandingName = "None";
 	const auto* floorAabbs = floorAABBs_ ? floorAABBs_ : GetResolvedWorldAABBs();
 	worldAABBs_ = floorAabbs;
 	Vector3 afterPos = GetCenterPosition();
@@ -87,7 +89,9 @@ void MeleeEnemy::Update(float deltaTime)
 		SetCenterPosition(afterPos);
 	}
 	collision_.lastResolvePush = afterPos - beforePos;
-	if (ResolveObstaclePenetrationXZ(deltaTime))
+	// 障害物上面に着地できるフレームは横押し出しより上面接地を優先する
+	const bool landedOnObstacleTop = TryLandOnObstacleTop(deltaTime);
+	if (!landedOnObstacleTop && ResolveObstaclePenetrationXZ(deltaTime))
 	{
 		afterPos = GetCenterPosition();
 		pathState_.lineBlocked = true;
@@ -139,7 +143,45 @@ void MeleeEnemy::Update(float deltaTime)
 	UpdateVisualAnimation(deltaTime);
 }
 
+bool MeleeEnemy::TryLandOnObstacleTop(float deltaTime)
+{
+	(void)deltaTime;
+	if (!move_.obstacleTopLandingEnabled) { return false; }
+	const auto* obstacleAabbs = wallObstacleAABBs_ ? wallObstacleAABBs_ : GetResolvedNavigationObstacleAABBs();
+	if (!obstacleAabbs || obstacleAabbs->empty()) { return false; }
+	const auto vel = GetVelocity();
+	if (vel.y > 0.0f) { return false; }
 
+	Vector3 pos = GetCenterPosition();
+	const Vector3 half = { 1.0f, 2.0f, 1.0f };
+	const float footY = pos.y - half.y;
+	const float prevFootY = footY - vel.y * deltaTime;
+	for (size_t i = 0; i < obstacleAabbs->size(); ++i)
+	{
+		const auto& o = (*obstacleAabbs)[i];
+		const float overlapX = std::min(pos.x + half.x, o.max.x) - std::max(pos.x - half.x, o.min.x);
+		const float overlapZ = std::min(pos.z + half.z, o.max.z) - std::max(pos.z - half.z, o.min.z);
+		if (overlapX < move_.obstacleTopLandingMinHorizontalOverlap || overlapZ < move_.obstacleTopLandingMinHorizontalOverlap) { continue; }
+		const float topY = o.max.y;
+		if (topY - footY > move_.obstacleTopLandingMaxHeight) { continue; }
+		const bool nearTop = std::abs(footY - topY) <= move_.obstacleTopLandingTolerance;
+		const bool crossedFromAbove = prevFootY >= topY - kEpsilon;
+		if (!nearTop || !crossedFromAbove) { continue; }
+		// 上から接触した障害物だけを床として扱い、ジャンプ着地を成立させる
+		pos.y = topY + half.y;
+		SetCenterPosition(pos);
+		auto nextVel = vel;
+		nextVel.y = 0.0f;
+		SetVelocity(nextVel);
+		grounded_ = true;
+		collision_.isOnFloor = true;
+		collision_.landedOnObstacleTop = true;
+		collision_.lastObstacleTopLandingName = "Obstacle[" + std::to_string(i) + "]";
+		collision_.lastWallObstacleName = collision_.lastObstacleTopLandingName;
+		return true;
+	}
+	return false;
+}
 
 bool MeleeEnemy::ResolveObstaclePenetrationXZ(float deltaTime)
 {
@@ -277,6 +319,10 @@ void MeleeEnemy::DrawImGui()
 		ImGui::SliderFloat("attackReturnSpeed", &animation_.attackReturnSpeed, 1.0f, 24.0f);
 		ImGui::SliderFloat("attackBodyLean", &animation_.attackBodyLean, 0.0f, 0.4f);
 		ImGui::SliderFloat("maxResolvePushPerFrame", &move_.maxResolvePushPerFrame, 0.05f, 2.0f);
+		ImGui::Checkbox("obstacleTopLandingEnabled", &move_.obstacleTopLandingEnabled);
+		ImGui::SliderFloat("obstacleTopLandingTolerance", &move_.obstacleTopLandingTolerance, 0.01f, 1.0f);
+		ImGui::SliderFloat("obstacleTopLandingMaxHeight", &move_.obstacleTopLandingMaxHeight, 0.3f, 8.0f);
+		ImGui::SliderFloat("obstacleTopLandingMinHorizontalOverlap", &move_.obstacleTopLandingMinHorizontalOverlap, 0.01f, 1.5f);
 		ImGui::SliderFloat("stuckCheckTime", &stuckSettings_.checkTime, 0.1f, 3.0f);
 		ImGui::SliderFloat("stuckDistance", &stuckSettings_.distance, 0.01f, 2.0f);
 		ImGui::SliderFloat("stuckMoveThreshold", &stuckSettings_.moveThreshold, 0.03f, 1.2f);
@@ -335,6 +381,8 @@ void MeleeEnemy::DrawImGui()
 		ImGui::Text("isOnFloor: %s", collision_.isOnFloor ? "true" : "false");
 		ImGui::Text("isOverlappingWallObstacle: %s", collision_.isOverlappingWallObstacle ? "true" : "false");
 		ImGui::Text("lastWallObstacleName: %s", collision_.lastWallObstacleName.c_str());
+		ImGui::Text("lastObstacleTopLandingName: %s", collision_.lastObstacleTopLandingName.c_str());
+		ImGui::Text("landedOnObstacleTop: %s", collision_.landedOnObstacleTop ? "true" : "false");
 		ImGui::Text("lastWallResolvePush: (%.2f, %.2f, %.2f)", collision_.lastWallResolvePush.x, collision_.lastWallResolvePush.y, collision_.lastWallResolvePush.z);
 		ImGui::Text("lastBlockedObstacleName: %s", collision_.lastBlockedObstacleName.c_str());
 		ImGui::Text("Path Node Count: %d", static_cast<int>(navigator_.GetCurrentPath().size()));

--- a/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.h
@@ -44,6 +44,10 @@ private: /// ---------- 構造体 ---------- ///
 		float rotateSpeed = 8.0f;				 // 回転速度
 		float maxResolvePushPerFrame = 0.75f;	 // ステージ衝突解決の最大押し戻し距離
 		float maxHorizontalPushPerFrame = 0.45f; // 水平方向の衝突解決の最大押し戻し距離
+		bool obstacleTopLandingEnabled = true;	 // 障害物上面への着地判定を有効にする
+		float obstacleTopLandingTolerance = 0.35f; // 障害物上面への着地を許容する足元の高さ誤差
+		float obstacleTopLandingMaxHeight = 3.5f; // 障害物上面へ着地可能な最大段差
+		float obstacleTopLandingMinHorizontalOverlap = 0.2f; // 上面着地に必要なXZ最小重なり量
 	};
 
 	// 落下と重力の設定
@@ -191,6 +195,8 @@ private: /// ---------- 構造体 ---------- ///
 		bool isOnFloor = false;										 // 床の上にいるかどうか
 		std::string lastWallObstacleName = "None";					 // 最後に重なった壁の障害物の名前（デバッグ用）
 		K4E::Vector3 lastWallResolvePush{};							 // 壁の障害物と重なっているときの最後の衝突解決の押し戻しベクトル（デバッグ用）
+		bool landedOnObstacleTop = false;								 // 障害物上面への着地が成立したかどうか
+		std::string lastObstacleTopLandingName = "None";				 // 最後に上面着地した障害物名（デバッグ用）
 	};
 
 	// 徘徊の状態管理
@@ -326,6 +332,8 @@ private: /// ---------- 内部処理 ---------- ///
 
 	// ジャンプを試みる処理（ターゲットの高さや距離、ジャンプのクールダウンなどを考慮してジャンプするかどうかを判断し、実際にジャンプする）
 	bool ResolveObstaclePenetrationXZ(float deltaTime);
+	// 障害物の上面へ着地できる場合にY位置を補正して横押し出しより優先する
+	bool TryLandOnObstacleTop(float deltaTime);
 
 	// ステージの衝突を解決する処理（AABBとの衝突を解決して押し戻す）
 	void UpdateStuckState(float deltaTime);


### PR DESCRIPTION
### Motivation
- Fix an issue where MeleeEnemy jumping onto obstacles (e.g. grey blocks) is laterally pushed out and falls because wall obstacles are treated only as side-push walls. 
- Implement landing-on-top behavior inside MeleeEnemy so stage AABB classification does not need to change.

### Description
- Added tuning parameters to `MoveSettings`: `obstacleTopLandingEnabled`, `obstacleTopLandingTolerance`, `obstacleTopLandingMaxHeight`, and `obstacleTopLandingMinHorizontalOverlap` for top-landing control. 
- Added collision debug fields `landedOnObstacleTop` and `lastObstacleTopLandingName` to `CollisionState` and exposed the parameters/state in ImGui. 
- Implemented `bool TryLandOnObstacleTop(float deltaTime)` which detects descending/overlapping cases and snaps the enemy Y to the obstacle top, sets `velocity.y = 0` and `grounded_ = true` when conditions match (XZ overlap, foot near obstacle top, crossed from above). 
- Updated `Update()` to call `TryLandOnObstacleTop()` before `ResolveObstaclePenetrationXZ()` and skip lateral push-out for obstacles that succeeded top-landing, while preserving existing side-collision push-out behavior.

### Testing
- Ran `git diff --check` to validate whitespace/patch issues, which reported no problems. 
- Performed repository scans using `rg` to verify new symbols (`TryLandOnObstacleTop`, `obstacleTopLanding*`, `landedOnObstacleTop`, `lastObstacleTopLandingName`) are present, which succeeded. 
- No unit tests or full build were executed in this change; runtime verification is expected during in-engine playtesting.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13b6388058832db1f040b15b98ee79)