### PR TITLE
MeleeEnemyの個体間重なりをXZ分離で解消

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
@@ -368,6 +368,45 @@ void MeleeEnemy::OnCollisionStay(K4E::Collider* other)
 {
 	OnCollisionEnter(other);
 }
+
+void MeleeEnemy::BeginSeparationFrame()
+{
+	// 毎フレームの個体間分離デバッグ状態を初期化する。
+	separationState_.overlappingEnemyCount = 0;
+	separationState_.lastSeparationPush = { 0.0f, 0.0f, 0.0f };
+}
+
+Vector3 MeleeEnemy::ApplySeparationPushXZ(const Vector3& desiredPush, float pushScale)
+{
+	// 個体間分離はXZ平面のみ反映し、Y方向の速度と位置は変更しない。
+	if (!separationSettings_.enabled) { return { 0.0f, 0.0f, 0.0f }; }
+	const float maxPush = std::max(0.0f, separationSettings_.maxPushPerFrame);
+	Vector3 push = { desiredPush.x * pushScale, 0.0f, desiredPush.z * pushScale };
+	const float pushLen = LengthXZ(push);
+	if (pushLen > maxPush && pushLen > kEpsilon)
+	{
+		const float s = maxPush / pushLen;
+		push.x *= s;
+		push.z *= s;
+	}
+	Vector3 pos = GetCenterPosition();
+	Vector3 nextPos = pos + push;
+	nextPos.y = pos.y;
+	if (collision_.hasStageBounds && !IsInsideStageBounds(nextPos))
+	{
+		// ステージ外へ出る方向の押し出しは破棄して、暴発を防ぐ。
+		return { 0.0f, 0.0f, 0.0f };
+	}
+	SetCenterPosition(nextPos);
+	separationState_.lastSeparationPush = push;
+	return push;
+}
+
+void MeleeEnemy::AddSeparationOverlapCount(int count)
+{
+	// 個体間分離で重なり相手が何体いたかをImGui表示用に蓄積する。
+	separationState_.overlappingEnemyCount += std::max(0, count);
+}
 void MeleeEnemy::Draw()
 {
 	EnemyBase::Draw();
@@ -429,6 +468,14 @@ void MeleeEnemy::Draw()
 	{
 		Wireframe::GetInstance()->DrawSphere(blocked.center + Vector3{ 0.0f, 0.2f, 0.0f }, blocked.radius, { 1.0f, 0.2f, 0.8f, 0.35f });
 	}
+	// 選択中個体の分離半径と押し出し方向を可視化して、重なり解消の挙動を確認しやすくする。
+	Wireframe::GetInstance()->DrawSphere(GetCenterPosition() + Vector3{ 0.0f, 0.15f, 0.0f }, separationSettings_.radius, { 0.2f, 0.8f, 1.0f, 0.35f });
+	if (separationState_.overlappingEnemyCount > 0)
+	{
+		const Vector3 lineStart = GetCenterPosition() + Vector3{ 0.0f, 1.1f, 0.0f };
+		const Vector3 lineEnd = lineStart + separationState_.lastSeparationPush * 12.0f;
+		Wireframe::GetInstance()->DrawLine(lineStart, lineEnd, { 0.0f, 1.0f, 0.35f, 1.0f });
+	}
 }
 
 void MeleeEnemy::DrawImGui()
@@ -468,6 +515,15 @@ void MeleeEnemy::DrawImGui()
 			ImGui::SliderFloat("上面着地高さ許容", &move_.obstacleTopLandingTolerance, 0.01f, 1.5f);
 			ImGui::SliderFloat("上面着地最大高さ", &move_.obstacleTopLandingMaxHeight, 0.1f, 8.0f);
 			ImGui::SliderFloat("上面着地最小重なり", &move_.obstacleTopLandingMinHorizontalOverlap, 0.01f, 1.0f);
