### PR TITLE
Separate floating cloud layer from SkyBox rendering

### DIFF
--- a/Project/Engine/Graphics/Renderer/SkyBox/CloudLayer.cpp
+++ b/Project/Engine/Graphics/Renderer/SkyBox/CloudLayer.cpp
@@ -1,0 +1,152 @@
+#include "CloudLayer.h"
+#include "CameraManager.h"
+#include "DirectXCommon.h"
+#include "ResourceManager.h"
+#include "SkyBoxManager.h"
+#include "TextureManager.h"
+
+#include <algorithm>
+#include <cmath>
+#include <filesystem>
+#include <iostream>
+
+namespace Ken4lowEngine
+{
+	void CloudLayer::Initialize()
+	{
+		dxCommon_ = DirectXCommon::GetInstance();
+		InitializeMaterial();
+		InitializeVertexBuffer();
+		InitializeIndexBuffer();
+		wvpResource_ = ResourceManager::CreateBufferResource(dxCommon_->GetDevice(), sizeof(TransformationMatrix));
+		wvpResource_->Map(0, nullptr, reinterpret_cast<void**>(&wvpData_));
+		wvpData_->World = Matrix4x4::MakeIdentity();
+		wvpData_->WVP = Matrix4x4::MakeIdentity();
+	}
+
+	void CloudLayer::Update()
+	{
+		const Vector3 cameraPosition = CameraManager::GetInstance()->GetActiveCameraPosition();
+		const float planeScale = kBasePlaneExtent * std::max(scale_, 0.01f);
+		// 雲は SkyBox の内側へ貼らず、カメラ上空へ追従する水平平面として配置する。
+		const Matrix4x4 world = Matrix4x4::MakeAffineMatrix(
+			{ planeScale, 1.0f, planeScale }, { 0.0f, 0.0f, 0.0f }, { cameraPosition.x, cameraPosition.y + height_, cameraPosition.z });
+		wvpData_->World = world;
+		wvpData_->WVP = Matrix4x4::Multiply(world, CameraManager::GetInstance()->GetActiveViewProjectionMatrix());
+	}
+
+	void CloudLayer::Draw()
+	{
+		if (!enabled_ || !textureAvailable_)
+		{
+			return;
+		}
+
+		ID3D12GraphicsCommandList* commandList = dxCommon_->GetCommandManager()->GetCommandList();
+		SkyBoxManager::GetInstance()->SetCloudRenderSetting();
+		materialData_->color = { tintColor_.x, tintColor_.y, tintColor_.z, tintColor_.w * alpha_ };
+		materialData_->textureIndex = textureIndex_;
+		materialData_->uvOffset = uvOffset_;
+		materialData_->cloudHeight = height_;
+		materialData_->cloudScale = scale_;
+		materialData_->textureAvailable = 1u;
+		commandList->IASetVertexBuffers(0, 1, &vertexBufferView_);
+		commandList->IASetIndexBuffer(&indexBufferView_);
+		commandList->SetGraphicsRootConstantBufferView(0, materialResource_->GetGPUVirtualAddress());
+		commandList->SetGraphicsRootConstantBufferView(1, wvpResource_->GetGPUVirtualAddress());
+		commandList->DrawIndexedInstanced(kNumIndex, 1, 0, 0, 0);
+	}
+
+	void CloudLayer::SetSettings(bool enabled, const std::string& texturePath, float height, float scale,
+		const Vector2& scrollSpeed, const Vector2& uvOffset, float alpha, const Vector4& tintColor, bool reloadTexture)
+	{
+		enabled_ = enabled;
+		height_ = height;
+		scale_ = scale;
+		scrollSpeed_ = scrollSpeed;
+		uvOffset_ = uvOffset;
+		alpha_ = alpha;
+		tintColor_ = tintColor;
+		if (texturePath_ != texturePath || reloadTexture)
+		{
+			textureAvailable_ = LoadTexture(texturePath, reloadTexture);
+		}
+		texturePath_ = texturePath;
+		std::cout << "[CloudLayer] texture path=Resources/Textures/Compiled/" << texturePath_
+			<< " enabled=" << (enabled_ ? "true" : "false")
+			<< " available=" << (textureAvailable_ ? "true" : "false")
+			<< " srvIndex=" << textureIndex_ << std::endl;
+	}
+
+	void CloudLayer::Advance(float deltaTime)
+	{
+		uvOffset_.x = std::fmod(uvOffset_.x + scrollSpeed_.x * deltaTime, 1.0f);
+		uvOffset_.y = std::fmod(uvOffset_.y + scrollSpeed_.y * deltaTime, 1.0f);
+	}
+
+	void CloudLayer::InitializeMaterial()
+	{
+		materialResource_ = ResourceManager::CreateBufferResource(dxCommon_->GetDevice(), sizeof(Material));
+		materialResource_->Map(0, nullptr, reinterpret_cast<void**>(&materialData_));
+		materialData_->color = tintColor_;
+		materialData_->uvTransform = Matrix4x4::MakeIdentity();
+		materialData_->topColor = {};
+		materialData_->bottomColor = {};
+		materialData_->horizonColor = {};
+		materialData_->textureIndex = textureIndex_;
+		materialData_->skyType = 3u;
+		materialData_->uvOffset = uvOffset_;
+		materialData_->cloudHeight = height_;
+		materialData_->cloudScale = scale_;
+		materialData_->textureAvailable = 0u;
+		materialData_->padding = 0.0f;
+	}
+
+	void CloudLayer::InitializeVertexBuffer()
+	{
+		vertexResource_ = ResourceManager::CreateBufferResource(dxCommon_->GetDevice(), sizeof(VertexData) * kNumVertex);
+		vertexBufferView_.BufferLocation = vertexResource_->GetGPUVirtualAddress();
+		vertexBufferView_.SizeInBytes = sizeof(VertexData) * kNumVertex;
+		vertexBufferView_.StrideInBytes = sizeof(VertexData);
+		vertexResource_->Map(0, nullptr, reinterpret_cast<void**>(&vertexData_));
+		vertexData_[0] = { { -1.0f, 0.0f, -1.0f, 1.0f }, { 0.0f, 0.0f, 0.0f } };
+		vertexData_[1] = { {  1.0f, 0.0f, -1.0f, 1.0f }, { 1.0f, 0.0f, 0.0f } };
+		vertexData_[2] = { { -1.0f, 0.0f,  1.0f, 1.0f }, { 0.0f, 1.0f, 0.0f } };
+		vertexData_[3] = { {  1.0f, 0.0f,  1.0f, 1.0f }, { 1.0f, 1.0f, 0.0f } };
+	}
+
+	void CloudLayer::InitializeIndexBuffer()
+	{
+		indexResource_ = ResourceManager::CreateBufferResource(dxCommon_->GetDevice(), sizeof(uint32_t) * kNumIndex);
+		indexBufferView_.BufferLocation = indexResource_->GetGPUVirtualAddress();
+		indexBufferView_.SizeInBytes = sizeof(uint32_t) * kNumIndex;
+		indexBufferView_.Format = DXGI_FORMAT_R32_UINT;
+		indexResource_->Map(0, nullptr, reinterpret_cast<void**>(&indexData_));
+		indexData_[0] = 0; indexData_[1] = 1; indexData_[2] = 2;
+		indexData_[3] = 2; indexData_[4] = 1; indexData_[5] = 3;
+	}
+
+	bool CloudLayer::LoadTexture(const std::string& texturePath, bool reloadTexture)
+	{
+		const std::filesystem::path compiledPath = std::filesystem::path("Resources/Textures/Compiled") / texturePath;
+		if (texturePath.empty() || !std::filesystem::exists(compiledPath))
+		{
+			return false;
+		}
+
+		DirectX::ScratchImage validationImage;
+		const std::wstring path = compiledPath.wstring();
+		const HRESULT result = compiledPath.extension() == ".dds"
+			? DirectX::LoadFromDDSFile(path.c_str(), DirectX::DDS_FLAGS_NONE, nullptr, validationImage)
+			: DirectX::LoadFromWICFile(path.c_str(), DirectX::WIC_FLAGS_FORCE_SRGB, nullptr, validationImage);
+		if (FAILED(result) || validationImage.GetMetadata().IsCubemap())
+		{
+			return false;
+		}
+
+		TextureManager* textureManager = TextureManager::GetInstance();
+		if (reloadTexture) textureManager->ReloadTexture(texturePath); else textureManager->LoadTexture(texturePath);
+		textureIndex_ = textureManager->GetSrvIndex(texturePath);
+		return true;
+	}
+}

