### PR TITLE
Fix cloud texture rendering path

### DIFF
--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -901,7 +901,9 @@ void DebugScene::DrawSkyBoxImGui()
 		if (ImGui::Button("Apply Cloud Texture Path")) { preset->cloud.texturePath = cloudTexturePathBuffer_.data(); ApplyActiveSkyBoxPreset(); }
 		ImGui::SameLine();
 		if (ImGui::Button("Reload Cloud Texture")) { preset->cloud.texturePath = cloudTexturePathBuffer_.data(); ApplyActiveSkyBoxPreset(true); }
-		ImGui::TextWrapped("Cloud Texture Path / Reload: 透過を持つシンプルな雲用Cubeテクスチャを変更、再読み込みします。");
+		ImGui::TextWrapped("Cloud Texture Path / Reload: 透過を持つシンプルな雲用2Dテクスチャを変更、再読み込みします。");
+		ImGui::Text("Actual Cloud DDS: Resources/Textures/Compiled/%s", skyBox_->GetCloudTexturePath().c_str());
+		ImGui::Text("Cloud Load Result: enabled=%s available=%s srvIndex=%u", skyBox_->IsCloudEnabled() ? "true" : "false", skyBox_->IsCloudTextureAvailable() ? "true" : "false", skyBox_->GetCloudTextureIndex());
 		if (ImGui::DragFloat("Cloud Height", &preset->cloud.height, 1.0f, 0.0f, 10000.0f)) ApplyActiveSkyBoxPreset();
 		ImGui::TextWrapped("Cloud Height: 雲レイヤーの見かけ上の高さを調整します。");
 		if (ImGui::DragFloat("Cloud Scale", &preset->cloud.scale, 0.01f, 0.01f, 20.0f)) ApplyActiveSkyBoxPreset();

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
@@ -7,6 +7,7 @@
 
 #include "LightManager.h"
 #include "SkyBoxManager.h"
+#include "JsonDataManager.h"
 #include "Wireframe.h"
 #include "Player.h"
 #include "EnemyBase.h"
@@ -36,6 +37,16 @@ void GamePlayWorld::Initialize(GamePlayStageContext& stageContext)
 
 	skyBox_ = std::make_unique<K4E::SkyBox>();
 	skyBox_->Initialize("SkyBox/skybox.dds");
+	K4E::JsonAssetEntry skyBoxPresetEntry;
+	if (K4E::JsonDataManager::SafeLoad("Resources/DataAssets/SkyBoxPresets/debug_skybox.json", skyBoxPresetEntry))
+	{
+		skyBoxPresets_.FromJson(skyBoxPresetEntry.data);
+		if (const K4E::SkyBoxPreset* skyBoxPreset = skyBoxPresets_.FindActivePreset())
+		{
+			// GamePlayでもJSONの雲パスを適用し、変換済みDDSが実描画へ到達するようにする。
+			K4E::ApplySkyBoxPreset(*skyBox_, *skyBoxPreset);
+		}
+	}
 
 	collisionManager_ = std::make_unique<CollisionManager>();
 	collisionManager_->Initialize();
@@ -200,6 +211,7 @@ void GamePlayWorld::Update(float deltaTime)
 	if (skyBox_)
 	{
 		skyBox_->Update();
+		skyBox_->AdvanceCloudLayer(deltaTime);
 	}
 
 	if (auto* player = characters_.GetPlayer())
@@ -320,6 +332,7 @@ void GamePlayWorld::UpdateEquipIntro(float deltaTime)
 	if (skyBox_)
 	{
 		skyBox_->Update();
+		skyBox_->AdvanceCloudLayer(deltaTime);
 	}
 }
 
@@ -329,6 +342,7 @@ void GamePlayWorld::Draw3D(bool hideCharactersDuringIntro)
 	if (skyBox_)
 	{
 		skyBox_->Draw();
+		skyBox_->DrawCloudLayer();
 	}
 
 	if (!hideCharactersDuringIntro)

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.h
@@ -7,6 +7,7 @@
 #include "Stage.h"
 #include "StageObjectiveManager.h"
 #include <SkyBox.h>
