### PR TITLE
Add ImGui shading controls and GPU lighting parameters (diffuse/specular/rim/half-Lambert/toon)

### DIFF
--- a/Project/Engine/Graphics/Lighting/LightManager.cpp
+++ b/Project/Engine/Graphics/Lighting/LightManager.cpp
@@ -383,6 +383,36 @@ namespace Ken4lowEngine
 			ImGui::ColorEdit3("Fog Color", &lightingSettings_.fogColor.x);
 			ImGui::SliderFloat("Fog Start", &lightingSettings_.fogStart, 0.0f, 250.0f);
 			ImGui::SliderFloat("Fog End", &lightingSettings_.fogEnd, lightingSettings_.fogStart + 1.0f, 500.0f);
+
+			if (ImGui::TreeNodeEx("Shading", ImGuiTreeNodeFlags_DefaultOpen))
+			{
+				// モデルごとの光の乗り方を実行中に切り分けるための調整UI。
+				const char* shadingModes[] = { "Normal", "HalfLambert", "ToonLike" };
+				int shadingMode = static_cast<int>(lightingSettings_.shadingMode);
+				if (ImGui::Combo("Shading Mode", &shadingMode, shadingModes, IM_ARRAYSIZE(shadingModes)))
+				{
+					lightingSettings_.shadingMode = static_cast<uint32_t>(shadingMode);
+				}
+
+				ImGui::SliderFloat("Diffuse Strength", &lightingSettings_.diffuseStrength, 0.0f, 3.0f);
+				ImGui::SliderFloat("Specular Power Scale", &lightingSettings_.specularPowerScale, 0.05f, 4.0f);
+				bool enableHalfLambert = lightingSettings_.enableHalfLambert != 0;
+				if (ImGui::Checkbox("Half Lambert Enable", &enableHalfLambert))
+				{
+					lightingSettings_.enableHalfLambert = enableHalfLambert ? 1u : 0u;
+				}
+
+				ImGui::SeparatorText("Rim Light");
+				bool enableRimLight = lightingSettings_.enableRimLight != 0;
+				if (ImGui::Checkbox("Rim Light Enable", &enableRimLight))
+				{
+					lightingSettings_.enableRimLight = enableRimLight ? 1u : 0u;
+				}
+				ImGui::SliderFloat("Rim Light Strength", &lightingSettings_.rimLightStrength, 0.0f, 2.0f);
+				ImGui::SliderFloat("Rim Light Power", &lightingSettings_.rimLightPower, 0.1f, 8.0f);
+				ImGui::ColorEdit4("Rim Light Color", &lightingSettings_.rimLightColor.x);
+				ImGui::TreePop();
+			}
 		}
 
 		if (ImGui::Button("+ Add Light"))
@@ -759,7 +789,7 @@ namespace Ken4lowEngine
 
 		if (lightingSettingsData_)
 		{
-			// HLSLのLightingSettingsへ最新のAmbient/Exposure/Contrast/Fogを送る。
+			// HLSLのLightingSettingsへ最新のAmbient/Exposure/Contrast/Fog/Shadingを送る。
 			*lightingSettingsData_ = lightingSettings_;
 		}
 
@@ -805,6 +835,22 @@ namespace Ken4lowEngine
 		preset.shadowNearZ = directionalShadowNearZ_;
 		preset.shadowFarZ = directionalShadowFarZ_;
 		preset.shadowFocusMode = static_cast<uint32_t>(shadowFocusMode_);