--- a/Project/Engine/Graphics/Renderer/SkyBox/CloudLayer.h
+++ b/Project/Engine/Graphics/Renderer/SkyBox/CloudLayer.h
@@ -1,0 +1,93 @@
+#pragma once
+#include "DX12Include.h"
+#include "Matrix4x4.h"
+#include "Vector2.h"
+#include "Vector3.h"
+#include "Vector4.h"
+
+#include <string>
+
+namespace Ken4lowEngine
+{
+	class DirectXCommon;
+
+	/// SkyBox とは独立して、カメラ上空へ水平な半透明の雲平面を描画する。
+	class CloudLayer final
+	{
+	private:
+		static inline const UINT kNumVertex = 4;
+		static inline const UINT kNumIndex = 6;
+		static inline constexpr float kBasePlaneExtent = 10000.0f;
+
+		struct Material final
+		{
+			Vector4 color;
+			Matrix4x4 uvTransform;
+			Vector4 topColor;
+			Vector4 bottomColor;
+			Vector4 horizonColor;
+			uint32_t textureIndex;
+			uint32_t skyType;
+			Vector2 uvOffset;
+			float cloudHeight;
+			float cloudScale;
+			uint32_t textureAvailable;
+			float padding;
+		};
+
+		struct VertexData final
+		{
+			Vector4 position;
+			Vector3 texcoord;
+		};
+
+		struct TransformationMatrix final
+		{
+			Matrix4x4 WVP;
+			Matrix4x4 World;
+		};
+
+	public:
+		void Initialize();
+		void Update();
+		void Draw();
+		void SetSettings(bool enabled, const std::string& texturePath, float height, float scale,
+			const Vector2& scrollSpeed, const Vector2& uvOffset, float alpha, const Vector4& tintColor, bool reloadTexture = false);
+		void Advance(float deltaTime);
+
+		Vector2 GetUvOffset() const { return uvOffset_; }
+		bool IsTextureAvailable() const { return textureAvailable_; }
+		bool IsEnabled() const { return enabled_; }
+		const std::string& GetTexturePath() const { return texturePath_; }
+		uint32_t GetTextureIndex() const { return textureIndex_; }
+
+	private:
+		void InitializeMaterial();
+		void InitializeVertexBuffer();
+		void InitializeIndexBuffer();
+		bool LoadTexture(const std::string& texturePath, bool reloadTexture);
+
+		DirectXCommon* dxCommon_ = nullptr;
+		ComPtr<ID3D12Resource> materialResource_;
+		Material* materialData_ = nullptr;
+		ComPtr<ID3D12Resource> vertexResource_;
+		D3D12_VERTEX_BUFFER_VIEW vertexBufferView_{};
+		VertexData* vertexData_ = nullptr;
+		ComPtr<ID3D12Resource> indexResource_;
+		D3D12_INDEX_BUFFER_VIEW indexBufferView_{};
+		uint32_t* indexData_ = nullptr;
+		ComPtr<ID3D12Resource> wvpResource_;
+		TransformationMatrix* wvpData_ = nullptr;
+
+		bool enabled_ = false;
+		bool textureAvailable_ = false;
+		std::string texturePath_;
+		uint32_t textureIndex_ = 0;
+		float height_ = 160.0f;
+		float scale_ = 1.5f;
+		Vector2 scrollSpeed_ = { 0.002f, 0.0005f };
+		Vector2 uvOffset_{};
+		float alpha_ = 0.55f;
+		Vector4 tintColor_ = { 1.0f, 1.0f, 1.0f, 1.0f };
+	};
+}