+#include "DataAssetPresets.h"
 #include "EnemyHPBarManager.h"
 #include "ItemManager.h"
 
@@ -90,6 +91,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	CharacterWorld characters_;
 
 	std::unique_ptr<K4E::SkyBox> skyBox_ = nullptr;
+	K4E::SkyBoxPresetCollection skyBoxPresets_{};
 	std::unique_ptr<K4E::Stage> stage_ = nullptr;
 	std::unique_ptr<WaveManager> waveManager_ = nullptr;
 	std::unique_ptr<HUDManager> hudManager_ = nullptr;

--- a/Project/Engine/Graphics/Renderer/SkyBox/SkyBox.cpp
+++ b/Project/Engine/Graphics/Renderer/SkyBox/SkyBox.cpp
@@ -8,6 +8,7 @@
 
 #include <filesystem>
 #include <cmath>
+#include <iostream>
 
 namespace Ken4lowEngine
 {
@@ -159,10 +160,16 @@ namespace Ken4lowEngine
 		cloudEnabled_ = enabled; cloudTexturePath_ = texturePath; cloudHeight_ = height; cloudScale_ = scale;
 		cloudScrollSpeed_ = scrollSpeed; cloudUvOffset_ = uvOffset; cloudAlpha_ = alpha; cloudTintColor_ = tintColor;
 		cloudTextureAvailable_ = TextureFileExists(texturePath);
-		if (!cloudTextureAvailable_) return;
-		TextureManager* textureManager = TextureManager::GetInstance();
-		if (reloadTexture) textureManager->ReloadTexture(texturePath); else textureManager->LoadTexture(texturePath);
-		cloudTextureIndex_ = textureManager->GetSrvIndex(texturePath);
+		if (cloudTextureAvailable_)
+		{
+			TextureManager* textureManager = TextureManager::GetInstance();
+			if (reloadTexture) textureManager->ReloadTexture(texturePath); else textureManager->LoadTexture(texturePath);
+			cloudTextureIndex_ = textureManager->GetSrvIndex(texturePath);
+		}
+		std::cout << "[SkyBox] Cloud texture path=Resources/Textures/Compiled/" << cloudTexturePath_
+			<< " enabled=" << (cloudEnabled_ ? "true" : "false")
+			<< " available=" << (cloudTextureAvailable_ ? "true" : "false")
+			<< " srvIndex=" << cloudTextureIndex_ << std::endl;
 	}
 
 	void SkyBox::AdvanceCloudLayer(float deltaTime)

--- a/Project/Engine/Graphics/Renderer/SkyBox/SkyBox.h
+++ b/Project/Engine/Graphics/Renderer/SkyBox/SkyBox.h
@@ -152,6 +152,9 @@ namespace Ken4lowEngine
 		void AdvanceCloudLayer(float deltaTime);
 		Vector2 GetCloudUvOffset() const { return cloudUvOffset_; }
 		bool IsCloudTextureAvailable() const { return cloudTextureAvailable_; }
+		bool IsCloudEnabled() const { return cloudEnabled_; }
+		const std::string& GetCloudTexturePath() const { return cloudTexturePath_; }
+		uint32_t GetCloudTextureIndex() const { return cloudTextureIndex_; }
 
 	private: /// ---------- 内部メンバ関数 ---------- ///
 

--- a/Project/Engine/Graphics/Renderer/SkyBox/SkyBoxManager.cpp
+++ b/Project/Engine/Graphics/Renderer/SkyBox/SkyBoxManager.cpp
@@ -35,6 +35,8 @@ namespace Ken4lowEngine
 			commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
 			SRVManager::GetInstance()->PreDraw();
 			SRVManager::GetInstance()->SetGraphicsRootDescriptorTable(2, 0);
