### PR TITLE
MidRange爆弾：メッシュ破片で爆発演出を強化

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.cpp
@@ -472,6 +472,8 @@ void MidRangeEnemy::ExplodeSuicideBomb(const std::string& reason)
     suicideBombState_.explosionPosition = explosionPos;
     // 追加: 自爆成立時に大規模爆発演出を再生する。
     bombEffectController_.PlaySuicideExplosionEffect(suicideBombState_.explosionPosition, suicideBomb_.explosionRadius);
+    // 追加: 自爆時はメッシュ破片も同時再生して爆発感を強化する。
+    bombEffectController_.PlaySuicideMeshExplosionEffect(suicideBombState_.explosionPosition, suicideBomb_.explosionRadius);
     suicideBombState_.explosionDrawTimer = drawTime;
     suicideBombState_.deathDelayTimer = 0.0f;
     suicideBombState_.active = false;
@@ -1134,6 +1136,8 @@ void MidRangeEnemy::ResetTuningToDefault()
     hitReaction_ = HitReactionSettings{};
     deathAnimation_ = DeathAnimationSettings{};
     suicideBomb_ = SuicideBombSettings{};
+    // 追加: 爆弾エフェクト調整値もデフォルトへ戻す。
+    bombEffectController_.ResetToDefault();
     // 追加: デフォルト復帰後も最大HPをEnemyBaseへ反映する。
     ApplyBasicStatsToEnemyBase();
     // 追加: デフォルト復帰後に各値を再検証して破綻を防ぐ。
@@ -1265,6 +1269,10 @@ bool MidRangeEnemy::SaveTuningToJson(const std::filesystem::path& path, std::str
         j["suicideBomb"]["useTargetDirectionForBreakApart"] = suicideBomb_.useTargetDirectionForBreakApart;
         j["suicideBomb"]["blinkColorA"] = { suicideBomb_.blinkColorA.x, suicideBomb_.blinkColorA.y, suicideBomb_.blinkColorA.z, suicideBomb_.blinkColorA.w };
         j["suicideBomb"]["blinkColorB"] = { suicideBomb_.blinkColorB.x, suicideBomb_.blinkColorB.y, suicideBomb_.blinkColorB.z, suicideBomb_.blinkColorB.w };
+        nlohmann::json bombEffectJson = nlohmann::json::object();
+        // 追加: bombEffectカテゴリへGPU/メッシュ爆発設定を保存する。
+        bombEffectController_.SaveToJson(bombEffectJson);
+        j["bombEffect"] = bombEffectJson;
 
         std::filesystem::create_directories(path.parent_path());
         std::ofstream ofs(path);

--- a/Project/ApplicationLayer/Character/Enemy/Effects/MidRangeBombEffectController.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Effects/MidRangeBombEffectController.cpp
@@ -7,6 +7,8 @@
 #include <imgui.h>
 
 #include <algorithm>
+#include <numbers>
+#include <cmath>
 
 using namespace Ken4lowEngine;
 
@@ -23,14 +25,20 @@ void MidRangeBombEffectController::Initialize()
     }
     // 追加: 爆弾演出専用のGPUエミッターを初期化する。
     CreateEmitters();
