### PR TITLE
Add GPU instancing path for stress-test melee enemies and performance stats

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.cpp
@@ -318,18 +318,34 @@ void EnemyBase::Draw()
 	}
 }
 
-void EnemyBase::DrawStressTestBatchProxy()
+size_t EnemyBase::DrawStressTestBatchProxy()
 {
-	if (removable_ || (isDead_ && !deathBreakActive_)) return;
+	if (removable_ || (isDead_ && !deathBreakActive_)) return 0;
 	// 大量敵描画の負荷を抑えるため、Stress TestではInstancing移行可能な同一モデルの胴体Proxyへ簡略化する。
-	if (body_.active && body_.object) body_.object->Draw();
+	if (!body_.active || !body_.object) return 0;
+	body_.object->Draw();
+	return body_.object->GetSubmeshCount();
+}
+
+bool EnemyBase::AppendStressTestInstanceWorldMatrix(std::vector<K4E::Matrix4x4>& worldMatrices) const
+{
+	if (removable_ || (isDead_ && !deathBreakActive_) || !body_.active || !body_.object) return false;
+	worldMatrices.push_back(body_.transform.worldMatrix_);
+	return true;
+}
+
+size_t EnemyBase::DrawStressTestInstanced(const std::vector<K4E::Matrix4x4>& worldMatrices)
+{
+	if (worldMatrices.empty() || !body_.active || !body_.object) return 0;
+	// StressTest用の同一モデル敵はDrawCall削減のためInstancing描画にまとめる。
+	return body_.object->DrawInstanced(worldMatrices);
 }
 
 size_t EnemyBase::GetDrawCallCount() const
 {
 	if (removable_ || (isDead_ && !deathBreakActive_)) return 0;
-	size_t count = body_.active && body_.object ? 1u : 0u;
-	for (const auto& part : parts_) if (part.active && part.object) ++count;
+	size_t count = body_.active && body_.object ? body_.object->GetSubmeshCount() : 0u;
+	for (const auto& part : parts_) if (part.active && part.object) count += part.object->GetSubmeshCount();
 	return count;
 }
 

--- a/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.h
@@ -52,7 +52,9 @@ public:
 	virtual void Update(float deltaTime);
 	virtual void Draw();
 	// Stress Test用: 同一モデル単位のInstancingへ移行しやすい胴体Proxyだけを描画する。
-	void DrawStressTestBatchProxy();
+	size_t DrawStressTestBatchProxy();
+	bool AppendStressTestInstanceWorldMatrix(std::vector<K4E::Matrix4x4>& worldMatrices) const;
+	size_t DrawStressTestInstanced(const std::vector<K4E::Matrix4x4>& worldMatrices);
 	size_t GetDrawCallCount() const;
 	virtual void DrawImGui();
 	virtual void UpdateShadowMatrix(const K4E::Matrix4x4& lightViewProjection);

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -375,7 +375,12 @@ void DebugScene::Draw3DObjects()
 	}
 	lastEnemyDrawCount_ = 0;
 	lastEnemyDrawCallCount_ = 0;
+	lastEnemyMeshDrawCount_ = 0;
+	lastEnemyInstanceCount_ = 0;
+	lastEnemyInstancedBatchCount_ = 0;
+	lastEnemyNormalDrawCount_ = 0;
 	lastEnemyDebugDrawCount_ = 0;
+	const auto enemyDrawStart = std::chrono::steady_clock::now();
 	if (enableEnemyDraw_)
 	{
 		auto drawEnemy = [this](EnemyBase* enemy)
@@ -383,23 +388,51 @@ void DebugScene::Draw3DObjects()
 				if (!enemy) return;
 				enemy->Draw();
 				++lastEnemyDrawCount_;
-				lastEnemyDrawCallCount_ += static_cast<int>(enemy->GetDrawCallCount());
+				const int meshDrawCount = static_cast<int>(enemy->GetDrawCallCount());
+				lastEnemyDrawCallCount_ += meshDrawCount;
+				lastEnemyMeshDrawCount_ += meshDrawCount;
+				lastEnemyNormalDrawCount_ += meshDrawCount;
 				if (enableEnemyDebugDraw_) ++lastEnemyDebugDrawCount_;
 			};