+		preset.ambientColor = lightingSettings_.ambientColor;
+		preset.fogColor = lightingSettings_.fogColor;
+		preset.exposure = lightingSettings_.exposure;
+		preset.contrast = lightingSettings_.contrast;
+		preset.fogStart = lightingSettings_.fogStart;
+		preset.fogEnd = lightingSettings_.fogEnd;
+		preset.enableFog = lightingSettings_.enableFog;
+		preset.specularStrength = lightingSettings_.specularStrength;
+		preset.diffuseStrength = lightingSettings_.diffuseStrength;
+		preset.specularPowerScale = lightingSettings_.specularPowerScale;
+		preset.rimLightStrength = lightingSettings_.rimLightStrength;
+		preset.rimLightPower = lightingSettings_.rimLightPower;
+		preset.enableRimLight = lightingSettings_.enableRimLight;
+		preset.enableHalfLambert = lightingSettings_.enableHalfLambert;
+		preset.rimLightColor = lightingSettings_.rimLightColor;
+		preset.shadingMode = lightingSettings_.shadingMode;
 		preset.ToJson(entry.data);
 		return JsonDataManager::SafeSave(entry);
 	}
@@ -838,6 +884,22 @@ namespace Ken4lowEngine
 		directionalShadowNearZ_ = preset.shadowNearZ;
 		directionalShadowFarZ_ = preset.shadowFarZ;
 		shadowFocusMode_ = static_cast<ShadowFocusMode>(preset.shadowFocusMode);
+		lightingSettings_.ambientColor = preset.ambientColor;
+		lightingSettings_.fogColor = preset.fogColor;
+		lightingSettings_.exposure = preset.exposure;
+		lightingSettings_.contrast = preset.contrast;
+		lightingSettings_.fogStart = preset.fogStart;
+		lightingSettings_.fogEnd = preset.fogEnd;
+		lightingSettings_.enableFog = preset.enableFog;
+		lightingSettings_.specularStrength = preset.specularStrength;
+		lightingSettings_.diffuseStrength = preset.diffuseStrength;
+		lightingSettings_.specularPowerScale = preset.specularPowerScale;
+		lightingSettings_.rimLightStrength = preset.rimLightStrength;
+		lightingSettings_.rimLightPower = preset.rimLightPower;
+		lightingSettings_.enableRimLight = preset.enableRimLight;
+		lightingSettings_.enableHalfLambert = preset.enableHalfLambert;
+		lightingSettings_.rimLightColor = preset.rimLightColor;
+		lightingSettings_.shadingMode = preset.shadingMode;
 		return true;
 	}
 } // namespace Ken4lowEngine

--- a/Project/Engine/Graphics/Lighting/LightManager.h
+++ b/Project/Engine/Graphics/Lighting/LightManager.h
@@ -83,7 +83,15 @@ namespace Ken4lowEngine
 			float fogEnd = 140.0f;
 			uint32_t enableFog = 0;
 			float specularStrength = 0.08f;
-			float pad[2] = {};
+			float diffuseStrength = 1.0f;
+			float specularPowerScale = 1.0f;
+			float rimLightStrength = 0.0f;
+			float rimLightPower = 2.0f;
+			uint32_t enableRimLight = 0;
+			uint32_t enableHalfLambert = 0;
+			Vector4 rimLightColor = { 1.0f, 1.0f, 1.0f, 1.0f };
+			uint32_t shadingMode = 0;
+			float pad[3] = {};
 		};
 
 	public: /// ---------- メンバ関数 ---------- ///

--- a/Project/Engine/System/JsonAssets/DataAssetPresets.cpp
+++ b/Project/Engine/System/JsonAssets/DataAssetPresets.cpp
@@ -14,8 +14,73 @@ namespace Ken4lowEngine
 		void FromJ(const nlohmann::json& j, Vector4& v) { if (j.is_array() && j.size() >= 4) { v.x = j[0].get<float>(); v.y = j[1].get<float>(); v.z = j[2].get<float>(); v.w = j[3].get<float>(); } }
 	}
 #define READ_NUM(name) if(inJson.contains(#name)){ name = inJson[#name].get<decltype(name)>(); }
