### PR TITLE
MeleeEnemy: 障害物を乗り越え可能/回避対象に分類し、ジャンプ判定を進行方向基準に改善

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
@@ -661,9 +661,13 @@ bool MeleeEnemy::IsObstacleClimbable(const K4E::AABB& obstacle, const K4E::Vecto
 	const float footY = selfPos.y - 2.0f;
 	const float obstacleHeight = obstacle.max.y - footY;
 	if (obstacleHeight <= 0.0f || obstacleHeight > traversal_.maxClimbHeight) { return false; }
+	// 床面付近に張り付いたAABBは床扱いとして除外する
+	if (std::abs(obstacle.max.y - obstacle.min.y) <= 0.05f) { return false; }
 	const float width = obstacle.max.x - obstacle.min.x;
 	const float depth = obstacle.max.z - obstacle.min.z;
 	if (width > traversal_.maxClimbObstacleWidth || depth > traversal_.maxClimbObstacleDepth) { return false; }
+	// 広すぎるステージ本体AABBは乗り越え候補から外す
+	if (width > traversal_.maxClimbObstacleWidth * 4.0f || depth > traversal_.maxClimbObstacleDepth * 4.0f) { return false; }
 	const K4E::Vector3 center = (obstacle.min + obstacle.max) * 0.5f;
 	const K4E::Vector3 toObs = center - selfPos;
 	const float horizontalDistance = LengthXZ(toObs);
@@ -681,17 +685,20 @@ void MeleeEnemy::UpdateTraversalObstacleClassification()
 	traversalState_.directClimbCandidateFound = false;
 	traversalState_.selectedObstacleJudgeReason = "None";
 	traversalState_.selectedObstacleRejectReason = "None";
-	const auto* src = wallObstacleAABBs_ ? wallObstacleAABBs_ : GetResolvedNavigationObstacleAABBs();
-	if (!src) { traversalState_.climbableObstacleCount = 0; traversalState_.blockingObstacleCount = 0; return; }
+	const auto* wallSrc = wallObstacleAABBs_;
+	const auto* navSrc = GetResolvedNavigationObstacleAABBs();
+	if (!wallSrc && !navSrc) { traversalState_.climbableObstacleCount = 0; traversalState_.blockingObstacleCount = 0; return; }
 	const K4E::Vector3 selfPos = GetCenterPosition();
 	K4E::Vector3 moveOrTargetDir = NormalizeXZ(GetVelocity());
 	if (LengthXZ(moveOrTargetDir) <= kEpsilon) { moveOrTargetDir = NormalizeXZ(GetTargetPosition() - selfPos); }
-	for (const auto& obstacle : *src)
+	auto classify = [&](const K4E::AABB& obstacle)
 	{
 		// 低くて小さい障害物は乗り越え候補、それ以外は経路探索の回避対象に分類する
 		if (IsObstacleClimbable(obstacle, selfPos, moveOrTargetDir)) { climbableObstacleAABBs_.push_back(obstacle); }
 		else { pathBlockingObstacleAABBs_.push_back(obstacle); }
-	}
+	};
+	if (wallSrc) { for (const auto& obstacle : *wallSrc) { classify(obstacle); } }
+	if (navSrc) { for (const auto& obstacle : *navSrc) { classify(obstacle); } }
 	traversalState_.climbableObstacleCount = static_cast<int>(climbableObstacleAABBs_.size());
 	traversalState_.blockingObstacleCount = static_cast<int>(pathBlockingObstacleAABBs_.size());
 }
@@ -748,9 +755,11 @@ bool MeleeEnemy::TryJumpOverClimbableObstacle(float)
 	if (jumpState_.cooldownTimer > 0.0f) { traversalState_.lastReason = "Cooldown"; jumpState_.lastReason = "Cooldown"; return false; }
 	if (climbableObstacleAABBs_.empty()) { traversalState_.nearClimbableObstacle = false; traversalState_.lastReason = "NoClimbable"; return false; }
 	const K4E::Vector3 selfPos = GetCenterPosition();
+	const K4E::Vector3 targetPos = GetTargetPosition();
 	K4E::Vector3 moveOrTargetDir = NormalizeXZ(GetVelocity());
 	if (LengthXZ(moveOrTargetDir) <= kEpsilon) { moveOrTargetDir = NormalizeXZ(GetTargetPosition() - selfPos); }
 	float bestDist = 9999.0f;
