### PR TITLE
Enemy performance debug toggles and counters (ImGui)

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.cpp
@@ -18,6 +18,10 @@ using namespace Ken4lowEngine;
 
 const std::vector<Ken4lowEngine::AABB>* EnemyBase::g_worldAABBs_ = nullptr;
 const std::vector<Ken4lowEngine::AABB>* EnemyBase::g_navigationObstacleAABBs_ = nullptr;
+bool EnemyBase::performanceDebugDrawEnabled_ = true;
+bool EnemyBase::performanceCollisionEnabled_ = true;
+bool EnemyBase::performanceAIEnabled_ = true;
+bool EnemyBase::performanceAttackEnabled_ = true;
 
 namespace
 {
@@ -253,7 +257,7 @@ void EnemyBase::Update(float deltaTime)
 	const auto* aabbs = (worldAABBs_ ? worldAABBs_ : g_worldAABBs_);
 	const auto& s = worldColOverride_ ? worldCol_ : worldCol_;
 
-	if (useWorldResolve_ && aabbs && !aabbs->empty())
+	if (performanceCollisionEnabled_ && useWorldResolve_ && aabbs && !aabbs->empty())
 	{
 		float vy = velocity_.y;
 

--- a/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.h
@@ -54,6 +54,16 @@ public:
 	virtual void UpdateShadowMatrix(const K4E::Matrix4x4& lightViewProjection);
 	virtual void DrawShadow();
 
+	// 敵の負荷原因を切り分けるため、更新・描画・AI・攻撃・衝突・デバッグ描画を個別に制御する。
+	static void SetPerformanceDebugDrawEnabled(bool enabled) { performanceDebugDrawEnabled_ = enabled; }
+	static void SetPerformanceCollisionEnabled(bool enabled) { performanceCollisionEnabled_ = enabled; }
+	static void SetPerformanceAIEnabled(bool enabled) { performanceAIEnabled_ = enabled; }
+	static void SetPerformanceAttackEnabled(bool enabled) { performanceAttackEnabled_ = enabled; }
+	static bool IsPerformanceDebugDrawEnabled() { return performanceDebugDrawEnabled_; }
+	static bool IsPerformanceCollisionEnabled() { return performanceCollisionEnabled_; }
+	static bool IsPerformanceAIEnabled() { return performanceAIEnabled_; }
+	static bool IsPerformanceAttackEnabled() { return performanceAttackEnabled_; }
+
 public:
 	// HP
 	void SetMaxHp(int v) { maxHp_ = v; hp_ = v; }
@@ -232,4 +242,8 @@ protected:
 private:
 	static const std::vector<K4E::AABB>* g_worldAABBs_;
 	static const std::vector<K4E::AABB>* g_navigationObstacleAABBs_;
+	static bool performanceDebugDrawEnabled_;
+	static bool performanceCollisionEnabled_;
+	static bool performanceAIEnabled_;
+	static bool performanceAttackEnabled_;
 };

--- a/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
@@ -82,7 +82,7 @@ void MeleeEnemy::Initialize()
 void MeleeEnemy::Update(float deltaTime)
 {
 	const Vector3 beforePos = GetCenterPosition();
-	attackController_.Update(*this, deltaTime);
+	if (IsPerformanceAttackEnabled()) { attackController_.Update(*this, deltaTime); }
 	// 被ダメージリアクションと死亡演出のタイマー更新を先に行う。
 	UpdateHitReaction(deltaTime);
 	UpdateDeathAnimation(deltaTime);
@@ -93,8 +93,14 @@ void MeleeEnemy::Update(float deltaTime)
 	attackSelectState_.lungeSelectCooldownTimer = std::max(0.0f, attackSelectState_.lungeSelectCooldownTimer - deltaTime);
 
 	// 優先度の高い行動から順に評価して近接敵の行動を決定する
-	EvaluateBehavior(deltaTime);
+	if (IsPerformanceAIEnabled()) { EvaluateBehavior(deltaTime); }
 	EnemyBase::Update(deltaTime);
+
+	if (!IsPerformanceCollisionEnabled())
+	{
+		UpdateVisualAnimation(deltaTime);
+		return;
+	}
 
 	collision_.usingWorldAABBCount = GetResolvedWorldAABBs() ? static_cast<int>(GetResolvedWorldAABBs()->size()) : 0;
 	collision_.usingObstacleAABBCount = GetResolvedNavigationObstacleAABBs() ? static_cast<int>(GetResolvedNavigationObstacleAABBs()->size()) : 0;
@@ -414,6 +420,7 @@ void MeleeEnemy::AddSeparationOverlapCount(int count)
 void MeleeEnemy::Draw()
 {
 	EnemyBase::Draw();
+	if (!IsPerformanceDebugDrawEnabled()) { return; }
 	if (!detailDebugDrawEnabled_) { return; }
 	const float colorPhase = pathDebugColorOffset_;
 	const Vector4 pathLineColor = pathDebugSelected_ ? Vector4{ 0.15f, 1.0f, 0.75f, 1.0f } : Vector4{ 0.2f + 0.25f * std::sin(colorPhase), 0.75f, 0.7f + 0.2f * std::cos(colorPhase), 0.9f };
@@ -880,6 +887,7 @@ void MeleeEnemy::StartDeathAnimation()
 
 void MeleeEnemy::MeleeAttackAction()
 {
+	if (!IsPerformanceAttackEnabled()) { CombatIdleAction(); return; }
 	FaceToTarget(1.0f / 60.0f);
 	StopMove();
 	if (!attackController_.IsAttacking() && attackController_.CanStartAttack())

--- a/Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.cpp
@@ -170,6 +170,11 @@ void MidRangeEnemy::Update(float deltaTime)
 {
     // 追加: まず基礎更新を行う。
     EnemyBase::Update(deltaTime);
+    if (!IsPerformanceAIEnabled())
+    {
+        UpdateVisualAnimation(deltaTime);
+        return;
+    }
     // 追加: 時限爆弾モード中のHP0は通常死亡より自爆を優先する。
     if (!IsDead() && !IsDeathActive() && GetHp() <= 0)
     {
@@ -199,9 +204,12 @@ void MidRangeEnemy::Update(float deltaTime)
         suicideBombState_.explosionDrawTimer = std::max(0.0f, suicideBombState_.explosionDrawTimer - deltaTime);
     }
 
-    for (auto& bomb : bombs_)
+    if (IsPerformanceAttackEnabled())
     {
-        bomb->Update(deltaTime);
+        for (auto& bomb : bombs_)
+        {
+            bomb->Update(deltaTime);
+        }
     }
 
     bombs_.erase(
@@ -228,7 +236,8 @@ void MidRangeEnemy::Update(float deltaTime)
         return;
     }
     // 追加: HP低下時の時限爆弾モード移行を通常行動より先に判定する。
-    if (suicideBomb_.enabled
+    if (IsPerformanceAttackEnabled()
+        && suicideBomb_.enabled
         && !suicideBombState_.active
         && !suicideBombState_.exploded
         && GetMaxHp() > 0
@@ -237,7 +246,7 @@ void MidRangeEnemy::Update(float deltaTime)
     {
         StartSuicideBombMode();
     }
-    if (suicideBombState_.active)
+    if (IsPerformanceAttackEnabled() && suicideBombState_.active)
     {
         // 追加: 時限爆弾モード中は通常AIより優先して更新する。
         UpdateSuicideBombMode(deltaTime);
@@ -271,7 +280,7 @@ void MidRangeEnemy::Update(float deltaTime)
         UpdateWanderBehavior(deltaTime);
     }
 
-    if (bombAttackState_.casting && targetState_.inDetectRange)
+    if (IsPerformanceAttackEnabled() && bombAttackState_.casting && targetState_.inDetectRange)
     {
         animationState_.animState = AnimState::Cast;
         if (bombAttackState_.castTimer >= bombAttack_.castTime && !bombAttackState_.thrownThisCast)
@@ -339,7 +348,7 @@ void MidRangeEnemy::UpdateCombatBehavior(float deltaTime)
     animationState_.animState = AnimState::Idle;
     behaviorState_.currentBehaviorName = "AttackReady";
     behaviorState_.lastReason = "攻撃距離内";
-    if (!bombAttackState_.casting && bombAttackState_.cooldownTimer <= 0.0f)
+    if (IsPerformanceAttackEnabled() && !bombAttackState_.casting && bombAttackState_.cooldownTimer <= 0.0f)
     {
         // 追加: 通常戦闘でのみ爆弾構えを開始する。
         bombAttackState_.casting = true;
@@ -882,6 +891,7 @@ void MidRangeEnemy::Draw()
     {
         bomb->Draw();
     }
+    if (!IsPerformanceDebugDrawEnabled()) { return; }
 
     if (pathState_.pathFound)
     {

--- a/Project/ApplicationLayer/Colliders/CollisionManager.cpp
+++ b/Project/ApplicationLayer/Colliders/CollisionManager.cpp
@@ -92,6 +92,7 @@ void CollisionManager::Reset()
 /// -------------------------------------------------------------
 void CollisionManager::CheckAllCollisions()
 {
+	lastEnemyCollisionCount_ = 0;
 	using CId = uint32_t;
 	const CId kPlayer = static_cast<CId>(CollisionTypeIdDef::kPlayer);
 	const CId kEnemy = static_cast<CId>(CollisionTypeIdDef::kEnemy);
@@ -133,6 +134,11 @@ void CollisionManager::CheckAllCollisions()
 				for (K4E::Collider* b : B)
 				{
 					if (!b) continue;
+					if (aId == kEnemy || bId == kEnemy)
+					{
+						if (!enableEnemyCollision_) { continue; }
+						++lastEnemyCollisionCount_;
+					}
 					CheckCollisionPair(a, b);
 				}
 			}

--- a/Project/ApplicationLayer/Colliders/CollisionManager.h
+++ b/Project/ApplicationLayer/Colliders/CollisionManager.h
@@ -35,6 +35,10 @@ public: /// ---------- メンバ関数 ---------- ///
 	// すべての当たり判定を確認する処理
 	void CheckAllCollisions();
 
+	// 敵を含む衝突ペアを負荷計測時に停止する。
+	void SetEnemyCollisionEnabled(bool enabled) { enableEnemyCollision_ = enabled; }
+	int GetLastEnemyCollisionCount() const { return lastEnemyCollisionCount_; }
+
 	// コライダーを追加
 	void AddCollider(K4E::Collider* other);
 
@@ -90,4 +94,6 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	// コライダーの可視化フラグ
 	bool isCollider_ = true;
+	bool enableEnemyCollision_ = true;
+	int lastEnemyCollisionCount_ = 0;
 };

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -253,28 +253,40 @@ void DebugScene::Update()
 		debugBoss_->Update(deltaTime);
 	}
 
-	if (debugMeleeEnemy_)
+	EnemyBase::SetPerformanceDebugDrawEnabled(enableEnemyDebugDraw_);
+	EnemyBase::SetPerformanceCollisionEnabled(enableEnemyCollision_);
+	EnemyBase::SetPerformanceAIEnabled(enableEnemyAI_);
+	EnemyBase::SetPerformanceAttackEnabled(enableEnemyAttack_);
+	if (collisionManager_) { collisionManager_->SetEnemyCollisionEnabled(enableEnemyCollision_); }
+	lastEnemyUpdateCount_ = 0;
+	if (enableEnemyUpdate_)
 	{
-		debugMeleeEnemy_->Update(deltaTime);
-	}
-	if (debugMidRangeEnemy_)
-	{
-		debugMidRangeEnemy_->SetTarget(meleeDummyTarget_.GetCenterPosition());
-		// 中距離敵にも床/障害物AABBを近接敵と同じ参照元で渡す。
-		debugMidRangeEnemy_->SetFloorAABBs(&stage_->GetFloorAABBs());
-		debugMidRangeEnemy_->SetWallObstacleAABBs(&stage_->GetWallObstacleAABBs());
-		debugMidRangeEnemy_->Update(deltaTime);
-	}
-	for (auto& enemy : stressTestMeleeEnemies_)
-	{
-		if (enemy) { enemy->Update(deltaTime); }
-	}
-	for (auto& enemy : stressTestMidRangeEnemies_)
-	{
-		if (enemy)
+		if (debugMeleeEnemy_)
 		{
-			enemy->SetTarget(meleeDummyTarget_.GetCenterPosition());
-			enemy->Update(deltaTime);
+			debugMeleeEnemy_->Update(deltaTime);
+			++lastEnemyUpdateCount_;
+		}
+		if (debugMidRangeEnemy_)
+		{
+			debugMidRangeEnemy_->SetTarget(meleeDummyTarget_.GetCenterPosition());
+			// 中距離敵にも床/障害物AABBを近接敵と同じ参照元で渡す。
+			debugMidRangeEnemy_->SetFloorAABBs(&stage_->GetFloorAABBs());
+			debugMidRangeEnemy_->SetWallObstacleAABBs(&stage_->GetWallObstacleAABBs());
+			debugMidRangeEnemy_->Update(deltaTime);
+			++lastEnemyUpdateCount_;
+		}
+		for (auto& enemy : stressTestMeleeEnemies_)
+		{
+			if (enemy) { enemy->Update(deltaTime); ++lastEnemyUpdateCount_; }
+		}
+		for (auto& enemy : stressTestMidRangeEnemies_)
+		{
+			if (enemy)
+			{
+				enemy->SetTarget(meleeDummyTarget_.GetCenterPosition());
+				enemy->Update(deltaTime);
+				++lastEnemyUpdateCount_;
+			}
 		}
 	}
 
@@ -334,30 +346,33 @@ void DebugScene::Draw3DObjects()
 	{
 		debugBoss_->Draw();
 	}
-	if (debugMeleeEnemy_)
+	lastEnemyDrawCount_ = 0;
+	lastEnemyDebugDrawCount_ = 0;
+	if (enableEnemyDraw_)
 	{
-		debugMeleeEnemy_->Draw();
-	}
-	if (debugMidRangeEnemy_)
-	{
-		debugMidRangeEnemy_->Draw();
-	}
-	for (const auto& enemy : stressTestMeleeEnemies_)
-	{
-		if (enemy) { enemy->Draw(); }
-	}
-	for (const auto& enemy : stressTestMidRangeEnemies_)
-	{
-		if (enemy) { enemy->Draw(); }
+		auto drawEnemy = [this](EnemyBase* enemy)
+		{
+			if (!enemy) { return; }
+			enemy->Draw();
+			++lastEnemyDrawCount_;
+			if (enableEnemyDebugDraw_) { ++lastEnemyDebugDrawCount_; }
+		};
+		drawEnemy(debugMeleeEnemy_.get());
+		drawEnemy(debugMidRangeEnemy_.get());
+		for (const auto& enemy : stressTestMeleeEnemies_) { drawEnemy(enemy.get()); }
+		for (const auto& enemy : stressTestMidRangeEnemies_) { drawEnemy(enemy.get()); }
 	}
 
 	if (stage_)
 	{
 		stage_->Draw();
 		// Stage Debugの茶色ワイヤーはNavigation/Wall用AABBではなくCollider由来OBBで描画する。
-		for (const auto& obstacleObb : stage_->GetWallObstacleOBBs())
+		if (enableStageBoundsDebugDraw_)
 		{
-			Wireframe::GetInstance()->DrawOBB(obstacleObb, { 0.60f, 0.35f, 0.12f, 0.90f });
+			for (const auto& obstacleObb : stage_->GetWallObstacleOBBs())
+			{
+				Wireframe::GetInstance()->DrawOBB(obstacleObb, { 0.60f, 0.35f, 0.12f, 0.90f });
+			}
 		}
 	}
 
@@ -372,12 +387,12 @@ void DebugScene::Draw3DObjects()
 		Wireframe::GetInstance()->DrawLine(c + Vector3{ 0.0f, -0.2f, 0.0f }, c + Vector3{ 0.0f, 0.2f, 0.0f }, { 0.8f, 1.0f, 0.2f, 1.0f });
 		Wireframe::GetInstance()->DrawLine(c + Vector3{ 0.0f, 0.0f, -0.2f }, c + Vector3{ 0.0f, 0.0f, 0.2f }, { 0.8f, 1.0f, 0.2f, 1.0f });
 	}
-	if (frustumCullingDebug_)
+	if (enableFrustumCullingDebugDraw_ && frustumCullingDebug_)
 	{
 		frustumCullingDebug_->DrawDebug();
 	}
 
-	collisionManager_->Draw();
+	collisionManager_->Draw(enableEnemyDebugDraw_);
 #endif // _DEBUG
 }
 
@@ -392,13 +407,12 @@ void DebugScene::DrawShadowObjects()
 	{
 		debugBoss_->DrawShadow();
 	}
-	if (debugMeleeEnemy_)
+	if (enableEnemyShadow_)
 	{
-		debugMeleeEnemy_->DrawShadow();
-	}
-	for (const auto& enemy : stressTestMeleeEnemies_)
-	{
-		if (enemy) { enemy->DrawShadow(); }
+		if (debugMeleeEnemy_) { debugMeleeEnemy_->DrawShadow(); }
+		if (debugMidRangeEnemy_) { debugMidRangeEnemy_->DrawShadow(); }
+		for (const auto& enemy : stressTestMeleeEnemies_) { if (enemy) { enemy->DrawShadow(); } }
+		for (const auto& enemy : stressTestMidRangeEnemies_) { if (enemy) { enemy->DrawShadow(); } }
 	}
 	if (stage_)
 	{
@@ -427,6 +441,10 @@ void DebugScene::Draw2DSprites()
 
 void DebugScene::Finalize()
 {
+	EnemyBase::SetPerformanceDebugDrawEnabled(true);
+	EnemyBase::SetPerformanceCollisionEnabled(true);
+	EnemyBase::SetPerformanceAIEnabled(true);
+	EnemyBase::SetPerformanceAttackEnabled(true);
 	// 入力状態を必ず戻す（ロック/非表示のまま終了しない）
 	input_->SetLockCursor(false);
 	input_->SetCursorVisible(true);
@@ -570,10 +588,27 @@ void DebugScene::DrawImGui()
 	ImGui::SliderInt("MidRange Enemy Count", &requestedStressTestMidRangeCount_, 0, 5000);
 	if (ImGui::Button("Apply Enemy Count")) { ApplyEnemyStressTestCounts(); }
 	if (ImGui::Button("Clear Stress Test Enemies")) { ClearStressTestEnemies(); }
+	ImGui::SeparatorText("Enemy Performance Debug");
+	ImGui::Checkbox("Enable Enemy Update", &enableEnemyUpdate_);
+	ImGui::Checkbox("Enable Enemy Draw", &enableEnemyDraw_);
+	ImGui::Checkbox("Enable Enemy Debug Draw", &enableEnemyDebugDraw_);
+	ImGui::Checkbox("Enable Enemy Collision", &enableEnemyCollision_);
+	ImGui::Checkbox("Enable Enemy AI", &enableEnemyAI_);
+	ImGui::Checkbox("Enable Enemy Attack", &enableEnemyAttack_);
+	ImGui::Checkbox("Enable Enemy Shadow", &enableEnemyShadow_);
+	ImGui::Checkbox("Enable Stage Bounds Debug Draw", &enableStageBoundsDebugDraw_);
+	ImGui::Checkbox("Enable Frustum Culling Debug Draw", &enableFrustumCullingDebugDraw_);
+	ImGui::Checkbox("Enable Dummy Target Wire Draw", &meleeDummyWireVisible_);
 	ImGui::Separator();
-	ImGui::Text("Current Melee Count: %zu", stressTestMeleeEnemies_.size());
-	ImGui::Text("Current MidRange Count: %zu", stressTestMidRangeEnemies_.size());
-	ImGui::Text("Total Enemy Count: %zu", stressTestMeleeEnemies_.size() + stressTestMidRangeEnemies_.size());
+	const size_t meleeEnemyCount = stressTestMeleeEnemies_.size() + (debugMeleeEnemy_ ? 1u : 0u);
+	const size_t midRangeEnemyCount = stressTestMidRangeEnemies_.size() + (debugMidRangeEnemy_ ? 1u : 0u);
+	ImGui::Text("Melee Enemy Count: %zu", meleeEnemyCount);
+	ImGui::Text("MidRange Enemy Count: %zu", midRangeEnemyCount);
+	ImGui::Text("Total Enemy Count: %zu", meleeEnemyCount + midRangeEnemyCount);
+	ImGui::Text("Enemy Update Count: %d", lastEnemyUpdateCount_);
+	ImGui::Text("Enemy Draw Count: %d", lastEnemyDrawCount_);
+	ImGui::Text("Enemy DebugDraw Count: %d", lastEnemyDebugDrawCount_);
+	ImGui::Text("Enemy Collision Count: %d", collisionManager_ ? collisionManager_->GetLastEnemyCollisionCount() : 0);
 	const auto* timer = K4E::GameTimer::GetInstance();
 	ImGui::Text("FPS: %.1f", timer ? timer->GetFPS() : 0.0f);
 	ImGui::Text("FrameTime: %.3f ms", timer ? timer->GetDeltaTime() * 1000.0f : 0.0f);
@@ -599,7 +634,6 @@ void DebugScene::DrawImGui()
 	{
 		meleeDummyTarget_.SetCenterPosition({ targetPosArray[0], targetPosArray[1], targetPosArray[2] });
 	}
-	ImGui::Checkbox("DummyTarget wire visible", &meleeDummyWireVisible_);
 	ImGui::SliderFloat("DummyTarget wire radius", &meleeDummyWireRadius_, 0.1f, 2.0f);
 	ImGui::Text("MeleeEnemy and dummy target are for BT behavior verification.");
 	ImGui::End();

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
@@ -112,6 +112,20 @@ private: /// ---------- メンバ変数 ---------- ///
 	int requestedStressTestMidRangeCount_ = 0;
 	std::string enemyStressTestLog_ = "Stress test enemies have not been applied.";
 
+	// 敵の負荷原因を切り分けるため、更新・描画・AI・デバッグ描画を個別に制御する。
+	bool enableEnemyUpdate_ = true;
+	bool enableEnemyDraw_ = true;
+	bool enableEnemyDebugDraw_ = true;
+	bool enableEnemyCollision_ = true;
+	bool enableEnemyAI_ = true;
+	bool enableEnemyAttack_ = true;
+	bool enableEnemyShadow_ = true;
+	bool enableStageBoundsDebugDraw_ = true;
+	bool enableFrustumCullingDebugDraw_ = true;
+	int lastEnemyUpdateCount_ = 0;
+	int lastEnemyDrawCount_ = 0;
+	int lastEnemyDebugDrawCount_ = 0;
+
 	// ステージ確認用（見た目＋衝突）
 	std::unique_ptr<K4E::Stage> stage_;
 


### PR DESCRIPTION
### Motivation
- 8体程度でFPSが急落するため、どの処理が重いかを切り分ける目的で、敵の更新/描画/デバッグ描画/衝突/AI/攻撃/シャドウなどを個別にON/OFFできる仕組みを追加します。 
- まずは挙動の切り分けと簡易計測を優先し、InstancingやObjectPool等の本格最適化は後段で行えるようにします。

### Description
- `Enemy Stress Test` に `Enemy Performance Debug` セクションを追加し、ImGuiで `Enable Enemy Update` / `Enable Enemy Draw` / `Enable Enemy Debug Draw` / `Enable Enemy Collision` / `Enable Enemy AI` / `Enable Enemy Attack` / `Enable Enemy Shadow` / `Enable Stage Bounds Debug Draw` / `Enable Frustum Culling Debug Draw` / `Enable Dummy Target Wire Draw` を実装しました (`Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp` / `.h`).
- 実処理の停止を行うために `EnemyBase` にグローバルフラグとAPI（`SetPerformance*` / `IsPerformance*`）を追加し、シャドウ・デバッグ描画・衝突解決の呼び出しをフラグでガードしました (`Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.*`)。 
- `MeleeEnemy` と `MidRangeEnemy` 側でAI判定、攻撃更新・生成、デバッグワイヤーフレーム描画、衝突関連（ワールド解決）の経路をフラグで分岐するように変更し、各処理を実際にスキップできるようにしました (`Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp`, `MidRangeEnemy.cpp`)。 
- `CollisionManager` に敵を含む衝突ペア処理を停止する制御と、敵衝突ペア処理数を計測するカウンタ（`GetLastEnemyCollisionCount`）を追加し、ImGui側で数値表示できるようにしました (`Project/ApplicationLayer/Colliders/CollisionManager.*`)。 
- DebugScene側で各種カウンタを集計して表示するようにし、`Melee/MidRange/Total`の個体数、`Enemy Update/Draw/DebugDraw/Collision` の処理数、`FPS`/`FrameTime` を確認できるようにしました (`Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp`)。 
- DebugSceneのFinalizeで追加フラグを既定値に戻す処理と、コメント（目的説明）を追加して影響を残さないようにしています。

### Testing
- ImGuiラベル存在チェック: 必須のUIラベル一覧について `rg` による存在確認を行い全て検出できました（成功）。
- ソース静的チェック: `git diff --check` と変更ファイルの中括弧バランス検査を実行し問題無いことを確認しました（成功）。
- ビルド検証: ソリューションのビルドはコンテナに `msbuild` / `dotnet` が無いため実行できませんでした（未実行、環境依存）。
- 追加の動作確認は実機で `Enable Enemy Debug Draw` / `Enable Enemy Shadow` / `Enable Enemy Collision` 等を切り替えてFPS改善の有無を観測することを推奨します（手順に沿った実行が必要）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d6ceb0358832db868a52c39dcb629)