### PR TITLE
Unify skinning object shading with Object3D lighting

### DIFF
--- a/Project/Engine/Graphics/Renderer/Animation/Core/AnimationModel.cpp
+++ b/Project/Engine/Graphics/Renderer/Animation/Core/AnimationModel.cpp
@@ -10,6 +10,7 @@
 #include <SRVManager.h>
 #include <UAVManager.h>
 #include <GameTimer.h>
+#include <LightManager.h>
 
 #include "AnimationLoader.h"
 #include "AnimationSampler.h"
@@ -126,6 +127,17 @@ namespace Ken4lowEngine
 		cameraResource = ResourceManager::CreateBufferResource(dxCommon_->GetDevice(), sizeof(CameraForGPU));
 		cameraResource->Map(0, nullptr, reinterpret_cast<void**>(&cameraData));
 		cameraData->worldPosition = camera_ ? CameraManager::GetInstance()->GetActiveCameraPosition() : Vector3{ 0.0f, 0.0f, 0.0f };
+
+		// Skinning PS でも LightingCommon の影パラメータを Object3D と同じ b4 に渡す。
+		shadowParameterResource_ = ResourceManager::CreateBufferResource(dxCommon_->GetDevice(), sizeof(ShadowParameterForGPU));
+		shadowParameterResource_->Map(0, nullptr, reinterpret_cast<void**>(&shadowParameterData_));
+		shadowParameterData_->lightViewProjection = Matrix4x4::MakeIdentity();
+		shadowParameterData_->shadowBias = 0.015f;
+		shadowParameterData_->normalBias = 0.02f;
+		shadowParameterData_->shadowStrength = 0.6f;
+		shadowParameterData_->shadowMode = 0u;
+		shadowParameterData_->shadowDebugMode = 0u;
+		shadowMapHandle_ = dxCommon_->GetShadowMapSrvHandleGPU();
 	}
 
 	/// -------------------------------------------------------------
@@ -299,6 +311,7 @@ namespace Ken4lowEngine
 
 		// アニメーション行列の更新
 		UpdateAnimation();
+		UpdateShadowParameters();
 
 		// マテリアルの更新処理
 		material_.Update();
@@ -406,8 +419,11 @@ namespace Ken4lowEngine
 
 		wvpResource.Reset();
 		cameraResource.Reset();
+		shadowParameterResource_.Reset();
 		wvpData_ = nullptr;
 		cameraData = nullptr;
+		shadowParameterData_ = nullptr;
+		shadowMapHandle_ = {};
 
 		// --- LOD 側で確保した UAV ヒープの SRV/UAV インデックスを解放 ---
 		for (auto& L : lods_)
@@ -540,6 +556,26 @@ namespace Ken4lowEngine
 	}
 
 	/// -------------------------------------------------------------
+	///				　		シャドウパラメータ更新
+	/// -------------------------------------------------------------
+	void AnimationModel::UpdateShadowParameters()
+	{
+		if (!shadowParameterData_) { return; }
+
+		const auto* lightMgr = LightManager::GetInstance();
+		const Vector3 focusPos = cameraData ? cameraData->worldPosition : CameraManager::GetInstance()->GetActiveCameraPosition();
+		shadowParameterData_->lightViewProjection = lightMgr->BuildShadowLightViewProjection(focusPos);
+		shadowParameterData_->shadowBias = lightMgr->GetShadowBias();
+		shadowParameterData_->normalBias = lightMgr->GetNormalBias();
+		shadowParameterData_->shadowStrength = lightMgr->GetShadowStrength();
+		const auto casterType = lightMgr->GetActiveShadowCasterType();
+		shadowParameterData_->shadowMode = lightMgr->IsShadowEnabled()
+			? (casterType == LightManager::ShadowCasterType::Spot ? 2u : (casterType == LightManager::ShadowCasterType::Directional ? 1u : 0u))
+			: 0u;
+		shadowParameterData_->shadowDebugMode = lightMgr->IsShadowMapDebugEnabled() ? 1u : (lightMgr->IsShadowFactorDebugEnabled() ? 2u : 0u);
+	}
+
+	/// -------------------------------------------------------------
 	///				　		ボーン初期化処理
 	/// -------------------------------------------------------------
 	void AnimationModel::InitializeBones()
