### PR TITLE
Fix GuardianBoss obstacle navigation

### DIFF
--- a/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.cpp
@@ -6,6 +6,7 @@
 #include "BehaviorTree/BTConditionNode.h"
 #include "BehaviorTree/BTSelectorNode.h"
 #include "BehaviorTree/BTSequenceNode.h"
+#include "Wireframe.h"
 
 #include <algorithm>
 #include <cmath>
@@ -50,6 +51,50 @@ void GuardianBoss::OnDamaged(float damage)
 void GuardianBoss::OnDead() { ChangeBossState(BossState::Dead); }
 void GuardianBoss::OnCollision(Collider* other) { (void)other; }
 
+void GuardianBoss::Draw()
+{
+	BossBase::Draw();
+	UpdateNavigationObstacleList();
+
+	if (obstacleDebugDrawEnabled_)
+	{
+		for (const auto& obstacle : pathBlockingObstacleAABBs_)
+		{
+			Wireframe::GetInstance()->DrawAABB(obstacle, { 1.0f, 0.2f, 0.2f, 0.35f });
+		}
+
+		for (const auto& inflated : navigator_.GetInflatedObstacleAABBs())
+		{
+			Wireframe::GetInstance()->DrawAABB(inflated, { 1.0f, 0.7f, 0.2f, 0.35f });
+		}
+	}
+
+	if (pathDebugDrawEnabled_)
+	{
+		const auto& path = navigator_.GetCurrentPath();
+		for (size_t i = 1; i < path.size(); ++i)
+		{
+			Wireframe::GetInstance()->DrawLine(
+				path[i - 1] + Vector3{ 0.0f, 0.15f, 0.0f },
+				path[i] + Vector3{ 0.0f, 0.15f, 0.0f },
+				{ 0.2f, 0.8f, 1.0f, 1.0f });
+		}
+
+		Wireframe::GetInstance()->DrawSphere(
+			pathState_.currentWaypoint + Vector3{ 0.0f, 0.2f, 0.0f },
+			0.4f,
+			{ 1.0f, 0.3f, 0.1f, 1.0f });
+
+		if (pathState_.lineBlocked)
+		{
+			Wireframe::GetInstance()->DrawLine(
+				pathState_.blockedSegmentFrom + Vector3{ 0.0f, 0.25f, 0.0f },
+				pathState_.blockedSegmentTo + Vector3{ 0.0f, 0.25f, 0.0f },
+				{ 1.0f, 0.1f, 0.1f, 1.0f });
+		}
+	}
+}
+
 void GuardianBoss::UpdateState(float deltaTime)
 {
 	runtime_.stateTimer += deltaTime;
@@ -66,25 +111,10 @@ void GuardianBoss::UpdateMovement(float deltaTime)
 {
 	if (GetState() != BossState::Move && runtime_.currentActionName != "Charge") { return; }
 	UpdateStuckState(deltaTime);
-	const float speed = (runtime_.currentActionName == "Charge") ? GetCurrentMoveSpeed() * 2.3f : GetCurrentMoveSpeed();
-	if (!MoveAlongPath(deltaTime))
+	if (MoveAlongPath(deltaTime))
 	{
-		Vector3 to{ GetTargetPosition().x - GetPosition().x, 0.0f, GetTargetPosition().z - GetPosition().z };
-		const float lenSq = to.x * to.x + to.z * to.z;
-		if (lenSq <= 0.0001f) { return; }
-		const float len = std::sqrt(lenSq);
-		to.x /= len; to.z /= len;
-		movementVelocity_ = Vector3{ to.x * speed, 0.0f, to.z * speed };
-		runtime_.isMoving = true;
-		runtime_.lastMoveDirection = Vector3{ to.x, 0.0f, to.z };
+		runtime_.walkAnimTimer += deltaTime;
 	}
-	Vector3 nextPos = GetPosition();
-	nextPos.x += movementVelocity_.x * deltaTime;
-	nextPos.z += movementVelocity_.z * deltaTime;
-	runtime_.walkAnimTimer += deltaTime;
-	SetPosition(nextPos);
-	const bool landedOnObstacleTop = TryLandOnObstacleTop(deltaTime);
-	if (!landedOnObstacleTop) { ResolveObstaclePenetrationXZ(deltaTime); }
 }
 
 void GuardianBoss::UpdateAttack(float deltaTime) { BossBase::UpdateAttack(deltaTime); (void)deltaTime; }
@@ -190,6 +220,8 @@ float GuardianBoss::GetCurrentMoveSpeed() const
 void GuardianBoss::DrawImGui()
 {
 #ifdef USE_IMGUI
+	UpdateNavigationObstacleList();
+
 	if (ImGui::Begin("PlainsGuardianBoss"))
 	{
 		BossBase::DrawImGui();
@@ -233,12 +265,15 @@ void GuardianBoss::DrawImGui()
 			ImGui::SliderFloat("再探索ターゲット閾値", &pathSettings_.targetRepathThreshold, 0.1f, 10.0f);
 			ImGui::SliderFloat("スタック再探索拡張", &pathSettings_.stuckRepathExpandBonus, 0.0f, 4.0f);
 			ImGui::SliderFloat("スタック再探索拡張最大", &pathSettings_.maxStuckRepathExpandBonus, 0.0f, 8.0f);
-			const int sourceObstacleCount = wallObstacleAABBs_ ? static_cast<int>(wallObstacleAABBs_->size()) : 0;
-			ImGui::Text("navigatorに渡している障害物数: %d", static_cast<int>(pathBlockingObstacleAABBs_.size()));
-			ImGui::Text("元の障害物数: %d", sourceObstacleCount);
-			ImGui::Text("経路発見: %s", pathState_.found ? "true" : "false");
+			ImGui::Checkbox("経路デバッグ描画", &pathDebugDrawEnabled_);
+			ImGui::Checkbox("障害物デバッグ描画", &obstacleDebugDrawEnabled_);
+			ImGui::Text("元の障害物AABB数: %d", pathState_.sourceObstacleAABBCount);
+			ImGui::Text("A*へ渡す障害物AABB数: %d", pathState_.blockingObstacleAABBCount);
+			ImGui::Text("経路あり: %s", pathState_.found ? "はい" : "いいえ");
 			ImGui::Text("失敗理由: %s", pathState_.failureReason.c_str());
-			ImGui::Text("再探索理由: %s", pathState_.lastRepathReason.c_str());
+			ImGui::Text("最後のリパス理由: %s", pathState_.lastRepathReason.c_str());
+			ImGui::Text("LineBlocked: %s", pathState_.lineBlocked ? "はい" : "いいえ");
+			ImGui::Text("BlockedObstacle: %s", pathState_.blockedObstacleName.c_str());
 		}
 	}
 	ImGui::End();
@@ -246,95 +281,180 @@ void GuardianBoss::DrawImGui()
 }
 
 