-	void LightPreset::ToJson(nlohmann::json& outJson) const { outJson = {{"directionalDirection",ToJ(directionalDirection)},{"color",ToJ(color)},{"intensity",intensity},{"enableShadow",enableShadow},{"shadowBias",shadowBias},{"normalBias",normalBias},{"shadowStrength",shadowStrength},{"shadowMapSize",shadowMapSize},{"shadowWidth",shadowWidth},{"shadowHeight",shadowHeight},{"shadowNearZ",shadowNearZ},{"shadowFarZ",shadowFarZ},{"shadowFocusMode",shadowFocusMode}}; }
-	void LightPreset::FromJson(const nlohmann::json& inJson) { FromJ(inJson.value("directionalDirection", nlohmann::json::array()), directionalDirection); FromJ(inJson.value("color", nlohmann::json::array()), color); READ_NUM(intensity); READ_NUM(enableShadow); READ_NUM(shadowBias); READ_NUM(normalBias); READ_NUM(shadowStrength); READ_NUM(shadowMapSize); READ_NUM(shadowWidth); READ_NUM(shadowHeight); READ_NUM(shadowNearZ); READ_NUM(shadowFarZ); READ_NUM(shadowFocusMode); }
+	void LightPreset::ToJson(nlohmann::json& outJson) const
+	{
+		outJson = {
+			{"directionalDirection",ToJ(directionalDirection)},
+			{"color",ToJ(color)},
+			{"intensity",intensity},
+			{"enableShadow",enableShadow},
+			{"shadowBias",shadowBias},
+			{"normalBias",normalBias},
+			{"shadowStrength",shadowStrength},
+			{"shadowMapSize",shadowMapSize},
+			{"shadowWidth",shadowWidth},
+			{"shadowHeight",shadowHeight},
+			{"shadowNearZ",shadowNearZ},
+			{"shadowFarZ",shadowFarZ},
+			{"shadowFocusMode",shadowFocusMode},
+			{"ambientColor",ToJ(ambientColor)},
+			{"fogColor",ToJ(fogColor)},
+			{"exposure",exposure},
+			{"contrast",contrast},
+			{"fogStart",fogStart},
+			{"fogEnd",fogEnd},
+			{"enableFog",enableFog},
+			{"specularStrength",specularStrength},
+			{"diffuseStrength",diffuseStrength},
+			{"specularPowerScale",specularPowerScale},
+			{"rimLightStrength",rimLightStrength},
+			{"rimLightPower",rimLightPower},
+			{"enableRimLight",enableRimLight},
+			{"enableHalfLambert",enableHalfLambert},
+			{"rimLightColor",ToJ(rimLightColor)},
+			{"shadingMode",shadingMode}
+		};
+	}
+
+	void LightPreset::FromJson(const nlohmann::json& inJson)
+	{
+		FromJ(inJson.value("directionalDirection", nlohmann::json::array()), directionalDirection);
+		FromJ(inJson.value("color", nlohmann::json::array()), color);
+		READ_NUM(intensity);
+		READ_NUM(enableShadow);
+		READ_NUM(shadowBias);
+		READ_NUM(normalBias);
+		READ_NUM(shadowStrength);
+		READ_NUM(shadowMapSize);
+		READ_NUM(shadowWidth);
+		READ_NUM(shadowHeight);
+		READ_NUM(shadowNearZ);
+		READ_NUM(shadowFarZ);
+		READ_NUM(shadowFocusMode);
+		FromJ(inJson.value("ambientColor", nlohmann::json::array()), ambientColor);
+		FromJ(inJson.value("fogColor", nlohmann::json::array()), fogColor);
+		READ_NUM(exposure);
+		READ_NUM(contrast);
+		READ_NUM(fogStart);
+		READ_NUM(fogEnd);
+		READ_NUM(enableFog);
+		READ_NUM(specularStrength);
+		READ_NUM(diffuseStrength);
+		READ_NUM(specularPowerScale);
+		READ_NUM(rimLightStrength);
+		READ_NUM(rimLightPower);
+		READ_NUM(enableRimLight);
+		READ_NUM(enableHalfLambert);
+		FromJ(inJson.value("rimLightColor", nlohmann::json::array()), rimLightColor);
+		READ_NUM(shadingMode);
+	}
 	void PostEffectPreset::ToJson(nlohmann::json& outJson) const { outJson = {{"enabled",enabled},{"activeEffect",activeEffect},{"bloomIntensity",bloomIntensity},{"vignetteIntensity",vignetteIntensity},{"grayscale",grayscale},{"sepia",sepia},{"fade",fade}}; }
 	void PostEffectPreset::FromJson(const nlohmann::json& inJson) { READ_NUM(enabled); if(inJson.contains("activeEffect")) activeEffect=inJson["activeEffect"].get<std::string>(); READ_NUM(bloomIntensity); READ_NUM(vignetteIntensity); READ_NUM(grayscale); READ_NUM(sepia); READ_NUM(fade); }
 	void Object3DPreset::ToJson(nlohmann::json& outJson) const { outJson={{"modelPath",modelPath},{"texturePath",texturePath},{"position",ToJ(position)},{"rotation",ToJ(rotation)},{"scale",ToJ(scale)},{"visible",visible},{"castShadow",castShadow},{"receiveShadow",receiveShadow}}; }