+    // 追加: 爆発破片用のメッシュパーティクルを初期化する。
+    meshDebrisEffect_.Initialize();
     initialized_ = true;
 }
 void MidRangeBombEffectController::Update(float deltaTime)
 {
     (void)deltaTime;
+    // 追加: メッシュ破片の生存時間と物理を更新する。
+    meshDebrisEffect_.Update();
 }
 void MidRangeBombEffectController::Draw()
 {
+    // 追加: 爆発破片のメッシュ描画を実行する。
+    meshDebrisEffect_.Draw();
 }
 void MidRangeBombEffectController::CreateEmitters()
 {
@@ -108,6 +116,19 @@ void MidRangeBombEffectController::PlayBombExplosionEffect(const Vector3& positi
     const float scale = settings_.explosionEffectScale * std::max(radius, 0.1f);
     // 追加: 通常爆弾の爆発パーティクルを再生する。
     RequestEffect("MidRangeBombExplosion", position, static_cast<uint32_t>(std::max(settings_.explosionParticleCount, 1.0f)), scale);
+    lastBombExplosionPosition_ = position;
+    lastBombExplosionPlayed_ = true;
+}
+void MidRangeBombEffectController::PlayBombMeshExplosionEffect(const Vector3& position, float radius)
+{
+    if (!settings_.meshExplosionEnabled)
+    {
+        return;
+    }
+    // 追加: 通常爆弾向けのメッシュ破片チューニングを適用する。
+    ApplyModelParticleTuning(settings_.meshDebrisSpeed, settings_.meshDebrisScale, settings_.meshDebrisLifeTime);
+    const Vector3 normal = { 0.0f, settings_.meshDebrisUpPower + radius, 0.0f };
+    meshDebrisEffect_.SpawnBurst(position, normal, static_cast<uint32_t>(std::max(settings_.meshDebrisCount, 1)));
 }
 void MidRangeBombEffectController::PlaySuicideChargeEffect(const Vector3& position)
 {
@@ -127,6 +148,19 @@ void MidRangeBombEffectController::PlaySuicideExplosionEffect(const Vector3& pos
     const float scale = settings_.suicideExplosionEffectScale * std::max(radius, 0.1f);
     // 追加: 自爆時の大規模爆発演出を再生する。
     RequestEffect("MidRangeBombSuicideExplosion", position, static_cast<uint32_t>(std::max(settings_.suicideExplosionParticleCount, 1.0f)), scale);
+    lastSuicideExplosionPosition_ = position;
+    lastSuicideExplosionPlayed_ = true;
+}
+void MidRangeBombEffectController::PlaySuicideMeshExplosionEffect(const Vector3& position, float radius)
+{
+    if (!settings_.meshExplosionEnabled)
+    {
+        return;
+    }
+    // 追加: 自爆向けに大きめのメッシュ破片チューニングを適用する。
+    ApplyModelParticleTuning(settings_.suicideMeshDebrisSpeed, settings_.suicideMeshDebrisScale, settings_.meshDebrisLifeTime);
+    const Vector3 normal = { 0.0f, settings_.meshDebrisUpPower + (radius * 1.5f), 0.0f };
+    meshDebrisEffect_.SpawnBurst(position, normal, static_cast<uint32_t>(std::max(settings_.suicideMeshDebrisCount, 1)));
 }
 void MidRangeBombEffectController::DrawImGui()
 {
@@ -150,6 +184,24 @@ void MidRangeBombEffectController::DrawImGui()
     ImGui::ColorEdit4("通常爆発色", &settings_.explosionColor.x);
     ImGui::ColorEdit4("自爆準備色", &settings_.suicideChargeColor.x);
     ImGui::ColorEdit4("自爆爆発色", &settings_.suicideExplosionColor.x);
+    ImGui::Checkbox("メッシュ破片を使う", &settings_.meshExplosionEnabled);
+    ImGui::SliderInt("通常爆弾の破片数", &settings_.meshDebrisCount, 1, 128);
+    ImGui::SliderInt("自爆の破片数", &settings_.suicideMeshDebrisCount, 1, 256);
+    ImGui::SliderFloat("通常破片速度", &settings_.meshDebrisSpeed, 0.5f, 24.0f);
+    ImGui::SliderFloat("自爆破片速度", &settings_.suicideMeshDebrisSpeed, 0.5f, 32.0f);
+    ImGui::SliderFloat("破片上方向力", &settings_.meshDebrisUpPower, 0.0f, 24.0f);
+    ImGui::SliderFloat("破片重力", &settings_.meshDebrisGravity, 0.1f, 48.0f);
+    ImGui::SliderFloat("破片寿命", &settings_.meshDebrisLifeTime, 0.1f, 2.5f);
+    ImGui::SliderFloat("通常破片スケール", &settings_.meshDebrisScale, 0.05f, 1.0f);
+    ImGui::SliderFloat("自爆破片スケール", &settings_.suicideMeshDebrisScale, 0.05f, 1.2f);
+    ImGui::ColorEdit4("破片色", &settings_.meshDebrisColor.x);
+    ImGui::Text("最後の通常爆発位置: (%.2f, %.2f, %.2f)", lastBombExplosionPosition_.x, lastBombExplosionPosition_.y, lastBombExplosionPosition_.z);
+    ImGui::Text("最後の自爆爆発位置: (%.2f, %.2f, %.2f)", lastSuicideExplosionPosition_.x, lastSuicideExplosionPosition_.y, lastSuicideExplosionPosition_.z);
+    ImGui::Text("最後に通常爆発を再生したか: %s", lastBombExplosionPlayed_ ? "はい" : "いいえ");
+    ImGui::Text("最後に自爆爆発を再生したか: %s", lastSuicideExplosionPlayed_ ? "はい" : "いいえ");
+    ImGui::Text("現在のメッシュ破片数: %u", GetActiveDebrisCount());
+    ImGui::Text("現在のトレイル再生数: N/A");
+    ImGui::Text("effectControllerが有効か: %s", initialized_ ? "はい" : "いいえ");
     if (ImGui::Button("投げ演出を再生"))
     {
         PlayThrowEffect({ 0.0f, 1.5f, 0.0f }, { 0.0f, 0.0f, 1.0f });
@@ -166,6 +218,24 @@ void MidRangeBombEffectController::DrawImGui()
     {
         PlaySuicideExplosionEffect({ 0.0f, 0.2f, 0.0f }, 4.0f);
     }
+    if (ImGui::Button("通常メッシュ破片を再生"))
+    {
+        PlayBombMeshExplosionEffect({ 0.0f, 0.2f, 0.0f }, 2.0f);
+    }
+    if (ImGui::Button("自爆メッシュ破片を再生"))
+    {
+        PlaySuicideMeshExplosionEffect({ 0.0f, 0.2f, 0.0f }, 4.0f);
+    }
+    if (ImGui::Button("全部まとめて通常爆発テスト"))
+    {
+        PlayBombExplosionEffect({ 0.0f, 0.2f, 0.0f }, 2.0f);
+        PlayBombMeshExplosionEffect({ 0.0f, 0.2f, 0.0f }, 2.0f);
+    }
+    if (ImGui::Button("全部まとめて自爆爆発テスト"))
+    {
+        PlaySuicideExplosionEffect({ 0.0f, 0.2f, 0.0f }, 4.0f);
+        PlaySuicideMeshExplosionEffect({ 0.0f, 0.2f, 0.0f }, 4.0f);
+    }
 }
 
 void MidRangeBombEffectController::LoadFromJson(const nlohmann::json& j)
@@ -179,6 +249,24 @@ void MidRangeBombEffectController::LoadFromJson(const nlohmann::json& j)
     settings_.explosionEffectEnabled = j.value("explosionEffectEnabled", settings_.explosionEffectEnabled);
     settings_.suicideChargeEffectEnabled = j.value("suicideChargeEffectEnabled", settings_.suicideChargeEffectEnabled);
     settings_.suicideExplosionEffectEnabled = j.value("suicideExplosionEffectEnabled", settings_.suicideExplosionEffectEnabled);
+    settings_.meshExplosionEnabled = j.value("meshExplosionEnabled", settings_.meshExplosionEnabled);
+    settings_.meshDebrisCount = j.value("meshDebrisCount", settings_.meshDebrisCount);
+    settings_.suicideMeshDebrisCount = j.value("suicideMeshDebrisCount", settings_.suicideMeshDebrisCount);
+    settings_.meshDebrisSpeed = j.value("meshDebrisSpeed", settings_.meshDebrisSpeed);
+    settings_.suicideMeshDebrisSpeed = j.value("suicideMeshDebrisSpeed", settings_.suicideMeshDebrisSpeed);
+    settings_.meshDebrisUpPower = j.value("meshDebrisUpPower", settings_.meshDebrisUpPower);
+    settings_.meshDebrisGravity = j.value("meshDebrisGravity", settings_.meshDebrisGravity);
+    settings_.meshDebrisLifeTime = j.value("meshDebrisLifeTime", settings_.meshDebrisLifeTime);
+    settings_.meshDebrisScale = j.value("meshDebrisScale", settings_.meshDebrisScale);
+    settings_.suicideMeshDebrisScale = j.value("suicideMeshDebrisScale", settings_.suicideMeshDebrisScale);
+    if (j.contains("meshDebrisColor"))
+    {
+        const auto& color = j["meshDebrisColor"];
+        if (color.is_array() && color.size() == 4)
+        {
+            settings_.meshDebrisColor = { color[0].get<float>(), color[1].get<float>(), color[2].get<float>(), color[3].get<float>() };
+        }
+    }
 }
 
 void MidRangeBombEffectController::SaveToJson(nlohmann::json& j) const
@@ -188,9 +276,41 @@ void MidRangeBombEffectController::SaveToJson(nlohmann::json& j) const
     j["explosionEffectEnabled"] = settings_.explosionEffectEnabled;
     j["suicideChargeEffectEnabled"] = settings_.suicideChargeEffectEnabled;
     j["suicideExplosionEffectEnabled"] = settings_.suicideExplosionEffectEnabled;
+    j["meshExplosionEnabled"] = settings_.meshExplosionEnabled;
+    j["meshDebrisCount"] = settings_.meshDebrisCount;
+    j["suicideMeshDebrisCount"] = settings_.suicideMeshDebrisCount;
+    j["meshDebrisSpeed"] = settings_.meshDebrisSpeed;
+    j["suicideMeshDebrisSpeed"] = settings_.suicideMeshDebrisSpeed;
+    j["meshDebrisUpPower"] = settings_.meshDebrisUpPower;
+    j["meshDebrisGravity"] = settings_.meshDebrisGravity;
+    j["meshDebrisLifeTime"] = settings_.meshDebrisLifeTime;
+    j["meshDebrisScale"] = settings_.meshDebrisScale;
+    j["suicideMeshDebrisScale"] = settings_.suicideMeshDebrisScale;
+    j["meshDebrisColor"] = { settings_.meshDebrisColor.x, settings_.meshDebrisColor.y, settings_.meshDebrisColor.z, settings_.meshDebrisColor.w };
+}
+
+void MidRangeBombEffectController::ResetToDefault()
+{
+    // 追加: 爆弾エフェクト設定をデフォルトへ戻す。
+    settings_ = BombEffectSettings{};
 }
 
 const MidRangeBombEffectController::BombEffectSettings& MidRangeBombEffectController::GetSettings() const
 {
     return settings_;
+}
+
+void MidRangeBombEffectController::ApplyModelParticleTuning(float speed, float scale, float lifeTime)
+{
+    // 追加: メッシュ破片の速度・重力・寿命・サイズ・色を爆弾設定から反映する。
+    const float safeSpeed = std::max(0.1f, speed);
+    const float safeScale = std::max(0.01f, scale);
+    const float safeLife = std::max(0.05f, lifeTime);
+    meshDebrisEffect_.SetBurstTuning(safeSpeed, -std::abs(settings_.meshDebrisGravity), safeLife * 0.6f, safeLife, safeScale);
+    meshDebrisEffect_.SetParticleColor(settings_.meshDebrisColor);
+}
+
+uint32_t MidRangeBombEffectController::GetActiveDebrisCount() const
+{
+    return meshDebrisEffect_.GetActiveCount();
 }

--- a/Project/ApplicationLayer/Character/Enemy/Effects/MidRangeBombEffectController.h
+++ b/Project/ApplicationLayer/Character/Enemy/Effects/MidRangeBombEffectController.h
@@ -7,6 +7,7 @@
 
 #include "Vector3.h"
 #include "Vector4.h"
+#include "ModelParticle.h"
 
 namespace K4E = ::Ken4lowEngine;
 
@@ -38,6 +39,17 @@ public:
         K4E::Vector4 explosionColor{ 1.0f, 0.25f, 0.05f, 1.0f };
         K4E::Vector4 suicideChargeColor{ 1.0f, 0.0f, 0.0f, 1.0f };
         K4E::Vector4 suicideExplosionColor{ 1.0f, 0.0f, 0.0f, 1.0f };
+        bool meshExplosionEnabled = true;
+        int meshDebrisCount = 18;
+        int suicideMeshDebrisCount = 36;
+        float meshDebrisSpeed = 8.0f;
+        float suicideMeshDebrisSpeed = 13.0f;
+        float meshDebrisUpPower = 7.0f;
+        float meshDebrisGravity = 18.0f;
+        float meshDebrisLifeTime = 0.8f;
+        float meshDebrisScale = 0.25f;
+        float suicideMeshDebrisScale = 0.35f;
+        K4E::Vector4 meshDebrisColor{ 0.9f, 0.45f, 0.1f, 1.0f };
     };
 
 public:
