### PR TITLE
Enemy stress-test: add instancing groundwork, spatial-hash collision, and staggered updates

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.cpp
@@ -318,6 +318,21 @@ void EnemyBase::Draw()
 	}
 }
 
+void EnemyBase::DrawStressTestBatchProxy()
+{
+	if (removable_ || (isDead_ && !deathBreakActive_)) return;
+	// 大量敵描画の負荷を抑えるため、Stress TestではInstancing移行可能な同一モデルの胴体Proxyへ簡略化する。
+	if (body_.active && body_.object) body_.object->Draw();
+}
+
+size_t EnemyBase::GetDrawCallCount() const
+{
+	if (removable_ || (isDead_ && !deathBreakActive_)) return 0;
+	size_t count = body_.active && body_.object ? 1u : 0u;
+	for (const auto& part : parts_) if (part.active && part.object) ++count;
+	return count;
+}
+
 /// -------------------------------------------------------------
 /// ImGui描画
 /// -------------------------------------------------------------

--- a/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.h
@@ -51,6 +51,9 @@ public:
 	virtual void Initialize();
 	virtual void Update(float deltaTime);
 	virtual void Draw();
+	// Stress Test用: 同一モデル単位のInstancingへ移行しやすい胴体Proxyだけを描画する。
+	void DrawStressTestBatchProxy();
+	size_t GetDrawCallCount() const;
 	virtual void DrawImGui();
 	virtual void UpdateShadowMatrix(const K4E::Matrix4x4& lightViewProjection);
 	virtual void DrawShadow();

--- a/Project/ApplicationLayer/Colliders/CollisionManager.cpp
+++ b/Project/ApplicationLayer/Colliders/CollisionManager.cpp
@@ -6,6 +6,9 @@
 
 #include <algorithm>
 #include <limits>
+#include <cmath>
+#include <unordered_set>
+#include <unordered_map>
 
 #ifdef USE_IMGUI
 #include <imgui.h>
@@ -131,18 +134,58 @@ void CollisionManager::CheckAllCollisions()
 			auto& B = buckets_[bId];
 			if (A.empty() || B.empty()) return;
 
+			const bool hasEnemy = aId == kEnemy || bId == kEnemy;
+			if (hasEnemy && !enableEnemyCollision_) return;
+			auto checkPair = [&](K4E::Collider* a, K4E::Collider* b)
+				{
+					if (!a || !b) return;
+					if (hasEnemy) ++lastEnemyCollisionCount_;
+					CheckCollisionPair(a, b);
+				};
+
+			if (!hasEnemy || !useSimpleStressTestCollision_)
+			{
+				for (K4E::Collider* a : A)
+				{
+					for (K4E::Collider* b : B) checkPair(a, b);
+				}
+				return;
+			}
+
+			constexpr float kCellSize = 8.0f;
+			auto cellCoordinate = [](float value) { return static_cast<int>(std::floor(value / kCellSize)); };
+			auto cellKey = [](int x, int z)
+				{
+					return (static_cast<uint64_t>(static_cast<uint32_t>(x)) << 32) | static_cast<uint32_t>(z);
+				};
+			std::unordered_map<uint64_t, std::vector<K4E::Collider*>> spatialHash;
+			spatialHash.reserve(B.size() * 2);
+			for (K4E::Collider* b : B)
+			{
+				if (!b) continue;
+				const K4E::Vector3 center = b->GetCenterPosition();
+				const K4E::Vector3 half = b->GetOBBHalfSize();
+				for (int x = cellCoordinate(center.x - half.x); x <= cellCoordinate(center.x + half.x); ++x)
+				{
+					for (int z = cellCoordinate(center.z - half.z); z <= cellCoordinate(center.z + half.z); ++z) spatialHash[cellKey(x, z)].push_back(b);
+				}
+			}
+
+			// 大量敵衝突の負荷を抑えるため、Spatial Hashの同一セルにいる候補だけ判定する。
 			for (K4E::Collider* a : A)
 			{
 				if (!a) continue;
-				for (K4E::Collider* b : B)
+				const K4E::Vector3 center = a->GetCenterPosition();
+				const K4E::Vector3 half = a->GetOBBHalfSize();
+				std::unordered_set<K4E::Collider*> checked;
+				for (int x = cellCoordinate(center.x - half.x); x <= cellCoordinate(center.x + half.x); ++x)
 				{
-					if (!b) continue;
-					if (aId == kEnemy || bId == kEnemy)
+					for (int z = cellCoordinate(center.z - half.z); z <= cellCoordinate(center.z + half.z); ++z)
 					{
-						if (!enableEnemyCollision_) { continue; }
-						++lastEnemyCollisionCount_;
+						auto it = spatialHash.find(cellKey(x, z));
+						if (it == spatialHash.end()) continue;
+						for (K4E::Collider* b : it->second) if (checked.insert(b).second) checkPair(a, b);
 					}
-					CheckCollisionPair(a, b);
 				}
 			}
 		};

