### PR TITLE
Initialize shading controls with a visible default directional light

### DIFF
--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
@@ -29,21 +29,10 @@ void GamePlayWorld::Initialize(GamePlayStageContext& stageContext)
 	const auto stageAssets = stageContext.GetCurrentStageAssets();
 	auto* lightManager = LightManager::GetInstance();
 
-	// GamePlayScene開始時に前シーンのライト状態が残らないよう、基本ライトを明示的に再構成する。
-	auto& gameplayLights = lightManager->GetMutablePunctualLightsForEditor();
-	gameplayLights.clear();
-	lightManager->AddDefaultDirectionalLight();
+	// GamePlayScene開始時は保存済みプリセットを優先し、なければ確認用ライトへ戻す。
+	lightManager->ResetToDefaultLighting();
 	lightManager->SetShadowCasterLightIndex(-1);
-	lightManager->SetShadowFocusMode(K4E::LightManager::ShadowFocusMode::StageCenter);
 	lightManager->SetManualShadowFocusPosition({ 0.0f, 0.0f, 0.0f });
-	lightManager->SetDirectionalShadowFrustum(120.0f, 120.0f, 0.1f, 180.0f);
-	lightManager->SetShadowMapSize(2048);
-
-	K4E::Vector3 dummy{};
-	if (!TryGetDirectionalLightFromManager(dummy))
-	{
-		lightManager->AddDefaultDirectionalLight();
-	}
 
 	skyBox_ = std::make_unique<K4E::SkyBox>();
 	skyBox_->Initialize("SkyBox/skybox.dds");
@@ -120,13 +109,6 @@ void GamePlayWorld::Initialize(GamePlayStageContext& stageContext)
 		characters_.Update(0.0f);
 	}
 
-	{
-		// 空だけ明るく地面が沈む見え方を避けるため、LightEditor互換の設定値をGamePlay初期値として少しだけ持ち上げる。
-		auto& lighting = LightManager::GetInstance()->GetMutableLightingSettingsForEditor();
-		lighting.ambientColor.w = std::max(lighting.ambientColor.w, 0.22f);
-		lighting.exposure = std::max(lighting.exposure, 1.10f);
-		lighting.specularStrength = std::max(lighting.specularStrength, 0.08f);
-	}
 
 	if (stage_)
 	{

--- a/Project/ApplicationLayer/Scene/TitleScene/TitleScene.cpp
+++ b/Project/ApplicationLayer/Scene/TitleScene/TitleScene.cpp
@@ -33,7 +33,7 @@ using namespace Ken4lowEngine;
 /// -------------------------------------------------------------
 void TitleScene::Initialize()
 {
-	LightManager::GetInstance()->AddDefaultDirectionalLight();
+	LightManager::GetInstance()->ResetToDefaultLighting();
 
 	dxCommon_ = DirectXCommon::GetInstance();
 	input_ = Input::GetInstance();

--- a/Project/Engine/Graphics/Lighting/LightManager.cpp
+++ b/Project/Engine/Graphics/Lighting/LightManager.cpp
@@ -108,6 +108,11 @@ namespace Ken4lowEngine
 
 		CreatePunctualLight();
 
+		if (punctualLights_.empty())
+		{
+			ResetToDefaultLighting();
+		}
+
 		punctualBuffer_->SetName(L"PunctualLightBuffer");
 		lightInfoResource_->SetName(L"LightInfoConstantBuffer");
 		if (lightingSettingsResource_)
@@ -387,6 +392,7 @@ namespace Ken4lowEngine
 			if (ImGui::TreeNodeEx("Shading", ImGuiTreeNodeFlags_DefaultOpen))
 			{
 				// モデルごとの光の乗り方を実行中に切り分けるための調整UI。
+				ImGui::TextUnformatted("シェーディング表現を調整します。Directional Light の向きによる明暗差を確認できます。");
 				const char* shadingModes[] = { "Normal", "HalfLambert", "ToonLike" };
 				int shadingMode = static_cast<int>(lightingSettings_.shadingMode);
 				if (ImGui::Combo("Shading Mode", &shadingMode, shadingModes, IM_ARRAYSIZE(shadingModes)))
@@ -394,13 +400,18 @@ namespace Ken4lowEngine
 					lightingSettings_.shadingMode = static_cast<uint32_t>(shadingMode);
 				}
 
+				ImGui::TextUnformatted("Shading Mode：陰影の計算方法を切り替えます。");
 				ImGui::SliderFloat("Diffuse Strength", &lightingSettings_.diffuseStrength, 0.0f, 3.0f);
+				ImGui::TextUnformatted("Diffuse Strength：ライトによる拡散光の強さを調整します。");
 				ImGui::SliderFloat("Specular Power Scale", &lightingSettings_.specularPowerScale, 0.05f, 4.0f);
+				ImGui::TextUnformatted("Specular Power Scale：ハイライトの鋭さを調整します。");
 				bool enableHalfLambert = lightingSettings_.enableHalfLambert != 0;
 				if (ImGui::Checkbox("Half Lambert Enable", &enableHalfLambert))
 				{
 					lightingSettings_.enableHalfLambert = enableHalfLambert ? 1u : 0u;
 				}
+
+				ImGui::TextUnformatted("Half Lambert Enable：暗い面を少し明るく見せる補正を有効にします。");
 
 				ImGui::SeparatorText("Rim Light");
 				bool enableRimLight = lightingSettings_.enableRimLight != 0;
@@ -408,9 +419,12 @@ namespace Ken4lowEngine
 				{
 					lightingSettings_.enableRimLight = enableRimLight ? 1u : 0u;
 				}
+				ImGui::TextUnformatted("Rim Light Enable：輪郭部分に光を足す表現を有効にします。");
 				ImGui::SliderFloat("Rim Light Strength", &lightingSettings_.rimLightStrength, 0.0f, 2.0f);
+				ImGui::TextUnformatted("Rim Light Strength：輪郭光の強さを調整します。");
 				ImGui::SliderFloat("Rim Light Power", &lightingSettings_.rimLightPower, 0.1f, 8.0f);
 				ImGui::ColorEdit4("Rim Light Color", &lightingSettings_.rimLightColor.x);
+				ImGui::TextUnformatted("Rim Light Color：輪郭光の色を調整します。");
 				ImGui::TreePop();
 			}
 		}
