### PR TITLE
Prevent full-screen bomb flash and remove flicker in mid-range bomb effects

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.cpp
@@ -811,20 +811,28 @@ void MidRangeEnemy::Draw()
     }
     if (suicideBombState_.active)
     {
-        // 追加: 時限爆弾モード中の爆発範囲と追跡線を描画する。
-        Wireframe::GetInstance()->DrawSphere(GetCenterPosition(), suicideBomb_.explosionRadius, { 1.0f, 0.1f, 0.1f, 0.35f });
-        Wireframe::GetInstance()->DrawLine(GetCenterPosition(), targetState_.position, { 1.0f, 0.1f, 0.1f, 1.0f });
+        const auto& effectSettings = bombEffectController_.GetSettings();
+        if (effectSettings.showSuicideRadius)
+        {
+            // 追加: 時限爆弾モード中の爆発範囲と追跡線を描画する。
+            Wireframe::GetInstance()->DrawSphere(GetCenterPosition(), suicideBomb_.explosionRadius, { 1.0f, 0.1f, 0.1f, 0.35f });
+            Wireframe::GetInstance()->DrawLine(GetCenterPosition(), targetState_.position, { 1.0f, 0.1f, 0.1f, 1.0f });
+        }
     }
     if (suicideBombState_.explosionDrawTimer > 0.0f)
     {
-        // 追加: 自爆直後は爆発地点に範囲表示を残す。
-        Vector3 drawPos = suicideBombState_.explosionPosition;
-        if (drawPos.y < suicideBomb_.explosionPositionMinY)
+        const auto& effectSettings = bombEffectController_.GetSettings();
+        if (effectSettings.showExplosionRadius)
         {
-            drawPos.y = suicideBomb_.explosionPositionMinY;
+            // 追加: 自爆直後は爆発地点に範囲表示を残す。
+            Vector3 drawPos = suicideBombState_.explosionPosition;
+            if (drawPos.y < suicideBomb_.explosionPositionMinY)
+            {
+                drawPos.y = suicideBomb_.explosionPositionMinY;
+            }
+            Wireframe::GetInstance()->DrawSphere(drawPos, suicideBomb_.explosionRadius, { 1.0f, 0.0f, 0.0f, 0.9f });
+            Wireframe::GetInstance()->DrawSphere(drawPos, suicideBomb_.explosionRadius * 0.5f, { 1.0f, 0.8f, 0.0f, 0.9f });
         }
-        Wireframe::GetInstance()->DrawSphere(drawPos, suicideBomb_.explosionRadius, { 1.0f, 0.0f, 0.0f, 0.9f });
-        Wireframe::GetInstance()->DrawSphere(drawPos, suicideBomb_.explosionRadius * 0.5f, { 1.0f, 0.8f, 0.0f, 0.9f });
     }
 
     const Vector3 faceEnd = GetCenterPosition() + animationState_.faceDirection * 2.0f;

