### PR TITLE
Add configurable SkyBox presets and ImGui controls for DebugScene

### DIFF
--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -9,6 +9,9 @@
 #include "Wireframe.h"
 #include "Object3D.h"
 #include "Camera.h"
+#include "SkyBox.h"
+#include "JsonAssetEntry.h"
+#include "JsonDataManager.h"
 #include "WinApp.h"
 #include <LightManager.h>
 #include <GameTimer.h>
@@ -119,6 +122,7 @@ void DebugScene::Initialize()
 
 	dxCommon_ = DirectXCommon::GetInstance();
 	input_ = Input::GetInstance();
+	InitializeSkyBox();
 
 	/*input_->SetLockCursor(true);
 	input_->SetCursorVisible(false);*/
@@ -147,10 +151,6 @@ void DebugScene::Initialize()
 	debugMidRangeEnemy_->Initialize();
 	debugMidRangeEnemy_->SetCenterPosition({ 3.0f, 2.5f, 18.0f });
 	debugMidRangeEnemy_->SetTarget(meleeDummyTarget_.GetCenterPosition());
-	// 追加: 中距離敵にも床/障害物AABBを近接敵と同じ参照元で渡す。
-	debugMidRangeEnemy_->SetFloorAABBs(&stage_->GetFloorAABBs());
-	debugMidRangeEnemy_->SetWallObstacleAABBs(&stage_->GetWallObstacleAABBs());
-
 	disintegrationDebug_ = std::make_unique<DisintegrationDebugController>();
 	// Disintegration系の確認処理は専用コントローラへ委譲し、DebugScene本体の責務を絞る。
 	disintegrationDebug_->Initialize();
@@ -171,6 +171,65 @@ void DebugScene::Initialize()
 		debugMeleeEnemy_->SetFloorAABBs(&stage_->GetFloorAABBs());
 		debugMeleeEnemy_->SetWallObstacleAABBs(&stage_->GetWallObstacleAABBs());
 	}
+	if (debugMidRangeEnemy_)
+	{
+		debugMidRangeEnemy_->SetFloorAABBs(&stage_->GetFloorAABBs());
+		debugMidRangeEnemy_->SetWallObstacleAABBs(&stage_->GetWallObstacleAABBs());
+	}
+}
+
+void DebugScene::InitializeSkyBox()
+{
+	LoadSkyBoxPresets();
+	K4E::SkyBoxPreset* preset = skyBoxPresets_.FindActivePreset();
+	if (!preset)
+	{
+		return;
+	}
+
+	skyBox_ = std::make_unique<K4E::SkyBox>();
+	skyBox_->Initialize(preset->texturePath);
+	ApplyActiveSkyBoxPreset();
+}
+
+void DebugScene::ApplyActiveSkyBoxPreset(bool reloadTexture)
+{
+	K4E::SkyBoxPreset* preset = skyBoxPresets_.FindActivePreset();
+	if (!skyBox_ || !preset)
+	{
+		return;
+	}
+
+	// 読み込んだプリセットを優先し、毎フレーム既定値で上書きしない。
+	K4E::ApplySkyBoxPreset(*skyBox_, *preset, reloadTexture);
+	std::snprintf(skyBoxTexturePathBuffer_.data(), skyBoxTexturePathBuffer_.size(), "%s", preset->texturePath.c_str());
+}
+
+bool DebugScene::LoadSkyBoxPresets()
+{
+	K4E::JsonAssetEntry entry;
+	if (!K4E::JsonDataManager::SafeLoad("Resources/DataAssets/SkyBoxPresets/debug_skybox.json", entry))
+	{
+		skyBoxPresetLog_ = "設定ファイルがないため、デフォルト設定で表示します。";
+		return false;
+	}
+
+	skyBoxPresets_.FromJson(entry.data);
+	skyBoxPresetLog_ = "SkyBox設定を読み込みました。";
+	return true;
+}
+
+bool DebugScene::SaveSkyBoxPresets()
+{
+	K4E::JsonAssetEntry entry;
+	entry.id = "debug_skybox";
+	entry.displayName = "Debug Scene SkyBox";
+	entry.type = "SkyBoxPresetCollection";
+	entry.path = "Resources/DataAssets/SkyBoxPresets/debug_skybox.json";
+	skyBoxPresets_.ToJson(entry.data);
+	const bool saved = K4E::JsonDataManager::SafeSave(entry);
+	skyBoxPresetLog_ = saved ? "SkyBox設定を保存しました。" : "SkyBox設定の保存に失敗しました。";
+	return saved;
 }
 
 void DebugScene::Update()