+			// PNG 由来の雲 DDS は 2D SRV のため、CubeMap と分離したテーブルへ同じヒープ先頭を公開する。
+			SRVManager::GetInstance()->SetGraphicsRootDescriptorTable(3, 0);
 		}
 	}
 

--- a/Project/Engine/Graphics/Renderer/SkyBox/SkyBoxPipelineSet.cpp
+++ b/Project/Engine/Graphics/Renderer/SkyBox/SkyBoxPipelineSet.cpp
@@ -33,18 +33,22 @@ namespace Ken4lowEngine
 		/// [0] PS b0 : Material
 		/// [1] VS b0 : TransformationMatrix
 		/// [2] PS t0 : 環境テクスチャ SRV テーブル
+		/// [3] PS t1024 : 2D 雲テクスチャ SRV テーブル
 		/// </summary>
-		D3D12_ROOT_SIGNATURE_DESC MakeSkyBoxRootSignatureDesc(D3D12_DESCRIPTOR_RANGE* descriptorRange, D3D12_ROOT_PARAMETER* rootParameters, D3D12_STATIC_SAMPLER_DESC* staticSampler)
+		D3D12_ROOT_SIGNATURE_DESC MakeSkyBoxRootSignatureDesc(D3D12_DESCRIPTOR_RANGE* descriptorRanges, D3D12_ROOT_PARAMETER* rootParameters, D3D12_STATIC_SAMPLER_DESC* staticSampler)
 		{
-			assert(descriptorRange != nullptr);
+			assert(descriptorRanges != nullptr);
 			assert(rootParameters != nullptr);
 			assert(staticSampler != nullptr);
 
-			descriptorRange[0] = {};
-			descriptorRange[0].BaseShaderRegister = 0;
-			descriptorRange[0].NumDescriptors = SRVManager::GetInstance()->GetkMaxSRVCount();
-			descriptorRange[0].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
-			descriptorRange[0].OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
+			descriptorRanges[0] = {};
+			descriptorRanges[0].BaseShaderRegister = 0;
+			descriptorRanges[0].NumDescriptors = SRVManager::GetInstance()->GetkMaxSRVCount();
+			descriptorRanges[0].RangeType = D3D12_DESCRIPTOR_RANGE_TYPE_SRV;
+			descriptorRanges[0].OffsetInDescriptorsFromTableStart = D3D12_DESCRIPTOR_RANGE_OFFSET_APPEND;
+
+			descriptorRanges[1] = descriptorRanges[0];
+			descriptorRanges[1].BaseShaderRegister = SRVManager::GetInstance()->GetkMaxSRVCount();
 
 			rootParameters[0] = {};
 			rootParameters[0].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
@@ -59,8 +63,11 @@ namespace Ken4lowEngine
 			rootParameters[2] = {};
 			rootParameters[2].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
 			rootParameters[2].ShaderVisibility = D3D12_SHADER_VISIBILITY_PIXEL;
-			rootParameters[2].DescriptorTable.pDescriptorRanges = descriptorRange;
+			rootParameters[2].DescriptorTable.pDescriptorRanges = &descriptorRanges[0];
 			rootParameters[2].DescriptorTable.NumDescriptorRanges = 1;
+
+			rootParameters[3] = rootParameters[2];
+			rootParameters[3].DescriptorTable.pDescriptorRanges = &descriptorRanges[1];
 
 			*staticSampler = {};
 			staticSampler->Filter = D3D12_FILTER_MIN_MAG_MIP_LINEAR;
@@ -74,7 +81,7 @@ namespace Ken4lowEngine
 
 			D3D12_ROOT_SIGNATURE_DESC desc{};
 			desc.Flags = D3D12_ROOT_SIGNATURE_FLAG_ALLOW_INPUT_ASSEMBLER_INPUT_LAYOUT;
-			desc.NumParameters = 3;
+			desc.NumParameters = 4;
 			desc.pParameters = rootParameters;
 			desc.NumStaticSamplers = 1;
 			desc.pStaticSamplers = staticSampler;
@@ -122,11 +129,11 @@ namespace Ken4lowEngine
 		ComPtr<IDxcBlob> vertexShaderBlob = ShaderCompiler::CompileShader(vsDesc, dxcManager);
 		ComPtr<IDxcBlob> pixelShaderBlob = ShaderCompiler::CompileShader(psDesc, dxcManager);
 
-		D3D12_DESCRIPTOR_RANGE descriptorRange{};
-		D3D12_ROOT_PARAMETER rootParameters[3]{};
+		D3D12_DESCRIPTOR_RANGE descriptorRanges[2]{};
+		D3D12_ROOT_PARAMETER rootParameters[4]{};
 		D3D12_STATIC_SAMPLER_DESC staticSampler{};
 
-		D3D12_ROOT_SIGNATURE_DESC rootSigDesc = MakeSkyBoxRootSignatureDesc(&descriptorRange, rootParameters, &staticSampler);
+		D3D12_ROOT_SIGNATURE_DESC rootSigDesc = MakeSkyBoxRootSignatureDesc(descriptorRanges, rootParameters, &staticSampler);
 
 		GraphicsPipelineDesc desc = MakeBaseSkyBoxDesc(rtvFormat, dsvFormat, inputLayout);
 		desc.debugName = L"SkyBox.Default";

--- a/Project/Resources/DataAssets/SkyBoxPresets/debug_skybox.json
+++ b/Project/Resources/DataAssets/SkyBoxPresets/debug_skybox.json
@@ -15,8 +15,8 @@
         "scale": [10000.0, 10000.0, 10000.0],
         "tintColor": [1.0, 1.0, 1.0, 1.0],
         "cloud": {
-          "enabled": false,
-          "texturePath": "",
+          "enabled": true,
+          "texturePath": "SkyBox/Cloud.dds",
           "height": 160.0,
           "scale": 1.5,
           "scrollSpeed": [0.002, 0.0005],

--- a/Project/Resources/Shaders/SkyBox/SkyBox.PS.hlsl
+++ b/Project/Resources/Shaders/SkyBox/SkyBox.PS.hlsl
@@ -24,6 +24,7 @@ struct Material
 static const uint textureCount = 1024;
 ConstantBuffer<Material> gMaterial : register(b0);
 TextureCube<float4> gTexture[textureCount] : register(t0);
+Texture2D<float4> gCloudTexture[textureCount] : register(t1024);
 SamplerState gSampler : register(s0);
 
 PixelShaderOutput main(VertexShaderOutput input)
@@ -48,12 +49,18 @@ PixelShaderOutput main(VertexShaderOutput input)
     }
     else
     {
-        float angle = gMaterial.uvOffset.x * 6.2831853f;
-        float cosine = cos(angle);
-        float sine = sin(angle);
-        float3 cloudDirection = float3(direction.x * cosine - direction.z * sine, direction.y, direction.x * sine + direction.z * cosine);
-        cloudDirection.y = cloudDirection.y * max(gMaterial.cloudScale, 0.001f) + gMaterial.uvOffset.y + gMaterial.cloudHeight * 0.0001f;
-        output.color = gTexture[gMaterial.textureIndex].Sample(gSampler, cloudDirection) * gMaterial.color;
+        if (gMaterial.skyType == 3)
+        {
+            float2 cloudUv;
+            cloudUv.x = atan2(direction.z, direction.x) / 6.2831853f + 0.5f;
+            cloudUv.y = acos(clamp(direction.y, -1.0f, 1.0f)) / 3.1415927f;
+            cloudUv = frac((cloudUv - 0.5f) * max(gMaterial.cloudScale, 0.001f) + 0.5f + gMaterial.uvOffset + float2(0.0f, gMaterial.cloudHeight * 0.0001f));
+            output.color = gCloudTexture[gMaterial.textureIndex].Sample(gSampler, cloudUv) * gMaterial.color;
+        }
+        else
+        {
+            output.color = gTexture[gMaterial.textureIndex].Sample(gSampler, direction) * gMaterial.color;
+        }
     }
     return output;
 }


