### PR TITLE
Limit MeleeEnemy head-look to detection range and expose debug state

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
@@ -443,6 +443,8 @@ void MeleeEnemy::DrawImGui()
 		ImGui::Text("headCurrentPitch(deg): %.1f", headLookState_.currentPitch);
 		ImGui::Text("headTargetYaw(deg): %.1f", headLookState_.targetYaw);
 		ImGui::Text("headTargetPitch(deg): %.1f", headLookState_.targetPitch);
+		ImGui::Text("headLookTargetVisible: %s", headLookState_.targetVisible ? "true" : "false");
+		ImGui::Text("headLookReason: %s", headLookState_.reason.c_str());
 		if (ImGui::Button("Force Scratch Attack")) { ForceAttack(MeleeAttackType::Scratch); }
 		ImGui::SameLine();
 		if (ImGui::Button("Force OneTwo Attack")) { ForceAttack(MeleeAttackType::OneTwo); }
@@ -949,19 +951,38 @@ void MeleeEnemy::UpdateVisualAnimation(float deltaTime)
 	// 頭だけをターゲット方向に向ける（bodyに対する相対Yaw/Pitch）
 	if (head < parts_.size())
 	{
+		// 頭向き制御のデフォルトは「正面へ戻す」にして、必要時だけ注視を有効化する
 		headLookState_.targetYaw = 0.0f;
 		headLookState_.targetPitch = 0.0f;
-		if (headLookSettings_.enabled && HasTarget())
+		headLookState_.targetVisible = false;
+		headLookState_.reason = "Disabled";
+		if (headLookSettings_.enabled)
 		{
-			const Vector3 toTarget = GetTargetPosition() - GetCenterPosition();
-			const float desiredYaw = std::atan2(-toTarget.x, toTarget.z);
-			const float bodyYaw = orientation_.y;
-			const float yawDelta = NormalizeAngleRad(desiredYaw - bodyYaw);
-			headLookState_.targetYaw = Clamp(yawDelta * (180.0f / kPi), -headLookSettings_.yawLimitDeg, headLookSettings_.yawLimitDeg);
-			const float horizontalDistance = std::max(LengthXZ(toTarget), kEpsilon);
-			const float pitchDeg = -std::atan2(toTarget.y, horizontalDistance) * (180.0f / kPi);
-			headLookState_.targetPitch = Clamp(pitchDeg, headLookSettings_.pitchMinDeg, headLookSettings_.pitchMaxDeg);
+			headLookState_.reason = "NoTarget";
+			if (HasTarget())
+			{
+				const Vector3 toTarget = GetTargetPosition() - GetCenterPosition();
+				const float targetDistance = std::sqrt(toTarget.x * toTarget.x + toTarget.y * toTarget.y + toTarget.z * toTarget.z);
+				if (targetDistance <= detection_.detectRange)
+				{
+					// detectRange内でのみ頭の注視ターゲットを有効化し、範囲外では正面へ戻す
+					headLookState_.targetVisible = true;
+					headLookState_.reason = "InRange";
+					const float desiredYaw = std::atan2(-toTarget.x, toTarget.z);
+					const float bodyYaw = orientation_.y;
+					const float yawDelta = NormalizeAngleRad(desiredYaw - bodyYaw);
+					headLookState_.targetYaw = Clamp(yawDelta * (180.0f / kPi), -headLookSettings_.yawLimitDeg, headLookSettings_.yawLimitDeg);
+					const float horizontalDistance = std::max(LengthXZ(toTarget), kEpsilon);
+					const float pitchDeg = -std::atan2(toTarget.y, horizontalDistance) * (180.0f / kPi);
+					headLookState_.targetPitch = Clamp(pitchDeg, headLookSettings_.pitchMinDeg, headLookSettings_.pitchMaxDeg);
+				}
+				else
+				{
+					headLookState_.reason = "OutOfRange";
+				}
+			}
 		}
+		// 体の向きは既存処理に任せ、頭だけを補間で自然に回頭/復帰させる
 		const float headLerp = std::min(1.0f, headLookSettings_.lerpSpeed * deltaTime);
 		headLookState_.currentYaw += (headLookState_.targetYaw - headLookState_.currentYaw) * headLerp;
 		headLookState_.currentPitch += (headLookState_.targetPitch - headLookState_.currentPitch) * headLerp;

--- a/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.h
@@ -195,6 +195,8 @@ private: /// ---------- 構造体 ---------- ///
 		float currentPitch = 0.0f;
 		float targetYaw = 0.0f;
 		float targetPitch = 0.0f;
+		bool targetVisible = false;
+		std::string reason = "Disabled";
 	};
 
 	// 衝突の状態管理


### PR DESCRIPTION
### Motivation

- Prevent enemies from staring at targets outside their detection radius and make head-look behavior only active while a target is recognized and within `detection_.detectRange`.
- Provide visibility into why the head is or is not tracking a target for easier debugging and tuning via ImGui.

### Description

- Added `bool targetVisible` and `std::string reason` to `HeadLookState` to record whether the head is actively tracking and the reason (`InRange` / `OutOfRange` / `NoTarget` / `Disabled`).
- Updated head-look logic in `UpdateVisualAnimation` so the head target yaw/pitch are only assigned when `headLookSettings_.enabled && HasTarget() && targetDistance <= detection_.detectRange`, otherwise the head target is reset to forward-facing.
- Preserved smoothing by continuing to interpolate head rotation using `headLookSettings_.lerpSpeed` for both tracking and returning-to-forward transitions, and left body orientation logic unchanged so only the head is rotated.
- Added ImGui text lines `headLookTargetVisible` and `headLookReason` to surface the new debug state, and added short one-line comments in modified sections.

### Testing

- Ran `git diff --check` to verify there are no whitespace/patch issues and it passed.
- Verified presence of new debug outputs and state fields via `rg` searches for `headLookTargetVisible`, `headLookReason`, `targetVisible`, and `reason` which succeeded.
- Full project build was not executed in this environment because top-level build definition files were not available here, so compilation was not run as part of these automated checks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a13c0d1a880832db7d64fa967237f87)