### PR TITLE
Enable multi-instance MeleeEnemy debug spawning and selection UI

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
@@ -371,6 +371,7 @@ void MeleeEnemy::OnCollisionStay(K4E::Collider* other)
 void MeleeEnemy::Draw()
 {
 	EnemyBase::Draw();
+	if (!detailDebugDrawEnabled_) { return; }
 	const Vector3 origin = GetCenterPosition() + Vector3{ 0.0f, 1.0f, 0.0f };
 	Wireframe::GetInstance()->DrawLine(origin, origin + animationState_.movementDirection * 1.8f, { 0.2f, 0.8f, 1.0f, 1.0f });
 	Wireframe::GetInstance()->DrawLine(origin, origin + animationState_.targetDirection * 2.0f, { 1.0f, 1.0f, 0.2f, 1.0f });

--- a/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.h
@@ -379,6 +379,12 @@ public: /// ---------- アクセッサ ---------- ///
 	// 選択されている攻撃の種類を取得
 	MeleeAttackType GetSelectedAttackType() const { return attackSettings_.selectedAttackType; }
 
+	// 選択中個体のみ詳細デバッグ描画するための表示切り替えを設定する
+	void SetDetailDebugDrawEnabled(bool enabled) { detailDebugDrawEnabled_ = enabled; }
+
+	// 複数体の行動状態確認用に現在行動名を返す
+	const char* GetCurrentBehaviorName() const { return currentBehaviorName_; }
+
 	// 攻撃中かどうかを取得
 	bool IsAttacking() const { return attackController_.IsAttacking(); }
 
@@ -582,6 +588,7 @@ private: /// ---------- メンバ変数 ---------- //
 
 	// デバッグ用の現在のアニメーション状態の名前
 	const char* currentBehaviorName_ = "None";
+	bool detailDebugDrawEnabled_ = true;
 
 	// 調整データのI/O状態
 	TuningIoState tuningIo_{};

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -133,15 +133,19 @@ void DebugScene::Initialize()
 	debugBoss_->SetPosition({ 0.0f, 2.25f, 30.0f });
 	debugBoss_->SetYaw(3.141592f); // 必要ならプレイヤー側へ向ける
 
-	debugMeleeEnemy_ = std::make_unique<MeleeEnemy>();
-	debugMeleeEnemy_->Initialize();
-	// ステージ床に確実に着地できるよう、初期位置は少し高めから開始する。
-	debugMeleeEnemy_->SetCenterPosition({ 0.0f, 2.0f, 18.0f });
-
 	meleeDummyTarget_.SetCenterPosition({ 0.0f, 2.0f, 24.0f });
 	meleeDummyTarget_.SetOBBHalfSize({ 0.8f, 1.0f, 0.8f });
-	debugMeleeEnemy_->SetTarget(&meleeDummyTarget_);
-	collisionManager_->AddCollider(debugMeleeEnemy_.get());
+	// 複数体同時検証のため、DebugScene起動時に近接敵を2〜3体まとめて生成する。
+	debugMeleeEnemies_.clear();
+	for (int i = 0; i < meleeEnemyCount_; ++i)
+	{
+		auto enemy = std::make_unique<MeleeEnemy>();
+		enemy->Initialize();
+		enemy->SetCenterPosition({ -2.5f + (2.5f * static_cast<float>(i)), 2.0f, 18.0f });
+		enemy->SetTarget(&meleeDummyTarget_);
+		collisionManager_->AddCollider(enemy.get());
+		debugMeleeEnemies_.push_back(std::move(enemy));
+	}
 
 	disintegrationDebug_ = std::make_unique<DisintegrationDebugController>();
 	// Disintegration系の確認処理は専用コントローラへ委譲し、DebugScene本体の責務を絞る。
@@ -158,8 +162,11 @@ void DebugScene::Initialize()
 	// DebugSceneでもステージAABBを共有し、EnemyBase系の敵が床と障害物に衝突できるようにする。
 	EnemyBase::SetGlobalStageWorldAABBs(&stage_->GetWorldAABBs());
 	EnemyBase::SetGlobalStageNavigationObstacleAABBs(&stage_->GetNavigationObstacleAABBs());
-	debugMeleeEnemy_->SetFloorAABBs(&stage_->GetFloorAABBs());
-	debugMeleeEnemy_->SetWallObstacleAABBs(&stage_->GetWallObstacleAABBs());
+	for (auto& enemy : debugMeleeEnemies_)
+	{
+		enemy->SetFloorAABBs(&stage_->GetFloorAABBs());
+		enemy->SetWallObstacleAABBs(&stage_->GetWallObstacleAABBs());
+	}
 }
 
 void DebugScene::Update()
