### PR TITLE
Fix MeleeEnemy jump to use fixed base velocity and restrictive jump gating

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
@@ -329,14 +329,14 @@ void MeleeEnemy::DrawImGui()
 		ImGui::SliderFloat("repathInterval", &pathSettings_.repathInterval, 0.05f, 2.0f);
 		ImGui::SliderFloat("waypointReachDistance", &pathSettings_.waypointReachDistance, 0.5f, 1.5f);
 		ImGui::Checkbox("pathFindEnabled", &pathSettings_.enabled);
-		ImGui::Checkbox("jumpEnabled", &jump_.enabled);
-		ImGui::SliderFloat("baseJumpVelocity", &jump_.baseVelocity, 2.0f, 18.0f);
-		ImGui::SliderFloat("jumpExtraBoost", &jump_.extraBoost, 0.0f, 8.0f);
-		ImGui::SliderFloat("jumpGravityEstimate", &jump_.gravityEstimate, 1.0f, 40.0f);
-		ImGui::SliderFloat("maxJumpVelocity", &jump_.maxVelocity, 1.0f, 30.0f);
-		ImGui::SliderFloat("jumpTargetHeightThreshold", &jump_.targetHeightThreshold, 0.1f, 5.0f);
-		ImGui::SliderFloat("jumpHorizontalDistanceMax", &jump_.horizontalDistanceMax, 0.5f, 20.0f);
-		ImGui::SliderFloat("jumpCooldown", &jump_.cooldown, 0.0f, 3.0f);
+		ImGui::Checkbox("jump.enabled", &jump_.enabled);
+		ImGui::SliderFloat("jump.baseVelocity", &jump_.baseVelocity, 2.0f, 18.0f);
+		ImGui::SliderFloat("jump.minTargetHeight", &jump_.minTargetHeight, 0.1f, 5.0f);
+		ImGui::SliderFloat("jump.maxTargetHeight", &jump_.maxTargetHeight, 0.5f, 8.0f);
+		ImGui::SliderFloat("jump.horizontalDistanceMax", &jump_.horizontalDistanceMax, 0.5f, 20.0f);
+		ImGui::Checkbox("jump.requireNearOrBlocked", &jump_.requireNearOrBlocked);
+		ImGui::SliderFloat("jump.nearTargetDistance", &jump_.nearTargetDistance, 0.5f, 8.0f);
+		ImGui::SliderFloat("jump.cooldown", &jump_.cooldown, 0.0f, 3.0f);
 		const float prevGridSize = pathSettings_.gridSize;
 		ImGui::SliderFloat("pathGridSize", &pathSettings_.gridSize, 0.5f, 1.0f);
 		if (std::abs(prevGridSize - pathSettings_.gridSize) > kEpsilon) { navigator_.Reset(); pathState_.lastRepathReason = "GridSizeChanged"; }
@@ -401,11 +401,11 @@ void MeleeEnemy::DrawImGui()
 		ImGui::Text("temporaryBlockedCellCount: %d", static_cast<int>(navigator_.GetTemporaryBlockedAreas().size()));
 		ImGui::Text("cornerCuttingDisabled: %s", pathSettings_.cornerCuttingDisabled ? "true" : "false");
 		ImGui::Text("Grounded: %s", grounded_ ? "true" : "false");
-		ImGui::Text("jumpCooldownTimer: %.2f", jumpState_.cooldownTimer);
-		ImGui::Text("targetHeightDelta: %.2f", jumpState_.targetHeightDelta);
-		ImGui::Text("calculatedJumpVelocity: %.2f", jumpState_.calculatedVelocity);
-		ImGui::Text("appliedJumpVelocity: %.2f", jumpState_.appliedVelocity);
-		ImGui::Text("lastJumpReason: %s", jumpState_.lastReason.c_str());
+		ImGui::Text("jumpState.cooldownTimer: %.2f", jumpState_.cooldownTimer);
+		ImGui::Text("jumpState.targetHeightDelta: %.2f", jumpState_.targetHeightDelta);
+		ImGui::Text("jumpState.horizontalDistance: %.2f", jumpState_.horizontalDistance);
+		ImGui::Text("jumpState.appliedVelocity: %.2f", jumpState_.appliedVelocity);
+		ImGui::Text("jumpState.lastReason: %s", jumpState_.lastReason.c_str());
 		ImGui::Text("AnimState: %s", GetAnimStateName());
 		ImGui::Text("lastSafePosition: (%.2f, %.2f, %.2f)", collision_.lastSafePosition.x, collision_.lastSafePosition.y, collision_.lastSafePosition.z);
 		ImGui::Text("isOutsideStage: %s", collision_.isOutsideStage ? "true" : "false");