@@ -607,7 +643,9 @@ namespace Ken4lowEngine
 
 		auto& L = lods_[lodIndex];
 
-		TextureManager::GetInstance()->SetGraphicsRootDescriptorTable(commandList, 4, environmentMapHandle_); // t4: 環境マップ
+		TextureManager::GetInstance()->SetGraphicsRootDescriptorTable(commandList, 4, environmentMapHandle_); // t1: 環境マップ
+		commandList->SetGraphicsRootConstantBufferView(7, shadowParameterResource_->GetGPUVirtualAddress());
+		commandList->SetGraphicsRootDescriptorTable(8, shadowMapHandle_);
 
 		// VB/IB
 		if (skinningCS_.IsSkinningModel())

--- a/Project/Engine/Graphics/Renderer/Animation/Core/AnimationModel.h
+++ b/Project/Engine/Graphics/Renderer/Animation/Core/AnimationModel.h
@@ -43,6 +43,17 @@ namespace Ken4lowEngine
 			Vector3 worldPosition; // ワールド座標系でのカメラ位置
 		};
 
+		struct ShadowParameterForGPU
+		{
+			Matrix4x4 lightViewProjection; // ライトのビュー射影行列
+			float shadowBias;              // シャドウバイアス
+			float normalBias;              // 法線方向オフセット量
+			float shadowStrength;          // 影の濃さ（DirectLight のみへ適用）
+			uint32_t shadowMode;           // 0:Off 1:Directional 2:Spot
+			uint32_t shadowDebugMode;      // 0:None 1:ShadowMap 2:ShadowFactor
+			float padding[1];              // パディング
+		};
+
 
 		// 互換用：旧 AnimationModel::BodyPartCollider 名を維持
 		using BodyPartCollider = ::Ken4lowEngine::BodyPartCollider;
@@ -332,6 +343,7 @@ namespace Ken4lowEngine
 		/// 現在のアニメーション時刻に基づいて、ジョイント変換などを更新します。
 		/// </summary>
 		void UpdateAnimation();
+		void UpdateShadowParameters();
 
 	public: /// ---------- ボーン情報の初期化 ---------- ///
 
@@ -385,9 +397,12 @@ namespace Ken4lowEngine
 		// バッファリソースの作成
 		TransformationAnimationMatrix* wvpData_ = nullptr;
 		CameraForGPU* cameraData = nullptr;
+		ShadowParameterForGPU* shadowParameterData_ = nullptr;
 
 		ComPtr <ID3D12Resource> wvpResource;	// 定数バッファ : ワールド変換行列
 		ComPtr <ID3D12Resource> cameraResource; // 定数バッファ : カメラ情報
+		ComPtr<ID3D12Resource> shadowParameterResource_; // Skinning PS 用 ShadowParameter
+		D3D12_GPU_DESCRIPTOR_HANDLE shadowMapHandle_{};
 
 		bool hideHead_ = false; // デフォルトは表示
 		float scaleFactor = 1.0f; // スケールファクター

--- a/Project/Engine/Graphics/Renderer/Animation/Pipeline/AnimationPipelineBuilder.cpp
+++ b/Project/Engine/Graphics/Renderer/Animation/Pipeline/AnimationPipelineBuilder.cpp
@@ -67,6 +67,7 @@ namespace Ken4lowEngine
 		commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
 
 		LightManager::GetInstance()->BindPunctualLights(5, 6);
+		LightManager::GetInstance()->BindLightingSettings(9);
 	}
 
 	/// ---------------------------------------------------------------