@@ -181,9 +188,9 @@ void DebugScene::Update()
 		debugBoss_->Update(deltaTime);
 	}
 
-	if (debugMeleeEnemy_)
+	for (auto& enemy : debugMeleeEnemies_)
 	{
-		debugMeleeEnemy_->Update(deltaTime);
+		enemy->Update(deltaTime);
 	}
 
 	UpdateDebugBossHitTest();
@@ -232,9 +239,12 @@ void DebugScene::Draw3DObjects()
 	{
 		debugBoss_->Draw();
 	}
-	if (debugMeleeEnemy_)
+	for (size_t i = 0; i < debugMeleeEnemies_.size(); ++i)
 	{
-		debugMeleeEnemy_->Draw();
+		// 個体ごとのデバッグ描画過多を避けるため、選択中個体のみ詳細表示する。
+		const bool isSelected = static_cast<int>(i) == selectedMeleeEnemyIndex_;
+		debugMeleeEnemies_[i]->SetDetailDebugDrawEnabled(!meleeEnemyDetailDebugDrawOnlySelected_ || isSelected);
+		debugMeleeEnemies_[i]->Draw();
 	}
 
 	if (stage_)
@@ -278,9 +288,9 @@ void DebugScene::DrawShadowObjects()
 	{
 		debugBoss_->DrawShadow();
 	}