@@ -800,15 +814,29 @@ namespace Ken4lowEngine
 	{
 		PunctualLightGPU light{};
 		light.lightType = 1; // Directional
-		light.color = { 1.0f, 1.0f, 1.0f, 1.0f };
-		light.intensity = 1.0f;
-		light.direction = Vector3::Normalize({ 0.3f, -1.0f, 0.2f });
+		light.color = { 1.0f, 0.97f, 0.92f, 1.0f };
+		light.intensity = 0.90f;
+		light.direction = Vector3::Normalize({ 0.45f, -1.0f, 0.35f });
 		light.enabled = 1u;
 
 		punctualLights_.clear();
 		punctualLights_.push_back(light);
+		lightingSettings_ = LightingSettingsGPU{};
+		lightingSettings_.ambientColor = { 0.10f, 0.11f, 0.13f, 0.18f };
+		lightingSettings_.diffuseStrength = 0.95f;
+		lightingSettings_.specularStrength = 0.10f;
+		lightingSettings_.rimLightStrength = 0.55f;
 	}
 
+	void LightManager::ResetToDefaultLighting()
+	{
+		punctualLights_.clear();
+		// 保存済み設定を優先し、ファイルがない場合だけ確認用の初期ライトを生成する。
+		if (!ApplyLightPresetByPath("Resources/DataAssets/LightPresets/default_light.json"))
+		{
+			AddDefaultDirectionalLight();
+		}
+	}
 
 	bool LightManager::SaveLightPreset(const std::string& assetId)
 	{

--- a/Project/Engine/Graphics/Lighting/LightManager.h
+++ b/Project/Engine/Graphics/Lighting/LightManager.h
@@ -149,6 +149,9 @@ namespace Ken4lowEngine
 		/// デフォルトの指向性ライトを追加します。
 		/// </summary>
 		void AddDefaultDirectionalLight();
+
+		/// <summary>既定プリセットを優先して初期ライトを再構成します。</summary>
+		void ResetToDefaultLighting();
 		bool SaveLightPreset(const std::string& assetId);
 		bool ApplyLightPresetByPath(const std::string& filePath);
 

--- a/Project/Resources/DataAssets/LightPresets/default_light.json
+++ b/Project/Resources/DataAssets/LightPresets/default_light.json
@@ -2,17 +2,17 @@
   "data": {
     "color": [
       1.0,
-      1.0,
-      1.0,
+      0.97,
+      0.92,
       1.0
     ],
     "directionalDirection": [
-      0.28221628069877625,
-      -0.9407208561897278,
-      0.18814417719841003
+      0.39056673645973206,
+      -0.8679261207580566,
+      0.3037741184234619
     ],
     "enableShadow": true,
-    "intensity": 1.0,
+    "intensity": 0.9,
     "normalBias": 0.02500000037252903,
     "shadowBias": 0.0,
     "shadowFarZ": 180.0,
@@ -21,7 +21,38 @@
     "shadowMapSize": 2048,
     "shadowNearZ": 0.10000000149011612,
     "shadowStrength": 0.6000000238418579,
-    "shadowWidth": 120.0
+    "shadowWidth": 120.0,
+    "ambientColor": [
+      0.1,
+      0.11,
+      0.13,
+      0.18
+    ],
+    "fogColor": [
+      0.58,
+      0.64,
+      0.7,
+      1.0
+    ],
+    "exposure": 1.0,
+    "contrast": 1.0,
+    "fogStart": 45.0,
+    "fogEnd": 140.0,
+    "enableFog": 0,
+    "specularStrength": 0.1,
+    "diffuseStrength": 0.95,
+    "specularPowerScale": 1.0,
+    "rimLightStrength": 0.55,
+    "rimLightPower": 2.0,
+    "enableRimLight": 0,
+    "enableHalfLambert": 0,
+    "rimLightColor": [
+      0.85,
+      0.92,
+      1.0,
+      1.0
+    ],
+    "shadingMode": 0
   },
   "displayName": "default_light",
   "id": "default_light",


### PR DESCRIPTION
### Motivation
- Improve out-of-the-box visibility of the new shading controls by ensuring a visible directional light exists on startup so ImGui changes (Shading Mode / Diffuse / Specular / Rim) produce obvious visual differences.
- Prefer persisted lighting presets over ad-hoc defaults so saved `LightPreset` data is not repeatedly overwritten by hard-coded defaults.
- Provide short Japanese descriptions in the ImGui `Shading` UI to make each control's purpose immediately clear.
- Keep preset serialization/compatibility intact and add any missing shading-related fields to the default preset data.

### Description
- Added `ResetToDefaultLighting()` to `Project/Engine/Graphics/Lighting/LightManager.{h,cpp}` which tries to load `Resources/DataAssets/LightPresets/default_light.json` and falls back to a tuned `AddDefaultDirectionalLight()` only if loading fails, and call it from `Initialize()` when no punctual lights are present; included one-line Japanese comment explaining the behavior.
- Tuned fallback directional light parameters in `LightManager::AddDefaultDirectionalLight()` (warmer color, `0.90` intensity, adjusted direction) and set initial `lightingSettings_` values so Rim/Specular/Diffuse changes are noticeable.
- Replaced direct calls to `AddDefaultDirectionalLight()` in `Project/ApplicationLayer/Scene/TitleScene/TitleScene.cpp` and `Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp` with `ResetToDefaultLighting()` and removed the gameplay-only post-adjust that forcibly raised ambient/exposure/specular, allowing presets to take precedence.
- Extended `Project/Resources/DataAssets/LightPresets/default_light.json` with shading-related fields (`ambientColor`, `fogColor`, `exposure`, `contrast`, `fogStart`, `fogEnd`, `enableFog`, `specularStrength`, `diffuseStrength`, `specularPowerScale`, `rimLightStrength`, `rimLightPower`, `enableRimLight`, `enableHalfLambert`, `rimLightColor`, `shadingMode`) to match `LightPreset` serialization.
- Enhanced ImGui: in `LightManager::DrawPunctualLightsInspector()` added short Japanese `ImGui::TextUnformatted` lines explaining `Shading Mode`, `Diffuse Strength`, `Specular Power Scale`, `Half Lambert Enable`, and `Rim Light` controls so the user understands what each slider/checkbox does (labels remain English).

### Testing
- Ran `git diff --check` and repository diff checks with no whitespace errors (passed).
- Performed static validation with Python scripts to verify that `default_light.json` contains all requested shading keys and that ImGui controls and HLSL shader consumers reference the same setting names (passed).
- Verified that `LightPreset` serialization (`ToJson`/`FromJson`) already handles the shading fields and that loading the JSON is attempted before generating fallback lights (checked via code inspection and tests above; passed).
- Build not executed: attempted to run Visual Studio build but `msbuild`/`dotnet`/`xbuild` are not available in this Linux container, so compilation and runtime UI visual confirmation were not performed (skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cf57c2bc8832d90a15bc8fff76cf8)