@@ -48,20 +60,30 @@ public:
     void PlayThrowEffect(const K4E::Vector3& position, const K4E::Vector3& direction);
     void PlayBombTrailEffect(const K4E::Vector3& position);
     void PlayBombExplosionEffect(const K4E::Vector3& position, float radius);
+    void PlayBombMeshExplosionEffect(const K4E::Vector3& position, float radius);
     void PlaySuicideChargeEffect(const K4E::Vector3& position);
     void PlaySuicideExplosionEffect(const K4E::Vector3& position, float radius);
+    void PlaySuicideMeshExplosionEffect(const K4E::Vector3& position, float radius);
 
     void DrawImGui();
     void LoadFromJson(const nlohmann::json& j);
     void SaveToJson(nlohmann::json& j) const;
+    void ResetToDefault();
 
     const BombEffectSettings& GetSettings() const;
 
 private:
     void CreateEmitters();
     void RequestEffect(const std::string& name, const K4E::Vector3& position, uint32_t count, float radiusScale);
+    void ApplyModelParticleTuning(float speed, float scale, float lifeTime);
+    uint32_t GetActiveDebrisCount() const;
 
 private:
     BombEffectSettings settings_{};
+    ModelParticle meshDebrisEffect_{};
+    K4E::Vector3 lastBombExplosionPosition_{};
+    K4E::Vector3 lastSuicideExplosionPosition_{};
+    bool lastBombExplosionPlayed_ = false;
+    bool lastSuicideExplosionPlayed_ = false;
     bool initialized_ = false;
 };