--- a/Project/Engine/Graphics/Renderer/SkyBox/SkyBox.cpp
+++ b/Project/Engine/Graphics/Renderer/SkyBox/SkyBox.cpp
@@ -7,8 +7,6 @@
 #include <SkyBoxManager.h>
 
 #include <filesystem>
-#include <cmath>
-#include <iostream>
 
 namespace Ken4lowEngine
 {
@@ -37,6 +35,10 @@ namespace Ken4lowEngine
 		worldTransform_.scale_ = { 10000.0f, 10000.0f, 10000.0f };
 		worldTransform_.rotate_ = { 0.0f, 0.0f, 0.0f };
 		worldTransform_.translate_ = { 0.0f, 0.0f, 0.0f };
+
+		// SkyBox と別メッシュの CloudLayer を初期化する
+		cloudLayer_ = std::make_unique<CloudLayer>();
+		cloudLayer_->Initialize();
 
 		// Material 定数バッファを初期化する
 		InitializeMaterial();
@@ -74,6 +76,7 @@ namespace Ken4lowEngine
 
 		wvpData->WVP = worldViewProjectionMatrix;
 		wvpData->World = worldMatrix;
+		cloudLayer_->Update();
 	}
 
 	/// -------------------------------------------------------------
@@ -90,8 +93,8 @@ namespace Ken4lowEngine
 		materialData_->textureIndex = textureIndex_;
 		materialData_->skyType = skyType_;
 		materialData_->uvOffset = {};