--- a/Project/ApplicationLayer/Colliders/CollisionManager.h
+++ b/Project/ApplicationLayer/Colliders/CollisionManager.h
@@ -37,6 +37,8 @@ public: /// ---------- メンバ関数 ---------- ///
 
 	// 敵を含む衝突ペアを負荷計測時に停止する。
 	void SetEnemyCollisionEnabled(bool enabled) { enableEnemyCollision_ = enabled; }
+	// Stress TestではSpatial Hashで近傍候補だけを調べ、Enemy x Worldの総当たりを避ける。
+	void SetUseSimpleStressTestCollision(bool enabled) { useSimpleStressTestCollision_ = enabled; }
 	int GetLastEnemyCollisionCount() const { return lastEnemyCollisionCount_; }
 	int GetLastEnemyPlayerCollisionCount() const { return lastEnemyPlayerCollisionCount_; }
 	int GetLastBulletEnemyCollisionCount() const { return lastBulletEnemyCollisionCount_; }
@@ -98,6 +100,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	// コライダーの可視化フラグ
 	bool isCollider_ = true;
 	bool enableEnemyCollision_ = true;
+	bool useSimpleStressTestCollision_ = false;
 	int lastEnemyCollisionCount_ = 0;
 	int lastEnemyPlayerCollisionCount_ = 0;
 	int lastBulletEnemyCollisionCount_ = 0;

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -261,7 +261,11 @@ void DebugScene::Update()
 	EnemyBase::SetPerformanceMovementEnabled(enableEnemyMovement_);
 	EnemyBase::SetPerformanceNavigationEnabled(enableEnemyNavigation_);
 	EnemyBase::SetPerformanceTransformUpdateEnabled(enableEnemyTransformUpdate_);
-	if (collisionManager_) { collisionManager_->SetEnemyCollisionEnabled(enableEnemyCollision_); }
+	if (collisionManager_)
+	{
+		collisionManager_->SetEnemyCollisionEnabled(enableEnemyCollision_);
+		collisionManager_->SetUseSimpleStressTestCollision(enemyStressTestEnabled_ && useSimpleStressTestCollision_);
+	}
 	lastEnemyUpdateCount_ = 0;
 	EnemyPerformanceProfiler::BeginFrame();
 	auto updateMeleeEnemy = [deltaTime, this](MeleeEnemy* enemy)
@@ -293,18 +297,18 @@ void DebugScene::Update()
 			debugMidRangeEnemy_->SetWallObstacleAABBs(&stage_->GetWallObstacleAABBs());
 			updateMidRangeEnemy(debugMidRangeEnemy_.get());
 		}
-		for (auto& enemy : stressTestMeleeEnemies_)
+		const uint64_t updateInterval = static_cast<uint64_t>(std::max(1, enemyUpdateInterval_));
+		for (size_t i = 0; i < stressTestMeleeEnemies_.size(); ++i)
 		{
-			updateMeleeEnemy(enemy.get());
+			// 更新フレームを敵ごとにずらし、大量敵のAI負荷が同じフレームへ集中しないようにする。
+			if ((enemyUpdateFrame_ + i) % updateInterval == 0) updateMeleeEnemy(stressTestMeleeEnemies_[i].get());
 		}
-		for (auto& enemy : stressTestMidRangeEnemies_)
+		for (size_t i = 0; i < stressTestMidRangeEnemies_.size(); ++i)
 		{
-			if (enemy)
-			{
-				updateMidRangeEnemy(enemy.get());
-			}
+			if ((enemyUpdateFrame_ + stressTestMeleeEnemies_.size() + i) % updateInterval == 0) updateMidRangeEnemy(stressTestMidRangeEnemies_[i].get());
 		}
 	}