+void GuardianBoss::UpdateNavigationObstacleList()
+{
+	pathBlockingObstacleAABBs_.clear();
+
+	const auto* source = wallObstacleAABBs_;
+	pathState_.sourceObstacleAABBCount = source ? static_cast<int>(source->size()) : 0;
+
+	if (!source)
+	{
+		pathState_.blockingObstacleAABBCount = 0;
+		return;
+	}
+
+	const Vector3 bossPos = GetPosition();
+
+	for (const auto& aabb : *source)
+	{
+		const float sizeX = aabb.max.x - aabb.min.x;
+		const float sizeY = aabb.max.y - aabb.min.y;
+		const float sizeZ = aabb.max.z - aabb.min.z;
+
+		// 床のように薄いAABBは経路障害物から除外し、壁や柱だけをA*へ渡す。
+		if (sizeY <= 0.05f)
+		{
+			continue;
+		}
+
+		// ボスの足元より大きく下にあるAABBは、経路探索の障害物から除外する。
+		if (aabb.max.y < bossPos.y - 1.5f)
+		{
+			continue;
+		}
+
+		// 極端に小さいAABBはノイズとして除外し、経路探索の誤反応を減らす。
+		if (sizeX <= 0.05f || sizeZ <= 0.05f)
+		{
+			continue;
+		}
+
+		pathBlockingObstacleAABBs_.push_back(aabb);
+	}
+
+	pathState_.blockingObstacleAABBCount = static_cast<int>(pathBlockingObstacleAABBs_.size());
+}
+
+void GuardianBoss::StopMove()
+{
+	// BossBaseには速度APIがないため、停止状態は移動フラグだけで管理する。
+	movementVelocity_ = Vector3{};
+	runtime_.isMoving = false;
+	pathState_.currentWaypoint = GetPosition();
+}
+
 bool GuardianBoss::MoveAlongPath(float deltaTime)
 {
 	if (!pathSettings_.enabled)
 	{
-		movementVelocity_ = Vector3{};
-		runtime_.isMoving = false;
+		StopMove();
 		return false;
 	}
-	EnemyAStarNavigator::Settings s = navigator_.GetSettings();
-	s.cellSize = pathSettings_.gridSize;
-	s.agentRadius = pathSettings_.obstacleExpandRadius + pathSettings_.stuckRepathExpandBonus;
-	s.searchRangeCells = static_cast<int>(pathSettings_.searchRadius);
-	s.repathIntervalSec = pathSettings_.repathInterval;
-	s.waypointReachDistance = pathSettings_.waypointReachDistance;
-	s.disableCornerCutting = pathSettings_.cornerCuttingDisabled;
-	navigator_.SetSettings(s);
-	const std::vector<K4E::AABB>* obstacleAabbs = wallObstacleAABBs_;
-	if (obstacleAabbs) { pathBlockingObstacleAABBs_ = *obstacleAabbs; }
-	else { pathBlockingObstacleAABBs_.clear(); }
-	navigator_.SetWorldAABBs(&pathBlockingObstacleAABBs_);
-	pathState_.lastRepathTimer += deltaTime;
-	navigator_.TickTemporaryBlocks(deltaTime);
+
+	const Vector3 currentPos = GetPosition();
 	const Vector3 targetPos = GetTargetPosition();
+
+	UpdateNavigationObstacleList();
+
+	EnemyAStarNavigator::Settings settings = navigator_.GetSettings();
+	settings.cellSize = pathSettings_.gridSize;
+	settings.agentRadius = pathSettings_.obstacleExpandRadius + pathSettings_.stuckRepathExpandBonus;
+	settings.searchRangeCells = static_cast<int>(pathSettings_.searchRadius);
+	settings.repathIntervalSec = pathSettings_.repathInterval;
+	settings.waypointReachDistance = pathSettings_.waypointReachDistance;
+	settings.disableCornerCutting = pathSettings_.cornerCuttingDisabled;
+	navigator_.SetSettings(settings);
+
+	// MeleeEnemyと同じく、分類済みの回避対象AABBだけをnavigatorへ渡す。
+	navigator_.SetWorldAABBs(&pathBlockingObstacleAABBs_);
+	navigator_.TickTemporaryBlocks(deltaTime);
+	pathState_.lastRepathTimer += deltaTime;
+
 	pathState_.targetMovedDistanceForRepath = LengthXZ(targetPos - pathState_.lastPathTargetPos);
-	if (pathState_.targetMovedDistanceForRepath >= pathSettings_.targetRepathThreshold || isStuck_) { navigator_.Reset(); pathState_.lastRepathReason = isStuck_ ? "StuckForceRepath" : "TargetMoved"; }
-	const Vector3 selfPos = GetPosition();
-	if (navigator_.GetNextWaypoint(selfPos, targetPos, selfPos.y, deltaTime, pathState_.currentWaypoint))
-	{
-		pathState_.found = true;
-		pathState_.failureReason = "None";
-		pathState_.lastPathTargetPos = targetPos;
-		pathState_.lastRepathReason = "Periodic";
-		int blockedIdx = -1;
-		if (navigator_.IsSegmentBlockedByObstacle(selfPos, pathState_.currentWaypoint, selfPos.y, &blockedIdx))
-		{
-			pathState_.lineBlocked = true;
-			pathState_.blockedWaypointIndex = navigator_.GetCurrentPathIndex();
-			pathState_.blockedObstacleName = (blockedIdx >= 0) ? ("Obstacle[" + std::to_string(blockedIdx) + "]") : "Unknown";
-			pathState_.blockedSegmentFrom = selfPos;
-			pathState_.blockedSegmentTo = pathState_.currentWaypoint;
-			navigator_.Reset();
-			navigator_.AddTemporaryBlockedArea(pathState_.currentWaypoint, pathSettings_.temporaryBlockRadius, pathSettings_.temporaryBlockDuration, "WaypointSegmentBlocked");
-			pathState_.lastRepathReason = "WaypointSegmentBlocked";
-			movementVelocity_ = Vector3{};
-			runtime_.isMoving = false;
-			return false;
-		}
-		pathState_.lineBlocked = false;
-		pathState_.blockedWaypointIndex = navigator_.GetCurrentPathIndex();
-		pathState_.blockedObstacleName = "None";
-		Vector3 dir = pathState_.currentWaypoint - selfPos;
-		dir.y = 0.0f;
-		const float dirLenSq = dir.x * dir.x + dir.z * dir.z;
-		if (dirLenSq <= 0.0001f)
-		{
-			movementVelocity_ = Vector3{};
-			runtime_.isMoving = false;
-			return false;
-		}
-		const float dirLen = std::sqrt(dirLenSq);
-		dir.x /= dirLen;
-		dir.z /= dirLen;
-		const float speed = (runtime_.currentActionName == "Charge") ? GetCurrentMoveSpeed() * 2.3f : GetCurrentMoveSpeed();
-		movementVelocity_ = Vector3{ dir.x * speed, 0.0f, dir.z * speed };
-		runtime_.isMoving = true;
-		runtime_.lastMoveDirection = dir;
-		runtime_.currentActionName = "Chase";
-		return true;
-	}
-	pathState_.found = false;
-	pathState_.failureReason = "PathNotFound";
-	pathState_.retryTimer += deltaTime;
-	pathState_.failedWaitTimer = std::max(0.0f, pathState_.failedWaitTimer - deltaTime);
-	if (pathState_.failedWaitTimer > 0.0f)
-	{
-		pathState_.lastRepathReason = "PathFailedWait";
-		movementVelocity_ = Vector3{};
-		runtime_.isMoving = false;
-		return false;
-	}
-	if (pathState_.retryTimer >= pathSettings_.repathInterval)
+	if (pathState_.targetMovedDistanceForRepath >= pathSettings_.targetRepathThreshold || isStuck_)
 	{
 		navigator_.Reset();
-		pathState_.retryTimer = 0.0f;
-		pathState_.lastRepathReason = "RetryAfterFailure";
+		pathState_.lastRepathReason = isStuck_ ? "StuckForceRepath" : "TargetMoved";
 	}
-	movementVelocity_ = Vector3{};
-	runtime_.isMoving = false;
-	return false;
+
+	Vector3 waypoint = targetPos;
+	if (!navigator_.GetNextWaypoint(currentPos, targetPos, currentPos.y, deltaTime, waypoint))
+	{
+		pathState_.found = false;
+		pathState_.failureReason = "PathNotFound";
+		pathState_.retryTimer += deltaTime;
+		pathState_.failedWaitTimer = std::max(0.0f, pathState_.failedWaitTimer - deltaTime);
+
+		if (pathState_.failedWaitTimer > 0.0f)
+		{
+			pathState_.lastRepathReason = "PathFailedWait";
+			StopMove();
+			return false;
+		}
+
+		if (pathState_.retryTimer >= pathSettings_.repathInterval)
+		{
+			navigator_.Reset();
+			pathState_.retryTimer = 0.0f;
+			pathState_.lastRepathReason = "RetryAfterFailure";
+		}
+
+		StopMove();
+		return false;
+	}
+
+	pathState_.found = true;
+	pathState_.failureReason = "None";
+	pathState_.currentWaypoint = waypoint;
+	pathState_.lastPathTargetPos = targetPos;
+	pathState_.retryTimer = 0.0f;
+	pathState_.lineBlocked = false;
+	pathState_.blockedWaypointIndex = -1;
+	pathState_.blockedObstacleName = "None";
+
+	int blockedIdx = -1;
+	if (navigator_.IsSegmentBlockedByObstacle(currentPos, waypoint, currentPos.y, &blockedIdx))
+	{
+		pathState_.lineBlocked = true;
+		pathState_.blockedWaypointIndex = navigator_.GetCurrentPathIndex();
+		pathState_.blockedObstacleName = (blockedIdx >= 0) ? ("Obstacle[" + std::to_string(blockedIdx) + "]") : "Unknown";
+		pathState_.blockedSegmentFrom = currentPos;
+		pathState_.blockedSegmentTo = waypoint;
+
+		navigator_.Reset();
+		navigator_.AddTemporaryBlockedArea(
+			waypoint,
+			pathSettings_.temporaryBlockRadius,
+			pathSettings_.temporaryBlockDuration,
+			"BossWaypointSegmentBlocked");
+
+		pathState_.lastRepathReason = "WaypointSegmentBlocked";
+		StopMove();
+		return false;
+	}
+
+	Vector3 dir = waypoint - currentPos;
+	dir.y = 0.0f;
+	const float dirLen = LengthXZ(dir);
+	if (dirLen <= 0.0001f)
+	{
+		StopMove();
+		return false;
+	}
+	dir.x /= dirLen;
+	dir.z /= dirLen;
+
+	const float moveSpeed = (runtime_.currentActionName == "Charge") ? GetCurrentMoveSpeed() * 2.3f : GetCurrentMoveSpeed();
+	Vector3 nextPos = currentPos;
+	nextPos.x += dir.x * moveSpeed * deltaTime;
+	nextPos.z += dir.z * moveSpeed * deltaTime;
+	SetPosition(nextPos);
+
+	if (!TryLandOnObstacleTop(deltaTime))
+	{
+		ResolveObstaclePenetrationXZ(deltaTime);
+	}
+
+	runtime_.isMoving = true;
+	runtime_.lastMoveDirection = dir;
+	movementVelocity_ = Vector3{ dir.x * moveSpeed, 0.0f, dir.z * moveSpeed };
+	if (runtime_.currentActionName != "Charge")
+	{
+		runtime_.currentActionName = "Chase";
+	}
+
+	return true;
 }
 
 void GuardianBoss::UpdateStuckState(float deltaTime)