-		auto drawStressEnemy = [this, &drawEnemy](EnemyBase* enemy)
+		auto drawStressProxy = [this](EnemyBase* enemy)
 			{
 				if (!enemy) return;
-				if (!useEnemyInstancingProxy_) { drawEnemy(enemy); return; }
-				// 大量敵描画の負荷を抑えるため、同一モデル単位で回し、Instancing移行用Proxyを描画する。
-				enemy->DrawStressTestBatchProxy();
+				const int meshDrawCount = static_cast<int>(enemy->DrawStressTestBatchProxy());
 				++lastEnemyDrawCount_;
-				++lastEnemyDrawCallCount_;
+				lastEnemyDrawCallCount_ += meshDrawCount;
+				lastEnemyMeshDrawCount_ += meshDrawCount;
+				lastEnemyNormalDrawCount_ += meshDrawCount;
 			};
 		drawEnemy(debugMeleeEnemy_.get());
 		drawEnemy(debugMidRangeEnemy_.get());
-		for (const auto& enemy : stressTestMeleeEnemies_) drawStressEnemy(enemy.get());
-		for (const auto& enemy : stressTestMidRangeEnemies_) drawStressEnemy(enemy.get());
+		if (useEnemyInstancingProxy_)
+		{
+			std::vector<K4E::Matrix4x4> meleeWorldMatrices;
+			meleeWorldMatrices.reserve(stressTestMeleeEnemies_.size());
+			EnemyBase* representative = nullptr;
+			for (const auto& enemy : stressTestMeleeEnemies_)
+			{
+				if (enemy && enemy->AppendStressTestInstanceWorldMatrix(meleeWorldMatrices)) representative = representative ? representative : enemy.get();
+			}
+			if (representative && !meleeWorldMatrices.empty())
+			{
+				const int meshDrawCount = static_cast<int>(representative->DrawStressTestInstanced(meleeWorldMatrices));
+				lastEnemyDrawCount_ += static_cast<int>(meleeWorldMatrices.size());
+				lastEnemyInstanceCount_ += static_cast<int>(meleeWorldMatrices.size());
+				lastEnemyDrawCallCount_ += meshDrawCount;
+				lastEnemyMeshDrawCount_ += meshDrawCount;
+				++lastEnemyInstancedBatchCount_;
+			}
+			// 中距離敵はパーティクルを復活させず、既存の胴体Proxy描画を維持する。
+			for (const auto& enemy : stressTestMidRangeEnemies_) drawStressProxy(enemy.get());
+		}
+		else
+		{
+			for (const auto& enemy : stressTestMeleeEnemies_) drawEnemy(enemy.get());
+			for (const auto& enemy : stressTestMidRangeEnemies_) drawEnemy(enemy.get());
+		}
 	}