--- a/Project/Engine/System/JsonAssets/DataAssetPresets.h
+++ b/Project/Engine/System/JsonAssets/DataAssetPresets.h
@@ -26,6 +26,22 @@ namespace Ken4lowEngine
 		float shadowNearZ = 0.1f;
 		float shadowFarZ = 120.0f;
 		uint32_t shadowFocusMode = 0;
+		Vector4 ambientColor = { 0.10f, 0.10f, 0.10f, 0.15f };
+		Vector4 fogColor = { 0.58f, 0.64f, 0.70f, 1.0f };
+		float exposure = 1.0f;
+		float contrast = 1.0f;
+		float fogStart = 45.0f;
+		float fogEnd = 140.0f;
+		uint32_t enableFog = 0;
+		float specularStrength = 0.08f;
+		float diffuseStrength = 1.0f;
+		float specularPowerScale = 1.0f;
+		float rimLightStrength = 0.0f;
+		float rimLightPower = 2.0f;
+		uint32_t enableRimLight = 0;
+		uint32_t enableHalfLambert = 0;
+		Vector4 rimLightColor = { 1.0f, 1.0f, 1.0f, 1.0f };
+		uint32_t shadingMode = 0;
 
 		void ToJson(nlohmann::json& outJson) const override;
 		void FromJson(const nlohmann::json& inJson) override;

--- a/Project/Resources/Shaders/Object3D/LightingCommon.hlsli
+++ b/Project/Resources/Shaders/Object3D/LightingCommon.hlsli
@@ -13,6 +13,10 @@ static const uint LIGHT_TYPE_SPOT = 3;
 static const uint LIGHT_TYPE_RECT_AREA = 4;
 static const uint LIGHT_TYPE_SPHERE_AREA = 5;
 
+static const uint SHADING_MODE_NORMAL = 0;
+static const uint SHADING_MODE_HALF_LAMBERT = 1;
+static const uint SHADING_MODE_TOON_LIKE = 2;
+
 struct PunctualLight
 {
     uint lightType;
@@ -39,7 +43,15 @@ struct LightingSettings
     float fogEnd;
     uint enableFog;
     float specularStrength;
-    float2 padding;
+    float diffuseStrength;
+    float specularPowerScale;
+    float rimLightStrength;
+    float rimLightPower;
+    uint enableRimLight;
+    uint enableHalfLambert;
+    float4 rimLightColor;
+    uint shadingMode;
+    float3 padding;
 };
 
 struct LightingTerms
@@ -48,16 +60,47 @@ struct LightingTerms
     float3 specular;
 };
 