@@ -199,9 +258,9 @@ void DebugScene::Update()
 	if (debugMidRangeEnemy_)
 	{
 		debugMidRangeEnemy_->SetTarget(meleeDummyTarget_.GetCenterPosition());
-	// 追加: 中距離敵にも床/障害物AABBを近接敵と同じ参照元で渡す。
-	debugMidRangeEnemy_->SetFloorAABBs(&stage_->GetFloorAABBs());
-	debugMidRangeEnemy_->SetWallObstacleAABBs(&stage_->GetWallObstacleAABBs());
+		// 中距離敵にも床/障害物AABBを近接敵と同じ参照元で渡す。
+		debugMidRangeEnemy_->SetFloorAABBs(&stage_->GetFloorAABBs());
+		debugMidRangeEnemy_->SetWallObstacleAABBs(&stage_->GetWallObstacleAABBs());
 		debugMidRangeEnemy_->Update(deltaTime);
 	}
 
@@ -231,6 +290,10 @@ void DebugScene::Update()
 	{
 		stage_->Update();
 	}
+	if (skyBox_)
+	{
+		skyBox_->Update();
+	}
 
 }
 
@@ -242,6 +305,13 @@ void DebugScene::ResolveMeleeEnemySeparation(float deltaTime)
 
 void DebugScene::Draw3DObjects()
 {
+	const K4E::SkyBoxPreset* skyBoxPreset = skyBoxPresets_.FindActivePreset();
+	if (skyBox_ && skyBoxPreset && skyBoxPreset->enabled)
+	{
+		// SkyBox は深度読み取り専用 PSO で先に描画し、ステージ描画を妨げない。
+		skyBox_->Draw();
+	}
+
 	if (disintegrationDebug_)
 	{
 		disintegrationDebug_->Draw3DObjects();
@@ -345,6 +415,7 @@ void DebugScene::Finalize()
 	cullingTestObjects_.clear();
 	frustumCullingDebug_.reset();
 	disintegrationDebug_.reset();
+	skyBox_.reset();
 	EnemyBase::SetGlobalStageWorldAABBs(nullptr);
 	debugBoss_.reset();
 	debugMidRangeEnemy_.reset();
@@ -361,6 +432,7 @@ void DebugScene::DrawImGui()
 #ifdef USE_IMGUI
 
 	LightManager::GetInstance()->DrawImGui();
+	DrawSkyBoxImGui();
 
 	if (debugBoss_)
 	{
@@ -769,6 +841,75 @@ void DebugScene::DrawImGui()
 
 #endif // USE_IMGUI
 
+}
+
+void DebugScene::DrawSkyBoxImGui()
+{
+#ifdef USE_IMGUI
+	K4E::SkyBoxPreset* preset = skyBoxPresets_.FindActivePreset();
+	ImGui::Begin("SkyBox Settings");
+	ImGui::TextWrapped("DebugSceneの背景SkyBoxを調整します。保存済みJsonがない場合はデフォルト設定を使用します。");
+	ImGui::Separator();
+
+	if (ImGui::BeginCombo("Active Preset", skyBoxPresets_.activePresetName.c_str()))
+	{
+		for (const K4E::SkyBoxPreset& candidate : skyBoxPresets_.presets)
+		{
+			const bool selected = candidate.name == skyBoxPresets_.activePresetName;
+			if (ImGui::Selectable(candidate.name.c_str(), selected))
+			{
+				skyBoxPresets_.activePresetName = candidate.name;
+				ApplyActiveSkyBoxPreset();
+				preset = skyBoxPresets_.FindActivePreset();
+			}
+			if (selected) ImGui::SetItemDefaultFocus();
+		}
+		ImGui::EndCombo();
+	}
+	ImGui::TextWrapped("Active Preset: 現在使用する名前付きSkyBox設定を選択します。");
+
+	if (preset)
+	{
+		if (ImGui::Checkbox("Enabled", &preset->enabled)) ApplyActiveSkyBoxPreset();
+		ImGui::TextWrapped("Enabled: SkyBox背景の表示ON/OFFを切り替えます。");
+		ImGui::Text("Current Texture: %s", preset->texturePath.c_str());
+		ImGui::TextWrapped("Texture Path: Resources/Textures/Compiledからの相対パスを指定します。");
+		ImGui::InputText("Texture Path", skyBoxTexturePathBuffer_.data(), skyBoxTexturePathBuffer_.size());
+		if (ImGui::Button("Apply Texture Path"))
+		{
+			preset->texturePath = skyBoxTexturePathBuffer_.data();
+			ApplyActiveSkyBoxPreset();
+		}
+		ImGui::SameLine();
+		if (ImGui::Button("Reload Texture"))
+		{
+			preset->texturePath = skyBoxTexturePathBuffer_.data();
+			ApplyActiveSkyBoxPreset(true);
+		}
+		ImGui::TextWrapped("Reload Texture: 編集したテクスチャをディスクから再読み込みします。");
+
+		if (ImGui::DragFloat3("Rotation", &preset->rotation.x, 0.01f)) ApplyActiveSkyBoxPreset();
+		ImGui::TextWrapped("Rotation: SkyBoxの向きをラジアン単位で調整します。");
+		if (ImGui::DragFloat3("Scale", &preset->scale.x, 10.0f, 1.0f, 50000.0f)) ApplyActiveSkyBoxPreset();
+		ImGui::TextWrapped("Scale: 背景キューブの大きさを調整します。");
+		if (ImGui::DragFloat("Brightness", &preset->brightness, 0.01f, 0.0f, 10.0f)) ApplyActiveSkyBoxPreset();
+		ImGui::TextWrapped("Brightness: SkyBoxの明るさ倍率を調整します。");
+		if (ImGui::ColorEdit4("Tint Color", &preset->tintColor.x)) ApplyActiveSkyBoxPreset();
+		ImGui::TextWrapped("Tint Color: SkyBoxへ重ねる色味を調整します。");
+	}
+
+	ImGui::Separator();
+	if (ImGui::Button("Save Settings")) SaveSkyBoxPresets();
+	ImGui::SameLine();
+	if (ImGui::Button("Load Settings"))
+	{
+		LoadSkyBoxPresets();
+		ApplyActiveSkyBoxPreset();
+	}
+	ImGui::TextWrapped("Save / Load Settings: SkyBox設定をJsonへ保存、またはJsonから復元します。");
+	ImGui::TextWrapped("%s", skyBoxPresetLog_.c_str());
+	ImGui::End();
+#endif // USE_IMGUI
 }
 
 void DebugScene::InitializeCullingTestObjects()

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
@@ -12,7 +12,9 @@
 #include "Vector3.h"
 #include "Vector4.h"
 #include "Stage.h"
+#include "DataAssetPresets.h"
 
+#include <array>
 #include <memory>
 #include <string>
 #include <vector>
@@ -20,6 +22,7 @@
 /// ---------- 前方宣言 ---------- ///
 namespace Ken4lowEngine { class DirectXCommon; }
 namespace Ken4lowEngine { class Input; }
+namespace Ken4lowEngine { class SkyBox; }
 namespace K4E = ::Ken4lowEngine;
 
 /// -------------------------------------------------------------
@@ -72,6 +75,13 @@ private: /// ---------- メンバ関数 ---------- ///
 	// カリング確認用 Object3D を初期化
 	void InitializeCullingTestObjects();
 
+	// SkyBox 設定はファイル欠落時だけ既定値へフォールバックする。
+	void InitializeSkyBox();
+	void ApplyActiveSkyBoxPreset(bool reloadTexture = false);
+	bool LoadSkyBoxPresets();
+	bool SaveSkyBoxPresets();
+	void DrawSkyBoxImGui();
+
 	/// -------------------------------------------------------------
 	/// BossHitPart を文字列へ変換
 	/// ログ確認用
@@ -93,6 +103,11 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	// ステージ確認用（見た目＋衝突）
 	std::unique_ptr<K4E::Stage> stage_;
+
+	std::unique_ptr<K4E::SkyBox> skyBox_;
+	K4E::SkyBoxPresetCollection skyBoxPresets_{};
+	std::array<char, 256> skyBoxTexturePathBuffer_{};
+	std::string skyBoxPresetLog_ = "SkyBox設定は未読み込みです。";
 
 	// --- 仮ヒット確認用パラメータ ---
 	bool debugBossHitTestEnabled_ = true; // 仮ヒット確認ON/OFF

--- a/Project/Engine/Graphics/Renderer/SkyBox/SkyBox.cpp
+++ b/Project/Engine/Graphics/Renderer/SkyBox/SkyBox.cpp
@@ -20,10 +20,7 @@ namespace Ken4lowEngine
 		camera_ = CameraManager::GetInstance()->GetMainCamera();
 
 		// 環境テクスチャを読み込む
-		TextureManager::GetInstance()->LoadTexture(filePath);
-
-		// 読み込んだテクスチャの SRV index を保存する
-		textureIndex_ = TextureManager::GetInstance()->GetSrvIndex(filePath);
+		SetTexture(filePath);
 
 		// SkyBox は十分大きなキューブとして配置する
 		worldTransform_.scale_ = { 10000.0f, 10000.0f, 10000.0f };
@@ -91,6 +88,35 @@ namespace Ken4lowEngine
 
 		// キューブをインデックス描画する
 		commandList->DrawIndexedInstanced(kNumIndex, 1, 0, 0, 0);
+	}
+
+	void SkyBox::SetTexture(const std::string& filePath, bool reloadTexture)
+	{
+		if (filePath.empty())
+		{
+			return;
+		}
+
+		TextureManager* textureManager = TextureManager::GetInstance();
+		if (reloadTexture)
+		{
+			textureManager->ReloadTexture(filePath);
+		}
+		else
+		{
+			textureManager->LoadTexture(filePath);
+		}
+		texturePath_ = filePath;
+		textureIndex_ = textureManager->GetSrvIndex(filePath);
+		gpuHandle_ = textureManager->GetSrvHandleGPU(filePath);
+	}
+
+	void SkyBox::SetColor(const Vector4& color)
+	{
+		if (materialData_)
+		{
+			materialData_->color = color;
+		}
 	}
 
 	/// -------------------------------------------------------------

--- a/Project/Engine/Graphics/Renderer/SkyBox/SkyBox.h
+++ b/Project/Engine/Graphics/Renderer/SkyBox/SkyBox.h
@@ -128,6 +128,13 @@ namespace Ken4lowEngine
 		WorldTransform& GetWorldTransform() { return worldTransform_; }
 		void SetWorldTransform(const WorldTransform& worldTransform) { worldTransform_ = worldTransform; }
 
+		/// 環境テクスチャを切り替え、必要に応じてディスクから再読み込みする。
+		void SetTexture(const std::string& filePath, bool reloadTexture = false);
+		const std::string& GetTexturePath() const { return texturePath_; }
+
+		/// 色味と明るさを合成した描画色を設定する。
+		void SetColor(const Vector4& color);
+
 	private: /// ---------- 内部メンバ関数 ---------- ///
 
 		/// <summary>
@@ -187,6 +194,9 @@ namespace Ken4lowEngine
 
 		/// 使用中の環境テクスチャ index
 		uint32_t textureIndex_ = 0;
+
+		/// 使用中の環境テクスチャパス
+		std::string texturePath_;
 	};
 
 } // namespace Ken4lowEngine