+	int selected = -1;
 	for (size_t i = 0; i < climbableObstacleAABBs_.size(); ++i)
 	{
 		const auto& obstacle = climbableObstacleAABBs_[i];
@@ -760,10 +769,15 @@ bool MeleeEnemy::TryJumpOverClimbableObstacle(float)
 		if (horizontalDistance > traversal_.climbJumpTriggerDistance) { traversalState_.lastReason = "TooFarFromObstacle"; continue; }
 		const K4E::Vector3 dirToObs = NormalizeXZ(toObs);
 		const float dirDot = dirToObs.x * moveOrTargetDir.x + dirToObs.z * moveOrTargetDir.z;
-		if (dirDot < 0.1f) { continue; }
-		if (horizontalDistance < bestDist) { bestDist = horizontalDistance; traversalState_.selectedClimbObstacleIndex = static_cast<int>(i); }
+		const bool inMoveDirection = dirDot >= 0.1f;
+		const float toTargetLineDistance = DistancePointToSegmentXZ(center, selfPos, targetPos);
+		const bool betweenSelfAndTarget = toTargetLineDistance <= traversal_.directLineWidth;
+		// 進行方向上か、敵-ターゲット間の障害物のみジャンプ対象とする
+		if (!inMoveDirection && !betweenSelfAndTarget) { continue; }
+		if (horizontalDistance < bestDist) { bestDist = horizontalDistance; selected = static_cast<int>(i); }
 	}
-	traversalState_.nearClimbableObstacle = traversalState_.selectedClimbObstacleIndex >= 0;
+	traversalState_.selectedClimbObstacleIndex = selected;
+	traversalState_.nearClimbableObstacle = selected >= 0;
 	if (!traversalState_.nearClimbableObstacle) { traversalState_.lastReason = "NoNearObstacle"; return false; }
 	const auto& selectedObstacle = climbableObstacleAABBs_[traversalState_.selectedClimbObstacleIndex];
 	// 近接乗り越えジャンプで選ばれた障害物の値を保持する


### PR DESCRIPTION
### Motivation
- MeleeEnemy のナビゲーションで低い障害物を "乗り越え可能" として扱い、A* へは回避対象のみ渡すことで不必要な迂回を防ぎつつ不要なジャンプを抑制する目的。 
- ターゲットの Y だけでジャンプ判定していたため不要に跳んでしまうケースがあり、それを実際の進行上の障害物に基づく判定へ切り替える目的。

### Description
- `IsObstacleClimbable()` を強化し、床付近の薄い AABB やステージ本体相当の巨大 AABB を乗り越え候補から除外するチェックを追加した。高さ・幅・奥行き・水平距離など既存の閾値判定は維持。 (MeleeEnemy.cpp)
- `UpdateTraversalObstacleClassification()` を修正して `wallObstacleAABBs_` と解決済みの `navigationObstacleAABBs_`（`GetResolvedNavigationObstacleAABBs()`）の両方を入力として処理し、障害物を `climbableObstacleAABBs_` と `pathBlockingObstacleAABBs_` に分類するようにした。これにより `navigator_.SetWorldAABBs()` には回避対象のみを渡す設計を維持する。 (MeleeEnemy.cpp)
- `TryJumpOverClimbableObstacle()` を更新し、ジャンプ実行候補を「進行方向上にある障害物」または「敵〜ターゲット間のライン上にある障害物」に限定するロジックを追加した（最寄り候補を選択）、ジャンプ力は既存の固定 `jump_.baseVelocity` をそのまま使用する挙動を維持。 (MeleeEnemy.cpp)
- 既存の障害物上面着地処理、ImGui 表示、日本語ラベル、デバッグ描画（乗り越え候補色・回避対象色・選択強調）は維持したまま変更を適用し、関連箇所に簡単なコメントを追加している。 (MeleeEnemy.cpp)

### Testing
- `cmake --build . --config Debug` を実行しましたが、CMake キャッシュが存在しない環境のためビルドは失敗しました（`Error: could not load cache`）。
- ソース差分とコンパイルに影響しそうな箇所を確認するための静的差分確認（`git diff`）は実行済みで変更内容は意図どおりです。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a14292cac74832da85385f14739f817)