-float3 ComputeSpecular(float3 normal, float3 lightDir, float3 viewDir, float shininess)
+float CalculateDiffuseFactor(float3 normal, float3 lightDir, LightingSettings lightingSettings)
+{
+    float lambert = saturate(dot(normal, lightDir));
+
+    if (lightingSettings.shadingMode == SHADING_MODE_TOON_LIKE)
+    {
+        // ToonLikeはライト境界を段階化して、影の違和感をデバッグしやすくする。
+        return saturate(floor(lambert * 3.0f) / 2.0f);
+    }
+
+    if (lightingSettings.enableHalfLambert != 0 || lightingSettings.shadingMode == SHADING_MODE_HALF_LAMBERT)
+    {
+        float halfLambert = dot(normal, lightDir) * 0.5f + 0.5f;
+        return saturate(halfLambert * halfLambert);
+    }
+
+    return lambert;
+}
+
+float3 ComputeSpecular(float3 normal, float3 lightDir, float3 viewDir, float shininess, LightingSettings lightingSettings)
 {
     float3 halfVector = normalize(lightDir + viewDir);
     float NdotH = saturate(dot(normal, halfVector));
 
-    // ちょっとだけ扱いやすくする
-    float specPower = max(shininess, 4.0f);
+    // ImGuiからハイライト幅を補正してモデルごとの光沢差を吸収する。
+    float specPower = max(shininess * max(lightingSettings.specularPowerScale, 0.01f), 4.0f);
     float specular = pow(NdotH, specPower);
 
     return specular.xxx;
+}
+
+float3 ComputeRimLight(float3 normal, float3 viewDir, LightingSettings lightingSettings)
+{
+    if (lightingSettings.enableRimLight == 0)
+    {
+        return 0.0.xxx;
+    }
+
+    float rimBase = 1.0f - saturate(dot(normal, viewDir));
+    float rim = pow(rimBase, max(lightingSettings.rimLightPower, 0.01f)) * lightingSettings.rimLightStrength;
+    return lightingSettings.rimLightColor.rgb * rim * lightingSettings.rimLightColor.a;
 }
 
 LightingTerms MakeEmptyLightingTerms()