+	lastEnemyDrawSubmitMs_ = std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - enemyDrawStart).count();
 
 	if (stage_)
 	{
@@ -445,12 +478,19 @@ void DebugScene::DrawShadowObjects()
 	{
 		debugBoss_->DrawShadow();
 	}
+	lastEnemyShadowDrawCount_ = 0;
 	if (enableEnemyShadow_)
 	{
-		if (debugMeleeEnemy_) { debugMeleeEnemy_->DrawShadow(); }
-		if (debugMidRangeEnemy_) { debugMidRangeEnemy_->DrawShadow(); }
-		for (const auto& enemy : stressTestMeleeEnemies_) { if (enemy) { enemy->DrawShadow(); } }
-		for (const auto& enemy : stressTestMidRangeEnemies_) { if (enemy) { enemy->DrawShadow(); } }
+		auto drawEnemyShadow = [this](EnemyBase* enemy)
+			{
+				if (!enemy) return;
+				enemy->DrawShadow();
+				lastEnemyShadowDrawCount_ += static_cast<int>(enemy->GetDrawCallCount());
+			};
+		drawEnemyShadow(debugMeleeEnemy_.get());
+		drawEnemyShadow(debugMidRangeEnemy_.get());
+		for (const auto& enemy : stressTestMeleeEnemies_) drawEnemyShadow(enemy.get());
+		for (const auto& enemy : stressTestMidRangeEnemies_) drawEnemyShadow(enemy.get());
 	}
 	if (stage_)
 	{
@@ -634,7 +674,9 @@ void DebugScene::DrawImGui()
 		enableEnemyShadow_ = false;
 	}
 	ImGui::Checkbox("Use Enemy Instancing", &useEnemyInstancingProxy_);
-	ImGui::TextDisabled("Stress Test proxy path: body model only; GPU instanced draw is the next stage.");
+	ImGui::TextDisabled(useEnemyInstancingProxy_
+		? "Stress Test melee path: body model only; GPU DrawIndexedInstanced enabled."
+		: "Stress Test path: normal enemy Draw().");
 	ImGui::Checkbox("Use Simple Stress Test Collision", &useSimpleStressTestCollision_);
 	ImGui::SliderInt("Enemy Update Interval", &enemyUpdateInterval_, 1, 60);
 	ImGui::SliderInt("Melee Enemy Count", &requestedStressTestMeleeCount_, 0, 5000);
@@ -664,6 +706,12 @@ void DebugScene::DrawImGui()
 	ImGui::Text("Enemy Update Count: %d", lastEnemyUpdateCount_);
 	ImGui::Text("Enemy Draw Count: %d", lastEnemyDrawCount_);
 	ImGui::Text("Enemy Draw Call Count: %d", lastEnemyDrawCallCount_);
+	ImGui::Text("Enemy Mesh Draw Count: %d", lastEnemyMeshDrawCount_);
+	ImGui::Text("Enemy Instance Count: %d", lastEnemyInstanceCount_);
+	ImGui::Text("Enemy Instanced Batch Count: %d", lastEnemyInstancedBatchCount_);
+	ImGui::Text("Enemy Normal Draw Count: %d", lastEnemyNormalDrawCount_);
+	ImGui::Text("Enemy Shadow Draw Count: %d", lastEnemyShadowDrawCount_);
+	ImGui::Text("Enemy Draw Submit Time: %.3f ms", lastEnemyDrawSubmitMs_);
 	ImGui::Text("Enemy DebugDraw Count: %d", lastEnemyDebugDrawCount_);
 	ImGui::Text("Enemy Collision Count: %d", collisionManager_ ? collisionManager_->GetLastEnemyCollisionCount() : 0);
 	ImGui::Text("  Enemy vs Player: %d", collisionManager_ ? collisionManager_->GetLastEnemyPlayerCollisionCount() : 0);
@@ -674,7 +722,7 @@ void DebugScene::DrawImGui()
 	const auto& midRangePerf = enemyPerf.types[static_cast<size_t>(EnemyPerformanceProfiler::EnemyType::MidRange)];
 	auto sectionMs = [&enemyPerf](EnemyPerformanceProfiler::Section section) { return enemyPerf.GetSectionMs(section); };
 	ImGui::SeparatorText("Enemy Update Timing (Debug Build)");
-	ImGui::Text("Total Enemy Update Time: %.3f ms", enemyPerf.GetTotalMs());
+	ImGui::Text("Enemy CPU Update Time: %.3f ms", enemyPerf.GetTotalMs());
 	ImGui::Text("Melee Enemy Update Time: %.3f ms", meleePerf.totalMs);
 	ImGui::Text("MidRange Enemy Update Time: %.3f ms", midRangePerf.totalMs);
 	ImGui::Text("Enemy AI Time: %.3f ms", sectionMs(EnemyPerformanceProfiler::Section::AI));

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
@@ -133,6 +133,12 @@ private: /// ---------- メンバ変数 ---------- ///
 	int lastEnemyUpdateCount_ = 0;
 	int lastEnemyDrawCount_ = 0;
 	int lastEnemyDrawCallCount_ = 0;
+	int lastEnemyMeshDrawCount_ = 0;
+	int lastEnemyInstanceCount_ = 0;
+	int lastEnemyInstancedBatchCount_ = 0;
+	int lastEnemyNormalDrawCount_ = 0;
+	int lastEnemyShadowDrawCount_ = 0;
+	double lastEnemyDrawSubmitMs_ = 0.0;
 	int lastEnemyDebugDrawCount_ = 0;
 
 	// ステージ確認用（見た目＋衝突）

--- a/Project/Engine/Graphics/Mesh/Mesh.cpp
+++ b/Project/Engine/Graphics/Mesh/Mesh.cpp
@@ -58,12 +58,18 @@ void Mesh::Initialize(const std::vector<VertexData>& modelVertices, const std::v
 /// -------------------------------------------------------------
 void Mesh::Draw()
 {
+	DrawInstanced(1);
+}
+
+void Mesh::DrawInstanced(uint32_t instanceCount)
+{
+	if (instanceCount == 0) return;
 	ID3D12GraphicsCommandList* commandList = DirectXCommon::GetInstance()->GetCommandManager()->GetCommandList();
 
 	commandList->IASetVertexBuffers(0, 1, &vertexBufferView); // 頂点バッファをセット
 	commandList->IASetIndexBuffer(&indexBufferView);		  // インデックスバッファをセット
 	commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST); // プリミティブ形状を設定
-	commandList->DrawIndexedInstanced(static_cast<UINT>(indices.size()), 1, 0, 0, 0); // インデックス描画
+	commandList->DrawIndexedInstanced(static_cast<UINT>(indices.size()), instanceCount, 0, 0, 0); // インデックス描画
 }
 
 } // namespace Ken4lowEngine

