### PR TITLE
Add enemy stress-test controls to DebugScene (ImGui)

### DIFF
--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -32,6 +32,8 @@
 #include <cstdio>
 #include <array>
 #include <numbers>
+#include <new>
+#include <exception>
 #include <unordered_map>
 #include <cmath>
 
@@ -263,6 +265,18 @@ void DebugScene::Update()
 		debugMidRangeEnemy_->SetWallObstacleAABBs(&stage_->GetWallObstacleAABBs());
 		debugMidRangeEnemy_->Update(deltaTime);
 	}
+	for (auto& enemy : stressTestMeleeEnemies_)
+	{
+		if (enemy) { enemy->Update(deltaTime); }
+	}
+	for (auto& enemy : stressTestMidRangeEnemies_)
+	{
+		if (enemy)
+		{
+			enemy->SetTarget(meleeDummyTarget_.GetCenterPosition());
+			enemy->Update(deltaTime);
+		}
+	}
 
 	UpdateDebugBossHitTest();
 
@@ -328,6 +342,14 @@ void DebugScene::Draw3DObjects()
 	{
 		debugMidRangeEnemy_->Draw();
 	}
+	for (const auto& enemy : stressTestMeleeEnemies_)
+	{
+		if (enemy) { enemy->Draw(); }
+	}
+	for (const auto& enemy : stressTestMidRangeEnemies_)
+	{
+		if (enemy) { enemy->Draw(); }
+	}
 
 	if (stage_)
 	{
@@ -374,6 +396,10 @@ void DebugScene::DrawShadowObjects()
 	{
 		debugMeleeEnemy_->DrawShadow();
 	}
+	for (const auto& enemy : stressTestMeleeEnemies_)
+	{
+		if (enemy) { enemy->DrawShadow(); }
+	}
 	if (stage_)
 	{
 		stage_->DrawShadow();
@@ -409,6 +435,7 @@ void DebugScene::Finalize()
 	disintegrationDebug_.reset();
 	skyBox_.reset();
 	EnemyBase::SetGlobalStageWorldAABBs(nullptr);
+	ClearStressTestEnemies();
 	debugBoss_.reset();
 	debugMidRangeEnemy_.reset();
 	debugMeleeEnemy_.reset();
@@ -417,6 +444,99 @@ void DebugScene::Finalize()
 
 	input_ = nullptr;
 	dxCommon_ = nullptr;
+}
+
+
+void DebugScene::ApplyEnemyStressTestCounts()
+{
+	constexpr size_t kMaxEnemyCountPerType = 5000;
+	const size_t meleeTarget = enemyStressTestEnabled_ ? static_cast<size_t>(std::clamp(requestedStressTestMeleeCount_, 0, static_cast<int>(kMaxEnemyCountPerType))) : 0;
+	const size_t midRangeTarget = enemyStressTestEnabled_ ? static_cast<size_t>(std::clamp(requestedStressTestMidRangeCount_, 0, static_cast<int>(kMaxEnemyCountPerType))) : 0;
+
+	auto shrinkMelee = [this](size_t target)
+		{
+			while (stressTestMeleeEnemies_.size() > target)
+			{
+				if (collisionManager_ && stressTestMeleeEnemies_.back())
+				{
+					collisionManager_->RemoveCollider(stressTestMeleeEnemies_.back().get());
+				}
+				stressTestMeleeEnemies_.pop_back();
+			}
+		};
+	shrinkMelee(meleeTarget);
+	if (stressTestMidRangeEnemies_.size() > midRangeTarget) { stressTestMidRangeEnemies_.resize(midRangeTarget); }
+
+	try
+	{
+		stressTestMeleeEnemies_.reserve(meleeTarget);
+		stressTestMidRangeEnemies_.reserve(midRangeTarget);
+		while (stressTestMeleeEnemies_.size() < meleeTarget)
+		{
+			auto enemy = std::make_unique<MeleeEnemy>();
+			if (!enemy) { break; }
+			enemy->Initialize();
+			enemy->SetCenterPosition(GetStressTestEnemyPosition(stressTestMeleeEnemies_.size(), false));
+			enemy->SetTarget(&meleeDummyTarget_);
+			if (stage_)
+			{
+				enemy->SetFloorAABBs(&stage_->GetFloorAABBs());
+				enemy->SetWallObstacleAABBs(&stage_->GetWallObstacleAABBs());
+			}
+			stressTestMeleeEnemies_.push_back(std::move(enemy));
+			if (collisionManager_) { collisionManager_->AddCollider(stressTestMeleeEnemies_.back().get()); }
+		}
+		while (stressTestMidRangeEnemies_.size() < midRangeTarget)
+		{
+			auto enemy = std::make_unique<MidRangeEnemy>();
+			if (!enemy) { break; }
+			enemy->Initialize();
+			enemy->SetCenterPosition(GetStressTestEnemyPosition(stressTestMidRangeEnemies_.size(), true));
+			enemy->SetTarget(meleeDummyTarget_.GetCenterPosition());
+			if (stage_)
+			{
+				enemy->SetFloorAABBs(&stage_->GetFloorAABBs());
+				enemy->SetWallObstacleAABBs(&stage_->GetWallObstacleAABBs());
+			}
+			stressTestMidRangeEnemies_.push_back(std::move(enemy));
+		}
+		enemyStressTestLog_ = "Applied stress test enemy counts.";
+	}
+	catch (const std::bad_alloc&)
+	{
+		enemyStressTestLog_ = "Stopped spawning: memory allocation failed.";
+	}
+	catch (const std::exception& e)
+	{
+		enemyStressTestLog_ = std::string("Stopped spawning: ") + e.what();
+	}
+}
+
+void DebugScene::ClearStressTestEnemies()
+{
+	if (collisionManager_)
+	{
+		for (const auto& enemy : stressTestMeleeEnemies_)
+		{
+			if (enemy) { collisionManager_->RemoveCollider(enemy.get()); }
+		}
+	}
+	stressTestMeleeEnemies_.clear();
+	stressTestMidRangeEnemies_.clear();
+	enemyStressTestLog_ = "Cleared stress test enemies.";
+}
+
+K4E::Vector3 DebugScene::GetStressTestEnemyPosition(size_t index, bool isMidRange) const
+{
+	constexpr size_t kGridColumns = 100;
+	constexpr float kGridSpacing = 3.5f;
+	const float baseX = isMidRange ? 20.0f : -360.0f;
+	const float baseZ = -220.0f;
+	return {
+		baseX + static_cast<float>(index % kGridColumns) * kGridSpacing,
+		2.5f,
+		baseZ + static_cast<float>(index / kGridColumns) * kGridSpacing
+	};
 }
 
 void DebugScene::DrawImGui()
@@ -443,6 +563,22 @@ void DebugScene::DrawImGui()
 	{
 		frustumCullingDebug_->DrawImGui();
 	}
+
+	ImGui::Begin("Enemy Stress Test");
+	ImGui::Checkbox("Enable Enemy Stress Test", &enemyStressTestEnabled_);
+	ImGui::SliderInt("Melee Enemy Count", &requestedStressTestMeleeCount_, 0, 5000);
+	ImGui::SliderInt("MidRange Enemy Count", &requestedStressTestMidRangeCount_, 0, 5000);
+	if (ImGui::Button("Apply Enemy Count")) { ApplyEnemyStressTestCounts(); }
+	if (ImGui::Button("Clear Stress Test Enemies")) { ClearStressTestEnemies(); }
+	ImGui::Separator();
+	ImGui::Text("Current Melee Count: %zu", stressTestMeleeEnemies_.size());
+	ImGui::Text("Current MidRange Count: %zu", stressTestMidRangeEnemies_.size());
+	ImGui::Text("Total Enemy Count: %zu", stressTestMeleeEnemies_.size() + stressTestMidRangeEnemies_.size());
+	const auto* timer = K4E::GameTimer::GetInstance();
+	ImGui::Text("FPS: %.1f", timer ? timer->GetFPS() : 0.0f);
+	ImGui::Text("FrameTime: %.3f ms", timer ? timer->GetDeltaTime() * 1000.0f : 0.0f);
+	ImGui::TextWrapped("%s", enemyStressTestLog_.c_str());
+	ImGui::End();
 
 	ImGui::Begin("Debug Boss Hit Test");
 

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
@@ -15,6 +15,7 @@
 #include "DataAssetPresets.h"
 
 #include <array>
+#include <cstddef>
 #include <memory>
 #include <string>
 #include <vector>
@@ -72,6 +73,11 @@ private: /// ---------- メンバ関数 ---------- ///
 	// 近接敵同士のXZ分離をまとめて解決する
 	void ResolveMeleeEnemySeparation(float deltaTime);
 
+	// 大量敵の負荷検証用に、ImGuiから生成数を調整できるようにする。
+	void ApplyEnemyStressTestCounts();
+	void ClearStressTestEnemies();
+	K4E::Vector3 GetStressTestEnemyPosition(size_t index, bool isMidRange) const;
+
 	// SkyBox 設定はファイル欠落時だけ既定値へフォールバックする。
 	void InitializeSkyBox();
 	void ApplyActiveSkyBoxPreset(bool reloadTexture = false);
@@ -97,6 +103,14 @@ private: /// ---------- メンバ変数 ---------- ///
 	std::unique_ptr<GuardianBoss> debugBoss_;
 	std::unique_ptr<MeleeEnemy> debugMeleeEnemy_;
 	std::unique_ptr<MidRangeEnemy> debugMidRangeEnemy_;
+
+	// 通常確認用の敵と混ざらないよう、負荷検証用の敵は専用コンテナで保持する。
+	std::vector<std::unique_ptr<MeleeEnemy>> stressTestMeleeEnemies_;
+	std::vector<std::unique_ptr<MidRangeEnemy>> stressTestMidRangeEnemies_;
+	bool enemyStressTestEnabled_ = false;
+	int requestedStressTestMeleeCount_ = 0;
+	int requestedStressTestMidRangeCount_ = 0;
+	std::string enemyStressTestLog_ = "Stress test enemies have not been applied.";
 
 	// ステージ確認用（見た目＋衝突）
 	std::unique_ptr<K4E::Stage> stage_;


### PR DESCRIPTION
### Motivation
- Provide a debug-only stress test to measure performance when many enemies are present so future optimization choices (pooling, instancing, throttling, spatial partitioning) can be informed by data.
- Keep boss and normal game enemies untouched while allowing configurable, separate large-scale enemy spawns for safe load testing.
- Ensure the stress-test is a debug helper (not automatic per-frame spawning) and is resilient to allocation failures.

### Description
- Added an `Enemy Stress Test` ImGui panel to `DebugScene::DrawImGui()` with `Enable Enemy Stress Test`, `Melee Enemy Count`, `MidRange Enemy Count`, `Apply Enemy Count`, `Clear Stress Test Enemies`, `Current Melee Count`, `Current MidRange Count`, `Total Enemy Count`, and `FPS`/`FrameTime` display (files: `Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp` and `.h`).
- Managed stress-test enemies separately from normal debug enemies using `stressTestMeleeEnemies_` and `stressTestMidRangeEnemies_` members, and only apply changes when `Apply Enemy Count` is pressed; slider movement alone does not create/destroy enemies.
- Implemented diff-style apply: `ApplyEnemyStressTestCounts()` creates or shrinks the vectors to reach the requested counts, calls `Initialize()` on new enemies, registers/deregisters colliders with `CollisionManager`, handles `nullptr` checks, and catches `std::bad_alloc`/`std::exception` to avoid crashing on heavy allocations.
- Placed generated enemies on a non-overlapping XZ grid (`GetStressTestEnemyPosition()`), used a 3.5 unit spacing and separate base regions for melee and mid-range, and preserved `MidRangeEnemy` particle-disabled behavior (`SetParticleEffectsEnabled(false)`).

### Testing
- Ran `git diff --check` and basic diff sanity checks to ensure no whitespace/issues (passed).
- Executed a Python-based static assertion script that verifies ImGui labels, container names, max count presence (5000), exception handling tokens, collider removal on clear, and that `MidRangeEnemy` particle effects remain disabled (all assertions passed).
- Attempted to build the Visual Studio solution on the CI host but `msbuild` was not available in this Linux container, so an actual binary build was not executed (build should be validated on Windows/CI with MSVC).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d3d47c630832d8a89c8cd27207a7f)