-	if (debugMeleeEnemy_)
+	for (auto& enemy : debugMeleeEnemies_)
 	{
-		debugMeleeEnemy_->DrawShadow();
+		enemy->DrawShadow();
 	}
 	if (stage_)
 	{
@@ -318,7 +328,7 @@ void DebugScene::Finalize()
 	disintegrationDebug_.reset();
 	EnemyBase::SetGlobalStageWorldAABBs(nullptr);
 	debugBoss_.reset();
-	debugMeleeEnemy_.reset();
+	debugMeleeEnemies_.clear();
 	collisionManager_.reset();
 	stage_.reset();
 
@@ -336,9 +346,10 @@ void DebugScene::DrawImGui()
 	{
 		debugBoss_->DrawImGui();
 	}
-	if (debugMeleeEnemy_)
+	if (!debugMeleeEnemies_.empty())
 	{
-		debugMeleeEnemy_->DrawImGui();
+		selectedMeleeEnemyIndex_ = std::clamp(selectedMeleeEnemyIndex_, 0, static_cast<int>(debugMeleeEnemies_.size()) - 1);
+		debugMeleeEnemies_[selectedMeleeEnemyIndex_]->DrawImGui();
 	}
 
 	if (frustumCullingDebug_)
@@ -486,11 +497,17 @@ void DebugScene::DrawImGui()
 		ImGui::Text("Fence: %d", colliderTypeCounts["Fence"]);
 		ImGui::Text("Tree: %d", colliderTypeCounts["Tree"]);
 
-		if (debugMeleeEnemy_)
+		if (!debugMeleeEnemies_.empty())
 		{
-			const Vector3 enemyPos = debugMeleeEnemy_->GetCenterPosition();
-			ImGui::Text("MeleeEnemy Pos: (%.2f, %.2f, %.2f)", enemyPos.x, enemyPos.y, enemyPos.z);
-			ImGui::Text("Grounded: %s", debugMeleeEnemy_->GetVelocity().y == 0.0f ? "Likely grounded" : "Falling/Moving");
+			selectedMeleeEnemyIndex_ = std::clamp(selectedMeleeEnemyIndex_, 0, static_cast<int>(debugMeleeEnemies_.size()) - 1);
+			const MeleeEnemy* selectedEnemy = debugMeleeEnemies_[selectedMeleeEnemyIndex_].get();
+			const Vector3 enemyPos = selectedEnemy->GetCenterPosition();
+			ImGui::Text("MeleeEnemy Count: %zu", debugMeleeEnemies_.size());
+			ImGui::SliderInt("MeleeEnemy Display Index", &selectedMeleeEnemyIndex_, 0, static_cast<int>(debugMeleeEnemies_.size()) - 1);
+			ImGui::Checkbox("Detail Debug Draw Only Selected", &meleeEnemyDetailDebugDrawOnlySelected_);
+			ImGui::Text("Selected Pos: (%.2f, %.2f, %.2f)", enemyPos.x, enemyPos.y, enemyPos.z);
+			ImGui::Text("Selected Action: %s", selectedEnemy->GetCurrentBehaviorName());
+			ImGui::Text("Grounded: %s", selectedEnemy->GetVelocity().y == 0.0f ? "Likely grounded" : "Falling/Moving");
 		}
 
 		ImGui::End();

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
@@ -84,7 +84,10 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	// 描画確認用ボス
 	std::unique_ptr<GuardianBoss> debugBoss_;
-	std::unique_ptr<MeleeEnemy> debugMeleeEnemy_;
+	std::vector<std::unique_ptr<MeleeEnemy>> debugMeleeEnemies_;
+	int meleeEnemyCount_ = 3;
+	int selectedMeleeEnemyIndex_ = 0;
+	bool meleeEnemyDetailDebugDrawOnlySelected_ = true;
 
 	// ステージ確認用（見た目＋衝突）
 	std::unique_ptr<K4E::Stage> stage_;


### PR DESCRIPTION
### Motivation
- Allow verifying MeleeEnemy behavior with multiple simultaneous instances in DebugScene while keeping per-instance state independent. 
- Provide an ImGui workflow to inspect and tune one selected MeleeEnemy at a time to avoid visual clutter from many debug draws.

### Description
- Replaced single `debugMeleeEnemy_` with `std::vector<std::unique_ptr<MeleeEnemy>> debugMeleeEnemies_` and added `meleeEnemyCount_`, `selectedMeleeEnemyIndex_`, and `meleeEnemyDetailDebugDrawOnlySelected_` to `DebugScene` to drive multi-spawn and selection UI. 
- `DebugScene::Initialize()` now spawns `meleeEnemyCount_` MeleeEnemy instances, assigns the same `meleeDummyTarget_` to all, registers each with `collisionManager_`, and after stage load assigns `floorAABBs`/`wallObstacleAABBs` to every instance. 
- Updated `DebugScene::Update()`, `Draw3DObjects()`, `DrawShadowObjects()`, `Finalize()`, and `DrawImGui()` to iterate over all spawned enemies, and made `DrawImGui()` call only the selected enemy's `DrawImGui()` so save/load affects the selected instance only. 
- Added per-instance control and query on `MeleeEnemy`: `SetDetailDebugDrawEnabled(bool)` and `GetCurrentBehaviorName()`, and guarded `MeleeEnemy::Draw()` to early-return when detailed debug draw is disabled so only the selected enemy shows detailed debug visuals. 

### Testing
- Verified repository-level edits and symbol wiring via quick code searches (`rg`) to ensure new members and calls are present and correctly referenced. 
- Applied code changes and committed them successfully to the branch (`git commit` recorded). 
- Attempted a full project build with CMake in the container but the build failed because there is no top-level `CMakeLists.txt` in this environment, so a complete build/test could not be executed here. 
- No automated unit tests were present or run as part of this change in this environment; runtime verification should be done in the full engine build/run environment to confirm multiple enemies track the shared target and have independent state.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a145cac82e0832d8cd06c6834a5bafe)