--- a/Project/ApplicationLayer/Character/Enemy/Projectile/MidRangeBombProjectile.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Projectile/MidRangeBombProjectile.cpp
@@ -119,10 +119,16 @@ void MidRangeBombProjectile::Explode()
 {
     // 追加: 爆発位置を記録して範囲表示タイマーを開始。
     explosionPosition_ = position_;
+    if (explosionPosition_.y < 0.05f)
+    {
+        // 追加: 爆発演出が地面下に埋まらないよう高さを補正する。
+        explosionPosition_.y = 0.05f;
+    }
     if (effectController_)
     {
-        // 追加: 通常爆弾の爆発演出を再生する。
+        // 追加: 通常爆弾はGPU爆発とメッシュ破片を同時再生する。
         effectController_->PlayBombExplosionEffect(explosionPosition_, settings_.explosionRadius);
+        effectController_->PlayBombMeshExplosionEffect(explosionPosition_, settings_.explosionRadius);
     }
     exploded_ = true;
     alive_ = false;

--- a/Project/ApplicationLayer/EffectLayer/ModelParticle.cpp
+++ b/Project/ApplicationLayer/EffectLayer/ModelParticle.cpp
@@ -139,7 +139,7 @@ void ModelParticle::SpawnBurst(const K4E::Vector3& pos, const K4E::Vector3& norm
 		// 寿命・サイズ・色
 		p->ttl = lifeMin_ + (lifeMax_ - lifeMin_) * urand_(rng_);
 		p->scale = startScale_;
-		p->obj->SetColor({ 1.0f, 0.5f, 0.0f, 1.0f });
+		p->obj->SetColor(particleColor_);
 
 		// 位置・姿勢
 		p->pos = pos;
@@ -160,4 +160,31 @@ void ModelParticle::SpawnBurst(const K4E::Vector3& pos, const K4E::Vector3& norm
 void ModelParticle::OnHit(const K4E::Vector3& hitPos, const K4E::Vector3& hitNormal)
 {
 	SpawnBurst(hitPos, hitNormal, defaultCount_);
+}
+
+void ModelParticle::SetBurstTuning(float baseSpeed, float gravityY, float lifeMin, float lifeMax, float startScale)
+{
+	baseSpeed_ = baseSpeed;
+	gravityY_ = gravityY;
+	lifeMin_ = lifeMin;
+	lifeMax_ = lifeMax;
+	startScale_ = startScale;
+}
+
+void ModelParticle::SetParticleColor(const K4E::Vector4& color)
+{
+	particleColor_ = color;
+}
+
+uint32_t ModelParticle::GetActiveCount() const
+{
+	uint32_t count = 0;
+	for (const auto& p : pool_)
+	{
+		if (p.alive)
+		{
+			++count;
+		}
+	}
+	return count;
 }

--- a/Project/ApplicationLayer/EffectLayer/ModelParticle.h
+++ b/Project/ApplicationLayer/EffectLayer/ModelParticle.h
@@ -44,6 +44,9 @@ public: /// ---------- メンバ関数 ---------- ///
 	void SpawnBurst(const K4E::Vector3& pos, const K4E::Vector3& normal, uint32_t count);
 
 	void OnHit(const K4E::Vector3& hitPos, const K4E::Vector3& hitNormal);
+	void SetBurstTuning(float baseSpeed, float gravityY, float lifeMin, float lifeMax, float startScale);
+	void SetParticleColor(const K4E::Vector4& color);
+	uint32_t GetActiveCount() const;
 
 private: /// ---------- メンバ変数 ---------- ///
 
@@ -71,5 +74,5 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	// 表示フラグ（従来の単体表示用）
 	bool isActive_ = false;
+	K4E::Vector4 particleColor_{ 1.0f, 0.5f, 0.0f, 1.0f };
 };
-


### PR DESCRIPTION
### Motivation
- 爆弾着弾/自爆時の視認性が低く、GPUパーティクルだけでは爆発感が弱かったため、既存のメッシュパーティクルを組み合わせて演出を派手にする目的で変更を行いました。 
- 既存の `ModelParticle` を再利用してメッシュ破片の挙動を整え、既存APIに合わせた実装にしています。 

### Description
- `MidRangeBombEffectController` にメッシュ破片用設定を追加し、`PlayBombMeshExplosionEffect` と `PlaySuicideMeshExplosionEffect` を実装して通常爆発／自爆でメッシュ破片を再生するようにしました。 
- `ModelParticle` を流用するために `SetBurstTuning` / `SetParticleColor` / `GetActiveCount` を追加し、`MidRangeBombEffectController` の `Initialize` / `Update` / `Draw` でメッシュ破片を初期化・更新・描画するよう統合しました。 
- `MidRangeBombProjectile::Explode()` と `MidRangeEnemy::ExplodeSuicideBomb()` にメッシュ破片再生の呼び出しを追加し、爆発位置のY補正（地面へ埋まらないよう）も加えました。 
- ImGui 項目を拡張して「メッシュ破片を使う」「破片数/速度/上方向力/重力/寿命/スケール/色」などの調整とデバッグボタン（通常/自爆の単体再生・まとめ再生）を追加しました。 
- `bombEffect` カテゴリへの JSON 保存/読み込み対応を追加し、`ResetTuningToDefault()` で爆弾エフェクト設定をリセットする `ResetToDefault()` を導入しました。 
- 指定された変更除外ファイル（`MeleeEnemy.*`, `EnemyBase.*`）には手を入れていません。 

### Testing
- コードベース検索で既存の GPU / メッシュパーティクル関連実装（`ModelParticle`, `GpuParticleEmitter` 等）を確認しました（`rg` 検索: 成功）。 
- 変更ファイルの差分を確認してコミットを作成しました（`git commit` 実行: 成功）。 
- 要求ブランチ `feature/mid-range-bomb-enemy` のチェックアウトはこの作業環境に存在せず失敗したため、ローカルの `work` ブランチ上で作業・コミットしました（チェックアウト試行: 失敗）。 
- ビルド/自動テストはこの変更で実行していないため、マージ前にビルドとランタイムでの演出確認をお願いします。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16e42d79d0832d83d7f557eea03359)