--- a/Project/ApplicationLayer/Character/Enemy/Effects/MidRangeBombEffectController.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Effects/MidRangeBombEffectController.cpp
@@ -35,7 +35,9 @@ void MidRangeBombEffectController::Initialize()
 }
 void MidRangeBombEffectController::Update(float deltaTime)
 {
-    (void)deltaTime;
+    // 追加: フレーム番号と経過時間を更新して再生回数デバッグに使う。
+    frameCounter_++;
+    lastExplosionPlayTime_ += std::max(0.0f, deltaTime);
     // 追加: メッシュ破片の生存時間と物理を更新する。
     meshDebrisEffect_.Update();
     flashEffect_.Update();
@@ -145,7 +147,8 @@ void MidRangeBombEffectController::PlaySmokeEffect(const Vector3& position, floa
     RequestEffect("MidRangeBombSmoke", smokePosition, 14, scale);
     ApplyModelParticleTuning(settings_.smokeSpreadRadius, settings_.smokeScale, settings_.smokeLifeTime);
     smokeEffect_.SetParticleColor(settings_.smokeColor);
-    smokeEffect_.SpawnBurst(smokePosition, { 0.0f, settings_.smokeUpPower, 0.0f }, 8);
+    // 追加: 煙の横方向速度を弱く固定して見失いを防ぐ。
+    smokeEffect_.SpawnBurst(smokePosition, { settings_.smokeHorizontalPower, settings_.smokeUpPower, settings_.smokeHorizontalPower * 0.25f }, 8);
 }
 void MidRangeBombEffectController::PlayExplosionFlashEffect(const Vector3& position, float radius)
 {
@@ -155,8 +158,12 @@ void MidRangeBombEffectController::PlayExplosionFlashEffect(const Vector3& posit
     }
     // 追加: 爆発瞬間を強調する中心フラッシュを再生する。
     const Vector3 effectPosition = SanitizeEffectPosition(position);
-    flashEffect_.SetBurstTuning(0.2f, 0.0f, settings_.flashDuration * 0.3f, settings_.flashDuration, settings_.flashScale * std::max(radius, 0.1f));
-    flashEffect_.SetParticleColor(settings_.flashColor);
+    const float safeRadius = std::max(radius, 0.1f);
+    const float flashScale = std::min(safeRadius * settings_.flashNormalRadiusRate, settings_.flashMaxScale);
+    flashEffect_.SetBurstTuning(0.08f, 0.0f, settings_.flashDuration * 0.3f, settings_.flashDuration, flashScale);
+    Vector4 flashColor = settings_.flashColor;
+    flashColor.w = settings_.flashAlpha;
+    flashEffect_.SetParticleColor(flashColor);
     flashEffect_.SpawnBurst(effectPosition, { 0.0f, 1.0f, 0.0f }, 12);
 }
 void MidRangeBombEffectController::PlayShockwaveEffect(const Vector3& position, float radius)
@@ -171,7 +178,9 @@ void MidRangeBombEffectController::PlayShockwaveEffect(const Vector3& position, 
     const float ringScale = std::max(settings_.shockwaveEndRadiusRate, settings_.shockwaveStartRadiusRate) * std::max(radius, 0.1f);
     RequestEffect("MidRangeBombShockwave", shockwavePosition, 12, ringScale);
     shockwaveEffect_.SetBurstTuning(ringScale, 0.0f, settings_.shockwaveDuration * 0.5f, settings_.shockwaveDuration, 0.06f);
-    shockwaveEffect_.SetParticleColor(settings_.shockwaveColor);
+    Vector4 shockwaveColor = settings_.shockwaveColor;
+    shockwaveColor.w = settings_.shockwaveAlpha;
+    shockwaveEffect_.SetParticleColor(shockwaveColor);
     shockwaveEffect_.SpawnBurst(shockwavePosition, { 0.0f, 0.0f, 1.0f }, 16);
 }
 void MidRangeBombEffectController::PlayBombMeshExplosionEffect(const Vector3& position, float radius)
@@ -188,12 +197,20 @@ void MidRangeBombEffectController::PlayBombMeshExplosionEffect(const Vector3& po
 }
 void MidRangeBombEffectController::PlayBombExplosionFullEffect(const Vector3& position, float radius)
 {
+    if (!settings_.enableProductionExplosionEffect)
+    {
+        return;
+    }
     // 追加: 通常爆弾の4段構成爆発演出を一本化して再生する。
-    PlayExplosionFlashEffect(position, radius * settings_.normalExplosionScale);
+    const float scaledRadius = radius * settings_.normalExplosionScale;
+    PlayExplosionFlashEffect(position, scaledRadius);
     PlayShockwaveEffect(position, radius * settings_.normalExplosionScale);
     PlayBombMeshExplosionEffect(position, radius);
     PlayBombExplosionEffect(position, radius);
     PlaySmokeEffect(position, radius);
+    // 追加: 通常爆発の呼び出し回数を記録して多重再生を監視する。
+    normalExplosionPlayCount_++;
+    lastExplosionPlayFrame_ = frameCounter_;
 }
 void MidRangeBombEffectController::PlaySuicideChargeEffect(const Vector3& position)
 {
@@ -231,12 +248,26 @@ void MidRangeBombEffectController::PlaySuicideMeshExplosionEffect(const Vector3&
 }
 void MidRangeBombEffectController::PlaySuicideExplosionFullEffect(const Vector3& position, float radius)
 {
+    if (!settings_.enableProductionExplosionEffect)
+    {
+        return;
+    }
     // 追加: 自爆の4段構成爆発演出を一本化して再生する。
-    PlayExplosionFlashEffect(position, radius * settings_.suicideFlashScale);
+    const float safeRadius = std::max(radius, 0.1f);
+    const float flashScale = std::min(safeRadius * settings_.flashSuicideRadiusRate, settings_.flashMaxScale);
+    const Vector3 effectPosition = SanitizeEffectPosition(position);
+    flashEffect_.SetBurstTuning(0.08f, 0.0f, settings_.flashDuration * 0.3f, settings_.flashDuration, flashScale);
+    Vector4 flashColor = settings_.flashColor;
+    flashColor.w = settings_.flashAlpha;
+    flashEffect_.SetParticleColor(flashColor);
+    flashEffect_.SpawnBurst(effectPosition, { 0.0f, 1.0f, 0.0f }, 12);
     PlayShockwaveEffect(position, radius * settings_.suicideExplosionScale);
     PlaySuicideMeshExplosionEffect(position, radius);
     PlaySuicideExplosionEffect(position, radius);
     PlaySmokeEffect(position, radius * 1.2f);
+    // 追加: 自爆爆発の呼び出し回数を記録して多重再生を監視する。
+    suicideExplosionPlayCount_++;
+    lastExplosionPlayFrame_ = frameCounter_;
 }
 void MidRangeBombEffectController::DrawImGui()
 {
@@ -260,6 +291,9 @@ void MidRangeBombEffectController::DrawImGui()
     ImGui::ColorEdit4("通常爆発色", &settings_.explosionColor.x);
     ImGui::ColorEdit4("自爆準備色", &settings_.suicideChargeColor.x);
     ImGui::ColorEdit4("自爆爆発色", &settings_.suicideExplosionColor.x);
+    ImGui::Checkbox("本番爆発エフェクトを使う", &settings_.enableProductionExplosionEffect);
+    ImGui::Checkbox("デバッグ爆発範囲を表示", &settings_.showExplosionRadius);
+    ImGui::Checkbox("デバッグ自爆範囲を表示", &settings_.showSuicideRadius);
     ImGui::Checkbox("メッシュ破片を使う", &settings_.meshExplosionEnabled);
     ImGui::SliderInt("通常爆弾の破片数", &settings_.meshDebrisCount, 1, 128);
     ImGui::SliderInt("自爆の破片数", &settings_.suicideMeshDebrisCount, 1, 256);
@@ -268,24 +302,29 @@ void MidRangeBombEffectController::DrawImGui()
     ImGui::SliderFloat("破片上方向力", &settings_.meshDebrisUpPower, 0.0f, 24.0f);
     ImGui::SliderFloat("破片重力", &settings_.meshDebrisGravity, 0.1f, 48.0f);
     ImGui::SliderFloat("破片寿命", &settings_.meshDebrisLifeTime, 0.1f, 2.5f);
-    ImGui::SliderFloat("通常破片スケール", &settings_.meshDebrisScale, 0.05f, 1.0f);
-    ImGui::SliderFloat("自爆破片スケール", &settings_.suicideMeshDebrisScale, 0.05f, 1.2f);
+    ImGui::SliderFloat("通常破片スケール", &settings_.meshDebrisScale, 0.05f, 0.6f);
+    ImGui::SliderFloat("自爆破片スケール", &settings_.suicideMeshDebrisScale, 0.05f, 0.8f);
+    ImGui::SliderFloat("破片最大スケール", &settings_.meshDebrisMaxScale, 0.1f, 1.0f);
     ImGui::ColorEdit4("破片色", &settings_.meshDebrisColor.x);
     ImGui::Checkbox("中心フラッシュを使う", &settings_.flashEnabled);
-    ImGui::SliderFloat("フラッシュ時間", &settings_.flashDuration, 0.03f, 0.5f);
-    ImGui::SliderFloat("通常フラッシュスケール", &settings_.flashScale, 0.2f, 3.0f);
-    ImGui::SliderFloat("自爆フラッシュスケール", &settings_.suicideFlashScale, 0.2f, 4.0f);
+    ImGui::SliderFloat("フラッシュ時間", &settings_.flashDuration, 0.08f, 0.18f);
+    ImGui::SliderFloat("通常フラッシュ半径率", &settings_.flashNormalRadiusRate, 0.25f, 0.45f);
+    ImGui::SliderFloat("自爆フラッシュ半径率", &settings_.flashSuicideRadiusRate, 0.5f, 0.8f);
+    ImGui::SliderFloat("フラッシュ最大スケール", &settings_.flashMaxScale, 0.2f, 6.0f);
+    ImGui::SliderFloat("フラッシュ透明度", &settings_.flashAlpha, 0.0f, 1.0f);
     ImGui::ColorEdit4("フラッシュ色", &settings_.flashColor.x);
     ImGui::Checkbox("衝撃波を使う", &settings_.shockwaveEnabled);
     ImGui::SliderFloat("衝撃波時間", &settings_.shockwaveDuration, 0.05f, 0.8f);
     ImGui::SliderFloat("衝撃波開始半径率", &settings_.shockwaveStartRadiusRate, 0.05f, 1.0f);
     ImGui::SliderFloat("衝撃波終了半径率", &settings_.shockwaveEndRadiusRate, 0.2f, 2.0f);
     ImGui::SliderFloat("衝撃波高さ", &settings_.shockwaveHeightOffset, 0.0f, 0.5f);
+    ImGui::SliderFloat("衝撃波透明度", &settings_.shockwaveAlpha, 0.0f, 1.0f);
     ImGui::ColorEdit4("衝撃波色", &settings_.shockwaveColor.x);
     ImGui::Checkbox("煙を使う", &settings_.smokeEnabled);
-    ImGui::SliderFloat("煙スケール", &settings_.smokeScale, 0.1f, 2.0f);
-    ImGui::SliderFloat("煙寿命", &settings_.smokeLifeTime, 0.2f, 2.5f);
-    ImGui::SliderFloat("煙上方向力", &settings_.smokeUpPower, 0.2f, 10.0f);
+    ImGui::SliderFloat("煙スケール", &settings_.smokeScale, 0.1f, 1.2f);
+    ImGui::SliderFloat("煙寿命", &settings_.smokeLifeTime, 0.2f, 1.8f);
+    ImGui::SliderFloat("煙上方向力", &settings_.smokeUpPower, 0.2f, 4.0f);
+    ImGui::SliderFloat("煙横方向力", &settings_.smokeHorizontalPower, 0.0f, 2.0f);
     ImGui::SliderFloat("煙拡散半径", &settings_.smokeSpreadRadius, 0.05f, 2.0f);
     ImGui::ColorEdit4("煙色", &settings_.smokeColor.x);
     ImGui::SliderFloat("通常爆発スケール", &settings_.normalExplosionScale, 0.2f, 2.5f);
@@ -300,6 +339,10 @@ void MidRangeBombEffectController::DrawImGui()
     ImGui::Text("現在のフラッシュ数: %u", flashEffect_.GetActiveCount());
     ImGui::Text("現在の衝撃波数: %u", shockwaveEffect_.GetActiveCount());
     ImGui::Text("現在の煙エミッター数: %u", smokeEffect_.GetActiveCount());
+    ImGui::Text("通常爆発再生回数: %u", normalExplosionPlayCount_);
+    ImGui::Text("自爆爆発再生回数: %u", suicideExplosionPlayCount_);
+    ImGui::Text("最後に爆発を再生したフレーム: %llu", static_cast<unsigned long long>(lastExplosionPlayFrame_));
+    ImGui::Text("最後に爆発を再生した時間: %.2f", lastExplosionPlayTime_);
     ImGui::Text("effectControllerが有効か: %s", initialized_ ? "はい" : "いいえ");
     if (ImGui::Button("投げ演出を再生"))
     {
@@ -325,6 +368,10 @@ void MidRangeBombEffectController::DrawImGui()
     {
         PlaySuicideMeshExplosionEffect({ 0.0f, 0.2f, 0.0f }, 4.0f);
     }
+    if (ImGui::Button("安全な爆発設定に戻す"))
+    {
+        ApplySafeExplosionDefaults();
+    }
     if (ImGui::Button("全部まとめて通常爆発テスト"))
     {
         PlayBombExplosionFullEffect({ 0.0f, 0.2f, 0.0f }, 2.0f);
@@ -333,6 +380,7 @@ void MidRangeBombEffectController::DrawImGui()
     {
         PlaySuicideExplosionFullEffect({ 0.0f, 0.2f, 0.0f }, 4.0f);
     }
+    ValidateSettings();
 }
 
 void MidRangeBombEffectController::LoadFromJson(const nlohmann::json& j)
@@ -358,22 +406,54 @@ void MidRangeBombEffectController::LoadFromJson(const nlohmann::json& j)
     settings_.suicideMeshDebrisScale = j.value("suicideMeshDebrisScale", settings_.suicideMeshDebrisScale);
     settings_.flashEnabled = j.value("flashEnabled", settings_.flashEnabled);
     settings_.flashDuration = j.value("flashDuration", settings_.flashDuration);
-    settings_.flashScale = j.value("flashScale", settings_.flashScale);
-    settings_.suicideFlashScale = j.value("suicideFlashScale", settings_.suicideFlashScale);
+    settings_.flashNormalRadiusRate = j.value("flashNormalRadiusRate", settings_.flashNormalRadiusRate);
+    settings_.flashSuicideRadiusRate = j.value("flashSuicideRadiusRate", settings_.flashSuicideRadiusRate);
+    settings_.flashMaxScale = j.value("flashMaxScale", settings_.flashMaxScale);
+    settings_.flashAlpha = j.value("flashAlpha", settings_.flashAlpha);
     settings_.shockwaveEnabled = j.value("shockwaveEnabled", settings_.shockwaveEnabled);
     settings_.shockwaveDuration = j.value("shockwaveDuration", settings_.shockwaveDuration);
     settings_.shockwaveStartRadiusRate = j.value("shockwaveStartRadiusRate", settings_.shockwaveStartRadiusRate);
     settings_.shockwaveEndRadiusRate = j.value("shockwaveEndRadiusRate", settings_.shockwaveEndRadiusRate);
     settings_.shockwaveHeightOffset = j.value("shockwaveHeightOffset", settings_.shockwaveHeightOffset);
+    settings_.shockwaveAlpha = j.value("shockwaveAlpha", settings_.shockwaveAlpha);
     settings_.smokeEnabled = j.value("smokeEnabled", settings_.smokeEnabled);
     settings_.smokeScale = j.value("smokeScale", settings_.smokeScale);
     settings_.smokeLifeTime = j.value("smokeLifeTime", settings_.smokeLifeTime);
     settings_.smokeUpPower = j.value("smokeUpPower", settings_.smokeUpPower);
+    settings_.smokeHorizontalPower = j.value("smokeHorizontalPower", settings_.smokeHorizontalPower);
     settings_.smokeSpreadRadius = j.value("smokeSpreadRadius", settings_.smokeSpreadRadius);
     settings_.normalExplosionScale = j.value("normalExplosionScale", settings_.normalExplosionScale);
     settings_.suicideExplosionScale = j.value("suicideExplosionScale", settings_.suicideExplosionScale);
     settings_.effectPositionMinY = j.value("effectPositionMinY", settings_.effectPositionMinY);
     settings_.effectHeightOffset = j.value("effectHeightOffset", settings_.effectHeightOffset);
+    settings_.meshDebrisMaxScale = j.value("meshDebrisMaxScale", settings_.meshDebrisMaxScale);
+    settings_.enableProductionExplosionEffect = j.value("enableProductionExplosionEffect", settings_.enableProductionExplosionEffect);
+    settings_.showExplosionRadius = j.value("showExplosionRadius", settings_.showExplosionRadius);
+    settings_.showSuicideRadius = j.value("showSuicideRadius", settings_.showSuicideRadius);
+    if (j.contains("flashColor"))
+    {
+        const auto& color = j["flashColor"];
+        if (color.is_array() && color.size() == 4)
+        {
+            settings_.flashColor = { color[0].get<float>(), color[1].get<float>(), color[2].get<float>(), color[3].get<float>() };
+        }
+    }
+    if (j.contains("shockwaveColor"))
+    {
+        const auto& color = j["shockwaveColor"];
+        if (color.is_array() && color.size() == 4)
+        {
+            settings_.shockwaveColor = { color[0].get<float>(), color[1].get<float>(), color[2].get<float>(), color[3].get<float>() };
+        }
+    }
+    if (j.contains("smokeColor"))
+    {
+        const auto& color = j["smokeColor"];
+        if (color.is_array() && color.size() == 4)
+        {
+            settings_.smokeColor = { color[0].get<float>(), color[1].get<float>(), color[2].get<float>(), color[3].get<float>() };
+        }
+    }
     if (j.contains("meshDebrisColor"))
     {
         const auto& color = j["meshDebrisColor"];
@@ -382,6 +462,7 @@ void MidRangeBombEffectController::LoadFromJson(const nlohmann::json& j)
             settings_.meshDebrisColor = { color[0].get<float>(), color[1].get<float>(), color[2].get<float>(), color[3].get<float>() };
         }
     }
+    ValidateSettings();
 }
 
 void MidRangeBombEffectController::SaveToJson(nlohmann::json& j) const
@@ -404,31 +485,40 @@ void MidRangeBombEffectController::SaveToJson(nlohmann::json& j) const
     j["meshDebrisColor"] = { settings_.meshDebrisColor.x, settings_.meshDebrisColor.y, settings_.meshDebrisColor.z, settings_.meshDebrisColor.w };
     j["flashEnabled"] = settings_.flashEnabled;
     j["flashDuration"] = settings_.flashDuration;
-    j["flashScale"] = settings_.flashScale;
-    j["suicideFlashScale"] = settings_.suicideFlashScale;
+    j["flashNormalRadiusRate"] = settings_.flashNormalRadiusRate;
+    j["flashSuicideRadiusRate"] = settings_.flashSuicideRadiusRate;
+    j["flashMaxScale"] = settings_.flashMaxScale;
+    j["flashAlpha"] = settings_.flashAlpha;
     j["flashColor"] = { settings_.flashColor.x, settings_.flashColor.y, settings_.flashColor.z, settings_.flashColor.w };
     j["shockwaveEnabled"] = settings_.shockwaveEnabled;
     j["shockwaveDuration"] = settings_.shockwaveDuration;
     j["shockwaveStartRadiusRate"] = settings_.shockwaveStartRadiusRate;
     j["shockwaveEndRadiusRate"] = settings_.shockwaveEndRadiusRate;
     j["shockwaveHeightOffset"] = settings_.shockwaveHeightOffset;
+    j["shockwaveAlpha"] = settings_.shockwaveAlpha;
     j["shockwaveColor"] = { settings_.shockwaveColor.x, settings_.shockwaveColor.y, settings_.shockwaveColor.z, settings_.shockwaveColor.w };
     j["smokeEnabled"] = settings_.smokeEnabled;
     j["smokeScale"] = settings_.smokeScale;
     j["smokeLifeTime"] = settings_.smokeLifeTime;
     j["smokeUpPower"] = settings_.smokeUpPower;
+    j["smokeHorizontalPower"] = settings_.smokeHorizontalPower;
     j["smokeSpreadRadius"] = settings_.smokeSpreadRadius;
     j["smokeColor"] = { settings_.smokeColor.x, settings_.smokeColor.y, settings_.smokeColor.z, settings_.smokeColor.w };
     j["normalExplosionScale"] = settings_.normalExplosionScale;
     j["suicideExplosionScale"] = settings_.suicideExplosionScale;
     j["effectPositionMinY"] = settings_.effectPositionMinY;
     j["effectHeightOffset"] = settings_.effectHeightOffset;
+    j["meshDebrisMaxScale"] = settings_.meshDebrisMaxScale;
+    j["enableProductionExplosionEffect"] = settings_.enableProductionExplosionEffect;
+    j["showExplosionRadius"] = settings_.showExplosionRadius;
+    j["showSuicideRadius"] = settings_.showSuicideRadius;
 }
 
 void MidRangeBombEffectController::ResetToDefault()
 {
     // 追加: 爆弾エフェクト設定をデフォルトへ戻す。
     settings_ = BombEffectSettings{};
+    ValidateSettings();
 }
 
 const MidRangeBombEffectController::BombEffectSettings& MidRangeBombEffectController::GetSettings() const
@@ -440,10 +530,53 @@ void MidRangeBombEffectController::ApplyModelParticleTuning(float speed, float s
 {
     // 追加: メッシュ破片の速度・重力・寿命・サイズ・色を爆弾設定から反映する。
     const float safeSpeed = std::max(0.1f, speed);
-    const float safeScale = std::max(0.01f, scale);
+    const float safeScale = std::min(std::max(0.01f, scale), settings_.meshDebrisMaxScale);
     const float safeLife = std::max(0.05f, lifeTime);
     meshDebrisEffect_.SetBurstTuning(safeSpeed, -std::abs(settings_.meshDebrisGravity), safeLife * 0.6f, safeLife, safeScale);
     meshDebrisEffect_.SetParticleColor(settings_.meshDebrisColor);
+}
+
+void MidRangeBombEffectController::ValidateSettings()
+{
+    // 追加: 旧JSONの危険値を安全範囲に収めて巨大化とチラつきを防ぐ。
+    settings_.flashDuration = std::clamp(settings_.flashDuration, 0.02f, 0.5f);
+    settings_.flashNormalRadiusRate = std::clamp(settings_.flashNormalRadiusRate, 0.05f, 2.0f);
+    settings_.flashSuicideRadiusRate = std::clamp(settings_.flashSuicideRadiusRate, 0.05f, 2.0f);
+    settings_.flashMaxScale = std::clamp(settings_.flashMaxScale, 0.1f, 6.0f);
+    settings_.shockwaveEndRadiusRate = std::clamp(settings_.shockwaveEndRadiusRate, 0.1f, 2.0f);
+    settings_.smokeScale = std::clamp(settings_.smokeScale, 0.05f, 2.0f);
+    settings_.meshDebrisScale = std::clamp(settings_.meshDebrisScale, 0.02f, 0.6f);
+    settings_.suicideMeshDebrisScale = std::clamp(settings_.suicideMeshDebrisScale, 0.02f, 0.8f);
+    settings_.normalExplosionScale = std::clamp(settings_.normalExplosionScale, 0.1f, 2.5f);
+    settings_.suicideExplosionScale = std::clamp(settings_.suicideExplosionScale, 0.1f, 3.5f);
+    settings_.explosionParticleCount = std::clamp(settings_.explosionParticleCount, 1.0f, 500.0f);
+    settings_.suicideExplosionParticleCount = std::clamp(settings_.suicideExplosionParticleCount, 1.0f, 800.0f);
+}
+
+void MidRangeBombEffectController::ApplySafeExplosionDefaults()
+{
+    // 追加: 巨大化しない安全な爆発演出プリセットを適用する。
+    settings_.flashDuration = 0.12f;
+    settings_.flashNormalRadiusRate = 0.35f;
+    settings_.flashSuicideRadiusRate = 0.65f;
+    settings_.flashMaxScale = 4.0f;
+    settings_.flashAlpha = 0.8f;
+    settings_.shockwaveDuration = 0.25f;
+    settings_.shockwaveEndRadiusRate = 1.0f;
+    settings_.shockwaveHeightOffset = 0.08f;
+    settings_.shockwaveAlpha = 0.55f;
+    settings_.smokeScale = 0.6f;
+    settings_.smokeLifeTime = 0.7f;
+    settings_.smokeUpPower = 1.5f;
+    settings_.smokeSpreadRadius = 0.6f;
+    settings_.smokeHorizontalPower = 0.4f;
+    settings_.meshDebrisCount = 16;
+    settings_.suicideMeshDebrisCount = 32;
+    settings_.meshDebrisScale = 0.2f;
+    settings_.suicideMeshDebrisScale = 0.3f;
+    settings_.meshDebrisLifeTime = 0.9f;
+    settings_.meshDebrisMaxScale = 0.45f;
+    ValidateSettings();
 }
 
 

--- a/Project/ApplicationLayer/Character/Enemy/Effects/MidRangeBombEffectController.h
+++ b/Project/ApplicationLayer/Character/Enemy/Effects/MidRangeBombEffectController.h
@@ -56,26 +56,34 @@ public:
         // 追加: 中心フラッシュ設定を管理する。
         bool flashEnabled = true;
         float flashDuration = 0.12f;
-        float flashScale = 1.2f;
-        float suicideFlashScale = 1.8f;
-        K4E::Vector4 flashColor{ 1.0f, 0.75f, 0.15f, 1.0f };
+        float flashNormalRadiusRate = 0.35f;
+        float flashSuicideRadiusRate = 0.65f;
+        float flashMaxScale = 4.0f;
+        float flashAlpha = 0.8f;
+        K4E::Vector4 flashColor{ 1.0f, 0.65f, 0.15f, 0.8f };
         // 追加: 衝撃波設定を管理する。
         bool shockwaveEnabled = true;
         float shockwaveDuration = 0.25f;
         float shockwaveStartRadiusRate = 0.2f;
         float shockwaveEndRadiusRate = 1.0f;
         float shockwaveHeightOffset = 0.05f;
+        float shockwaveAlpha = 0.55f;
         K4E::Vector4 shockwaveColor{ 1.0f, 0.55f, 0.1f, 0.8f };
         // 追加: 煙設定を管理する。
         bool smokeEnabled = true;
         float smokeScale = 0.8f;
-        float smokeLifeTime = 0.9f;
-        float smokeUpPower = 3.8f;
-        float smokeSpreadRadius = 0.25f;
+        float smokeLifeTime = 0.7f;
+        float smokeUpPower = 1.5f;
+        float smokeSpreadRadius = 0.6f;
+        float smokeHorizontalPower = 0.4f;
         K4E::Vector4 smokeColor{ 0.25f, 0.25f, 0.25f, 0.9f };
         // 追加: 通常爆弾と自爆のスケール差を管理する。
         float normalExplosionScale = 1.0f;
         float suicideExplosionScale = 1.35f;
+        float meshDebrisMaxScale = 0.45f;
+        bool enableProductionExplosionEffect = true;
+        bool showExplosionRadius = true;
+        bool showSuicideRadius = true;
     };
 
 public:
@@ -109,6 +117,8 @@ private:
     K4E::Vector3 SanitizeEffectPosition(const K4E::Vector3& position) const;
     void ApplyModelParticleTuning(float speed, float scale, float lifeTime);
     uint32_t GetActiveDebrisCount() const;
+    void ValidateSettings();
+    void ApplySafeExplosionDefaults();
 
 private:
     BombEffectSettings settings_{};
@@ -121,4 +131,9 @@ private:
     bool lastBombExplosionPlayed_ = false;
     bool lastSuicideExplosionPlayed_ = false;
     bool initialized_ = false;
+    uint32_t normalExplosionPlayCount_ = 0;
+    uint32_t suicideExplosionPlayCount_ = 0;
+    float lastExplosionPlayTime_ = 0.0f;
+    uint64_t lastExplosionPlayFrame_ = 0;
+    uint64_t frameCounter_ = 0;
 };