@@ -363,27 +483,64 @@ bool GuardianBoss::TryLandOnObstacleTop(float)
 	return false;
 }
 
-bool GuardianBoss::ResolveObstaclePenetrationXZ(float)
+bool GuardianBoss::ResolveObstaclePenetrationXZ(float deltaTime)
 {
-	if (!wallObstacleAABBs_) { return false; }
-	Vector3 pos = GetPosition();
-	const float half = 1.1f;
-	bool resolved = false;
-	for (const auto& o : *wallObstacleAABBs_)
+	(void)deltaTime;
+
+	if (pathBlockingObstacleAABBs_.empty())
 	{
-		if (pos.x + half <= o.min.x || pos.x - half >= o.max.x || pos.z + half <= o.min.z || pos.z - half >= o.max.z) { continue; }
-		const float pushLeft = o.min.x - (pos.x + half);
-		const float pushRight = o.max.x - (pos.x - half);
-		const float pushBack = o.min.z - (pos.z + half);
-		const float pushFront = o.max.z - (pos.z - half);
-		float minAbs = std::abs(pushLeft);
-		Vector3 push{ pushLeft, 0.0f, 0.0f };
-		if (std::abs(pushRight) < minAbs) { minAbs = std::abs(pushRight); push = { pushRight, 0.0f, 0.0f }; }
-		if (std::abs(pushBack) < minAbs) { minAbs = std::abs(pushBack); push = { 0.0f, 0.0f, pushBack }; }
-		if (std::abs(pushFront) < minAbs) { push = { 0.0f, 0.0f, pushFront }; }
-		pos.x += push.x; pos.z += push.z;
+		return false;
+	}
+
+	Vector3 pos = GetPosition();
+	const Vector3 half{ 1.8f, 3.0f, 1.8f };
+
+	bool resolved = false;
+
+	for (const auto& o : pathBlockingObstacleAABBs_)
+	{
+		if (pos.y + half.y < o.min.y || pos.y - half.y > o.max.y)
+		{
+			continue;
+		}
+
+		const float overlapX = std::min(pos.x + half.x, o.max.x) - std::max(pos.x - half.x, o.min.x);
+		const float overlapZ = std::min(pos.z + half.z, o.max.z) - std::max(pos.z - half.z, o.min.z);
+
+		if (overlapX <= 0.0f || overlapZ <= 0.0f)
+		{
+			continue;
+		}
+
+		float pushX = 0.0f;
+		float pushZ = 0.0f;
+
+		if (overlapX < overlapZ)
+		{
+			pushX = pos.x < (o.min.x + o.max.x) * 0.5f ? -overlapX : overlapX;
+		}
+		else
+		{
+			pushZ = pos.z < (o.min.z + o.max.z) * 0.5f ? -overlapZ : overlapZ;
+		}
+
+		const float maxPush = 0.6f;
+		pushX = std::clamp(pushX, -maxPush, maxPush);
+		pushZ = std::clamp(pushZ, -maxPush, maxPush);
+
+		pos.x += pushX;
+		pos.z += pushZ;
+
 		resolved = true;
 	}
-	if (resolved) { SetPosition(pos); }
+
+	if (resolved)
+	{
+		// 直接移動で障害物へめり込んだ場合に押し戻し、次フレームで再経路探索させる。
+		SetPosition(pos);
+		navigator_.Reset();
+		pathState_.lastRepathReason = "BossObstaclePushResolve";
+	}
+
 	return resolved;
 }

