### PR TITLE
MeleeEnemy: multi-instance path debug modes, stronger separation and ImGui controls

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
@@ -411,6 +411,8 @@ void MeleeEnemy::Draw()
 {
 	EnemyBase::Draw();
 	if (!detailDebugDrawEnabled_) { return; }
+	const float colorPhase = pathDebugColorOffset_;
+	const Vector4 pathLineColor = pathDebugSelected_ ? Vector4{ 0.15f, 1.0f, 0.75f, 1.0f } : Vector4{ 0.2f + 0.25f * std::sin(colorPhase), 0.75f, 0.7f + 0.2f * std::cos(colorPhase), 0.9f };
 	const Vector3 origin = GetCenterPosition() + Vector3{ 0.0f, 1.0f, 0.0f };
 	Wireframe::GetInstance()->DrawLine(origin, origin + animationState_.movementDirection * 1.8f, { 0.2f, 0.8f, 1.0f, 1.0f });
 	Wireframe::GetInstance()->DrawLine(origin, origin + animationState_.targetDirection * 2.0f, { 1.0f, 1.0f, 0.2f, 1.0f });
@@ -419,22 +421,24 @@ void MeleeEnemy::Draw()
 	const auto& path = navigator_.GetCurrentPath();
 	for (size_t i = 1; i < path.size(); ++i)
 	{
-		Wireframe::GetInstance()->DrawLine(path[i - 1] + Vector3{ 0.0f, 0.15f, 0.0f }, path[i] + Vector3{ 0.0f, 0.15f, 0.0f }, { 0.1f, 1.0f, 0.6f, 1.0f });
+		Wireframe::GetInstance()->DrawLine(path[i - 1] + Vector3{ 0.0f, 0.15f, 0.0f }, path[i] + Vector3{ 0.0f, 0.15f, 0.0f }, pathLineColor);
 	}
+	if (pathDebugDrawEnabled_)
 	for (size_t i = 0; i < path.size(); ++i)
 	{
 		const Vector4 c = (static_cast<int>(i) == navigator_.GetCurrentPathIndex()) ? Vector4{ 1.0f, 0.3f, 0.1f, 1.0f } : Vector4{ 0.1f, 0.9f, 1.0f, 1.0f };
 		Wireframe::GetInstance()->DrawSphere(path[i] + Vector3{ 0.0f, 0.2f, 0.0f }, (static_cast<int>(i) == navigator_.GetCurrentPathIndex()) ? 0.26f : 0.16f, c);
 	}
-	if (pathState_.lineBlocked)
+	if (pathDetailDebugDrawEnabled_ && pathState_.lineBlocked)
 	{
 		Wireframe::GetInstance()->DrawLine(pathState_.blockedSegmentFrom + Vector3{ 0.0f, 0.2f, 0.0f }, pathState_.blockedSegmentTo + Vector3{ 0.0f, 0.2f, 0.0f }, { 1.0f, 0.15f, 0.1f, 1.0f });
 	}
-	if (HasTarget())
+	if (pathDetailDebugDrawEnabled_ && HasTarget())
 	{
 		// ジャンプ追跡判定の可視化として、敵からターゲットへの線を専用色で表示する
 		Wireframe::GetInstance()->DrawLine(origin + Vector3{ 0.0f, 0.2f, 0.0f }, GetTargetPosition() + Vector3{ 0.0f, 0.2f, 0.0f }, { 0.5f, 1.0f, 0.1f, 1.0f });
 	}
+	if (pathDetailDebugDrawEnabled_)
 	for (const auto& inflated : navigator_.GetInflatedObstacleAABBs())
 	{
 		Wireframe::GetInstance()->DrawAABB(inflated, { 1.0f, 0.7f, 0.2f, 0.35f });
@@ -522,6 +526,9 @@ void MeleeEnemy::DrawImGui()
 			ImGui::SliderFloat("分離強度", &separationSettings_.strength, 0.0f, 2.0f);
 			ImGui::SliderFloat("1フレーム最大押し出し", &separationSettings_.maxPushPerFrame, 0.01f, 0.6f);
 			ImGui::SliderFloat("攻撃中の押し出し倍率", &separationSettings_.attackPushScale, 0.0f, 1.0f);
+			ImGui::Checkbox("ターゲット付近の横ずれ補正", &separationSettings_.targetNearLateralEnabled);
+			ImGui::SliderFloat("横ずれ補正の強さ", &separationSettings_.targetNearLateralStrength, 0.0f, 1.5f);
+			ImGui::SliderFloat("横ずれ補正距離", &separationSettings_.targetNearLateralOffset, 0.0f, 1.0f);
 			ImGui::Text("重なっている敵数: %d", separationState_.overlappingEnemyCount);
 			ImGui::Text("最後の分離押し出し量: (%.3f, %.3f, %.3f)", separationState_.lastSeparationPush.x, separationState_.lastSeparationPush.y, separationState_.lastSeparationPush.z);
 		}
@@ -1261,7 +1268,7 @@ void MeleeEnemy::UpdateVisualAnimation(float deltaTime)
 		if (headLookSettings_.enabled)
 		{
 			headLookState_.reason = "NoTarget";
-			if (HasTarget())
+			if (pathDetailDebugDrawEnabled_ && HasTarget())
 			{
 				const Vector3 toTarget = GetTargetPosition() - GetCenterPosition();
 				const float targetDistance = std::sqrt(toTarget.x * toTarget.x + toTarget.y * toTarget.y + toTarget.z * toTarget.z);
@@ -1406,6 +1413,9 @@ bool MeleeEnemy::LoadTuningFromJson(const std::filesystem::path& path, std::stri
 		separationSettings_.strength = separationJ.value("strength", separationSettings_.strength);
 		separationSettings_.maxPushPerFrame = separationJ.value("maxPushPerFrame", separationSettings_.maxPushPerFrame);
 		separationSettings_.attackPushScale = separationJ.value("attackPushScale", separationSettings_.attackPushScale);
+		separationSettings_.targetNearLateralEnabled = separationJ.value("targetNearLateralEnabled", separationSettings_.targetNearLateralEnabled);
+		separationSettings_.targetNearLateralOffset = separationJ.value("targetNearLateralOffset", separationSettings_.targetNearLateralOffset);
+		separationSettings_.targetNearLateralStrength = separationJ.value("targetNearLateralStrength", separationSettings_.targetNearLateralStrength);
 		if (auto* s = attackController_.FindPattern(MeleeAttackType::Scratch))
 		{
 			auto& st = s->steps[0];
@@ -1478,7 +1488,7 @@ bool MeleeEnemy::SaveTuningToJson(const std::filesystem::path& path, std::string
 		j["attack"] = { { "selectedAttackType", static_cast<int>(attackSettings_.selectedAttackType) }, { "lockTime", attackSettings_.lockTime } };
 		j["animation"] = { { "visualYawOffset", animation_.visualYawOffset }, { "walkAnimSpeed", animation_.walkAnimSpeed }, { "walkArmSwing", animation_.walkArmSwing }, { "walkLegSwing", animation_.walkLegSwing }, { "attackArmSwing", animation_.attackArmSwing }, { "attackReturnSpeed", animation_.attackReturnSpeed }, { "attackBodyLean", animation_.attackBodyLean } };
 		j["headLook"] = { { "enabled", headLookSettings_.enabled }, { "yawLimitDeg", headLookSettings_.yawLimitDeg }, { "pitchMinDeg", headLookSettings_.pitchMinDeg }, { "pitchMaxDeg", headLookSettings_.pitchMaxDeg }, { "lerpSpeed", headLookSettings_.lerpSpeed } };
-		j["separation"] = { { "enabled", separationSettings_.enabled }, { "radius", separationSettings_.radius }, { "strength", separationSettings_.strength }, { "maxPushPerFrame", separationSettings_.maxPushPerFrame }, { "attackPushScale", separationSettings_.attackPushScale } };
+		j["separation"] = { { "enabled", separationSettings_.enabled }, { "radius", separationSettings_.radius }, { "strength", separationSettings_.strength }, { "maxPushPerFrame", separationSettings_.maxPushPerFrame }, { "attackPushScale", separationSettings_.attackPushScale }, { "targetNearLateralEnabled", separationSettings_.targetNearLateralEnabled }, { "targetNearLateralOffset", separationSettings_.targetNearLateralOffset }, { "targetNearLateralStrength", separationSettings_.targetNearLateralStrength } };
 		// 保存対象は設定値のみで、ランタイム状態は書き出さない。
 		if (const auto* s = attackController_.FindPattern(MeleeAttackType::Scratch)) { const auto& st = s->steps[0]; j["attackPatterns"]["scratch"] = { {"damage", st.damage}, {"range", st.range}, {"radius", st.radius}, {"startTime", st.startTime}, {"activeTime", st.activeTime}, {"recoveryTime", s->recoveryTime}, {"cooldown", s->cooldown} }; }
 		if (const auto* o = attackController_.FindPattern(MeleeAttackType::OneTwo)) { const auto& l = o->steps[0]; const auto& r = o->steps[1]; j["attackPatterns"]["oneTwo"] = { {"leftDamage", l.damage}, {"rightDamage", r.damage}, {"leftRange", l.range}, {"rightRange", r.range}, {"leftRadius", l.radius}, {"rightRadius", r.radius}, {"leftStartTime", l.startTime}, {"rightStartTime", r.startTime}, {"leftActiveTime", l.activeTime}, {"rightActiveTime", r.activeTime}, {"forwardMoveSpeed", o->forwardMoveSpeed}, {"forwardMoveDuration", o->forwardMoveDuration}, {"recoveryTime", o->recoveryTime}, {"cooldown", o->cooldown} }; }

--- a/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.h
@@ -271,10 +271,13 @@ private: /// ---------- 構造体 ---------- ///
 	struct SeparationSettings
 	{
 		bool enabled = true;
-		float radius = 1.1f;
-		float strength = 0.6f;
-		float maxPushPerFrame = 0.15f;
-		float attackPushScale = 0.35f;
+		float radius = 1.6f;
+		float strength = 1.1f;
+		float maxPushPerFrame = 0.28f;
+		float attackPushScale = 0.5f;
+		bool targetNearLateralEnabled = true;
+		float targetNearLateralOffset = 0.25f;
+		float targetNearLateralStrength = 0.65f;
 	};
 
 	// 個体間分離の状態管理
@@ -398,6 +401,18 @@ public: /// ---------- アクセッサ ---------- ///
 
 	// 選択中個体のみ詳細デバッグ描画するための表示切り替えを設定する
 	void SetDetailDebugDrawEnabled(bool enabled) { detailDebugDrawEnabled_ = enabled; }
+
+	// 全体/選択のみの経路描画を切り替えるため、個体ごとに表示モードを受け取る。
+	void SetPathDebugDrawEnabled(bool enabled) { pathDebugDrawEnabled_ = enabled; }
+
+	// 全体表示時の軽量化のため、詳細デバッグ要素の描画を切り替える。
+	void SetPathDetailDebugDrawEnabled(bool enabled) { pathDetailDebugDrawEnabled_ = enabled; }
+
+	// 個体識別しやすいように経路色オフセットを設定する。
+	void SetPathDebugColorOffset(float offset) { pathDebugColorOffset_ = offset; }
+
+	// 選択中個体の強調表示を切り替える。
+	void SetPathDebugSelected(bool selected) { pathDebugSelected_ = selected; }
 
 	// 分離設定を取得する
 	const SeparationSettings& GetSeparationSettings() const { return separationSettings_; }
@@ -630,6 +645,10 @@ private: /// ---------- メンバ変数 ---------- //
 	// デバッグ用の現在のアニメーション状態の名前
 	const char* currentBehaviorName_ = "None";
 	bool detailDebugDrawEnabled_ = true;
+	bool pathDebugDrawEnabled_ = true;
+	bool pathDetailDebugDrawEnabled_ = true;
+	bool pathDebugSelected_ = false;
+	float pathDebugColorOffset_ = 0.0f;
 
 	// 調整データのI/O状態
 	TuningIoState tuningIo_{};

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -249,7 +249,8 @@ void DebugScene::ResolveMeleeEnemySeparation(float deltaTime)
 			Vector3 delta = posA - posB;
 			delta.y = 0.0f;
 			const float distance = std::sqrt(delta.x * delta.x + delta.z * delta.z);
-			const float minDistance = std::min(separationA.radius, separationB.radius);
+			// 当たりサイズに近い分離距離を取るため、半径は平均で扱う。
+			const float minDistance = std::max(0.1f, (separationA.radius + separationB.radius) * 0.5f);
 			if (distance >= minDistance) { continue; }
 			Vector3 pushDir = { 1.0f, 0.0f, 0.0f };
 			if (distance > 0.0001f)
@@ -258,7 +259,17 @@ void DebugScene::ResolveMeleeEnemySeparation(float deltaTime)
 			}
 			const float overlap = minDistance - distance;
 			const float strength = std::min(separationA.strength, separationB.strength);
-			const Vector3 basePush = pushDir * (overlap * strength);
+			Vector3 basePush = pushDir * (overlap * strength);
+			// ターゲット付近で同一点へ戻りにくくするため、左右タンジェントへ少し散らす。
+			const Vector3 toTarget = enemyA->GetTargetPositionForAttack() - enemyA->GetCenterPosition();
+			const float targetDistXZ = std::sqrt(toTarget.x * toTarget.x + toTarget.z * toTarget.z);
+			if (targetDistXZ < 4.0f)
+			{
+				const Vector3 forward = (targetDistXZ > 0.0001f) ? Vector3{ toTarget.x / targetDistXZ, 0.0f, toTarget.z / targetDistXZ } : Vector3{ 0.0f, 0.0f, 1.0f };
+				const Vector3 tangent{ -forward.z, 0.0f, forward.x };
+				const float laneSign = ((static_cast<int>(i + j) & 1) == 0) ? 1.0f : -1.0f;
+				basePush = basePush + tangent * (separationA.targetNearLateralOffset * separationA.targetNearLateralStrength * laneSign);
+			}
 			const float attackScaleA = enemyA->IsAttacking() ? separationA.attackPushScale : 1.0f;
 			const float attackScaleB = enemyB->IsAttacking() ? separationB.attackPushScale : 1.0f;
 			const float deadScaleA = enemyA->IsDeadEnemy() ? 0.10f : 1.0f;
@@ -291,9 +302,15 @@ void DebugScene::Draw3DObjects()
 	}
 	for (size_t i = 0; i < debugMeleeEnemies_.size(); ++i)
 	{
-		// 個体ごとのデバッグ描画過多を避けるため、選択中個体のみ詳細表示する。
+		// 経路表示モードに応じて、選択中のみ/全体/オフを個体へ反映する。
 		const bool isSelected = static_cast<int>(i) == selectedMeleeEnemyIndex_;
-		debugMeleeEnemies_[i]->SetDetailDebugDrawEnabled(!meleeEnemyDetailDebugDrawOnlySelected_ || isSelected);
+		const bool drawPath = (meleeEnemyPathDrawMode_ == 1) || (meleeEnemyPathDrawMode_ == 0 && isSelected);
+		const bool drawDetailPath = (meleeEnemyPathDrawMode_ == 0 && isSelected) || (meleeEnemyPathDrawMode_ == 1 && meleeEnemyPathDetailAll_);
+		debugMeleeEnemies_[i]->SetDetailDebugDrawEnabled(!meleeEnemyDetailDebugDrawOnlySelected_ || isSelected || drawPath);
+		debugMeleeEnemies_[i]->SetPathDebugDrawEnabled(drawPath);
+		debugMeleeEnemies_[i]->SetPathDetailDebugDrawEnabled(drawDetailPath);
+		debugMeleeEnemies_[i]->SetPathDebugSelected(isSelected);
+		debugMeleeEnemies_[i]->SetPathDebugColorOffset(static_cast<float>(i) * 0.85f);
 		debugMeleeEnemies_[i]->Draw();
 	}
 
@@ -555,6 +572,11 @@ void DebugScene::DrawImGui()
 			ImGui::Text("MeleeEnemy Count: %zu", debugMeleeEnemies_.size());
 			ImGui::SliderInt("MeleeEnemy Display Index", &selectedMeleeEnemyIndex_, 0, static_cast<int>(debugMeleeEnemies_.size()) - 1);
 			ImGui::Checkbox("Detail Debug Draw Only Selected", &meleeEnemyDetailDebugDrawOnlySelected_);
+			const char* pathModes[] = { "選択中の敵だけ経路表示", "全ての敵の経路表示", "経路表示OFF" };
+			ImGui::Combo("経路表示モード", &meleeEnemyPathDrawMode_, pathModes, IM_ARRAYSIZE(pathModes));
+			ImGui::Checkbox("全体経路表示時に詳細も表示", &meleeEnemyPathDetailAll_);
+			ImGui::Text("選択中の敵Index: %d", selectedMeleeEnemyIndex_);
+			ImGui::Text("全体経路表示ON/OFF: %s", meleeEnemyPathDrawMode_ == 1 ? "ON" : "OFF");
 			ImGui::Text("Selected Pos: (%.2f, %.2f, %.2f)", enemyPos.x, enemyPos.y, enemyPos.z);
 			ImGui::Text("Selected Action: %s", selectedEnemy->GetCurrentBehaviorName());
 			ImGui::Text("Grounded: %s", selectedEnemy->GetVelocity().y == 0.0f ? "Likely grounded" : "Falling/Moving");

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
@@ -91,6 +91,8 @@ private: /// ---------- メンバ変数 ---------- ///
 	int meleeEnemyCount_ = 3;
 	int selectedMeleeEnemyIndex_ = 0;
 	bool meleeEnemyDetailDebugDrawOnlySelected_ = true;
+	int meleeEnemyPathDrawMode_ = 0; // 0:選択のみ 1:全体 2:OFF
+	bool meleeEnemyPathDetailAll_ = false;
 
 	// ステージ確認用（見た目＋衝突）
 	std::unique_ptr<K4E::Stage> stage_;


### PR DESCRIPTION
### Motivation
- Provide per-instance and global navigation debug visualization so all spawned `MeleeEnemy` paths can be inspected simultaneously while keeping default UI focused on the selected enemy.
- Reduce unnatural overlap of multiple `MeleeEnemy` around targets by strengthening and improving the separation behavior so groups spread more naturally without touching Y or jump mechanics.

### Description
- Added per-enemy path debug flags and color-offset/selection emphasis accessors to `MeleeEnemy` and gated detailed path elements, so each instance can draw lightweight or detailed path visuals independently (files changed: `MeleeEnemy.h`, `MeleeEnemy.cpp`).
- Implemented scene-level path display mode in `DebugScene` with three choices (0: selected only default, 1: all enemies, 2: off) and an optional "all detail" toggle, and propagate per-instance draw flags and a per-instance color phase offset when drawing (files changed: `DebugScene.h`, `DebugScene.cpp`).
- Increased default `SeparationSettings` (radius/strength/maxPush/attackScale), switched pair-distance calculation to use the average radius for practical spacing, and added an optional target-near lateral tangent offset that nudges units left/right to avoid re-stacking at a single point while preserving XZ-only pushes and clamping via existing `ApplySeparationPushXZ` (files changed: `MeleeEnemy.h`, `DebugScene.cpp`).
- Exposed new separation parameters in ImGui under 個体間分離 (enabled/radius/strength/maxPush/attackScale/横ずれ補正 on+strength+distance), and added the path display controls and status info in the Japanese DebugScene UI; the new separation params are persisted in the tuning JSON load/save while runtime state is still not serialized (files changed: `MeleeEnemy.cpp`, `DebugScene.cpp`).

### Testing
- Attempted an automated build with `cd Project && cmake --build .`, but the environment reported `could not load cache` so a full build could not be executed here.
- No other automated test suite was available in this environment; changes were validated by static inspection and local code updates to ensure members and calls compile in-context.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1461dee7ec832dabc2807e1e523093)