### PR TITLE
GuardianBoss のナビゲーションを BossBase API に合わせて修正

### DIFF
--- a/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.cpp
@@ -23,6 +23,11 @@ float WrapAngle(float angle)
 	while (angle < -3.14159265f) { angle += 6.28318530f; }
 	return angle;
 }
+
+float LengthXZ(const Vector3& v)
+{
+	return std::sqrt(v.x * v.x + v.z * v.z);
+}
 }
 
 void GuardianBoss::SetupBoss()
@@ -69,9 +74,12 @@ void GuardianBoss::UpdateMovement(float deltaTime)
 		if (lenSq <= 0.0001f) { return; }
 		const float len = std::sqrt(lenSq);
 		to.x /= len; to.z /= len;
-		SetVelocity({ to.x * speed, GetVelocity().y, to.z * speed });
+		movementVelocity_ = Vector3{ to.x * speed, 0.0f, to.z * speed };
 	}
-	SetPosition({ GetPosition().x + GetVelocity().x * deltaTime, GetPosition().y, GetPosition().z + GetVelocity().z * deltaTime });
+	Vector3 nextPos = GetPosition();
+	nextPos.x += movementVelocity_.x * deltaTime;
+	nextPos.z += movementVelocity_.z * deltaTime;
+	SetPosition(nextPos);
 	const bool landedOnObstacleTop = TryLandOnObstacleTop(deltaTime);
 	if (!landedOnObstacleTop) { ResolveObstaclePenetrationXZ(deltaTime); }
 }
@@ -208,25 +216,26 @@ bool GuardianBoss::MoveAlongPath(float deltaTime)
 	const Vector3 targetPos = GetTargetPosition();
 	pathState_.targetMovedDistanceForRepath = LengthXZ(targetPos - pathState_.lastPathTargetPos);
 	if (pathState_.targetMovedDistanceForRepath >= pathSettings_.targetRepathThreshold || isStuck_) { navigator_.Reset(); }
-	if (navigator_.GetNextWaypoint(GetCenterPosition(), targetPos, GetCenterPosition().y, deltaTime, pathState_.currentWaypoint))
+	const Vector3 selfPos = GetPosition();
+	if (navigator_.GetNextWaypoint(selfPos, targetPos, selfPos.y, deltaTime, pathState_.currentWaypoint))
 	{
 		pathState_.found = true;
 		pathState_.failureReason = "None";
 		pathState_.lastPathTargetPos = targetPos;
-		Vector3 dir = pathState_.currentWaypoint - GetCenterPosition();
+		Vector3 dir = pathState_.currentWaypoint - selfPos;
 		dir.y = 0.0f;
 		const float dirLenSq = dir.x * dir.x + dir.z * dir.z;
-		if (dirLenSq <= 0.0001f) { SetVelocity({ 0.0f, GetVelocity().y, 0.0f }); return false; }
+		if (dirLenSq <= 0.0001f) { movementVelocity_ = Vector3{ 0.0f, 0.0f, 0.0f }; return false; }
 		const float dirLen = std::sqrt(dirLenSq);
 		dir.x /= dirLen;
 		dir.z /= dirLen;
 		const float speed = (runtime_.currentActionName == "Charge") ? GetCurrentMoveSpeed() * 2.3f : GetCurrentMoveSpeed();
-		SetVelocity({ dir.x * speed, GetVelocity().y, dir.z * speed });
+		movementVelocity_ = Vector3{ dir.x * speed, 0.0f, dir.z * speed };
 		return true;
 	}
 	pathState_.found = false;
 	pathState_.failureReason = "PathNotFound";
-	SetVelocity({ 0.0f, GetVelocity().y, 0.0f });
+	movementVelocity_ = Vector3{ 0.0f, 0.0f, 0.0f };
 	return false;
 }
 