--- a/Project/Engine/System/JsonAssets/DataAssetPresets.cpp
+++ b/Project/Engine/System/JsonAssets/DataAssetPresets.cpp
@@ -1,6 +1,10 @@
 #include "DataAssetPresets.h"
 
+#include "SkyBox.h"
 #include "Sprite.h"
+
+#include <algorithm>
+#include <utility>
 
 namespace Ken4lowEngine
 {
@@ -14,6 +18,84 @@ namespace Ken4lowEngine
 		void FromJ(const nlohmann::json& j, Vector4& v) { if (j.is_array() && j.size() >= 4) { v.x = j[0].get<float>(); v.y = j[1].get<float>(); v.z = j[2].get<float>(); v.w = j[3].get<float>(); } }
 	}
 #define READ_NUM(name) if(inJson.contains(#name)){ name = inJson[#name].get<decltype(name)>(); }
+	void SkyBoxPreset::ToJson(nlohmann::json& outJson) const
+	{
+		outJson = {
+			{"name",name},
+			{"enabled",enabled},
+			{"texturePath",texturePath},
+			{"rotation",ToJ(rotation)},
+			{"scale",ToJ(scale)},
+			{"brightness",brightness},
+			{"tintColor",ToJ(tintColor)}
+		};
+	}
+
+	void SkyBoxPreset::FromJson(const nlohmann::json& inJson)
+	{
+		if (inJson.contains("name")) name = inJson["name"].get<std::string>();
+		READ_NUM(enabled);
+		if (inJson.contains("texturePath")) texturePath = inJson["texturePath"].get<std::string>();
+		FromJ(inJson.value("rotation", nlohmann::json::array()), rotation);
+		FromJ(inJson.value("scale", nlohmann::json::array()), scale);
+		READ_NUM(brightness);
+		FromJ(inJson.value("tintColor", nlohmann::json::array()), tintColor);
+	}
+
+	SkyBoxPreset* SkyBoxPresetCollection::FindActivePreset()
+	{
+		auto it = std::find_if(presets.begin(), presets.end(), [this](const SkyBoxPreset& preset) { return preset.name == activePresetName; });
+		return it != presets.end() ? &(*it) : nullptr;
+	}
+
+	const SkyBoxPreset* SkyBoxPresetCollection::FindActivePreset() const
+	{
+		auto it = std::find_if(presets.begin(), presets.end(), [this](const SkyBoxPreset& preset) { return preset.name == activePresetName; });
+		return it != presets.end() ? &(*it) : nullptr;
+	}
+
+	void SkyBoxPresetCollection::ToJson(nlohmann::json& outJson) const
+	{
+		outJson = nlohmann::json::object();
+		outJson["activePresetName"] = activePresetName;
+		outJson["presets"] = nlohmann::json::array();
+		for (const SkyBoxPreset& preset : presets)
+		{
+			nlohmann::json presetJson;
+			preset.ToJson(presetJson);
+			outJson["presets"].push_back(presetJson);
+		}
+	}
+
+	void SkyBoxPresetCollection::FromJson(const nlohmann::json& inJson)
+	{
+		if (inJson.contains("activePresetName")) activePresetName = inJson["activePresetName"].get<std::string>();
+		if (inJson.contains("presets") && inJson["presets"].is_array())
+		{
+			std::vector<SkyBoxPreset> loadedPresets;
+			for (const auto& presetJson : inJson["presets"])
+			{
+				SkyBoxPreset preset;
+				preset.FromJson(presetJson);
+				loadedPresets.push_back(preset);
+			}
+			if (!loadedPresets.empty()) presets = std::move(loadedPresets);
+		}
+		if (!FindActivePreset() && !presets.empty()) activePresetName = presets.front().name;
+	}
+
+	void ApplySkyBoxPreset(SkyBox& skyBox, const SkyBoxPreset& preset, bool reloadTexture)
+	{
+		skyBox.SetTexture(preset.texturePath, reloadTexture);
+		skyBox.GetWorldTransform().rotate_ = preset.rotation;
+		skyBox.GetWorldTransform().scale_ = preset.scale;
+		skyBox.SetColor({
+			preset.tintColor.x * preset.brightness,
+			preset.tintColor.y * preset.brightness,
+			preset.tintColor.z * preset.brightness,
+			preset.tintColor.w
+		});
+	}
 	void LightPreset::ToJson(nlohmann::json& outJson) const
 	{
 		outJson = {

--- a/Project/Engine/System/JsonAssets/DataAssetPresets.h
+++ b/Project/Engine/System/JsonAssets/DataAssetPresets.h
@@ -6,10 +6,40 @@
 #include "Vector4.h"
 
 #include <string>
+#include <vector>
 
 namespace Ken4lowEngine
 {
+	class SkyBox;
 	class Sprite;
+
+	struct SkyBoxPreset : public JsonSerializable
+	{
+		std::string name = "DefaultSky";
+		bool enabled = true;
+		std::string texturePath = "SkyBox/skybox.dds";
+		Vector3 rotation{};
+		Vector3 scale = { 10000.0f, 10000.0f, 10000.0f };
+		float brightness = 1.0f;
+		Vector4 tintColor = { 1.0f, 1.0f, 1.0f, 1.0f };
+
+		void ToJson(nlohmann::json& outJson) const override;
+		void FromJson(const nlohmann::json& inJson) override;
+	};
+
+	struct SkyBoxPresetCollection : public JsonSerializable
+	{
+		std::string activePresetName = "DefaultSky";
+		std::vector<SkyBoxPreset> presets = { SkyBoxPreset{} };
+
+		SkyBoxPreset* FindActivePreset();
+		const SkyBoxPreset* FindActivePreset() const;
+		void ToJson(nlohmann::json& outJson) const override;
+		void FromJson(const nlohmann::json& inJson) override;
+	};
+
+	// SkyBox の見た目だけを共通適用し、表示可否は描画側で扱う。
+	void ApplySkyBoxPreset(SkyBox& skyBox, const SkyBoxPreset& preset, bool reloadTexture = false);
 
 	struct LightPreset : public JsonSerializable
 	{

--- a/Project/Resources/DataAssets/SkyBoxPresets/debug_skybox.json
+++ b/Project/Resources/DataAssets/SkyBoxPresets/debug_skybox.json
@@ -1,0 +1,38 @@
+{
+  "data": {
+    "activePresetName": "DefaultSky",
+    "presets": [
+      {
+        "name": "DefaultSky",
+        "enabled": true,
+        "texturePath": "SkyBox/skybox.dds",
+        "rotation": [0.0, 0.0, 0.0],
+        "scale": [10000.0, 10000.0, 10000.0],
+        "brightness": 1.0,
+        "tintColor": [1.0, 1.0, 1.0, 1.0]
+      },
+      {
+        "name": "NightSky",
+        "enabled": true,
+        "texturePath": "SkyBox/skybox.dds",
+        "rotation": [0.0, 0.0, 0.0],
+        "scale": [10000.0, 10000.0, 10000.0],
+        "brightness": 0.45,
+        "tintColor": [0.55, 0.65, 1.0, 1.0]
+      },
+      {
+        "name": "BossStageSky",
+        "enabled": true,
+        "texturePath": "SkyBox/skybox.dds",
+        "rotation": [0.0, 0.35, 0.0],
+        "scale": [10000.0, 10000.0, 10000.0],
+        "brightness": 0.8,
+        "tintColor": [1.0, 0.55, 0.45, 1.0]
+      }
+    ]
+  },
+  "displayName": "Debug Scene SkyBox",
+  "id": "debug_skybox",
+  "type": "SkyBoxPresetCollection",
+  "version": 1
+}


### PR DESCRIPTION
### Motivation
- Provide SkyBox rendering and editable named presets in `DebugScene` so designers can adjust background appearance via ImGui and persist settings as JSON.
- Follow the existing `JsonAsset` / `DataAssetPresets` patterns so SkyBox data can be saved/loaded alongside other engine presets without breaking existing GamePlayScene behavior.

### Description
- Add `SkyBoxPreset` and `SkyBoxPresetCollection` types in `Project/Engine/System/JsonAssets/DataAssetPresets.*` with fields `name`, `enabled`, `texturePath`, `rotation`, `scale`, `brightness`, and `tintColor`, plus JSON (de)serialization and `activePresetName` support.
- Add `ApplySkyBoxPreset` helper and a sample JSON file `Project/Resources/DataAssets/SkyBoxPresets/debug_skybox.json` containing `DefaultSky`, `NightSky`, and `BossStageSky` presets.
- Extend `SkyBox` (header + cpp) with runtime APIs `SetTexture(...)`, optional reload, and `SetColor(...)`, reusing existing camera-follow update and the existing SkyBox PSO/pipeline for depth-read-only background rendering.
- Integrate SkyBox into `DebugScene` by initializing/loading presets, creating/updating/drawing the SkyBox (drawn before other 3D objects when enabled), adding ImGui controls (Japanese explanatory text) for ON/OFF, texture path, reload, rotation, scale, brightness, tint color, save, and load, and ensure presets are applied only on explicit events to avoid inadvertent per-frame overwrites.
- Fix ordering issue by moving mid-range enemy AABB setup to after `stage_` initialization to avoid dereferencing before construction.

### Testing
- Ran `git diff --check` and `git diff --cached --check` to ensure there are no whitespace/patch issues and the staged changes are clean, and both passed.
- Validated sample JSON with `python3 -m json.tool Project/Resources/DataAssets/SkyBoxPresets/debug_skybox.json` which succeeded and confirmed required fields and preset names via a small Python validation script.
- Performed static checks verifying fallback load path (`JsonDataManager::SafeLoad`), that DebugScene applies presets at initialization and on ImGui actions, and that SkyBox is drawn before other 3D objects in `Draw3DObjects`; all checks passed in the container.
- Could not run a full Visual Studio / DirectX build or interactive DebugScene verification because `msbuild` / Windows tooling is not available in this Linux container, so runtime graphical validation should be performed on a Windows development machine.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cfa55cedc832d9677115ba34a78d5)