--- a/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.h
+++ b/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.h
@@ -70,14 +70,16 @@ private:
 		float targetMovedDistanceForRepath = 0.0f;
 		float lastMovedDistance = 0.0f;
 		std::string lastRepathReason = "None";
+		int sourceObstacleAABBCount = 0;
+		int blockingObstacleAABBCount = 0;
+		bool lineBlocked = false;
+		int blockedWaypointIndex = -1;
 		std::string blockedObstacleName = "None";
 		K4E::Vector3 lastStuckCheckPosition{};
 		K4E::Vector3 lastPathTargetPos{};
 		K4E::Vector3 currentWaypoint{};
 		K4E::Vector3 blockedSegmentFrom{};
 		K4E::Vector3 blockedSegmentTo{};
-		int blockedWaypointIndex = -1;
-		bool lineBlocked = false;
 	};
 
 public:
@@ -87,6 +89,7 @@ public:
 	void OnDamaged(float damage) override;
 	void OnDead() override;
 	void OnCollision(K4E::Collider* other) override;
+	void Draw() override;
 	void DrawImGui() override;
 
 protected:
@@ -100,7 +103,9 @@ protected:
 
 private:
 	void FaceTarget(float deltaTime);
+	void UpdateNavigationObstacleList();
 	bool MoveAlongPath(float deltaTime);