@@ -698,13 +698,6 @@ bool MeleeEnemy::MoveAlongPath(float deltaTime)
 	return false;
 }
 
-float MeleeEnemy::CalculateJumpVelocityForHeight(float heightDelta) const
-{
-	// 高さ差に必要な初速を重力推定値から算出し、段差追従ジャンプの不足を防ぐ
-	const float clampedHeight = std::max(0.0f, heightDelta);
-	return std::sqrt(2.0f * std::max(jump_.gravityEstimate, 0.0f) * clampedHeight);
-}
-
 void MeleeEnemy::TryJumpToTarget(float)
 {
 	if (!jump_.enabled) { jumpState_.lastReason = "Disabled"; return; }
@@ -720,27 +713,28 @@ void MeleeEnemy::TryJumpToTarget(float)
 	const float heightDelta = toTarget.y;
 	const float horizontalDistance = LengthXZ(toTarget);
 	jumpState_.targetHeightDelta = heightDelta;
-	jumpState_.calculatedVelocity = CalculateJumpVelocityForHeight(heightDelta);
+	jumpState_.horizontalDistance = horizontalDistance;
+	jumpState_.appliedVelocity = 0.0f;
 
-	if (heightDelta < jump_.targetHeightThreshold) { jumpState_.lastReason = "TargetNotHigher"; jumpState_.appliedVelocity = 0.0f; return; }
+	if (heightDelta < jump_.minTargetHeight) { jumpState_.lastReason = "TooLow"; return; }
+	if (heightDelta > jump_.maxTargetHeight) { jumpState_.lastReason = "TooHigh"; return; }
 	if (horizontalDistance > jump_.horizontalDistanceMax) { jumpState_.lastReason = "TooFar"; return; }
 
-	const bool obstacleJumpCandidate = collision_.blockedByObstacle || pathState_.lineBlocked || stuck_.isStuck || collision_.isOverlappingWallObstacle;
-	if (obstacleJumpCandidate)
+	const bool isNearTarget = horizontalDistance <= jump_.nearTargetDistance;
+	const bool blockedByObstacle = collision_.blockedByObstacle || collision_.isOverlappingWallObstacle;
+	const bool lineBlocked = pathState_.lineBlocked;
+	if (jump_.requireNearOrBlocked && !isNearTarget && !blockedByObstacle && !lineBlocked && !stuck_.isStuck)
 	{
-		jumpState_.lastReason = "TargetHigherBlocked";
+		jumpState_.lastReason = "NotNearOrBlocked";
+		return;
 	}
-	else
-	{
-		jumpState_.lastReason = "TargetHigher";
-	}
-	// 水平速度は維持しつつY速度だけを上書きし、段差追跡ジャンプを行う
+	// 通常近接雑魚は高さに応じた加速を使わず、固定ジャンプ力だけを適用する
 	Vector3 v = GetVelocity();
-	const float requested = std::max(jump_.baseVelocity, jumpState_.calculatedVelocity + jump_.extraBoost);
-	jumpState_.appliedVelocity = std::clamp(requested, 0.0f, jump_.maxVelocity);
-	v.y = jumpState_.appliedVelocity;
+	jumpState_.appliedVelocity = jump_.baseVelocity;
+	v.y = jump_.baseVelocity;
 	SetVelocity(v);
 	jumpState_.cooldownTimer = jump_.cooldown;
+	jumpState_.lastReason = "Jump";
 }
 
 void MeleeEnemy::UpdateStuckState(float deltaTime)

