### PR TITLE
Remove Collider owner from MidRangeBombProjectile and update Launch call

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/Core/MidRangeBombProjectile.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MidRangeBombProjectile.cpp
@@ -1,5 +1,4 @@
 #include "MidRangeBombProjectile.h"
-#include "Collider.h"
 #include "Wireframe.h"
 #include <algorithm>
 #include <cmath>
@@ -14,13 +13,12 @@ namespace
 	}
 }
 
-void MidRangeBombProjectile::Launch(const Vector3& startPosition, const Vector3& targetPosition, const BombProjectileSettings& settings, Collider* target)
+void MidRangeBombProjectile::Launch(const Vector3& startPosition, const Vector3& targetPosition, const BombProjectileSettings& settings)
 {
 	// 追加: 投擲開始時に弾の初期状態をリセットする。
 	position_ = startPosition;
 	settings_ = settings;
-	// ビルド優先: owner参照は一旦持たない。
-	target_ = target;
+	// 修正: owner Colliderを使わない設計に統一。
 	lifeTimer_ = 0.0f;
 	exploded_ = false;
 	alive_ = true;
@@ -54,17 +52,6 @@ void MidRangeBombProjectile::Update(float deltaTime, const std::vector<AABB>* fl
 	velocity_.y -= settings_.gravity * deltaTime;
 	position_ += velocity_ * deltaTime;
 
-	if (target_)
-	{
-		const Vector3 toTarget = target_->GetCenterPosition() - position_;
-		const float sqDist = toTarget.x * toTarget.x + toTarget.y * toTarget.y + toTarget.z * toTarget.z;
-		if (sqDist <= settings_.hitRadius * settings_.hitRadius)
-		{
-			directHitEvent_ = true;
-			Explode("プレイヤー直撃");
-			return;
-		}
-	}
 
 	if (CheckAabbHit(floorAabbs) || CheckAabbHit(obstacleAabbs))
 	{

--- a/Project/ApplicationLayer/Character/Enemy/Core/MidRangeBombProjectile.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MidRangeBombProjectile.h
@@ -8,7 +8,6 @@
 
 namespace K4E = ::Ken4lowEngine;
 
-class Collider;
 
 struct BombProjectileSettings
 {
@@ -26,11 +25,11 @@ struct BombProjectileSettings
 class MidRangeBombProjectile
 {
 public:
+	// 修正: Collider依存を外すためLaunchのowner引数を削除。
 	void Launch(
 		const K4E::Vector3& startPosition,
 		const K4E::Vector3& targetPosition,
-		const BombProjectileSettings& settings,
-		Collider* target); // ビルド優先: owner引数を廃止して型不一致を解消。
+		const BombProjectileSettings& settings);
 
 	void Update(float deltaTime, const std::vector<K4E::AABB>* floorAabbs, const std::vector<K4E::AABB>* obstacleAabbs);
 	void DrawDebug() const;
@@ -52,8 +51,6 @@ private:
 	float lifeTimer_ = 0.0f;
 	bool exploded_ = false;
 	bool alive_ = false;
-	// ビルド優先: owner保持を廃止し、将来はownerId等で再設計する。
-	Collider* target_ = nullptr;
 	std::string debugLastReason_ = "未発射";
 	BombProjectileSettings settings_{};
 	bool directHitEvent_ = false;

--- a/Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.cpp
@@ -1,5 +1,4 @@
 #include "MidRangeEnemy.h"
-#include <Collider.h>
 #include <Wireframe.h>
 #include <fstream>
 #include <cmath>
@@ -86,7 +85,8 @@ void MidRangeEnemy::ThrowBomb(const Vector3& toTarget)
 	Vector3 startPos = GetCenterPosition();
 	startPos.y += bombAttackSettings_.throwHeightOffset;
 	// ビルド優先: MidRangeEnemy* を渡さず Launch の引数数を合わせる。
-	activeBomb_.Launch(startPos, startPos + toTarget, bombProjectileSettings_, target_);
+	// 修正: Launchの第4引数(owner Collider)を削除。
+	activeBomb_.Launch(startPos, startPos + toTarget, bombProjectileSettings_);
 	lastThrowReason_ = "通常投擲";
 }
 


### PR DESCRIPTION
### Motivation
- Remove the leftover `Collider` dependency and fix the mismatched `Launch` signature that caused build errors in the mid-range enemy bomb path.
- Make the bomb projectile independent of an owning `Collider` to follow the previously chosen design direction.

### Description
- Removed `class Collider;` forward declaration and the `Collider*` member from `MidRangeBombProjectile.h` and updated `Launch` to `Launch(start, target, settings)` with a one-line comment explaining the change.
- Updated `MidRangeBombProjectile.cpp` to remove `#include "Collider.h"`, changed the `Launch` definition to the 3-argument form, removed the `target_`-based direct-hit block, and added a one-line comment at the launch site.
- Updated `MidRangeEnemy.cpp` to call `activeBomb_.Launch(startPos, startPos + toTarget, bombProjectileSettings_);` and removed the now-unnecessary `#include <Collider.h>`, with a one-line comment noting the signature change.
- Limited changes to only `MidRangeBombProjectile.*` and `MidRangeEnemy.cpp` and left `MeleeEnemy` untouched as requested.

### Testing
- Ran a targeted search with `rg -n "Collider|Launch\("` on the three modified files to verify `Collider` references and `Launch` signatures were updated, and the search confirmed the changes.
- Attempted to build with `msbuild` via `cd Project && msbuild Ken4lowEngine.sln /t:Build /p:Configuration=Debug /p:Platform=x64`, but the environment lacks `msbuild` so a full build could not be performed (command failed: `msbuild: command not found`).
- All edits were committed locally after verification that the three target files no longer contain the obsolete `Collider` dependency.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a164f868220832d9de45a85a03d386b)