--- a/Project/Engine/Graphics/Mesh/Mesh.h
+++ b/Project/Engine/Graphics/Mesh/Mesh.h
@@ -27,6 +27,7 @@ public: /// ---------- メンバ関数 ---------- ///
 	/// 描画処理
 	/// </summary>
 	void Draw();
+	void DrawInstanced(uint32_t instanceCount);
 
 private: /// ---------- メンバ変数 ---------- ///
 

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3D.cpp
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3D.cpp
@@ -166,6 +166,53 @@ namespace Ken4lowEngine
 		DrawInternal(&meshIndices);
 	}
 
+	void Object3D::EnsureInstanceBufferCapacity(size_t instanceCount)
+	{
+		if (instanceCount <= instanceTransformCapacity_) return;
+		instanceTransformCapacity_ = std::max(instanceCount, instanceTransformCapacity_ * 2u);
+		instanceTransformResource_ = ResourceManager::CreateBufferResource(dxCommon_->GetDevice(), sizeof(TransformationMatrix) * instanceTransformCapacity_);
+		instanceTransformResource_->Map(0, nullptr, reinterpret_cast<void**>(&instanceTransformData_));
+		instanceTransformResource_->SetName(L"Object3D::InstanceTransforms");
+	}
+
+	size_t Object3D::DrawInstanced(const std::vector<Matrix4x4>& worldMatrices)
+	{
+		if (!model_ || worldMatrices.empty()) return 0;
+		EnsureInstanceBufferCapacity(worldMatrices.size());
+		const Matrix4x4 viewProjection = CameraManager::GetInstance()->GetActiveViewProjectionMatrix();
+		for (size_t i = 0; i < worldMatrices.size(); ++i)
+		{
+			instanceTransformData_[i].World = worldMatrices[i];
+			instanceTransformData_[i].WVP = Matrix4x4::Multiply(worldMatrices[i], viewProjection);
+			instanceTransformData_[i].WorldInversedTranspose = Matrix4x4::Transpose(Matrix4x4::Inverse(worldMatrices[i]));
+		}
+
+		ID3D12GraphicsCommandList* commandList = dxCommon_->GetCommandManager()->GetCommandList();
+		Object3DCommon::GetInstance()->SetInstancedRenderSetting();
+		material_.SetPipeline();
+		commandList->SetGraphicsRootShaderResourceView(1, instanceTransformResource_->GetGPUVirtualAddress());
+		commandList->SetGraphicsRootConstantBufferView(3, cameraResource->GetGPUVirtualAddress());
+		TextureManager::GetInstance()->SetGraphicsRootDescriptorTable(commandList, 4, environmentMapHandle_);
+		commandList->SetGraphicsRootConstantBufferView(7, constantBuffer_->GetGPUVirtualAddress());
+		TextureManager::GetInstance()->SetGraphicsRootDescriptorTable(commandList, 8, dissolveMaskHandle_);
+		commandList->SetGraphicsRootConstantBufferView(9, shadowParameterResource_->GetGPUVirtualAddress());
+		commandList->SetGraphicsRootDescriptorTable(10, shadowMapHandle_);
+
+		auto& meshes = model_->GetMeshes();
+		for (size_t i = 0; i < meshes.size(); ++i)
+		{
+			if (i < materialSRVs_.size())
+			{
+				TextureManager::GetInstance()->SetGraphicsRootDescriptorTable(commandList, 2, materialSRVs_[i]);
+				material_.SetUsePointSampling(i < materialUsePointSampling_.size() ? materialUsePointSampling_[i] : false);
+				material_.Update();
+			}
+			meshes[i].DrawInstanced(static_cast<uint32_t>(worldMatrices.size()));
+		}
+		return meshes.size();
+	}
+
+
 	void Object3D::DrawInternal(const std::vector<size_t>* meshIndices)
 	{
 		if (!model_) { return; }

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3D.h
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3D.h
@@ -64,6 +64,7 @@ namespace Ken4lowEngine
 		void UpdateShadowMatrix(const Matrix4x4& lightViewProjection);
 		void DrawImGui();
 		void Draw();
+		size_t DrawInstanced(const std::vector<Matrix4x4>& worldMatrices);
 		void DrawMeshes(const std::vector<size_t>& meshIndices);
 		void DrawShadow();
 
@@ -113,6 +114,7 @@ namespace Ken4lowEngine
 		bool HasMeshWorldBounds(size_t meshIndex) const;
 		void DrawInternal(const std::vector<size_t>* meshIndices);
 		void DrawBoundsDebug(const BoundingSphere& bounds, bool visible) const;
+		void EnsureInstanceBufferCapacity(size_t instanceCount);
 
 	private: /// ---------- メンバ変数 ---------- ///
 
@@ -152,6 +154,10 @@ namespace Ken4lowEngine
 		D3D12_GPU_DESCRIPTOR_HANDLE dissolveMaskHandle_{};
 
 		// ディゾルブの設定
+		Microsoft::WRL::ComPtr<ID3D12Resource> instanceTransformResource_;
+		TransformationMatrix* instanceTransformData_ = nullptr;
+		size_t instanceTransformCapacity_ = 0;
+
 		Microsoft::WRL::ComPtr<ID3D12Resource> constantBuffer_;
 		DissolveSetting* dissolveSetting_ = nullptr;
 

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3DCommon.cpp
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3DCommon.cpp
@@ -84,6 +84,19 @@ namespace Ken4lowEngine
 		LightManager::GetInstance()->BindLightingSettings(11);
 	}
 