+		}
+		if (ImGui::CollapsingHeader("個体間分離", ImGuiTreeNodeFlags_DefaultOpen)) {
+			ImGui::Checkbox("個体間分離を使う", &separationSettings_.enabled);
+			ImGui::SliderFloat("分離半径", &separationSettings_.radius, 0.2f, 4.0f);
+			ImGui::SliderFloat("分離強度", &separationSettings_.strength, 0.0f, 2.0f);
+			ImGui::SliderFloat("1フレーム最大押し出し", &separationSettings_.maxPushPerFrame, 0.01f, 0.6f);
+			ImGui::SliderFloat("攻撃中の押し出し倍率", &separationSettings_.attackPushScale, 0.0f, 1.0f);
+			ImGui::Text("重なっている敵数: %d", separationState_.overlappingEnemyCount);
+			ImGui::Text("最後の分離押し出し量: (%.3f, %.3f, %.3f)", separationState_.lastSeparationPush.x, separationState_.lastSeparationPush.y, separationState_.lastSeparationPush.z);
 		}
 		if (ImGui::CollapsingHeader("ジャンプ", ImGuiTreeNodeFlags_DefaultOpen)) {
 			ImGui::Checkbox("ジャンプを使う", &jump_.enabled);
@@ -1282,6 +1338,7 @@ bool MeleeEnemy::LoadTuningFromJson(const std::filesystem::path& path, std::stri
 		const nlohmann::json& attackJ = j.contains("attack") ? j["attack"] : j;
 		const nlohmann::json& animationJ = j.contains("animation") ? j["animation"] : j;
 		const nlohmann::json& headLookJ = j.contains("headLook") ? j["headLook"] : j;
+		const nlohmann::json& separationJ = j.contains("separation") ? j["separation"] : j;
 		const nlohmann::json& attackPatternsJ = j.contains("attackPatterns") ? j["attackPatterns"] : j;
 		const nlohmann::json& scratchJ = attackPatternsJ.contains("scratch") ? attackPatternsJ["scratch"] : j;
 		const nlohmann::json& oneTwoJ = attackPatternsJ.contains("oneTwo") ? attackPatternsJ["oneTwo"] : j;
@@ -1344,6 +1401,11 @@ bool MeleeEnemy::LoadTuningFromJson(const std::filesystem::path& path, std::stri
 		headLookSettings_.pitchMinDeg = headLookJ.value("pitchMinDeg", headLookJ.value("headPitchMinDeg", headLookSettings_.pitchMinDeg));
 		headLookSettings_.pitchMaxDeg = headLookJ.value("pitchMaxDeg", headLookJ.value("headPitchMaxDeg", headLookSettings_.pitchMaxDeg));
 		headLookSettings_.lerpSpeed = headLookJ.value("lerpSpeed", headLookJ.value("headLookLerpSpeed", headLookSettings_.lerpSpeed));
+		separationSettings_.enabled = separationJ.value("enabled", separationSettings_.enabled);
+		separationSettings_.radius = separationJ.value("radius", separationSettings_.radius);
+		separationSettings_.strength = separationJ.value("strength", separationSettings_.strength);
+		separationSettings_.maxPushPerFrame = separationJ.value("maxPushPerFrame", separationSettings_.maxPushPerFrame);
+		separationSettings_.attackPushScale = separationJ.value("attackPushScale", separationSettings_.attackPushScale);
 		if (auto* s = attackController_.FindPattern(MeleeAttackType::Scratch))
 		{
 			auto& st = s->steps[0];
@@ -1416,6 +1478,7 @@ bool MeleeEnemy::SaveTuningToJson(const std::filesystem::path& path, std::string
 		j["attack"] = { { "selectedAttackType", static_cast<int>(attackSettings_.selectedAttackType) }, { "lockTime", attackSettings_.lockTime } };
 		j["animation"] = { { "visualYawOffset", animation_.visualYawOffset }, { "walkAnimSpeed", animation_.walkAnimSpeed }, { "walkArmSwing", animation_.walkArmSwing }, { "walkLegSwing", animation_.walkLegSwing }, { "attackArmSwing", animation_.attackArmSwing }, { "attackReturnSpeed", animation_.attackReturnSpeed }, { "attackBodyLean", animation_.attackBodyLean } };
 		j["headLook"] = { { "enabled", headLookSettings_.enabled }, { "yawLimitDeg", headLookSettings_.yawLimitDeg }, { "pitchMinDeg", headLookSettings_.pitchMinDeg }, { "pitchMaxDeg", headLookSettings_.pitchMaxDeg }, { "lerpSpeed", headLookSettings_.lerpSpeed } };
+		j["separation"] = { { "enabled", separationSettings_.enabled }, { "radius", separationSettings_.radius }, { "strength", separationSettings_.strength }, { "maxPushPerFrame", separationSettings_.maxPushPerFrame }, { "attackPushScale", separationSettings_.attackPushScale } };
 		// 保存対象は設定値のみで、ランタイム状態は書き出さない。
 		if (const auto* s = attackController_.FindPattern(MeleeAttackType::Scratch)) { const auto& st = s->steps[0]; j["attackPatterns"]["scratch"] = { {"damage", st.damage}, {"range", st.range}, {"radius", st.radius}, {"startTime", st.startTime}, {"activeTime", st.activeTime}, {"recoveryTime", s->recoveryTime}, {"cooldown", s->cooldown} }; }
 		if (const auto* o = attackController_.FindPattern(MeleeAttackType::OneTwo)) { const auto& l = o->steps[0]; const auto& r = o->steps[1]; j["attackPatterns"]["oneTwo"] = { {"leftDamage", l.damage}, {"rightDamage", r.damage}, {"leftRange", l.range}, {"rightRange", r.range}, {"leftRadius", l.radius}, {"rightRadius", r.radius}, {"leftStartTime", l.startTime}, {"rightStartTime", r.startTime}, {"leftActiveTime", l.activeTime}, {"rightActiveTime", r.activeTime}, {"forwardMoveSpeed", o->forwardMoveSpeed}, {"forwardMoveDuration", o->forwardMoveDuration}, {"recoveryTime", o->recoveryTime}, {"cooldown", o->cooldown} }; }
@@ -1445,6 +1508,7 @@ void MeleeEnemy::ResetTuningToDefault()
 	attackSettings_ = AttackSettings{};
 	animation_ = AnimationSettings{};
 	headLookSettings_ = HeadLookSettings{};
+	separationSettings_ = SeparationSettings{};
 	attackController_.Initialize();
 	navigator_.Reset();
 }

--- a/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.h
@@ -267,6 +267,23 @@ private: /// ---------- 構造体 ---------- ///
 		std::string reason = "Disabled";
 	};
 
+	// 個体間分離の設定
+	struct SeparationSettings
+	{
+		bool enabled = true;
+		float radius = 1.1f;
+		float strength = 0.6f;
+		float maxPushPerFrame = 0.15f;
+		float attackPushScale = 0.35f;
+	};
+
+	// 個体間分離の状態管理
+	struct SeparationState
+	{
+		int overlappingEnemyCount = 0;
+		K4E::Vector3 lastSeparationPush{};
+	};
+
 	// 衝突の状態管理
 	struct CollisionState
 	{
@@ -304,7 +321,7 @@ private: /// ---------- 構造体 ---------- ///
 		std::string lastLoadResult = "未実行";
 		std::string lastSaveResult = "未実行";
 		int jsonFormatVersion = 2;
-		int savedCategoryCount = 10;
+		int savedCategoryCount = 11;
 	};
 
 	// 徘徊の状態管理
@@ -381,6 +398,24 @@ public: /// ---------- アクセッサ ---------- ///
 
 	// 選択中個体のみ詳細デバッグ描画するための表示切り替えを設定する
 	void SetDetailDebugDrawEnabled(bool enabled) { detailDebugDrawEnabled_ = enabled; }
+
+	// 分離設定を取得する
+	const SeparationSettings& GetSeparationSettings() const { return separationSettings_; }
+
+	// 分離状態を取得する
+	const SeparationState& GetSeparationState() const { return separationState_; }
+
+	// 死亡状態かを取得する
+	bool IsDeadEnemy() const { return IsDead(); }
+
+	// 現フレームの分離状態をリセットする
+	void BeginSeparationFrame();
+
+	// 個体間分離の押し出しをXZ平面へ適用する
+	K4E::Vector3 ApplySeparationPushXZ(const K4E::Vector3& desiredPush, float pushScale);
+
+	// 個体間分離で重なり相手を検出した回数を加算する
+	void AddSeparationOverlapCount(int count);
 
 	// 複数体の行動状態確認用に現在行動名を返す
 	const char* GetCurrentBehaviorName() const { return currentBehaviorName_; }
@@ -558,6 +593,12 @@ private: /// ---------- メンバ変数 ---------- //
 
 	// 頭の注視状態
 	HeadLookState headLookState_{};
+
+	// 個体間分離の設定
+	SeparationSettings separationSettings_{};
+
+	// 個体間分離の状態
+	SeparationState separationState_{};
 
 	// 衝突の状態管理
 	CollisionState collision_{};

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -30,6 +30,7 @@
 #include <array>
 #include <numbers>
 #include <unordered_map>
+#include <cmath>
 
 using namespace Ken4lowEngine;
 
@@ -192,6 +193,8 @@ void DebugScene::Update()
 	{
 		enemy->Update(deltaTime);
 	}
+	// 通常更新の後段で個体間分離を適用し、移動やジャンプの挙動を壊しにくくする。
+	ResolveMeleeEnemySeparation(deltaTime);
 
 	UpdateDebugBossHitTest();
 
@@ -220,6 +223,53 @@ void DebugScene::Update()
 		stage_->Update();
 	}
 
+}
+
+void DebugScene::ResolveMeleeEnemySeparation(float deltaTime)
+{
+	(void)deltaTime;
+	for (auto& enemy : debugMeleeEnemies_)
+	{
+		enemy->BeginSeparationFrame();
+	}
+	for (size_t i = 0; i < debugMeleeEnemies_.size(); ++i)
+	{
+		MeleeEnemy* enemyA = debugMeleeEnemies_[i].get();
+		if (!enemyA) { continue; }
+		const auto& separationA = enemyA->GetSeparationSettings();
+		if (!separationA.enabled) { continue; }
+		for (size_t j = i + 1; j < debugMeleeEnemies_.size(); ++j)
+		{
+			MeleeEnemy* enemyB = debugMeleeEnemies_[j].get();
+			if (!enemyB) { continue; }
+			const auto& separationB = enemyB->GetSeparationSettings();
+			if (!separationB.enabled) { continue; }
+			const Vector3 posA = enemyA->GetCenterPosition();
+			const Vector3 posB = enemyB->GetCenterPosition();
+			Vector3 delta = posA - posB;
+			delta.y = 0.0f;
+			const float distance = std::sqrt(delta.x * delta.x + delta.z * delta.z);
+			const float minDistance = std::min(separationA.radius, separationB.radius);
+			if (distance >= minDistance) { continue; }
+			Vector3 pushDir = { 1.0f, 0.0f, 0.0f };
+			if (distance > 0.0001f)
+			{
+				pushDir = { delta.x / distance, 0.0f, delta.z / distance };
+			}
+			const float overlap = minDistance - distance;
+			const float strength = std::min(separationA.strength, separationB.strength);
+			const Vector3 basePush = pushDir * (overlap * strength);
+			const float attackScaleA = enemyA->IsAttacking() ? separationA.attackPushScale : 1.0f;
+			const float attackScaleB = enemyB->IsAttacking() ? separationB.attackPushScale : 1.0f;
+			const float deadScaleA = enemyA->IsDeadEnemy() ? 0.10f : 1.0f;
+			const float deadScaleB = enemyB->IsDeadEnemy() ? 0.10f : 1.0f;
+			// 片寄らないようにA/Bへ半分ずつ押し出し、攻撃中や死亡中は弱める。
+			enemyA->ApplySeparationPushXZ(basePush * 0.5f, attackScaleA * deadScaleA);
+			enemyB->ApplySeparationPushXZ(basePush * -0.5f, attackScaleB * deadScaleB);
+			enemyA->AddSeparationOverlapCount(1);
+			enemyB->AddSeparationOverlapCount(1);
+		}
+	}
 }
 
 void DebugScene::Draw3DObjects()

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
@@ -65,6 +65,9 @@ private: /// ---------- メンバ関数 ---------- ///
 	/// テスト用GPUパーティクル発火
 	void UpdateDebugParticleTest();
 
+	// 近接敵同士のXZ分離をまとめて解決する
+	void ResolveMeleeEnemySeparation(float deltaTime);
+
 	// カリング確認用 Object3D を初期化
 	void InitializeCullingTestObjects();
 


### PR DESCRIPTION
### Motivation
- MeleeEnemyが同じターゲットに向かうときにXZ平面で重なってしまう問題を防ぐため、敵同士の分離処理を追加する必要があった。 
- 分離はY方向に影響を与えず、ジャンプや上面着地など既存の移動挙動を壊さないようにする。 
- デバッグ・調整のためにImGuiとJSONで設定を操作／保存できるようにする。 

### Description
- `MeleeEnemy`に分離用データ構造を追加 (`SeparationSettings`, `SeparationState`) と関連アクセッサを追加し、フレーム開始リセット・XZ押し出し適用・重なりカウント増分のAPIを実装した。 (変更: `Project/.../MeleeEnemy.h`, `Project/.../MeleeEnemy.cpp`) 
- XZ限定の押し出し適用を `ApplySeparationPushXZ` で実装し、Yは変更せず、1フレーム最大押し出しでクランプ、ステージ境界外へ出る押し出しは破棄する安全処理を導入した。 (変更: `MeleeEnemy.cpp`) 
- デバッグ可視化を追加し、選択中個体に分離半径の球表示と、重複があるときの押し出し方向ラインを描画するようにした。 (変更: `MeleeEnemy::Draw`) 
- ImGuiに日本語カテゴリ「個体間分離」を追加し、分離の有効化・半径・強度・1フレーム最大押し出し・攻撃時倍率・重なり数・最後の押し出し量を操作・確認できるようにした。 (変更: `MeleeEnemy::DrawImGui`) 
- JSON保存/読み込み/リセット対象に `separation` セクションを追加し、永続化できるようにした。 (変更: `MeleeEnemy::LoadTuningFromJson`, `SaveTuningToJson`, `ResetTuningToDefault`) 
- `DebugScene`側に `ResolveMeleeEnemySeparation(float)` を追加し、敵の通常更新後に呼び出して全個体のペアごとにXZ距離を判定、重なりがあれば `pushDir * overlap * strength` を計算してA/Bに半分ずつ押し出すロジックを実装した。攻撃中は押し出しを弱め、死亡中はさらに弱くする。 (変更: `Project/.../DebugScene.h`, `DebugScene.cpp`) 

### Testing
- 実施した自動チェック: `git diff --check` が成功（ホワイトスペース等の問題なし）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a145e9fdac0832db8a6c8c8c0f5af91)