@@ -75,14 +118,14 @@ LightingTerms EvaluateDirectionalLight(
     float3 viewDir,
     ShadowParameter shadowParam,
     float shininess,
+    LightingSettings lightingSettings,
     Texture2D<float> shadowMap,
     SamplerComparisonState shadowSampler)
 {
     LightingTerms terms = MakeEmptyLightingTerms();
 
     float3 lightDir = normalize(-light.direction);
-    // 通常Lambertで面の向きによる明暗差を出す。
-    float NdotL = saturate(dot(normal, lightDir));
+    float NdotL = CalculateDiffuseFactor(normal, lightDir, lightingSettings);
     float3 lightColor = light.color.rgb * light.intensity;
 
     float shadow = CalculateShadow(
@@ -94,7 +137,7 @@ LightingTerms EvaluateDirectionalLight(
         shadowSampler);
 
     terms.diffuse = lightColor * NdotL * shadow;
-    terms.specular = lightColor * ComputeSpecular(normal, lightDir, viewDir, shininess) * shadow;
+    terms.specular = lightColor * ComputeSpecular(normal, lightDir, viewDir, shininess, lightingSettings) * shadow;
     return terms;
 }
 
@@ -103,7 +146,8 @@ LightingTerms EvaluatePointLight(
     float3 worldPosition,
     float3 normal,
     float3 viewDir,
-    float shininess)
+    float shininess,
+    LightingSettings lightingSettings)
 {
     LightingTerms terms = MakeEmptyLightingTerms();
 
@@ -116,11 +160,11 @@ LightingTerms EvaluatePointLight(
     float atten = pow(saturate(1.0f - d / range), max(light.decay, kMinRange)) * rangeMask;
 
     // ライト範囲外はDirect Lightを0にしてAmbientだけ残す。
-    float NdotL = saturate(dot(normal, lightDir));
+    float NdotL = CalculateDiffuseFactor(normal, lightDir, lightingSettings);
     float3 lightColor = light.color.rgb * (light.intensity * atten);
 
     terms.diffuse = lightColor * NdotL;
-    terms.specular = lightColor * ComputeSpecular(normal, lightDir, viewDir, shininess) * NdotL;
+    terms.specular = lightColor * ComputeSpecular(normal, lightDir, viewDir, shininess, lightingSettings) * NdotL;
     return terms;
 }
 
@@ -131,6 +175,7 @@ LightingTerms EvaluateSpotLight(
     float3 viewDir,
     ShadowParameter shadowParam,
     float shininess,
+    LightingSettings lightingSettings,
     Texture2D<float> shadowMap,
     SamplerComparisonState shadowSampler)
 {
@@ -148,17 +193,16 @@ LightingTerms EvaluateSpotLight(
     float ct = dot(-dir, lightDir);
     float spot = smoothstep(light.cosAngle, light.cosFalloffStart, ct) * step(light.cosAngle, ct);
 
-    // スポット光もHalf Lambertではなく通常Lambertを基本にする。
-    float NdotL = saturate(dot(normal, lightDir));
+    float NdotL = CalculateDiffuseFactor(normal, lightDir, lightingSettings);
     float3 lightColor = light.color.rgb * (light.intensity * atten * spot);
 
     float shadow = (shadowParam.shadowMode == 2) ? CalculateShadow(worldPosition, normal, lightDir, shadowParam, shadowMap, shadowSampler) : 1.0f;
     terms.diffuse = lightColor * NdotL * shadow;
-    terms.specular = lightColor * ComputeSpecular(normal, lightDir, viewDir, shininess) * NdotL * shadow;
+    terms.specular = lightColor * ComputeSpecular(normal, lightDir, viewDir, shininess, lightingSettings) * NdotL * shadow;
     return terms;
 }
 
-LightingTerms EvaluateRectAreaLightApprox(PunctualLight light, float3 worldPosition, float3 normal, float3 viewDir, float shininess)
+LightingTerms EvaluateRectAreaLightApprox(PunctualLight light, float3 worldPosition, float3 normal, float3 viewDir, float shininess, LightingSettings lightingSettings)
 {
     LightingTerms terms = MakeEmptyLightingTerms();
     float3 dir = normalize(light.direction);
@@ -176,10 +220,10 @@ LightingTerms EvaluateRectAreaLightApprox(PunctualLight light, float3 worldPosit
     float3 lightDir = toL / max(d, kMinLightLength);
     float range = max(light.distance, kMinRange);
     float atten = pow(saturate(1.0f - d / range), max(light.decay, kMinRange)) * step(d, range);
-    float NdotL = saturate(dot(normal, lightDir));
+    float NdotL = CalculateDiffuseFactor(normal, lightDir, lightingSettings);
     float3 lightColor = light.color.rgb * (light.intensity * atten);
     terms.diffuse = lightColor * NdotL;
-    terms.specular = lightColor * ComputeSpecular(normal, lightDir, viewDir, shininess) * NdotL;
+    terms.specular = lightColor * ComputeSpecular(normal, lightDir, viewDir, shininess, lightingSettings) * NdotL;
     return terms;
 }
 
@@ -215,6 +259,7 @@ float3 AccumulateLighting(
                 viewDir,
                 shadowParam,
                 shininess,
+                lightingSettings,
                 shadowMap,
                 shadowSampler);
             activeLightCount++;
@@ -227,7 +272,8 @@ float3 AccumulateLighting(
                 worldPosition,
                 normal,
                 viewDir,
-                shininess);
+                shininess,
+                lightingSettings);
             activeLightCount++;
         }
         else if (light.lightType == LIGHT_TYPE_SPOT)
@@ -239,13 +285,14 @@ float3 AccumulateLighting(
                 viewDir,
                 shadowParam,
                 shininess,
+                lightingSettings,
                 shadowMap,
                 shadowSampler);
             activeLightCount++;
         }
         else if (light.lightType == LIGHT_TYPE_RECT_AREA || light.lightType == LIGHT_TYPE_SPHERE_AREA)
         {
-            terms = EvaluateRectAreaLightApprox(light, worldPosition, normal, viewDir, shininess);
+            terms = EvaluateRectAreaLightApprox(light, worldPosition, normal, viewDir, shininess, lightingSettings);
             activeLightCount++;
         }
         else
