### PR TITLE
MeleeEnemy: 最大HPをBasicStatsとしてデータ化し、ImGui/JSONで編集可能に

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.h
@@ -3,6 +3,7 @@
 #include <cstdint>
 #include <string>
 #include <vector>
+#include <algorithm>
 
 #include "Collider.h"
 #include "Object3D.h"
@@ -57,6 +58,11 @@ public:
 public:
 	// HP
 	void SetMaxHp(int v) { maxHp_ = v; hp_ = v; }
+	// 現在HPを安全な範囲へ補正して設定する
+	void SetCurrentHp(int v)
+	{
+		hp_ = std::max(0, std::min(v, maxHp_));
+	}
 	// 現在HPを返す
 	int GetHp() const { return hp_; }
 

--- a/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
@@ -65,7 +65,6 @@ namespace
 void MeleeEnemy::Initialize()
 {
 	EnemyBase::Initialize();
-	SetMaxHp(160);
 	SetCenterPosition({ 0.0f, 2.0f, 10.0f });
 	wander_.timer = 0.0f;
 	currentBehaviorName_ = "Wander";
@@ -503,6 +502,14 @@ void MeleeEnemy::DrawImGui()
 			// 調整JSONの運用情報をデバッグ表示する。
 			ImGui::Text("現在のJSON形式バージョン: v%d", tuningIo_.jsonFormatVersion);
 			ImGui::Text("保存対象カテゴリ数: %d", tuningIo_.savedCategoryCount);
+		}
+		if (ImGui::CollapsingHeader("基本ステータス", ImGuiTreeNodeFlags_DefaultOpen))
+		{
+			// 近接敵の最大HPを調整しやすいよう、基本ステータスを専用カテゴリで編集できるようにする。
+			ImGui::SliderInt("最大HP", &basicStats_.maxHp, 1, 1000);
+			ImGui::Checkbox("読み込み時にHPを最大に戻す", &basicStats_.resetHpOnLoad);
+			ImGui::Text("現在HP: %d", GetHp());
+			ImGui::Text("最大HP(現在適用): %d", GetMaxHp());
 		}
 		if (ImGui::CollapsingHeader("検知・攻撃距離", ImGuiTreeNodeFlags_DefaultOpen)) {
 			ImGui::SliderFloat("検知範囲", &detection_.detectRange, 1.0f, 50.0f);
@@ -1562,6 +1569,7 @@ bool MeleeEnemy::LoadTuningFromJson(const std::filesystem::path& path, std::stri
 		ifs >> j;
 		// 新形式カテゴリJSONを優先し、旧flat形式も後方互換で読む。
 		const nlohmann::json& detectionJ = j.contains("detection") ? j["detection"] : j;
+		const nlohmann::json& basicStatsJ = j.contains("basicStats") ? j["basicStats"] : j;
 		const nlohmann::json& moveJ = j.contains("move") ? j["move"] : j;
 		const nlohmann::json& jumpJ = j.contains("jump") ? j["jump"] : j;
 		const nlohmann::json& traversalJ = j.contains("traversal") ? j["traversal"] : j;
@@ -1574,6 +1582,15 @@ bool MeleeEnemy::LoadTuningFromJson(const std::filesystem::path& path, std::stri
 		const nlohmann::json& attackPatternsJ = j.contains("attackPatterns") ? j["attackPatterns"] : j;
 		const nlohmann::json& scratchJ = attackPatternsJ.contains("scratch") ? attackPatternsJ["scratch"] : j;
 		const nlohmann::json& lungeScratchJ = attackPatternsJ.contains("lungeScratch") ? attackPatternsJ["lungeScratch"] : (attackPatternsJ.contains("oneTwo") ? attackPatternsJ["oneTwo"] : j);
+		const int previousHp = GetHp();
+		basicStats_.maxHp = basicStatsJ.value("maxHp", basicStats_.maxHp);
+		basicStats_.resetHpOnLoad = basicStatsJ.value("resetHpOnLoad", basicStats_.resetHpOnLoad);
+		// JSON読み込み後に基本ステータスを本体HPへ反映する。
+		SetMaxHp(basicStats_.maxHp);
+		if (!basicStats_.resetHpOnLoad)
+		{
+			SetCurrentHp(previousHp);
+		}
 
 		detection_.detectRange = detectionJ.value("detectRange", detection_.detectRange);
 		detection_.meleeAttackRange = detectionJ.value("meleeAttackRange", detection_.meleeAttackRange);
@@ -1712,6 +1729,10 @@ bool MeleeEnemy::SaveTuningToJson(const std::filesystem::path& path, std::string
 	{
 		nlohmann::json j;
 		j["jsonVersion"] = tuningIo_.jsonFormatVersion;
+		j["basicStats"] = {
+			{ "maxHp", basicStats_.maxHp },
+			{ "resetHpOnLoad", basicStats_.resetHpOnLoad }
+		};
 		j["detection"] = {
 			{ "detectRange", detection_.detectRange }, { "meleeAttackRange", detection_.meleeAttackRange }, { "stopDistance", detection_.stopDistance },
 			{ "attackStartRange", detection_.attackStartRange }, { "resumeChaseDistance", detection_.resumeChaseDistance }, { "minLungeForwardDistance", detection_.minLungeForwardDistance }
@@ -1787,6 +1808,7 @@ bool MeleeEnemy::SaveTuningToJson(const std::filesystem::path& path, std::string
 void MeleeEnemy::ResetTuningToDefault()
 {
 	// 調整値を既定値へ戻すために設定構造体を再初期化する
+	basicStats_ = BasicStatsSettings{};
 	detection_ = DetectionSettings{};
 	move_ = MoveSettings{};
 	jump_ = JumpSettings{};
@@ -1797,6 +1819,12 @@ void MeleeEnemy::ResetTuningToDefault()
 	animation_ = AnimationSettings{};
 	headLookSettings_ = HeadLookSettings{};
 	separationSettings_ = SeparationSettings{};
+	// デフォルト復帰直後に基本ステータスを実HPへ反映する。
+	SetMaxHp(basicStats_.maxHp);
+	if (basicStats_.resetHpOnLoad)
+	{
+		SetCurrentHp(GetMaxHp());
+	}
 	attackController_.Initialize();
 	navigator_.Reset();
 }

--- a/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.h
@@ -324,6 +324,14 @@ private: /// ---------- 構造体 ---------- ///
 		std::string reason = "Disabled";
 	};
 
+
+	// 基本ステータスの設定
+	struct BasicStatsSettings
+	{
+		int maxHp = 160;
+		bool resetHpOnLoad = true;
+	};
+
 	// 個体間分離の設定
 	struct SeparationSettings
 	{
@@ -381,7 +389,7 @@ private: /// ---------- 構造体 ---------- ///
 		std::string lastLoadResult = "未実行";
 		std::string lastSaveResult = "未実行";
 		int jsonFormatVersion = 2;
-		int savedCategoryCount = 11;
+		int savedCategoryCount = 12;
 	};
 
 	// 徘徊の状態管理
@@ -611,6 +619,8 @@ private: /// ---------- メンバ変数 ---------- //
 	K4E::Collider* target_ = nullptr;
 
 	// 各種設定と状態管理の構造体
+	BasicStatsSettings basicStats_{};
+
 	DetectionSettings detection_{};
 
 	// 移動と回転の設定
@@ -672,6 +682,14 @@ private: /// ---------- メンバ変数 ---------- //
 
 	// 頭の注視状態
 	HeadLookState headLookState_{};
+
+
+	// 基本ステータスの設定
+	struct BasicStatsSettings
+	{
+		int maxHp = 160;
+		bool resetHpOnLoad = true;
+	};
 
 	// 個体間分離の設定
 	SeparationSettings separationSettings_{};


### PR DESCRIPTION
### Motivation
- MeleeEnemy の最大HPが `Initialize()` 内で直書きされており調整が困難だったため、設定をデータ化してランタイムで編集・保存/読み込みできるようにするため。
- JSON読み込み後にHP反映を行うことで、外部からのチューニングが即座に適用されるようにするため。
- 現在HPの安全な設定インターフェースが無かったため、誤った値を設定して挙動が壊れるリスクを防ぐため。

### Description
- `MeleeEnemy` に `BasicStatsSettings` を追加し、メンバ `basicStats_`（`maxHp`, `resetHpOnLoad`）を導入しました（ファイル: `MeleeEnemy.h`）。
- `MeleeEnemy::Initialize()` 内の `SetMaxHp(160)` を削除し、`LoadTuningFromJson()` 実行後に `basicStats_.maxHp` を `SetMaxHp()` で反映するようにしました（ファイル: `MeleeEnemy.cpp`）。
- JSON 入出力を拡張し `basicStats` カテゴリ（`maxHp`, `resetHpOnLoad`）を保存/読み込み対象に追加し、旧 flat 形式との後方互換も維持しました（ファイル: `MeleeEnemy.cpp`）。
- ImGui に日本語カテゴリ「基本ステータス」を追加し、最大HP を `SliderInt(1..1000)`、読み込み時にHPを最大に戻すフラグを `Checkbox`、および現在HP/最大HPの表示を実装しました（ファイル: `MeleeEnemy.cpp`）。
- `EnemyBase` に `SetCurrentHp(int)` を追加して 0..max の範囲へクランプして現在HPを安全に設定するようにし、`ResetTuningToDefault()` で basicStats の初期化とHP反映を行うようにしました（ファイル: `EnemyBase.h`, `MeleeEnemy.cpp`）。
- JSONカテゴリ数のメタ値 `savedCategoryCount` を 11 → 12 に更新しました（ファイル: `MeleeEnemy.h`）。

### Testing
- 自動チェックとして `git diff --check` を実行し問題は検出されませんでした（成功）。
- 変更点はコンパイルに影響するヘッダ/実装の追加修正を含むため、実環境でのビルド/ランタイム確認を推奨します。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a15cbfb0dac832d89ae03d534a6be69)