-		materialData_->cloudHeight = cloudHeight_;
-		materialData_->cloudScale = cloudScale_;
+		materialData_->cloudHeight = 0.0f;
+		materialData_->cloudScale = 1.0f;
 		materialData_->textureAvailable = textureAvailable_ ? 1u : 0u;
 		commandList->IASetVertexBuffers(0, 1, &vertexBufferView);
 		commandList->IASetIndexBuffer(&indexBufferView);
@@ -102,25 +105,7 @@ namespace Ken4lowEngine
 
 	void SkyBox::DrawCloudLayer()
 	{
-		if (!cloudEnabled_ || !cloudTextureAvailable_)
-		{
-			return;
-		}
-		ID3D12GraphicsCommandList* commandList = dxCommon_->GetCommandManager()->GetCommandList();
-		// 雲は背景SkyBoxの直後に半透明レイヤーとして描画し、ステージより手前へ出さない。
-		SkyBoxManager::GetInstance()->SetCloudRenderSetting();
-		materialData_->textureIndex = cloudTextureIndex_;
-		materialData_->skyType = 3;
-		materialData_->uvOffset = cloudUvOffset_;
-		materialData_->cloudHeight = cloudHeight_;
-		materialData_->cloudScale = cloudScale_;
-		materialData_->textureAvailable = 1u;
-		materialData_->color = { cloudTintColor_.x, cloudTintColor_.y, cloudTintColor_.z, cloudTintColor_.w * cloudAlpha_ };
-		commandList->IASetVertexBuffers(0, 1, &vertexBufferView);
-		commandList->IASetIndexBuffer(&indexBufferView);
-		commandList->SetGraphicsRootConstantBufferView(0, materialResource.Get()->GetGPUVirtualAddress());
-		commandList->SetGraphicsRootConstantBufferView(1, wvpResource->GetGPUVirtualAddress());
-		commandList->DrawIndexedInstanced(kNumIndex, 1, 0, 0, 0);
+		cloudLayer_->Draw();
 	}
 
 	void SkyBox::SetTexture(const std::string& filePath, bool reloadTexture)