+	void Object3DCommon::SetInstancedRenderSetting()
+	{
+		auto* commandList = dxCommon_->GetCommandManager()->GetCommandList();
+		const PipelineBundle& pipeline = pipelineSet_.GetInstanced();
+
+		commandList->SetGraphicsRootSignature(pipeline.rootSignature.Get());
+		commandList->SetPipelineState(pipeline.pipelineState.Get());
+		commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
+
+		LightManager::GetInstance()->BindPunctualLights(5, 6);
+		LightManager::GetInstance()->BindLightingSettings(11);
+	}
+
 	bool Object3DCommon::ShouldDrawObject(const BoundingSphere& worldBounds, bool objectCullingEnabled, bool hasBounds, bool isStageObject)
 	{
 		const auto unit = isStageObject ? FrustumCullingSystem::CullingUnit::StageObject : FrustumCullingSystem::CullingUnit::Object;

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3DCommon.h
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3DCommon.h
@@ -31,6 +31,7 @@ namespace Ken4lowEngine
 	public: /// ---------- 描画設定関数 ---------- ///
 
 		void SetRenderSetting();
+		void SetInstancedRenderSetting();
 		void SetShadowMapRenderSetting();
 		bool ShouldDrawObject(const BoundingSphere& worldBounds, bool objectCullingEnabled, bool hasBounds, bool isStageObject = false);
 		bool ShouldDrawMesh(const BoundingSphere& worldBounds, bool objectCullingEnabled, bool hasBounds);

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3DPipelineSet.cpp
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3DPipelineSet.cpp
@@ -52,7 +52,8 @@ namespace Ken4lowEngine
 		D3D12_ROOT_SIGNATURE_DESC MakeObject3DRootSignatureDesc(
 			std::array<D3D12_DESCRIPTOR_RANGE, 5>& ranges,
 			std::array<D3D12_ROOT_PARAMETER, Object3DRootParameterIndex::kCount>& rootParameters,
-			std::array<D3D12_STATIC_SAMPLER_DESC, 3>& staticSamplers)
+			std::array<D3D12_STATIC_SAMPLER_DESC, 3>& staticSamplers,
+			bool instanced = false)
 		{
 			ranges[0] = {};
 			ranges[0].BaseShaderRegister = 0;
@@ -90,9 +91,9 @@ namespace Ken4lowEngine
 			rootParameters[kMaterialCBV].Descriptor.ShaderRegister = 0;
 
 			rootParameters[kTransformCBV] = {};
-			rootParameters[kTransformCBV].ParameterType = D3D12_ROOT_PARAMETER_TYPE_CBV;
+			rootParameters[kTransformCBV].ParameterType = instanced ? D3D12_ROOT_PARAMETER_TYPE_SRV : D3D12_ROOT_PARAMETER_TYPE_CBV;
 			rootParameters[kTransformCBV].ShaderVisibility = D3D12_SHADER_VISIBILITY_VERTEX;
-			rootParameters[kTransformCBV].Descriptor.ShaderRegister = 0;
+			rootParameters[kTransformCBV].Descriptor.ShaderRegister = instanced ? 5 : 0;
 
 			rootParameters[kBaseTextureSRV] = {};
 			rootParameters[kBaseTextureSRV].ParameterType = D3D12_ROOT_PARAMETER_TYPE_DESCRIPTOR_TABLE;
@@ -250,14 +251,17 @@ namespace Ken4lowEngine
 		inputLayout.NumElements = static_cast<UINT>(inputElements.size());
 
 		const ShaderDescriptor& objectVs = Object3DShaderManifest::Get(Object3DShaderId::Object3DVS);
+		const ShaderDescriptor& objectInstancedVs = Object3DShaderManifest::Get(Object3DShaderId::Object3DInstancedVS);
 		const ShaderDescriptor& objectPs = Object3DShaderManifest::Get(Object3DShaderId::Object3DPS);
 		const ShaderDescriptor& shadowVs = Object3DShaderManifest::Get(Object3DShaderId::ShadowMapVS);
 
 		assert(objectVs.stage == ShaderStage::Vertex);
+		assert(objectInstancedVs.stage == ShaderStage::Vertex);
 		assert(objectPs.stage == ShaderStage::Pixel);
 		assert(shadowVs.stage == ShaderStage::Vertex);
 
 		ComPtr<IDxcBlob> objectVsBlob = ShaderCompiler::CompileShader(objectVs, dxcManager);
+		ComPtr<IDxcBlob> objectInstancedVsBlob = ShaderCompiler::CompileShader(objectInstancedVs, dxcManager);
 		ComPtr<IDxcBlob> objectPsBlob = ShaderCompiler::CompileShader(objectPs, dxcManager);
 		ComPtr<IDxcBlob> shadowVsBlob = ShaderCompiler::CompileShader(shadowVs, dxcManager);
 
@@ -287,6 +291,25 @@ namespace Ken4lowEngine
 		}
 
 		{
+			std::array<D3D12_DESCRIPTOR_RANGE, 5> ranges{};
+			std::array<D3D12_ROOT_PARAMETER, Object3DRootParameterIndex::kCount> rootParameters{};
+			std::array<D3D12_STATIC_SAMPLER_DESC, 3> staticSamplers{};
+
+			D3D12_ROOT_SIGNATURE_DESC rootSigDesc =
+				MakeObject3DRootSignatureDesc(ranges, rootParameters, staticSamplers, true);
+
+			GraphicsPipelineDesc desc = MakeBaseObject3DDesc(rtvFormat, dsvFormat, inputLayout);
+			desc.debugName = L"Object3D.Instanced";
+			desc.shaders.vertexShader.blob = objectInstancedVsBlob;
+			desc.shaders.pixelShader.blob = objectPsBlob;
+
+			instancedPipeline_ = factory.CreateGraphicsPipeline(desc, rootSigDesc);
+
+			if (instancedPipeline_.rootSignature) instancedPipeline_.rootSignature->SetName(L"Object3D.Instanced.RootSignature");
+			if (instancedPipeline_.pipelineState) instancedPipeline_.pipelineState->SetName(L"Object3D.Instanced.PSO");
+		}
+
+		{
 			std::array<D3D12_ROOT_PARAMETER, 1> rootParameters{};
 			D3D12_ROOT_SIGNATURE_DESC rootSigDesc = MakeShadowRootSignatureDesc(rootParameters);
 
@@ -310,6 +333,7 @@ namespace Ken4lowEngine
 	void Object3DPipelineSet::Finalize()
 	{
 		defaultPipeline_.Reset();
+		instancedPipeline_.Reset();
 		shadowPipeline_.Reset();
 	}
 }

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3DPipelineSet.h
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3DPipelineSet.h
@@ -18,10 +18,12 @@ namespace Ken4lowEngine
 		void Finalize();
 
 		const PipelineBundle& GetDefault() const { return defaultPipeline_; }