### PR DESCRIPTION
### Motivation
- 新規の雲テクスチャがゲーム内に反映されなかったため、変換済み DDS の実ファイル種別・ロード経路・描画経路を追跡して修正します。 
- 原因はプリセットで雲が無効になっていた点と、PNG由来の DDS が 2D テクスチャなのにシェーダー側で Cube サンプラーとして扱っていた点、加えて GamePlay 側でプリセット適用／雲の更新・描画が接続されていなかった点の複合です。

### Description
- シェーダーで SkyBox 用 `TextureCube` と雲用 `Texture2D` を分離し、雲 (`skyType == 3`) は球面 UV に変換して `gCloudTexture[...] : register(t1024)` からサンプルするよう変更しました (`Project/Resources/Shaders/SkyBox/SkyBox.PS.hlsl`)。 
- 2D 雲テクスチャ用の SRV テーブルを追加して RootSignature を拡張し、`SkyBoxPipelineSet` と `SkyBoxManager` 側で雲用テーブルをバインドするようにしました（Descriptor / root parameter を追加、`SetGraphicsRootDescriptorTable(3, 0)` を設定）。
- `SkyBox::SetCloudLayer` を既存の `TextureManager` 設計に沿って修正し、存在チェック・`LoadTexture`/`ReloadTexture`・SRV index の取得を行い、実際のコンパイル済みパスと有効性を標準ログへ出力するデバッグ出力とアクセサを追加しました（`SkyBox.h` / `SkyBox.cpp`）。
- `GamePlayWorld` で JSON プリセットを読み込み `ApplySkyBoxPreset` を適用するようにして雲設定が実行時に反映されるようにし、毎フレーム `AdvanceCloudLayer` を呼ぶよう接続、描画順を `SkyBox` の直後に `DrawCloudLayer` を実行するようにしました（`Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.*`）。
- Debug 用 UI を拡張し、ImGui に実際に使われるコンパイル済みパスとロード結果（enabled/available/SRV index）が表示されるようにしました（`Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp`）。
- デフォルトプリセット `Resources/DataAssets/SkyBoxPresets/debug_skybox.json` で雲レイヤーを有効化し、`SkyBox/Cloud.dds` を参照するよう更新しました。