@@ -157,25 +142,12 @@ namespace Ken4lowEngine
 	void SkyBox::SetCloudLayer(bool enabled, const std::string& texturePath, float height, float scale,
 		const Vector2& scrollSpeed, const Vector2& uvOffset, float alpha, const Vector4& tintColor, bool reloadTexture)
 	{
-		cloudEnabled_ = enabled; cloudTexturePath_ = texturePath; cloudHeight_ = height; cloudScale_ = scale;
-		cloudScrollSpeed_ = scrollSpeed; cloudUvOffset_ = uvOffset; cloudAlpha_ = alpha; cloudTintColor_ = tintColor;
-		cloudTextureAvailable_ = TextureFileExists(texturePath);
-		if (cloudTextureAvailable_)
-		{
-			TextureManager* textureManager = TextureManager::GetInstance();
-			if (reloadTexture) textureManager->ReloadTexture(texturePath); else textureManager->LoadTexture(texturePath);
-			cloudTextureIndex_ = textureManager->GetSrvIndex(texturePath);
-		}
-		std::cout << "[SkyBox] Cloud texture path=Resources/Textures/Compiled/" << cloudTexturePath_
-			<< " enabled=" << (cloudEnabled_ ? "true" : "false")
-			<< " available=" << (cloudTextureAvailable_ ? "true" : "false")
-			<< " srvIndex=" << cloudTextureIndex_ << std::endl;
+		cloudLayer_->SetSettings(enabled, texturePath, height, scale, scrollSpeed, uvOffset, alpha, tintColor, reloadTexture);
 	}
 
 	void SkyBox::AdvanceCloudLayer(float deltaTime)
 	{
-		cloudUvOffset_.x = std::fmod(cloudUvOffset_.x + cloudScrollSpeed_.x * deltaTime, 1.0f);
-		cloudUvOffset_.y = std::fmod(cloudUvOffset_.y + cloudScrollSpeed_.y * deltaTime, 1.0f);
+		cloudLayer_->Advance(deltaTime);
 	}
 
 	/// -------------------------------------------------------------
@@ -198,8 +170,8 @@ namespace Ken4lowEngine
 		materialData_->textureIndex = textureIndex_;
 		materialData_->skyType = skyType_;
 		materialData_->uvOffset = {};
-		materialData_->cloudHeight = cloudHeight_;
-		materialData_->cloudScale = cloudScale_;
+		materialData_->cloudHeight = 0.0f;
+		materialData_->cloudScale = 1.0f;
 		materialData_->textureAvailable = textureAvailable_ ? 1u : 0u;
 	}
 

--- a/Project/Engine/Graphics/Renderer/SkyBox/SkyBox.h
+++ b/Project/Engine/Graphics/Renderer/SkyBox/SkyBox.h
@@ -2,6 +2,7 @@
 #include "DX12Include.h"
 #include "WorldTransform.h"
 #include "Camera.h"
+#include "CloudLayer.h"
 
 #include "Vector2.h"
 #include "Vector4.h"
@@ -150,11 +151,11 @@ namespace Ken4lowEngine
 		void SetCloudLayer(bool enabled, const std::string& texturePath, float height, float scale,
 			const Vector2& scrollSpeed, const Vector2& uvOffset, float alpha, const Vector4& tintColor, bool reloadTexture = false);
 		void AdvanceCloudLayer(float deltaTime);
-		Vector2 GetCloudUvOffset() const { return cloudUvOffset_; }
-		bool IsCloudTextureAvailable() const { return cloudTextureAvailable_; }
-		bool IsCloudEnabled() const { return cloudEnabled_; }
-		const std::string& GetCloudTexturePath() const { return cloudTexturePath_; }
-		uint32_t GetCloudTextureIndex() const { return cloudTextureIndex_; }
+		Vector2 GetCloudUvOffset() const { return cloudLayer_->GetUvOffset(); }
+		bool IsCloudTextureAvailable() const { return cloudLayer_->IsTextureAvailable(); }
+		bool IsCloudEnabled() const { return cloudLayer_->IsEnabled(); }
+		const std::string& GetCloudTexturePath() const { return cloudLayer_->GetTexturePath(); }
+		uint32_t GetCloudTextureIndex() const { return cloudLayer_->GetTextureIndex(); }
 
 	private: /// ---------- 内部メンバ関数 ---------- ///
 
@@ -224,16 +225,7 @@ namespace Ken4lowEngine
 		Vector4 bottomColor_ = { 0.72f, 0.88f, 1.0f, 1.0f };
 		Vector4 horizonColor_ = { 0.92f, 0.96f, 1.0f, 1.0f };
 		bool textureAvailable_ = false;