+		const PipelineBundle& GetInstanced() const { return instancedPipeline_; }
 		const PipelineBundle& GetShadow() const { return shadowPipeline_; }
 
 	private:
 		PipelineBundle defaultPipeline_{};
+		PipelineBundle instancedPipeline_{};
 		PipelineBundle shadowPipeline_{};
 	};
 }

--- a/Project/Engine/Graphics/Shader/Manifest/Object3DShaderManifest.h
+++ b/Project/Engine/Graphics/Shader/Manifest/Object3DShaderManifest.h
@@ -11,6 +11,7 @@ namespace Ken4lowEngine
 	enum class Object3DShaderId : uint32_t
 	{
 		Object3DVS,
+		Object3DInstancedVS,
 		Object3DPS,
 		ShadowMapVS,
 	};
@@ -30,6 +31,18 @@ namespace Ken4lowEngine
 				static const ShaderDescriptor desc{
 					L"Object3DVS",
 					L"Resources/Shaders/Object3D/Object3D.VS.hlsl",
+					L"main",
+					L"vs_6_0",
+					ShaderStage::Vertex,
+					RootSignatureType::Object3D
+				};
+				return desc;
+			}
+			case Object3DShaderId::Object3DInstancedVS:
+			{
+				static const ShaderDescriptor desc{
+					L"Object3DInstancedVS",
+					L"Resources/Shaders/Object3D/Object3DInstanced.VS.hlsl",
 					L"main",
 					L"vs_6_0",
 					ShaderStage::Vertex,

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -606,6 +606,10 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
     </FxCompile>
+    <FxCompile Include="Resources\Shaders\Object3D\Object3DInstanced.VS.hlsl">
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
+      <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>
+    </FxCompile>
     <FxCompile Include="Resources\Shaders\Object3D\Object3d.VS.hlsl">
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">true</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">true</ExcludedFromBuild>

--- a/Project/Ken4lowEngine.vcxproj.filters
+++ b/Project/Ken4lowEngine.vcxproj.filters
@@ -37,6 +37,9 @@
     <FxCompile Include="Resources\Shaders\PostEffect\FullScreen.VS.hlsl">
       <Filter>Shader\VertexShader</Filter>
     </FxCompile>
+    <FxCompile Include="Resources\Shaders\Object3D\Object3DInstanced.VS.hlsl">
+      <Filter>Shader\VertexShader</Filter>
+    </FxCompile>
     <FxCompile Include="Resources\Shaders\Object3D\Object3d.VS.hlsl">
       <Filter>Shader\VertexShader</Filter>
     </FxCompile>

--- a/Project/Resources/Shaders/Object3D/Object3DInstanced.VS.hlsl
+++ b/Project/Resources/Shaders/Object3D/Object3DInstanced.VS.hlsl
@@ -1,0 +1,33 @@
+#include "Object3d.hlsli"
+#include "ShadowCommon.hlsli"
+
+struct TransformationMatrix
+{
+    float4x4 WVP;
+    float4x4 World;
+    float4x4 WorldInverseTranspose;
+};
+
+StructuredBuffer<TransformationMatrix> gInstanceTransforms : register(t5);
+ConstantBuffer<ShadowParameter> gShadowParameter : register(b4);
+
+struct VertexShaderInput
+{
+    float4 position : POSITION0;
+    float2 texcoord : TEXCOORD0;
+    float3 normal : NORMAL0;
+};
+
+VertexShaderOutput main(VertexShaderInput input, uint instanceId : SV_InstanceID)
+{
+    VertexShaderOutput output;
+    TransformationMatrix transform = gInstanceTransforms[instanceId];
+    float4 worldPosition = mul(input.position, transform.World);
+
+    output.position = mul(input.position, transform.WVP);
+    output.texcoord = input.texcoord;
+    output.normal = normalize(mul(input.normal, (float3x3) transform.WorldInverseTranspose));
+    output.worldPosition = worldPosition.xyz;
+    output.shadowPosition = mul(worldPosition, gShadowParameter.lightViewProjection);
+    return output;
+}


### PR DESCRIPTION
### Motivation
- Reduce DrawCall overhead during Stress Test by batching identical melee enemy body draws into GPU instanced draws. 
- Provide detailed per-enemy rendering and timing statistics to verify whether instancing actually reduces DrawCalls and CPU/GPU submit work. 
- Keep the existing non-stress/gameplay rendering paths unchanged and avoid double-drawing stress-test enemies. 

### Description
- Implemented GPU instancing by adding `Mesh::DrawInstanced(uint32_t)` and `Object3D::DrawInstanced(const std::vector<Matrix4x4>&)` which pack per-instance `TransformationMatrix` data into an instance buffer and call `DrawIndexedInstanced` per submesh. 
- Added an instanced vertex shader `Resources/Shaders/Object3D/Object3DInstanced.VS.hlsl` using `StructuredBuffer<TransformationMatrix>` and `SV_InstanceID`, and registered a dedicated instanced pipeline via `Object3DPipelineSet` and `Object3DCommon::SetInstancedRenderSetting()`. 
- Built a safe Stress Test instancing flow: `EnemyBase` now exposes `AppendStressTestInstanceWorldMatrix`, `DrawStressTestInstanced`, and an updated `DrawStressTestBatchProxy` so `DebugScene` can collect body world matrices and submit one instanced batch instead of per-enemy `Draw()` calls, while non-stress rendering remains unchanged. 
- Extended `DebugScene` ImGui stats and controls to show `Enemy Draw Call Count`, `Enemy Mesh Draw Count`, `Enemy Instance Count`, `Enemy Instanced Batch Count`, `Enemy Normal Draw Count`, `Enemy Shadow Draw Count`, `Enemy Draw Submit Time`, `Enemy CPU Update Time`, `Enemy Collision Time`, and `Enemy Transform Update Time`, and updated UI messaging for the instanced path. 

### Testing
- Ran a whitespace/diff check with `git diff --cached --check` and validated there were no newline/whitespace issues. (succeeded) 
- Parsed `Project/Ken4lowEngine.vcxproj` and `Project/Ken4lowEngine.vcxproj.filters` with Python's XML parser to ensure project XML remained valid after adding the instanced shader entry. (succeeded) 
- Executed Python assertions that verify presence of the new ImGui stats, instance matrix collection, `DrawIndexedInstanced` usage, structured-buffer usage in the shader, `SV_InstanceID` usage, and the required in-code comment. (succeeded) 
- Attempted to run a Windows solution build with `msbuild Project/Ken4lowEngine.sln /p:Configuration=Debug /p:Platform=x64`, but `msbuild` is not available in this Linux container so an in-container build could not be performed; runtime verification (FPS / RenderDoc/PIX capture) must be done on a Windows DX12 environment. (not executed in this environment)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d7da545b8832d8bcc997fdd1a3d2a)