@@ -257,11 +304,14 @@ float3 AccumulateLighting(
         specularSum += terms.specular;
     }
 
-    // CPUから渡したAmbientをそのまま使い、強すぎる環境光を調整できるようにする。
+    // CPUから渡したシェーディング係数で、Direct/Ambient/Rimをリアルタイム調整する。
     float3 ambient = lightingSettings.ambientColor.rgb * lightingSettings.ambientColor.a;
+    float3 direct = diffuseSum * lightingSettings.diffuseStrength;
+    float3 specular = specularSum * lightingSettings.specularStrength;
+    float3 rim = ComputeRimLight(normal, viewDir, lightingSettings);
 
     // ライト0本時だけ旧挙動に近い明るさを残し、ライトありではAmbientを明示値に抑える。
-    return (activeLightCount == 0) ? 1.0.xxx : (ambient + diffuseSum + specularSum * lightingSettings.specularStrength);
+    return (activeLightCount == 0) ? 1.0.xxx : (ambient + direct + specular + rim);
 }
 
 float3 ApplySimpleToneMapping(float3 color, LightingSettings lightingSettings)


### PR DESCRIPTION
### Motivation
- モデルのシェーディングに違和感があり、実行時に微調整できるUIとGPU側パラメータが必要だったため、シェーディング挙動の調整項目を追加しました。 
- 通常モデルとスキニングモデルで見た目のズレが出ないよう、共通の `LightingCommon.hlsli` ベースで処理を揃える方針にしました。 

### Description
- HLSL 側 `Project/Resources/Shaders/Object3D/LightingCommon.hlsli` にシェーディング制御パラメータを追加し、`diffuseStrength`、`specularPowerScale`、`rimLightStrength` / `rimLightPower` / `rimLightColor`、`enableRimLight`、`enableHalfLambert`、`shadingMode`（`Normal`/`HalfLambert`/`ToonLike`）を導入し、Half-Lambert/ToonLike の拡散計算・リムライト・スペキュラ補正を実装しました。 
- CPU 側 `LightingSettingsGPU`（`Project/Engine/Graphics/Lighting/LightManager.h`）に上記パラメータを追加し、毎フレーム GPU へ書き込むために `BindLightingSettings()` で `lightingSettings_` を ConstantBuffer に反映するようにしました。 
- ImGui 側 `LightManager::DrawPunctualLightsInspector()` に `Shading` ツリーを追加して `ImGui::Combo` / `ImGui::SliderFloat` / `ImGui::Checkbox` / `ImGui::ColorEdit4` を配置し、実行中に `lightingSettings_` を直接調整できるようにしました（UI 内に説明コメントを1行追加）。 
- `AccumulateLighting()` と評価関数群に `LightingSettings` 引数を渡すように更新し、`Object3d.PS.hlsl` と `SkinningObject3d.PS.hlsl` は共通の `LightingCommon.hlsli` と `gLightingSettings`（`b5`）を使うため同一のシェーディング調整が適用されるようにしました。 
- LightPreset（`Project/Engine/System/JsonAssets/DataAssetPresets.*`）の JSON 変換にシェーディング設定を追加し、プリセットの保存/読み込みで `lightingSettings_` を復元/保存できるようにしました。 

### Testing
- `git diff --check` を実行して差分にチェックエラーがないことを確認しました（成功）。 
- シェーダー変更の静的トークンチェックとして内部の Python スクリプトで `LightingCommon.hlsli` に期待するトークン（`diffuseStrength`、`specularPowerScale`、`enableRimLight`、`enableHalfLambert`、`SHADING_MODE_TOON_LIKE`、`ComputeSpecular(..., lightingSettings)` など）が存在することを確認しました（成功）。 
- ソリューション全体のビルドはこのコンテナに `dotnet`/MSBuild がインストールされていないため実行できず、ビルドは未実行です（`dotnet build` 実行は環境不足で失敗）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a5bcc4e64832d962f18fbf3b9714f)