-		bool cloudEnabled_ = false;
-		bool cloudTextureAvailable_ = false;
-		std::string cloudTexturePath_;
-		uint32_t cloudTextureIndex_ = 0;
-		float cloudHeight_ = 160.0f;
-		float cloudScale_ = 1.5f;
-		Vector2 cloudScrollSpeed_ = { 0.002f, 0.0005f };
-		Vector2 cloudUvOffset_{};
-		float cloudAlpha_ = 0.55f;
-		Vector4 cloudTintColor_ = { 1.0f, 1.0f, 1.0f, 1.0f };
+		std::unique_ptr<CloudLayer> cloudLayer_;
 	};
 
 } // namespace Ken4lowEngine

--- a/Project/Engine/Graphics/Renderer/SkyBox/SkyBoxPipelineSet.cpp
+++ b/Project/Engine/Graphics/Renderer/SkyBox/SkyBoxPipelineSet.cpp
@@ -143,6 +143,7 @@ namespace Ken4lowEngine
 		defaultPipeline_ = factory.CreateGraphicsPipeline(desc, rootSigDesc);
 
 		desc.blendState = PipelineStatePresets::MakeBlendAlpha();
+		desc.rasterizerState.CullMode = D3D12_CULL_MODE_NONE;
 		desc.debugName = L"SkyBox.Cloud";
 		cloudPipeline_ = factory.CreateGraphicsPipeline(desc, rootSigDesc);
 

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -394,6 +394,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="Engine\Graphics\Renderer\Object3D\Object3DCommon.cpp" />
     <ClCompile Include="Engine\Graphics\Renderer\Particle\Core\ParticleFactory.cpp" />
     <ClCompile Include="Engine\Graphics\Renderer\Particle\Manager\ParticleManager.cpp" />
+    <ClCompile Include="Engine\Graphics\Renderer\SkyBox\CloudLayer.cpp" />
     <ClCompile Include="Engine\Graphics\Renderer\SkyBox\SkyBox.cpp" />
     <ClCompile Include="Engine\Graphics\Renderer\SkyBox\SkyBoxManager.cpp" />
     <ClCompile Include="Engine\Graphics\Renderer\Sprite\NumberSpriteDrawer.cpp" />
@@ -1052,6 +1053,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="Engine\Graphics\Renderer\Particle\Core\ParticleEffectType.h" />
     <ClInclude Include="Engine\Graphics\Renderer\Particle\Core\ParticleFactory.h" />
     <ClInclude Include="Engine\Graphics\Renderer\Particle\Manager\ParticleManager.h" />
+    <ClInclude Include="Engine\Graphics\Renderer\SkyBox\CloudLayer.h" />
     <ClInclude Include="Engine\Graphics\Renderer\SkyBox\SkyBox.h" />
     <ClInclude Include="Engine\Graphics\Renderer\SkyBox\SkyBoxManager.h" />
     <ClInclude Include="Engine\Graphics\Renderer\Sprite\NumberSpriteDrawer.h" />

--- a/Project/Ken4lowEngine.vcxproj.filters
+++ b/Project/Ken4lowEngine.vcxproj.filters
@@ -790,6 +790,9 @@
     <ClCompile Include="Engine\Graphics\Renderer\Sprite\SpritePipelineSet.cpp">
       <Filter>Engine\Graphics\Renderer\Sprite</Filter>
     </ClCompile>
+    <ClCompile Include="Engine\Graphics\Renderer\SkyBox\CloudLayer.cpp">
+      <Filter>Engine\Graphics\Renderer\SkyBox</Filter>
+    </ClCompile>
     <ClCompile Include="Engine\Graphics\Renderer\SkyBox\SkyBox.cpp">
       <Filter>Engine\Graphics\Renderer\SkyBox</Filter>
     </ClCompile>
@@ -1781,6 +1784,9 @@
     </ClInclude>
     <ClInclude Include="Engine\Graphics\Renderer\Sprite\SpritePipelineSet.h">
       <Filter>Engine\Graphics\Renderer\Sprite</Filter>
+    </ClInclude>
+    <ClInclude Include="Engine\Graphics\Renderer\SkyBox\CloudLayer.h">
+      <Filter>Engine\Graphics\Renderer\SkyBox</Filter>
     </ClInclude>
     <ClInclude Include="Engine\Graphics\Renderer\SkyBox\SkyBox.h">
       <Filter>Engine\Graphics\Renderer\SkyBox</Filter>