### PR DESCRIPTION
### Motivation
- 巨大な中心フラッシュや衝撃波が画面全体を覆い、爆発時にチカチカ見える問題を解消するための調整を行いました。 
- 本番エフェクトとデバッグ用範囲表示を分離してZファイトや重複再生によるちらつきを抑える狙いです。 
- 古いJSONに残った過大な設定値が原因で発生するリスクに対処するため、設定の検証と安全プリセットを用意しました。 

### Description
- 中心フラッシュを半径率（`flashNormalRadiusRate` / `flashSuicideRadiusRate`）× 爆発半径で計算し、`flashMaxScale` で上限クランプするように変更して巨大ビルボード化を防止しました（`MidRangeBombEffectController.*` を修正）。
- フラッシュ寿命を安全域に調整し（ImGuiで調整可能）、フラッシュ／衝撃波のアルファを分離可能にして明示的に制御できるようにしました（`flashAlpha` / `shockwaveAlpha` 追加）。
- 煙の発生位置を爆発中心に固定し、横方向速度を弱める `smokeHorizontalPower` を追加して煙がどこかへ飛んで見えなくなる問題を緩和しました。 
- 本番／デバッグの切り替え (`enableProductionExplosionEffect`, `showExplosionRadius`, `showSuicideRadius`) と ImGui の診断（通常/自爆再生回数、最後の再生フレーム/時間、各アクティブ数）を追加して多重再生や範囲表示の原因追跡を容易にしました。 
- 旧JSONやImGui編集後に危険な値を制限する `ValidateSettings()` と「安全な爆発設定に戻す」プリセット `ApplySafeExplosionDefaults()` を実装し、Load/Save の項目も更新しました。 
- `MidRangeEnemy::Draw()` 側はデバッグ用ワイヤー球描画を設定に応じて表示するよう変更し、本番エフェクトとデバッグ表示の重なりを回避しています。 
- 変更ファイル: `Project/ApplicationLayer/Character/Enemy/Effects/MidRangeBombEffectController.h/.cpp`, `Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.cpp`。 
- 重要ファイル（`MeleeEnemy.*` / `EnemyBase.*`）は触っていません。 

### Testing
- 自動チェックとしてリポジトリ内の参照検索を行う `rg` により関連箇所の検査を実行し、該当コードが期待箇所で更新されたことを確認しました（成功）。
- 変更をステージして `git commit` によりローカルコミットを作成し変更を記録しました（成功）。
- 対象ブランチ `feature/mid-range-bomb-enemy` はローカルに存在しなかったため `git checkout` は失敗しましたが、作業は現行のローカルブランチで行っています（失敗）。
- ビルドやユニットテストの自動実行は今回行っておらず、ビルド実行は開発環境での確認を推奨します（未実行）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a16eaf575c0832d99cec4e6850317de)