+	void StopMove();
 	void UpdateStuckState(float deltaTime);
 	bool ResolveObstaclePenetrationXZ(float deltaTime);
 	bool TryLandOnObstacleTop(float deltaTime);
@@ -128,6 +133,8 @@ private:
 	const std::vector<K4E::AABB>* wallObstacleAABBs_ = nullptr;
 	std::vector<K4E::AABB> pathBlockingObstacleAABBs_{};
 	std::vector<K4E::AABB> climbableObstacleAABBs_{};
+	bool pathDebugDrawEnabled_ = true;
+	bool obstacleDebugDrawEnabled_ = true;
 	float stuckTimer_ = 0.0f;
 	bool isStuck_ = false;
 	K4E::Vector3 movementVelocity_{};

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -152,6 +152,11 @@ void DebugScene::Initialize()
 	// DebugSceneでもステージAABBを共有し、EnemyBase系の敵が床と障害物に衝突できるようにする。
 	EnemyBase::SetGlobalStageWorldAABBs(&stage_->GetWorldAABBs());
 	EnemyBase::SetGlobalStageNavigationObstacleAABBs(&stage_->GetNavigationObstacleAABBs());
+	if (debugBoss_)
+	{
+		debugBoss_->SetFloorAABBs(&stage_->GetFloorAABBs());
+		debugBoss_->SetWallObstacleAABBs(&stage_->GetNavigationObstacleAABBs());
+	}
 }
 
 void DebugScene::Update()