--- a/Project/Resources/Shaders/SkyBox/SkyBox.PS.hlsl
+++ b/Project/Resources/Shaders/SkyBox/SkyBox.PS.hlsl
@@ -51,10 +51,8 @@ PixelShaderOutput main(VertexShaderOutput input)
     {
         if (gMaterial.skyType == 3)
         {
-            float2 cloudUv;
-            cloudUv.x = atan2(direction.z, direction.x) / 6.2831853f + 0.5f;
-            cloudUv.y = acos(clamp(direction.y, -1.0f, 1.0f)) / 3.1415927f;
-            cloudUv = frac((cloudUv - 0.5f) * max(gMaterial.cloudScale, 0.001f) + 0.5f + gMaterial.uvOffset + float2(0.0f, gMaterial.cloudHeight * 0.0001f));
+            // CloudLayer は水平平面の UV をスクロールし、透明部分から背景の空を見せる。
+            float2 cloudUv = frac(input.texcoord.xy + gMaterial.uvOffset);
             output.color = gCloudTexture[gMaterial.textureIndex].Sample(gSampler, cloudUv) * gMaterial.color;
         }
         else

--- a/Project/Resources/Shaders/SkyBox/SkyBox.VS.hlsl
+++ b/Project/Resources/Shaders/SkyBox/SkyBox.VS.hlsl
@@ -19,6 +19,6 @@ VertexShaderOutput main(VertexShaderInput input)
 {
     VertexShaderOutput output;
     output.position = mul(input.position, gTransformationMatrix.WVP).xywz;
-    output.texcoord = input.position.xyz;
+    output.texcoord = input.texcoord;
     return output;
 }


### PR DESCRIPTION
### Motivation
- The existing implementation sampled a 2D cloud texture but rendered it using the SkyBox cube geometry, causing the cloud texture to cover the entire skydome instead of appearing as a separate floating layer above the camera.
- The goal is to keep SkyBox responsible for background (blue sky / horizon / brightness) while rendering clouds as an independent, camera-following translucent layer so the sky remains visible through transparent cloud areas.

### Description
- Add a new `CloudLayer` class (`Project/Engine/Graphics/Renderer/SkyBox/CloudLayer.h` + `.cpp`) that renders a 4-vertex horizontal plane mesh positioned above the camera and scaled by `Cloud Scale`, with UVs that scroll for movement and an API to set cloud settings (`SetSettings`, `Advance`, `Draw`).
- Delegate existing SkyBox cloud configuration and runtime calls to the new `CloudLayer` (SkyBox now initializes/updates/draws the `CloudLayer` and uses it as the source of cloud state), preserving SkyBox gradient, bottom/horizon color, brightness, rotation and scale behavior.
- Validate cloud texture before use: `CloudLayer::LoadTexture` checks compiled path existence, attempts DDS/WIC load and rejects cubemaps or failed loads so cloud rendering is safely skipped when texture is missing/invalid.
- Change shaders and pipeline for planar cloud rendering: the pixel shader uses the plane UV (`frac(input.texcoord.xy + gMaterial.uvOffset)`) instead of spherical coords; the cloud PSO uses alpha blending and disables face culling so the horizontal plane renders correctly from both sides.
- Register new source and header in the Visual Studio project files so the new files are included in builds (`Project/Ken4lowEngine.vcxproj` / `.filters`).

### Testing
- Ran whitespace/diff checks (`diff --check`) and found no issues (passed).
- Validated Visual Studio project XML parsing for `Project/Ken4lowEngine.vcxproj` and `Project/Ken4lowEngine.vcxproj.filters` with a Python XML parse (passed).
- Performed static verification checks via scripts for expected project registration, presence of `Resources/Textures/Compiled/SkyBox/Cloud.dds`, planar UV shader change (`frac(input.texcoord.xy + gMaterial.uvOffset)`), cloud-plane texture-availability guard (`if (!enabled_ || !textureAvailable_)`), and cloud pipeline culling change (passed).
- Attempted to run a Windows build (`msbuild`) but the container environment does not provide `msbuild`/DXC, so a full binary build was not executed (not run in this environment).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d176d1e2c832db9dd5980f11c2522)