### PR TITLE
Fix MidRangeEnemy bullet spawning and DebugScene wiring

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.cpp
@@ -80,15 +80,18 @@ void MidRangeEnemy::FireProjectile(const Vector3& toTarget)
 {
 	if (!bulletManager_) return;
 	const Vector3 dir = NormalizeXZ(toTarget);
-	auto bullet = std::make_unique<Bullet>();
-	bullet->SetCenterPosition(GetCenterPosition() + Vector3{ 0.0f, 1.2f, 0.0f });
-	bullet->SetVelocity({ dir.x * attackSettings_.projectileSpeed, 0.0f, dir.z * attackSettings_.projectileSpeed });
-	bullet->SetRadius(attackSettings_.attackRadius);
-	bullet->SetDamage(attackSettings_.damage);
-	bullet->SetLifeTime(attackSettings_.projectileLifeTime);
-	bullet->SetCollisionAttribute(CollisionTypeIdDef::kCollisionAttributeEnemyBullet);
-	bullet->SetCollisionMask(CollisionTypeIdDef::kCollisionMaskEnemyBullet);
-	bulletManager_->AddBullet(std::move(bullet));
+	// 既存のBulletManager::Spawn APIに合わせて中距離敵弾を生成する。
+	Vector3 muzzle = GetCenterPosition() + Vector3{ 0.0f, 1.2f, 0.0f };
+	muzzle = muzzle + dir * 1.0f;
+	bulletManager_->Spawn(
+		muzzle,
+		dir,
+		attackSettings_.projectileSpeed,
+		attackSettings_.damage,
+		attackSettings_.projectileLifeTime,
+		GetCenterPosition(),
+		GetUniqueID(),
+		static_cast<uint32_t>(CollisionTypeIdDef::kEnemyBullet));
 }
 
 void MidRangeEnemy::DrawImGui()

--- a/Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.h
@@ -4,6 +4,7 @@
 #include "../Navigation/EnemyAStarNavigator.h"
 #include <filesystem>
 #include <string>
+#include <vector>
 
 class BulletManager;
 
@@ -71,6 +72,10 @@ public:
 
 	void SetTarget(K4E::Collider* target) { target_ = target; }
 	void SetBulletManager(BulletManager* bm) { bulletManager_ = bm; }
+	// 追加: DebugSceneから床AABBを受け取り、移動/接地判定に使えるようにする。
+	void SetFloorAABBs(const std::vector<K4E::AABB>* aabbs) { floorAABBs_ = aabbs; }
+	// 追加: DebugSceneから壁障害物AABBを受け取り、将来の障害物回避に備える。
+	void SetWallObstacleAABBs(const std::vector<K4E::AABB>* aabbs) { wallObstacleAABBs_ = aabbs; }
 	const char* GetCurrentBehaviorName() const;
 
 private:
@@ -93,6 +98,8 @@ private:
 	MidRangeAttackSettings attackSettings_{};
 	HeadLookSettings headLookSettings_{};
 	TuningIo tuningIo_{};
+	const std::vector<K4E::AABB>* floorAABBs_ = nullptr;
+	const std::vector<K4E::AABB>* wallObstacleAABBs_ = nullptr;
 	float cooldownTimer_ = 0.0f;
 	float castTimer_ = 0.0f;
 	float yaw_ = 0.0f;

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -125,6 +125,9 @@ void DebugScene::Initialize()
 
 	collisionManager_ = std::make_unique<CollisionManager>();
 	collisionManager_->Initialize();
+	// 追加: DebugSceneでもBulletManagerを初期化し、中距離敵の弾生成先を用意する。
+	bulletManager_ = std::make_unique<BulletManager>();
+	bulletManager_->Initialize(collisionManager_.get());
 
 	debugBoss_ = std::make_unique<GuardianBoss>();
 	debugBoss_->Initialize();
@@ -173,6 +176,7 @@ void DebugScene::Initialize()
 	debugMidRangeEnemy_->Initialize();
 	debugMidRangeEnemy_->SetCenterPosition({ 2.0f, 2.5f, 18.0f });
 	debugMidRangeEnemy_->SetTarget(&meleeDummyTarget_);