@@ -302,6 +307,7 @@ void DebugScene::Finalize()
 	frustumCullingDebug_.reset();
 	disintegrationDebug_.reset();
 	EnemyBase::SetGlobalStageWorldAABBs(nullptr);
+	EnemyBase::SetGlobalStageNavigationObstacleAABBs(nullptr);
 	debugBoss_.reset();
 
 	collisionManager_.reset();

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
@@ -80,6 +80,7 @@ void GamePlayWorld::Initialize(GamePlayStageContext& stageContext)
 	stage_->Update();
 
 	EnemyBase::SetGlobalStageWorldAABBs(&stage_->GetWorldAABBs());
+	EnemyBase::SetGlobalStageNavigationObstacleAABBs(&stage_->GetNavigationObstacleAABBs());
 
 	if (auto* player = characters_.GetPlayer())
 	{
@@ -159,6 +160,7 @@ void GamePlayWorld::Finalize()
 	hudManager_.reset();
 
 	EnemyBase::SetGlobalStageWorldAABBs(nullptr);
+	EnemyBase::SetGlobalStageNavigationObstacleAABBs(nullptr);
 	itemManager_.Clear();
 
 	characters_.Finalize();


### PR DESCRIPTION
### Motivation

- GuardianBoss was not reliably recognizing or avoiding stage obstacles, causing it to ignore AABBs and get stuck or clip into geometry; the goal is to bring its navigation flow in line with `MeleeEnemy` so A* sees the correct obstacles and the boss is pushed out when penetrating geometry.

### Description

- Add debug counters and members (`pathBlockingObstacleAABBs_`, `pathDebugDrawEnabled_`, `obstacleDebugDrawEnabled_`, `sourceObstacleAABBCount`, `blockingObstacleAABBCount`, `lineBlocked`, `blockedWaypointIndex`) and public setters `SetFloorAABBs()` / `SetWallObstacleAABBs()` to `GuardianBoss` for receiving stage AABBs.
- Implement `UpdateNavigationObstacleList()` to classify `wallObstacleAABBs_` (filter out floor-like thin AABBs, obstacles far below the boss, and tiny noise) and populate `pathBlockingObstacleAABBs_` for A*.
- Change `MoveAlongPath()` to use the classified list: call `UpdateNavigationObstacleList()`, set `navigator_.SetWorldAABBs(&pathBlockingObstacleAABBs_)`, call `TickTemporaryBlocks()`, check `IsSegmentBlockedByObstacle()` after path lookup, move via `SetPosition()` toward the waypoint, and call `ResolveObstaclePenetrationXZ()` after moving.
- Add `StopMove()` to centrally manage stopping state and refactor `ResolveObstaclePenetrationXZ()` to operate against `pathBlockingObstacleAABBs_` with an XZ pushback using a fixed `half{1.8f,3.0f,1.8f}` and reset the navigator when a pushback occurs.
- Add visual debug drawing in `Draw()` (red AABBs for classified obstacles, yellow inflated AABBs from navigator, path lines, waypoint sphere, blocked-segment line) and extend `DrawImGui()` with the obstacle counts and status (including checkboxes to toggle debug draws).
- Ensure the stage supplies AABBs to bosses by calling `SetFloorAABBs()` / `SetWallObstacleAABBs()` for the debug `GuardianBoss` in `DebugScene`, and register/unregister navigation obstacle AABBs globally in `GamePlayWorld` so enemies/bosses can receive them.

### Testing

- Ran `git diff --check` and static searches to verify the new API usage and presence of the new functions and debug keys (passed as checks for the added symbols and calls).
- Performed repository-wide `rg` searches for `UpdateNavigationObstacleList`, the debug flags, `SetWorldAABBs(&pathBlockingObstacleAABBs_)`, `IsSegmentBlockedByObstacle`, `ResolveObstaclePenetrationXZ`, and `SetWallObstacleAABBs(&stage_->GetNavigationObstacleAABBs())` to confirm integration points (found and validated).
- Attempted C++ syntax-only checks with `clang++` for Debug/Release modes, but the environment lacks the DirectX header (`d3d12.h`), so full compile/syntax validation could not be completed here; please run a local Windows build (`msbuild`/Visual Studio) to confirm build and runtime behavior.
- Attempted to run `msbuild` in this environment but `msbuild` is not available, so full build verification was not performed in CI here; recommend running Debug/Release builds on the usual Windows build environment to verify acceptance criteria.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a184d0bc178832da1156fe7ade7e64c)