+	++enemyUpdateFrame_;
 
 	UpdateDebugBossHitTest();
 
@@ -370,20 +374,31 @@ void DebugScene::Draw3DObjects()
 		debugBoss_->Draw();
 	}
 	lastEnemyDrawCount_ = 0;
+	lastEnemyDrawCallCount_ = 0;
 	lastEnemyDebugDrawCount_ = 0;
 	if (enableEnemyDraw_)
 	{
 		auto drawEnemy = [this](EnemyBase* enemy)
-		{
-			if (!enemy) { return; }
-			enemy->Draw();
-			++lastEnemyDrawCount_;
-			if (enableEnemyDebugDraw_) { ++lastEnemyDebugDrawCount_; }
-		};
+			{
+				if (!enemy) return;
+				enemy->Draw();
+				++lastEnemyDrawCount_;
+				lastEnemyDrawCallCount_ += static_cast<int>(enemy->GetDrawCallCount());
+				if (enableEnemyDebugDraw_) ++lastEnemyDebugDrawCount_;
+			};
+		auto drawStressEnemy = [this, &drawEnemy](EnemyBase* enemy)
+			{
+				if (!enemy) return;
+				if (!useEnemyInstancingProxy_) { drawEnemy(enemy); return; }
+				// 大量敵描画の負荷を抑えるため、同一モデル単位で回し、Instancing移行用Proxyを描画する。
+				enemy->DrawStressTestBatchProxy();
+				++lastEnemyDrawCount_;
+				++lastEnemyDrawCallCount_;
+			};
 		drawEnemy(debugMeleeEnemy_.get());
 		drawEnemy(debugMidRangeEnemy_.get());
-		for (const auto& enemy : stressTestMeleeEnemies_) { drawEnemy(enemy.get()); }
-		for (const auto& enemy : stressTestMidRangeEnemies_) { drawEnemy(enemy.get()); }
+		for (const auto& enemy : stressTestMeleeEnemies_) drawStressEnemy(enemy.get());
+		for (const auto& enemy : stressTestMidRangeEnemies_) drawStressEnemy(enemy.get());
 	}
 
 	if (stage_)
@@ -609,7 +624,19 @@ void DebugScene::DrawImGui()
 	}
 
 	ImGui::Begin("Enemy Stress Test");
-	ImGui::Checkbox("Enable Enemy Stress Test", &enemyStressTestEnabled_);
+	if (ImGui::Checkbox("Enable Enemy Stress Test", &enemyStressTestEnabled_) && enemyStressTestEnabled_)
+	{
+		// Stress Test開始時は重複描画を既定OFFにし、敵本体の負荷を測定しやすくする。
+		enableEnemyDebugDraw_ = false;
+		enableStageBoundsDebugDraw_ = false;
+		enableFrustumCullingDebugDraw_ = false;
+		meleeDummyWireVisible_ = false;
+		enableEnemyShadow_ = false;
+	}
+	ImGui::Checkbox("Use Enemy Instancing", &useEnemyInstancingProxy_);
+	ImGui::TextDisabled("Stress Test proxy path: body model only; GPU instanced draw is the next stage.");
+	ImGui::Checkbox("Use Simple Stress Test Collision", &useSimpleStressTestCollision_);
+	ImGui::SliderInt("Enemy Update Interval", &enemyUpdateInterval_, 1, 60);
 	ImGui::SliderInt("Melee Enemy Count", &requestedStressTestMeleeCount_, 0, 5000);
 	ImGui::SliderInt("MidRange Enemy Count", &requestedStressTestMidRangeCount_, 0, 5000);
 	if (ImGui::Button("Apply Enemy Count")) { ApplyEnemyStressTestCounts(); }
@@ -636,6 +663,7 @@ void DebugScene::DrawImGui()
 	ImGui::Text("Total Enemy Count: %zu", meleeEnemyCount + midRangeEnemyCount);
 	ImGui::Text("Enemy Update Count: %d", lastEnemyUpdateCount_);
 	ImGui::Text("Enemy Draw Count: %d", lastEnemyDrawCount_);