+	debugMidRangeEnemy_->SetBulletManager(bulletManager_.get());
 	debugMidRangeEnemy_->SetFloorAABBs(&stage_->GetFloorAABBs());
 	debugMidRangeEnemy_->SetWallObstacleAABBs(&stage_->GetWallObstacleAABBs());
 	collisionManager_->AddCollider(debugMidRangeEnemy_.get());
@@ -228,6 +232,10 @@ void DebugScene::Update()
 	for (auto& object : cullingTestObjects_)
 	{
 		object->Update();
+	}
+	if (bulletManager_)
+	{
+		bulletManager_->Update(deltaTime);
 	}
 
 	collisionManager_->Update();
@@ -328,6 +336,14 @@ void DebugScene::Draw3DObjects()
 		debugMeleeEnemies_[i]->SetPathDebugColorOffset(static_cast<float>(i) * 0.85f);
 		debugMeleeEnemies_[i]->Draw();
 	}
+	if (debugMidRangeEnemy_)
+	{
+		debugMidRangeEnemy_->Draw();
+	}
+	if (bulletManager_)
+	{
+		bulletManager_->Draw();
+	}
 
 	if (stage_)
 	{
@@ -411,6 +427,7 @@ void DebugScene::Finalize()
 	EnemyBase::SetGlobalStageWorldAABBs(nullptr);
 	debugBoss_.reset();
 	debugMeleeEnemies_.clear();
+	bulletManager_.reset();
 	collisionManager_.reset();
 	stage_.reset();
 

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
@@ -85,6 +85,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	bool isDebugCamera_ = false; // デバッグカメラ使用フラグ
 
 	std::unique_ptr<CollisionManager> collisionManager_; // 衝突管理マネージャー
+	std::unique_ptr<BulletManager> bulletManager_; // 中距離敵の発射弾を管理する
 
 	// 描画確認用ボス
 	std::unique_ptr<GuardianBoss> debugBoss_;


### PR DESCRIPTION
### Motivation
- MidRangeEnemy 呼び出しが既存の `Bullet` API と整合しておらずビルドエラーが発生していたため、既存の弾生成フローに合わせて修正する目的で変更を行いました。
- `DebugScene` 側から `MidRangeEnemy` に対して呼ばれるステージ AABB 設定関数が存在せずコンパイルエラーになっていたため、その橋渡しを追加しました。

### Description
- `MidRangeEnemy::FireProjectile()` を直接 `Bullet` の不存在セッター群（`SetVelocity`/`SetRadius`/`SetDamage`/`SetLifeTime`/`SetCollisionAttribute`/`SetCollisionMask`）や不整合な `AddBullet` 呼び出しから、既存の `BulletManager::Spawn(...)` API を使う実装に差し替えました。(`Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.cpp`)
- `MidRangeEnemy` に `SetFloorAABBs(...)` と `SetWallObstacleAABBs(...)` を追加して DebugScene の呼び出しに合わせ、メンバ変数 `floorAABBs_` / `wallObstacleAABBs_` を追加しました。(`Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.h`)
- `DebugScene` に `std::unique_ptr<BulletManager> bulletManager_` を追加し、`CollisionManager` を渡して初期化、`MidRangeEnemy` に注入するように配線して更新/描画/終了処理へ弾管理を組み込みました。(`Project/ApplicationLayer/Scene/DebugScene/DebugScene.h`、`Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp`)
- 変更はビルドパスを壊さないよう最小の修正に留め、既存の弾管理設計に沿った実装にしています（大規模な弾システム改修は行っていません）。

### Testing
- コード検索で既存の不存在 API 参照が除去されたことを確認するために `rg` を実行し、該当参照が消えていることを確認しました（成功）。
- `cmake --build Project` を試行しましたが、この実行環境では CMake のキャッシュが存在せず `Error: could not load cache` となりビルドは行えませんでした（失敗）。
- 変更はローカルの静的差分確認・テキスト検索で整合性を確認済みで、DebugScene 経由で `MidRangeEnemy` が出現して向きを向き、既存の `BulletManager::Spawn(...)` を用いて弾を発射する経路が通るように修正しています。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1646f44554832d9d2648ea944fd53e)