@@ -234,12 +243,12 @@ void GuardianBoss::UpdateStuckState(float deltaTime)
 {
 	stuckTimer_ += deltaTime;
 	if (stuckTimer_ < 0.8f) { return; }
-	const float moved = LengthXZ(GetCenterPosition() - pathState_.lastStuckCheckPosition);
+	const float moved = LengthXZ(GetPosition() - pathState_.lastStuckCheckPosition);
 	isStuck_ = (GetState() == BossState::Move) && moved <= 0.2f && GetDistanceToTargetXZ() > attackSettings_.moveStopDistance;
 	pathState_.lastMovedDistance = moved;
 	if (isStuck_)
 	{
-		navigator_.AddTemporaryBlockedArea(GetCenterPosition(), pathSettings_.temporaryBlockRadius, pathSettings_.temporaryBlockDuration, "StuckPosition");
+		navigator_.AddTemporaryBlockedArea(GetPosition(), pathSettings_.temporaryBlockRadius, pathSettings_.temporaryBlockDuration, "StuckPosition");
 		navigator_.Reset();
 		pathSettings_.stuckRepathExpandBonus = std::min(pathSettings_.stuckRepathExpandBonus + 0.1f, pathSettings_.maxStuckRepathExpandBonus);
 	}
@@ -247,7 +256,7 @@ void GuardianBoss::UpdateStuckState(float deltaTime)
 	{
 		pathSettings_.stuckRepathExpandBonus = std::max(0.0f, pathSettings_.stuckRepathExpandBonus - 0.05f);
 	}
-	pathState_.lastStuckCheckPosition = GetCenterPosition();
+	pathState_.lastStuckCheckPosition = GetPosition();
 	stuckTimer_ = 0.0f;
 }
 

--- a/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.h
+++ b/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.h
@@ -2,7 +2,6 @@
 #include "BaseTypes/HumanoidBossBase.h"
 #include "BehaviorTree/IBTNode.h"
 #include "ApplicationLayer/Character/Enemy/Navigation/EnemyAStarNavigator.h"
-#include "Math/MathUtils.h"
 
 #include <memory>
 #include <string>
@@ -128,4 +127,5 @@ private:
 	std::vector<K4E::AABB> climbableObstacleAABBs_{};
 	float stuckTimer_ = 0.0f;
 	bool isStuck_ = false;
+	K4E::Vector3 movementVelocity_{};
 };


### PR DESCRIPTION
### Motivation
- GuardianBoss に MeleeEnemy 由来のナビゲーションをそのまま移植した結果、`Math/MathUtils.h` が存在せず、`SetVelocity`/`GetVelocity` 等 EnemyBase 固有 API を参照してビルドエラーになっていたため、BossBase の API（`GetPosition`/`SetPosition` 等）に合わせて移植箇所を修正する。

### Description
- `GuardianBoss.h` から存在しない `Math/MathUtils.h` を削除し不要なヘッダ依存を除去した。
- `GuardianBoss` に `movementVelocity_` (type `K4E::Vector3`) を追加して `SetVelocity`/`GetVelocity` を使わない局所的な移動速度管理へ置き換えた。
- `GuardianBoss.cpp` に `LengthXZ` のローカル実装を追加し、敵側ユーティリティ参照を排除した。
- `UpdateMovement` / `MoveAlongPath` / `UpdateStuckState` 等の経路追従ロジックを `GetPosition()` / `SetPosition()` ベースへ切り替え、`SetPosition({ ... })` の initializer-list 直渡しを `Vector3 nextPos` を経由する形に変更した。
- ナビゲータ呼び出しやスタック判定での自己位置参照を `GetCenterPosition()` から `GetPosition()`（`selfPos` 変数）へ統一し、BossBase 階層で利用可能な API に合わせた。

### Testing
- `rg` によるコード検索で `GuardianBoss` 側ファイルに残る `Math/MathUtils.h` インクルードや `SetVelocity`/`GetVelocity` 参照がないことを確認した（検索式例: `rg -n "Math/MathUtils.h|SetVelocity\\(|GetVelocity\\(|LengthXZ\\(|GetCenterPosition\\(" Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.*`).
- `GuardianBoss.cpp` / `GuardianBoss.h` の差分を確認し、移動関連呼び出しが `movementVelocity_` と `GetPosition`/`SetPosition` に置き換わっていることを確認した。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a17a055e7ac832d815953f7553d0935)