+	ImGui::Text("Enemy Draw Call Count: %d", lastEnemyDrawCallCount_);
 	ImGui::Text("Enemy DebugDraw Count: %d", lastEnemyDebugDrawCount_);
 	ImGui::Text("Enemy Collision Count: %d", collisionManager_ ? collisionManager_->GetLastEnemyCollisionCount() : 0);
 	ImGui::Text("  Enemy vs Player: %d", collisionManager_ ? collisionManager_->GetLastEnemyPlayerCollisionCount() : 0);

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
@@ -16,6 +16,7 @@
 
 #include <array>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
@@ -108,6 +109,10 @@ private: /// ---------- メンバ変数 ---------- ///
 	std::vector<std::unique_ptr<MeleeEnemy>> stressTestMeleeEnemies_;
 	std::vector<std::unique_ptr<MidRangeEnemy>> stressTestMidRangeEnemies_;
 	bool enemyStressTestEnabled_ = false;
+	bool useEnemyInstancingProxy_ = true;
+	bool useSimpleStressTestCollision_ = true;
+	int enemyUpdateInterval_ = 1;
+	uint64_t enemyUpdateFrame_ = 0;
 	int requestedStressTestMeleeCount_ = 0;
 	int requestedStressTestMidRangeCount_ = 0;
 	std::string enemyStressTestLog_ = "Stress test enemies have not been applied.";
@@ -127,6 +132,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	bool enableFrustumCullingDebugDraw_ = true;
 	int lastEnemyUpdateCount_ = 0;
 	int lastEnemyDrawCount_ = 0;
+	int lastEnemyDrawCallCount_ = 0;
 	int lastEnemyDebugDrawCount_ = 0;
 
 	// ステージ確認用（見た目＋衝突）


### PR DESCRIPTION
### Motivation
- 敵ストレステストで描画・衝突・更新がボトルネックになっているため、まず安全な前段として描画と衝突判定の軽量化基盤を作る。 
- 既存のボス・通常挙動を壊さず、Stress Test 用の経路だけを限定して負荷を下げられるようにする。 

### Description
- 追加: `EnemyBase` に Stress Test 用の軽量描画プロキシ `DrawStressTestBatchProxy` と描画呼び出し数取得 `GetDrawCallCount()` を追加し、Stress Test 敵では胴体モデルを中心に描画する土台を作成した（ファイル: `Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.*`）。
- 追加/変更: デバッグ用シーンの ImGui に `Use Enemy Instancing`（プロキシ経路）、`Use Simple Stress Test Collision`、`Enemy Update Interval`、`Enemy Draw Call Count` 等の表示と制御を追加し、Stress Test 有効時に重複デバッグ描画や影描画を既定OFFにする（ファイル: `Project/ApplicationLayer/Scene/DebugScene/DebugScene.*`）。
- 追加: 衝突マネージャに Stress Test 向けの切替 `SetUseSimpleStressTestCollision` を追加し、敵を含む判定ペアに対して XZ 平面の Spatial Hash を使って近傍セル内の候補のみを判定する簡易実装を導入して総当たりを回避した（ファイル: `Project/ApplicationLayer/Colliders/CollisionManager.*`）。
- 追加: Stress Test 用の更新分散機能として `Enemy Update Interval` を導入し、敵ごとに更新フレームをずらすことで全敵のAI更新が単一フレームに集中しないようにした（ファイル: `DebugScene.cpp`）。
- 安全性: ボス・通常敵・ステージ処理は変更せず、今回の描画はあくまで「Instancing へ移行しやすいプロキシ経路」の整備であり、まだ `DrawIndexedInstanced` による完全なGPUインスタンシング置換は行っていない点を明記している。
- 最低1行の注釈コメントを主要箇所へ追加し、実装意図（プロキシ化・Spatial Hash 利用等）をソースへ残した。

### Testing
- 自動チェック: `git diff --check` を実行して差分の空白エラーは無しを確認済み（成功）。
- 表示ラベル確認: `rg` による ImGui 表示ラベルの存在確認を行い、追加した UI ラベル（`Use Enemy Instancing` / `Use Simple Stress Test Collision` / `Enemy Update Interval` / `Enemy Draw Call Count` 等）を検出できた（成功）。
- リポジトリ整合性: `git status` / `git commit` を実行して変更をコミット済み（成功）。
- ビルド: Visual Studio ソリューションの実ビルドは Linux コンテナに `msbuild` が無いため実行できず（未実行／続行要）、Windows 環境でのビルドと実動作確認を推奨する（警告）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d799ec254832d8159378a72dd2274)