### Testing
- `python3 -m json.tool` による JSON 構文チェックは成功しました（`debug_skybox.json` の更新を確認）。
- Python スクリプトで PNG/DDS ヘッダを解析し `Cloud.png` が RGBA 1536x1024、生成済み `Cloud.dds` が同解像度の 2D DDS（Cubemap ではない）であることと `Cloud.dds.buildmeta.json` の内容一致を確認しました。 
- 静的ワイヤリング検査（シンボル検索 / ステートメント確認）で、雲用 `Texture2D`・`t1024` テーブル・Pipeline Root の追加・`ApplySkyBoxPreset` の GamePlay 適用・`AdvanceCloudLayer`/`DrawCloudLayer` 呼出し・Debug ImGui 表示が存在することを確認しました。 
- `BuildTextures.ps1` の incremental 分岐をソース解析し、変換不要なファイルは `"[BuildTextures] Skip:"` によりスキップされ、変換成功時に `Write-TextureBuildMeta` が呼ばれる分岐でメタデータを書き込むことを確認しました。 
- 環境制約により `pwsh` / PowerShell と `msbuild` がコンテナに存在しないため、`BuildTextures.ps1` の実行および Windows ソリューションの実ビルドはこの環境で実行できませんでした（そのため実機ビルド／TextureConverter 実行は未実行）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d144a6dd0832d877d12a37419c7fd)