@@ -88,7 +89,7 @@ namespace Ken4lowEngine
 		D3D12_ROOT_SIGNATURE_DESC descriptionRootSignature{};
 		descriptionRootSignature.Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
 
-		D3D12_STATIC_SAMPLER_DESC staticSamplers[1] = {};
+		D3D12_STATIC_SAMPLER_DESC staticSamplers[2] = {};
 		staticSamplers[0].Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
 		staticSamplers[0].AddressU = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
 		staticSamplers[0].AddressV = D3D12_TEXTURE_ADDRESS_MODE_WRAP;
@@ -97,6 +98,17 @@ namespace Ken4lowEngine
 		staticSamplers[0].MaxLOD = D3D12_FLOAT32_MAX;
 		staticSamplers[0].ShaderRegister = 0;
 		staticSamplers[0].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+		staticSamplers[1] = {};
+		staticSamplers[1].Filter = D3D12_FILTER_COMPARISON_MIN_MAG_LINEAR_MIP_POINT;
+		staticSamplers[1].AddressU = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		staticSamplers[1].AddressV = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		staticSamplers[1].AddressW = D3D12_TEXTURE_ADDRESS_MODE_BORDER;
+		staticSamplers[1].ComparisonFunc = D3D12_COMPARISON_FUNC_LESS_EQUAL;
+		staticSamplers[1].BorderColor = D3D12_STATIC_BORDER_COLOR_OPAQUE_WHITE;
+		staticSamplers[1].MaxLOD = D3D12_FLOAT32_MAX;
+		staticSamplers[1].ShaderRegister = 1;
+		staticSamplers[1].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+
 		descriptionRootSignature.pStaticSamplers = staticSamplers;
 		descriptionRootSignature.NumStaticSamplers = _countof(staticSamplers);
 
@@ -118,7 +130,13 @@ namespace Ken4lowEngine
 		lightArrayRange.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
 		lightArrayRange.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
 
-		D3D12_ROOT_PARAMETER rootParameters[7] = {};
+		D3D12_DESCRIPTOR_RANGE shadowMapRange{};
+		shadowMapRange.BaseShaderRegister = 4;
+		shadowMapRange.NumDescriptors = 1;
+		shadowMapRange.RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
+		shadowMapRange.OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
+
+		D3D12_ROOT_PARAMETER rootParameters[10] = {};
 
 		rootParameters[0].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
 		rootParameters[0].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
@@ -150,6 +168,20 @@ namespace Ken4lowEngine
 		rootParameters[6].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
 		rootParameters[6].DescriptorTable.pDescriptorRanges = &lightArrayRange;
 		rootParameters[6].DescriptorTable.NumDescriptorRanges = 1;
+
+		rootParameters[7].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
+		rootParameters[7].ShaderVisibility = D3D12_SHADER_VISIBILITY_ALL;
+		rootParameters[7].Descriptor.ShaderRegister = 4;
+
+		rootParameters[8].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
+		rootParameters[8].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+		rootParameters[8].DescriptorTable.pDescriptorRanges = &shadowMapRange;
+		rootParameters[8].DescriptorTable.NumDescriptorRanges = 1;
+
+		// Skinning PS も Object3D と同じ Ambient/Exposure/Contrast/Fog を参照する。
+		rootParameters[9].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
+		rootParameters[9].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
+		rootParameters[9].Descriptor.ShaderRegister = 5;
 
 		descriptionRootSignature.pParameters = rootParameters;
 		descriptionRootSignature.NumParameters = _countof(rootParameters);

--- a/Project/Resources/Shaders/Skinning/SkinningObject3d.PS.hlsl
+++ b/Project/Resources/Shaders/Skinning/SkinningObject3d.PS.hlsl
@@ -1,4 +1,5 @@
 #include "SkinningObject3d.hlsli"
