### PR TITLE
Remove owner Collider* from MidRangeBombProjectile::Launch to fix type mismatch

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/Core/MidRangeBombProjectile.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MidRangeBombProjectile.cpp
@@ -14,12 +14,12 @@ namespace
 	}
 }
 
-void MidRangeBombProjectile::Launch(const Vector3& startPosition, const Vector3& targetPosition, const BombProjectileSettings& settings, Collider* owner, Collider* target)
+void MidRangeBombProjectile::Launch(const Vector3& startPosition, const Vector3& targetPosition, const BombProjectileSettings& settings, Collider* target)
 {
 	// 追加: 投擲開始時に弾の初期状態をリセットする。
 	position_ = startPosition;
 	settings_ = settings;
-	owner_ = owner;
+	// ビルド優先: owner参照は一旦持たない。
 	target_ = target;
 	lifeTimer_ = 0.0f;
 	exploded_ = false;

--- a/Project/ApplicationLayer/Character/Enemy/Core/MidRangeBombProjectile.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MidRangeBombProjectile.h
@@ -30,8 +30,7 @@ public:
 		const K4E::Vector3& startPosition,
 		const K4E::Vector3& targetPosition,
 		const BombProjectileSettings& settings,
-		Collider* owner,
-		Collider* target);
+		Collider* target); // ビルド優先: owner引数を廃止して型不一致を解消。
 
 	void Update(float deltaTime, const std::vector<K4E::AABB>* floorAabbs, const std::vector<K4E::AABB>* obstacleAabbs);
 	void DrawDebug() const;
@@ -53,7 +52,7 @@ private:
 	float lifeTimer_ = 0.0f;
 	bool exploded_ = false;
 	bool alive_ = false;
-	Collider* owner_ = nullptr;
+	// ビルド優先: owner保持を廃止し、将来はownerId等で再設計する。
 	Collider* target_ = nullptr;
 	std::string debugLastReason_ = "未発射";
 	BombProjectileSettings settings_{};

--- a/Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.cpp
@@ -85,7 +85,8 @@ void MidRangeEnemy::ThrowBomb(const Vector3& toTarget)
 	// 追加: MidRangeEnemy専用の爆弾投擲を行う。
 	Vector3 startPos = GetCenterPosition();
 	startPos.y += bombAttackSettings_.throwHeightOffset;
-	activeBomb_.Launch(startPos, startPos + toTarget, bombProjectileSettings_, this, target_);
+	// ビルド優先: MidRangeEnemy* を渡さず Launch の引数数を合わせる。
+	activeBomb_.Launch(startPos, startPos + toTarget, bombProjectileSettings_, target_);
 	lastThrowReason_ = "通常投擲";
 }
 


### PR DESCRIPTION
### Motivation
- Fix a build error where `MidRangeEnemy*` was being passed to `MidRangeBombProjectile::Launch` as a `Collider*`, causing a type mismatch. 
- Prioritize restoring buildability by removing the `owner` `Collider*` parameter from the `Launch` API and avoiding broader API or enemy changes. 
- Keep collision/owner design for future work (e.g. `ownerId` / `ownerType`) rather than attempting a large refactor now.

### Description
- Changed `MidRangeBombProjectile::Launch` signature in `MidRangeBombProjectile.h` to remove the `Collider* owner` parameter and added a one-line comment documenting the build-priority change. 
- Removed the `owner_` member usage in `MidRangeBombProjectile.h` by replacing it with a comment indicating future redesign, and adjusted the class to keep only `target_`. 
- Updated `MidRangeBombProjectile::Launch` implementation in `MidRangeBombProjectile.cpp` to match the new signature and removed the `owner_` assignment while adding a one-line comment. 
- Updated `MidRangeEnemy::ThrowBomb` in `MidRangeEnemy.cpp` to call `activeBomb_.Launch(...)` without passing `this`, and added a one-line comment explaining the temporary change.

### Testing
- Ran a repository search with `rg -n "Launch\(|owner_|activeBomb_\.Launch"` to verify call-site/signature consistency for the modified bomb flow, and found no remaining owner-argument mismatches. 
- Attempted a project build with `msbuild` (`cd /workspace/Ken4lowEngine/Project && msbuild Ken4lowEngine.vcxproj /t:Build /p:Configuration=Debug /p:Platform=x64`), but the environment reports `msbuild: command not found`, so a full build could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a164bd289d0832dacfd91116f37221a)