--- a/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.h
@@ -53,14 +53,14 @@ private: /// ---------- 構造体 ---------- ///
 	// 落下と重力の設定
 	struct JumpSettings
 	{
-		bool enabled = true;				// ジャンプを有効にするかどうか
-		float baseVelocity = 12.0f;			// ジャンプの基本垂直速度
-		float extraBoost = 0.8f;			// 攻撃の種類や状況に応じた追加の垂直速度の倍率
-		float gravityEstimate = 20.0f;		// ジャンプの軌道計算に使用する重力の推定値（実際の重力とは異なる場合がある）
-		float maxVelocity = 18.0f;			// ジャンプの最大垂直速度
-		float targetHeightThreshold = 1.0f;	// ターゲットの高さとの差がこの値以上ある場合にジャンプを試みる
-		float horizontalDistanceMax = 8.0f;	// ジャンプを試みる最大水平距離
-		float cooldown = 0.9f;				// ジャンプのクールダウン時間
+		bool enabled = true;				 // ジャンプを有効にするかどうか
+		float baseVelocity = 11.0f;			 // 通常近接雑魚は高さ依存ではなく固定のY速度で跳ぶ
+		float minTargetHeight = 1.0f;		 // ジャンプを検討する最小高さ差
+		float maxTargetHeight = 3.8f;		 // 通常敵が登ろうとする高さ差の上限
+		float horizontalDistanceMax = 5.0f;	 // ジャンプを検討する最大水平距離
+		bool requireNearOrBlocked = true;	 // 近距離または障害物で詰まっている時だけジャンプする
+		float nearTargetDistance = 2.8f;	 // 近距離判定の閾値
+		float cooldown = 0.9f;				 // ジャンプのクールダウン時間
 	};
 
 	// ジャンプの状態管理
@@ -68,7 +68,7 @@ private: /// ---------- 構造体 ---------- ///
 	{
 		float cooldownTimer = 0.0f;		 // ジャンプのクールダウンタイマー
 		float targetHeightDelta = 0.0f;	 // ジャンプ開始時のターゲットの高さとの差
-		float calculatedVelocity = 0.0f; // ジャンプの軌道計算から得られる垂直速度
+		float horizontalDistance = 0.0f; // ジャンプ判定時のターゲットとの水平距離
 		float appliedVelocity = 0.0f;	 // 実際に適用された垂直速度
 		std::string lastReason = "None"; // ジャンプを試みた最後の理由（デバッグ用）
 	};
@@ -326,9 +326,6 @@ private: /// ---------- 内部処理 ---------- ///
 
 	// 障害物を避ける処理（壁の障害物やステージの衝突を解決する）
 	void TryJumpToTarget(float deltaTime);
-
-	// ジャンプの軌道計算を行い、ターゲットの高さに合わせた垂直速度を計算する処理
-	float CalculateJumpVelocityForHeight(float heightDelta) const;
 
 	// ジャンプを試みる処理（ターゲットの高さや距離、ジャンプのクールダウンなどを考慮してジャンプするかどうかを判断し、実際にジャンプする）
 	bool ResolveObstaclePenetrationXZ(float deltaTime);


### PR DESCRIPTION
### Motivation
- Make normal MeleeEnemy behave like a typical humanoid melee grunt by removing height-scaled jump power and limiting jumps to reachable, near-step situations. 
- Prevent enemies from aggressively scaling tall height differences or jumping across large horizontal gaps when the target is a distant high point.

### Description
- Reworked jump config in `MeleeEnemy.h`: replaced height-dependent fields with `jump.enabled`, `jump.baseVelocity`, `jump.minTargetHeight`, `jump.maxTargetHeight`, `jump.horizontalDistanceMax`, `jump.requireNearOrBlocked`, `jump.nearTargetDistance`, and `jump.cooldown`.
- Simplified runtime state in `JumpState` by adding `horizontalDistance` and keeping `appliedVelocity` and `lastReason`, and removed the height-to-velocity calculation declaration and usage.
- Updated `TryJumpToTarget` in `MeleeEnemy.cpp` to perform the new gating sequence (disabled/NoTarget/Dead/Attack/Airborne/Cooldown checks, compute `heightDelta` and `horizontalDistance`, enforce `min/maxTargetHeight` and `horizontalDistanceMax`, require near/blocked/stuck when configured) and to apply a fixed vertical velocity `jump.baseVelocity` while preserving `velocity.x/z`.
- Removed use of `CalculateJumpVelocityForHeight` and related boost/max-velocity logic so jumps do not scale with height, and updated ImGui debug/controls to expose `jump.*` settings and `jumpState.*` telemetry (including `lastReason`).

### Testing
- Ran static inspections and searches (`rg`) to verify removed/renamed symbols and updated usage paths, and checked git status to confirm changed files were staged.
- Committed the changes successfully to the working branch.
- Attempted a local CMake build, but the repository root does not contain a `CMakeLists.txt`, so a full compile/test could not be executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13ba09b894832d9f75e8c25d633e75)