+#include "../Object3D/LightingCommon.hlsli"
 
 //ピクセルシェーダーの出力
 struct PixelShaderOutput
@@ -11,185 +12,121 @@ struct Material
 {
     float4 color; // オブジェクトの色
     float shininess; // 光沢度
+    float3 padding0;
     float4x4 uvTransform; // UVTransform
     float reflectionRate; // 反射率
+    float roughness; // 粗さ
+    float usePointSampling; // Object3D と同じ定数バッファレイアウトを保つ
+    float padding1;
 };
 
 // カメラ
 struct Camera
 {
     float3 worldPosition; // カメラの位置
-};
-
-// パンクチュアルライトの定数バッファ
-struct PunctualLight
-{
-    uint lightType; // ライトの種類（0：None、1：Directional、2：Point、3：Spot、4：RectArea、5：SphereArea）
-    float4 color; // ライトの色 （全ライト共通）
-    float intensity; // 輝度 （全ライト共通）
-    float3 position; // ライトの位置 （点光源、スポットライト用）
-    float radius; // ライトの届く最大距離 （点光源用）
-    float decay; // 減衰率 （点光源、スポットライト用）
-    float3 direction; // スポットライトの方向 （平行光源、スポットライト用）
-    float distance; // ライトの届く最大距離 （スポットライト用）
-    float cosFalloffStart; // 開始角度 （スポットライト用）
-    float cosAngle; // スポットライトの余弦 （スポットライト用）
-    float3 areaSize; // 疑似AreaLightサイズ (x=width, y=height, z=radius)
-    uint enabled; // 有効フラグ
+    float padding0;
 };
 
 struct LightInfo
 {
     uint gLightCount;
+    float padding0;
 };
 
 ConstantBuffer<Material> gMaterial : register(b0);
 ConstantBuffer<Camera> gCamera : register(b1);
 ConstantBuffer<LightInfo> gLightInfo : register(b2);
+ConstantBuffer<ShadowParameter> gShadowParameter : register(b4);
+ConstantBuffer<LightingSettings> gLightingSettings : register(b5);
 
 Texture2D<float4> gTexture : register(t0); // テクスチャ
 TextureCube<float4> gEnvironmentTexture : register(t1); // 環境マップ
 StructuredBuffer<PunctualLight> gPunctualLights : register(t2); // パンクチュアルライト
+Texture2D<float> gShadowMap : register(t4); // シャドウマップ
 
 SamplerState gSampler : register(s0);
+SamplerComparisonState gShadowSampler : register(s1);
+
+static const float kAlphaDiscardThreshold = 0.001f;
+
+float ComputeFresnelSchlick(float cosTheta, float f0)
+{
+    return f0 + (1.0f - f0) * pow(1.0f - cosTheta, 5.0f);
+}
 
 // ピクセルシェーダー (PS) のメイン関数 (メインエントリーポイント)
 PixelShaderOutput main(VertexShaderOutput input)
 {
     PixelShaderOutput output;
 
-    // UV設定
+    // SRGB SRV は Sample 時点で線形化されるため、Object3D と同じく手動 pow は行わない。
     float4 transformedUV = mul(float4(input.texcoord, 0.0f, 1.0f), gMaterial.uvTransform);
-    float4 textureColor = gTexture.Sample(gSampler, transformedUV.xy); // テクスチャの色
-    textureColor.rgb = pow(textureColor.rgb, 2.2f); // ガンマ補正済みのテクスチャの場合、リニア空間に変換
-    
-    // 座標
-    float3 position = input.worldPosition; // ワールド座標
-    
-    // ライトの法線
-    float3 normal = normalize(input.normal); // 法線の正規化
-    
-    // カメラ方向
-    float3 viewDir = normalize(gCamera.worldPosition - position); // 視線方向（カメラ方向）
-    
-    // 環境マップ用
-    float3 reflectionDir = reflect(-viewDir, normal); // 反射ベクトル
-    float3 environmentColor = gEnvironmentTexture.Sample(gSampler, reflectionDir).rgb; // 環境マップの色
-    
-    // === 複数ライト合成（拡散） ===
-    float3 lightSum = 0.0.xxx;
+    float4 textureColor = gTexture.Sample(gSampler, transformedUV.xy);
 
-    // === 拡散・鏡面の累積 ===
-    float3 diffSum = 0.0.xxx;
-    float3 specSum = 0.0.xxx;
-    
-    // ライト0本のときに暗くならないように：ベース係数は1、ライトがあるときは弱いアンビエント
-    float3 ambient = (gLightInfo.gLightCount == 0) ? 1.0.xxx : 0.02.xxx;
-    
-    [loop]
-    for (uint i = 0; i < gLightInfo.gLightCount; ++i)
+    float3 worldPosition = input.worldPosition;
+    float3 normal = normalize(input.normal);
+    float3 viewDir = normalize(gCamera.worldPosition - worldPosition);
+
+    float spotShadowFactor = 1.0f;
+    if (gShadowParameter.shadowMode == 2)
     {
-        PunctualLight L = gPunctualLights[i]; // ★ gLights → gPunctualLights
-        if (L.enabled == 0) { continue; }
-
-        float atten = 1.0;
-        float3 Ldir = normalize(L.direction);
-        
-        if (L.lightType == 1)
+        float3 dominantSpotDir = float3(0.0f, -1.0f, 0.0f);
+        [loop]
+        for (uint i = 0; i < gLightInfo.gLightCount; ++i)
         {
-            // Directional
-            float NdotL = saturate(dot(normal, Ldir));
-            lightSum += L.color.rgb * (L.intensity * NdotL);
+            if (gPunctualLights[i].lightType == LIGHT_TYPE_SPOT)
+            {
+                dominantSpotDir = normalize(gPunctualLights[i].position - worldPosition);
+                break;
+            }
         }
-        else if (L.lightType == 2)
-        {
-            // Point
-            float3 toL = L.position - position;
-            float d = length(toL);
-            Ldir = toL / max(d, 1e-4);
-
-            float range = max(L.radius, 1e-3);
-            atten = pow(saturate(1.0 - d / range), max(L.decay, 1e-3));
-
-            float NdotL = saturate(dot(normal, Ldir));
-            lightSum += L.color.rgb * (L.intensity * atten * NdotL);
-        }
-        else if (L.lightType == 3)
-        {
-            // Spot
-            // ① ライト→点 ベクトルにする（position - L.position）
-            float3 toL = L.position - position;
-            float d = length(toL);
-            float3 Ldir = toL / max(d, 1e-4);
-
-            // 距離減衰
-            float range = max(L.distance, 1e-3);
-            float atten = pow(saturate(1.0 - d / range), max(L.decay, 1e-3));
-
-            // ② スポット角の評価：
-            //    ct = dot(-dir, L) で「向いている先」と「ライト→点」を比較
-            float3 dir = normalize(L.direction); // 「向いている先」
-            float ct = dot(-dir, Ldir);
-
-            // 内側>=外側（UI/CPUで担保）を前提に smoothstep(edge0=edgeOuter, edge1=edgeInner, x=ct)
-            float spot = smoothstep(L.cosAngle, L.cosFalloffStart, ct);
-
-            // Lambert（N は点の法線、Lambert は 点→光 のベクトルを使うので -Ldir）
-            float NdotL = saturate(dot(normal, Ldir));
-
-            lightSum += L.color.rgb * (L.intensity * atten * spot * NdotL);
-        }
-        else if (L.lightType == 4 || L.lightType == 5)
-        {
-            float3 dir = normalize(L.direction);
-            float3 up = (abs(dir.y) > 0.95f) ? float3(1, 0, 0) : float3(0, 1, 0);
-            float3 right = normalize(cross(up, dir));
-            up = normalize(cross(dir, right));
-            float2 halfSize = max(L.areaSize.xy * 0.5, 0.05.xx);
-            float3 local = position - L.position;
-            float2 uv = float2(dot(local, right), dot(local, up));
-            float2 clamped = clamp(uv, -halfSize, halfSize);
-            // 最近点を仮想PointLight化して広い面光源っぽい照明を作る。
-            float3 virtualPoint = L.position + right * clamped.x + up * clamped.y;
-            float3 toL = virtualPoint - position;
-            float d = length(toL);
-            Ldir = toL / max(d, 1e-4);
-            float range = max(L.distance, 1e-3);
-            atten = pow(saturate(1.0 - d / range), max(L.decay, 1e-3));
-            float NdotL = saturate(dot(normal, Ldir));
-            lightSum += L.color.rgb * (L.intensity * atten * NdotL);
-        }
-        else
-        {
-            continue;
-        }
-        
-        float NdotL = saturate(dot(normal, -Ldir));
-        float3 lightColor = L.color.rgb * (L.intensity * atten);
-        
-        // 拡散
-        diffSum += lightColor * NdotL;
-        
-        // 鏡面反射
-        float3 halfVector = normalize(Ldir + viewDir);
-        float NdotH = saturate(dot(normal, halfVector));
-        float specular = pow(NdotH, max(gMaterial.shininess, 1.0f));
-        specSum += lightColor * specular;
+        spotShadowFactor = CalculateShadow(worldPosition, normal, dominantSpotDir, gShadowParameter, gShadowMap, gShadowSampler);
     }
 
-    // お好みでほんの少し環境光（なければ 0.0 でOK）
-    lightSum = (gLightInfo.gLightCount == 0) ? 1.0.xxx : (lightSum + 0.02.xxx);
+    if (gShadowParameter.shadowDebugMode == 1)
+    {
+        float4 shadowPosition = mul(float4(worldPosition, 1.0f), gShadowParameter.lightViewProjection);
+        float3 proj = shadowPosition.xyz / max(shadowPosition.w, 1e-5f);
+        float2 uv = float2(proj.x * 0.5f + 0.5f, -proj.y * 0.5f + 0.5f);
+        float depth = gShadowMap.SampleLevel(gSampler, saturate(uv), 0.0f);
+        output.color = float4(depth.xxx, 1.0f);
+        return output;
+    }
+    if (gShadowParameter.shadowDebugMode == 2)
+    {
+        output.color = float4(spotShadowFactor.xxx, 1.0f);
+        return output;
+    }
 
-    // === 既存の出力処理（変数名そのまま） ===
-    output.color = gMaterial.color * textureColor; // αもここで確保
-    output.color.rgb *= lightSum; // ライティング適用（RGBのみ）
+    float3 lighting = AccumulateLighting(gPunctualLights,
+        gLightInfo.gLightCount,
+        worldPosition,
+        normal,
+        viewDir,
+        gShadowParameter,
+        gMaterial.shininess,
+        gShadowMap,
+        gShadowSampler,
+        gLightingSettings);
 
-    // 既存の環境マップ合成（そのまま）
-    output.color.rgb += environmentColor.rgb * gMaterial.reflectionRate;
-    output.color.rgb = lerp(output.color.rgb, environmentColor.rgb, gMaterial.reflectionRate);
-    
-    // α値がほぼ0の場合にピクセルを破棄
-    if (output.color.a < 0.001f)
+    float3 baseColor = gMaterial.color.rgb * textureColor.rgb;
+
+    float3 reflectionDir = reflect(-viewDir, normal);
+    float3 environmentColor = gEnvironmentTexture.Sample(gSampler, reflectionDir).rgb;
+    float fresnel = ComputeFresnelSchlick(saturate(dot(normal, viewDir)), 0.02f);
+    float envBlend = saturate(gMaterial.reflectionRate * 0.12f + fresnel * 0.03f);
+
+    float3 shadedColor = baseColor * lighting;
+    shadedColor = lerp(shadedColor, environmentColor, envBlend);
+
+    shadedColor = ApplyFog(shadedColor, worldPosition, gCamera.worldPosition, gLightingSettings);
+    shadedColor = ApplySimpleToneMapping(shadedColor, gLightingSettings);
+    shadedColor = ApplyContrast(shadedColor, gLightingSettings);
+
+    output.color.rgb = shadedColor;
+    output.color.a = gMaterial.color.a * textureColor.a;
+
+    if (output.color.a < kAlphaDiscardThreshold)
     {
         discard;
     }


### PR DESCRIPTION
### Motivation
- Make skinned model shading match regular Object3D by reusing the shared lighting/tonemapping pipeline so diffuse/specular, environment reflection, fog and tone/contrast behave the same.
- Replace the old, ad-hoc skinning lighting math with `LightingCommon.hlsli`/`AccumulateLighting()` while preserving existing Object3D visual behavior and not enabling PointLight cube shadows.
- Ensure shader constant buffer layouts, root signature indices and descriptor bindings remain consistent so runtime bindings for shadow parameters, lighting settings and samplers remain valid.

### Description
- Switched `Project/Resources/Shaders/Skinning/SkinningObject3d.PS.hlsl` to `#include` `../Object3D/LightingCommon.hlsli` and route lighting through `AccumulateLighting()`, using Lambert diffuse and `ComputeSpecular()` for specular, plus unified environment reflection, fog, tone mapping and contrast flow; also removed manual double `pow()` gamma correction and added `kAlphaDiscardThreshold` and small explanatory comments.
- Aligned the `Material`/`Camera`/`LightInfo` HLSL layouts and added `ShadowParameter`/`LightingSettings` CBVs and `gShadowMap`/`gShadowSampler` bindings in the skinning PS to match Object3D conventions.
- Extended the animation graphics root signature setup in `Project/Engine/Graphics/Renderer/Animation/Pipeline/AnimationPipelineBuilder.cpp` to add a shadow map SRV range, a comparison sampler, and a CBV for lighting settings so the skinning PS can read the same per-frame lighting/shadow parameters as Object3D.
- Added GPU shadow-parameter support to animation model code by adding `ShadowParameterForGPU`, allocating/mapping `shadowParameterResource_`, wiring `shadowMapHandle_`, updating the shadow CB contents every frame via `UpdateShadowParameters()`, and binding the shadow CBV + shadow SRV when drawing skinned models in `AnimationModel`.
- Kept Object3D behaviour intact and left PointLight shadow implementation unchanged (PointLight shadows remain unimplemented as before), and added short comments at key change points to document intent.

### Testing
- Ran `git diff --check` to validate whitespace/merge issues and found none (success).
- Searched shader and binding usages with `rg -n "pow\(textureColor\.rgb|AccumulateLighting|LightingCommon|register\(b[0-9]\)|register\(t[0-9]\)|register\(s[0-9]\)"` to verify inclusion and register usage (success).
- Attempted to build/shader-compile in this environment: `msbuild Project/Ken4lowEngine.sln` could not be run because `msbuild` is not available here (tooling missing), and `dxc`/DXC was not found so HLSL compilation was not executed; no runtime build/test was performed due to those missing tools.
- Modified files (tested by static inspection): `Project/Resources/Shaders/Skinning/SkinningObject3d.PS.hlsl`, `Project/Engine/Graphics/Renderer/Animation/Pipeline/AnimationPipelineBuilder.cpp`, `Project/Engine/Graphics/Renderer/Animation/Core/AnimationModel.cpp`, and `Project/Engine/Graphics/Renderer/Animation/Core/AnimationModel.h` (changes compile-time checked visually for register/struct consistency but not compiled here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a535f3954832d9dbbff2667a21494)