### PR TITLE
Add enemy scalability stress test foundation

### DIFF
--- a/Project/ApplicationLayer/DebugTools/EnemyScalability/EnemyScalabilitySystem.cpp
+++ b/Project/ApplicationLayer/DebugTools/EnemyScalability/EnemyScalabilitySystem.cpp
@@ -1,0 +1,244 @@
+#include "EnemyScalabilitySystem.h"
+
+#include "Wireframe.h"
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+
+namespace Ken4lowEngine
+{
+	namespace
+	{
+		using Clock = std::chrono::steady_clock;
+
+		float ToMilliseconds(const Clock::time_point& begin, const Clock::time_point& end)
+		{
+			return std::chrono::duration<float, std::milli>(end - begin).count();
+		}
+
+		float LengthXZ(const Vector3& value)
+		{
+			return std::sqrt(value.x * value.x + value.z * value.z);
+		}
+	}
+
+	void EnemyScalabilitySystem::ApplyStressTestCounts(uint32_t meleeEnemyCount, uint32_t midRangeEnemyCount)
+	{
+		Clear();
+		enemies_.reserve(static_cast<size_t>(meleeEnemyCount) + midRangeEnemyCount);
+		meleeEnemyInstanceData_.reserve(meleeEnemyCount);
+		midRangeEnemyInstanceData_.reserve(midRangeEnemyCount);
+		for (uint32_t index = 0; index < meleeEnemyCount; ++index)
+		{
+			SpawnEnemy(index, ScalableEnemyType::Melee);
+		}
+		for (uint32_t index = 0; index < midRangeEnemyCount; ++index)
+		{
+			SpawnEnemy(meleeEnemyCount + index, ScalableEnemyType::MidRange);
+		}
+		RebuildInstanceData();
+	}
+
+	void EnemyScalabilitySystem::Clear()
+	{
+		enemies_.clear();
+		meleeEnemyInstanceData_.clear();
+		midRangeEnemyInstanceData_.clear();
+		metrics_ = {};
+	}
+
+	void EnemyScalabilitySystem::SpawnEnemy(uint32_t spawnIndex, ScalableEnemyType enemyType)
+	{
+		constexpr float goldenAngle = 2.39996323f;
+		const float angle = goldenAngle * static_cast<float>(spawnIndex);
+		const float radius = 8.0f + std::sqrt(static_cast<float>(spawnIndex)) * 2.25f;
+
+		ScalableEnemyData enemy{};
+		enemy.position = { std::cos(angle) * radius, 1.0f, 24.0f + std::sin(angle) * radius };
+		enemy.rotation = { 0.0f, angle + 3.14159265f, 0.0f };
+		enemy.scale = enemyType == ScalableEnemyType::Melee ? Vector3{ 0.75f, 0.75f, 0.75f } : Vector3{ 0.9f, 0.9f, 0.9f };
+		enemy.enemyType = enemyType;
+		enemy.state = ScalableEnemyState::Moving;
+		enemy.hp = enemyType == ScalableEnemyType::Melee ? 100.0f : 80.0f;
+		enemy.updateGroupId = spawnIndex;
+		enemies_.push_back(enemy);
+	}
+
+	void EnemyScalabilitySystem::Update(float deltaTime, const Vector3& playerPosition)
+	{
+		const Clock::time_point updateBegin = Clock::now();
+		++frameCount_;
+		metrics_.updatedEnemyCountThisFrame = 0;
+		metrics_.skippedEnemyCountThisFrame = 0;
+
+		for (ScalableEnemyData& enemy : enemies_)
+		{
+			if (!enemy.isActive)
+			{
+				++metrics_.skippedEnemyCountThisFrame;
+				continue;
+			}
+
+			const Vector3 playerOffset = playerPosition - enemy.position;
+			enemy.distanceToPlayer = LengthXZ(playerOffset);
+			const uint32_t updateInterval = GetUpdateInterval(enemy);
+			// 大量敵の負荷を抑えるため、距離と updateGroupId に応じて更新頻度と更新フレームを分散する。
+			if (updateInterval == 0)
+			{
+				enemy.velocity = {};
+				enemy.state = ScalableEnemyState::Dormant;
+				++metrics_.skippedEnemyCountThisFrame;
+				continue;
+			}
+			if ((enemy.updateGroupId + frameCount_) % updateInterval != 0)
+			{
+				++metrics_.skippedEnemyCountThisFrame;
+				continue;
+			}
+
+			UpdateEnemy(enemy, deltaTime * static_cast<float>(updateInterval), playerPosition);
+			++metrics_.updatedEnemyCountThisFrame;
+		}
+		metrics_.enemyUpdateTimeMs = ToMilliseconds(updateBegin, Clock::now());
+
+		const Clock::time_point collisionBegin = Clock::now();
+		UpdateSimpleCollisions(playerPosition);
+		metrics_.enemyCollisionTimeMs = ToMilliseconds(collisionBegin, Clock::now());
+
+		const Clock::time_point drawSubmitBegin = Clock::now();
+		RebuildInstanceData();
+		metrics_.enemyDrawSubmitTimeMs = ToMilliseconds(drawSubmitBegin, Clock::now());
+	}
+
+	uint32_t EnemyScalabilitySystem::GetUpdateInterval(const ScalableEnemyData& enemy) const
+	{
+		if (!updateLodSettings_.useEnemyUpdateLod)
+		{
+			return 1;
+		}
+		if (enemy.distanceToPlayer <= updateLodSettings_.nearUpdateDistance)
+		{
+			return std::max(updateLodSettings_.nearUpdateInterval, 1u);
+		}
+		if (enemy.distanceToPlayer <= updateLodSettings_.midUpdateDistance)
+		{
+			return std::max(updateLodSettings_.midUpdateInterval, 1u);
+		}
+		if (enemy.distanceToPlayer <= updateLodSettings_.farUpdateDistance)
+		{
+			return std::max(updateLodSettings_.farUpdateInterval, 1u);
+		}
+		return 0; // 遠すぎる敵は停止し、描画バッチからも除外する。
+	}
+
+	void EnemyScalabilitySystem::UpdateEnemy(ScalableEnemyData& enemy, float deltaTime, const Vector3& playerPosition)
+	{
+		Vector3 direction = playerPosition - enemy.position;
+		direction.y = 0.0f;
+		const float distance = LengthXZ(direction);
+		if (distance <= 0.001f)
+		{
+			enemy.velocity = {};
+			enemy.state = ScalableEnemyState::Idle;
+			return;
+		}
+
+		const float inverseDistance = 1.0f / distance;
+		direction.x *= inverseDistance;
+		direction.z *= inverseDistance;
+		const float speed = enemy.enemyType == ScalableEnemyType::Melee ? 1.5f : 0.8f;
+		enemy.velocity = direction * speed;
+		enemy.position += enemy.velocity * deltaTime;
+		enemy.rotation.y = std::atan2(direction.x, direction.z);
+		enemy.state = ScalableEnemyState::Moving;
+	}
+
+	void EnemyScalabilitySystem::UpdateSimpleCollisions(const Vector3& playerPosition)
+	{
+		metrics_.collisionCheckCount = 0;
+		if (!useSimpleCollision_)
+		{
+			return;
+		}
+
+		// 判定をこの関数へ隔離し、次段階で Spatial Hash / Uniform Grid の候補抽出へ置き換えやすくする。
+		constexpr float playerCollisionRadius = 1.0f;
+		constexpr float enemyCollisionRadius = 0.6f;
+		const float collisionDistance = playerCollisionRadius + enemyCollisionRadius;
+		const float collisionDistanceSquared = collisionDistance * collisionDistance;
+		for (ScalableEnemyData& enemy : enemies_)
+		{
+			if (!enemy.isActive || enemy.distanceToPlayer > updateLodSettings_.nearUpdateDistance)
+			{
+				continue;
+			}
+			++metrics_.collisionCheckCount;
+			Vector3 offset = enemy.position - playerPosition;
+			offset.y = 0.0f;
+			const float distanceSquared = offset.x * offset.x + offset.z * offset.z;
+			if (distanceSquared > 0.0001f && distanceSquared < collisionDistanceSquared)
+			{
+				const float scale = collisionDistance / std::sqrt(distanceSquared);
+				enemy.position.x = playerPosition.x + offset.x * scale;
+				enemy.position.z = playerPosition.z + offset.z * scale;
+			}
+		}
+	}
+
+	void EnemyScalabilitySystem::RebuildInstanceData()
+	{
+		meleeEnemyInstanceData_.clear();
+		midRangeEnemyInstanceData_.clear();
+		metrics_.meleeEnemyCount = 0;
+		metrics_.midRangeEnemyCount = 0;
+
+		for (uint32_t index = 0; index < enemies_.size(); ++index)
+		{
+			const ScalableEnemyData& enemy = enemies_[index];
+			if (!enemy.isActive)
+			{
+				continue;
+			}
+			if (enemy.enemyType == ScalableEnemyType::Melee)
+			{
+				++metrics_.meleeEnemyCount;
+			}
+			else
+			{
+				++metrics_.midRangeEnemyCount;
+			}
+			if (enemy.distanceToPlayer > updateLodSettings_.farUpdateDistance)
+			{
+				continue;
+			}
+
+			EnemyInstanceData instance{};
+			instance.worldMatrix = Matrix4x4::MakeAffineMatrix(enemy.scale, enemy.rotation, enemy.position);
+			instance.enemyIndex = index;
+			auto& instances = enemy.enemyType == ScalableEnemyType::Melee ? meleeEnemyInstanceData_ : midRangeEnemyInstanceData_;
+			instances.push_back(instance);
+		}
+		metrics_.totalEnemyCount = static_cast<uint32_t>(enemies_.size());
+		metrics_.drawEnemyCount = static_cast<uint32_t>(meleeEnemyInstanceData_.size() + midRangeEnemyInstanceData_.size());
+	}
+
+	void EnemyScalabilitySystem::DrawDebugInstances() const
+	{
+		if (!enemyDebugDraw_)
+		{
+			return;
+		}
+		for (const ScalableEnemyData& enemy : enemies_)
+		{
+			if (!enemy.isActive || enemy.distanceToPlayer > updateLodSettings_.farUpdateDistance)
+			{
+				continue;
+			}
+			const Vector4 color = enemy.enemyType == ScalableEnemyType::Melee
+				? Vector4{ 1.0f, 0.25f, 0.15f, 0.8f }
+				: Vector4{ 0.25f, 0.55f, 1.0f, 0.8f };
+			Wireframe::GetInstance()->DrawSphere(enemy.position, 0.6f, color);
+		}
+	}
+}

--- a/Project/ApplicationLayer/DebugTools/EnemyScalability/EnemyScalabilitySystem.h
+++ b/Project/ApplicationLayer/DebugTools/EnemyScalability/EnemyScalabilitySystem.h
@@ -1,0 +1,107 @@
+#pragma once
+
+#include "Matrix4x4.h"
+#include "Vector3.h"
+
+#include <cstdint>
+#include <vector>
+
+namespace Ken4lowEngine
+{
+	enum class ScalableEnemyType : uint8_t
+	{
+		Melee,
+		MidRange,
+	};
+
+	enum class ScalableEnemyState : uint8_t
+	{
+		Idle,
+		Moving,
+		Dormant,
+	};
+
+	/// StressTest 専用の軽量敵データ。通常 Enemy の AI、攻撃、ナビゲーション、描画オブジェクトは所有しない。
+	struct ScalableEnemyData
+	{
+		Vector3 position{};
+		Vector3 rotation{};
+		Vector3 scale{ 1.0f, 1.0f, 1.0f };
+		Vector3 velocity{};
+		ScalableEnemyType enemyType = ScalableEnemyType::Melee;
+		ScalableEnemyState state = ScalableEnemyState::Idle;
+		float hp = 100.0f;
+		bool isActive = true;
+		uint32_t updateGroupId = 0;
+		float distanceToPlayer = 0.0f;
+	};
+
+	/// DrawIndexedInstanced へ移行するときに、そのまま GPU 転送元として使う描画単位。
+	struct EnemyInstanceData
+	{
+		Matrix4x4 worldMatrix = Matrix4x4::MakeIdentity();
+		uint32_t enemyIndex = 0;
+	};
+
+	struct EnemyUpdateLodSettings
+	{
+		bool useEnemyUpdateLod = true;
+		float nearUpdateDistance = 20.0f;
+		float midUpdateDistance = 50.0f;
+		float farUpdateDistance = 100.0f;
+		uint32_t nearUpdateInterval = 1;
+		uint32_t midUpdateInterval = 4;
+		uint32_t farUpdateInterval = 12;
+	};
+
+	struct EnemyScalabilityMetrics
+	{
+		uint32_t totalEnemyCount = 0;
+		uint32_t meleeEnemyCount = 0;
+		uint32_t midRangeEnemyCount = 0;
+		uint32_t updatedEnemyCountThisFrame = 0;
+		uint32_t skippedEnemyCountThisFrame = 0;
+		uint32_t drawEnemyCount = 0;
+		uint32_t collisionCheckCount = 0;
+		float enemyUpdateTimeMs = 0.0f;
+		float enemyDrawSubmitTimeMs = 0.0f;
+		float enemyCollisionTimeMs = 0.0f;
+	};
+
+	/// 大量敵の検証データを通常 Enemy と分離し、更新 LOD・簡易衝突・描画バッチを一括管理する。
+	class EnemyScalabilitySystem
+	{
+	public:
+		void Update(float deltaTime, const Vector3& playerPosition);
+		void Clear();
+		void ApplyStressTestCounts(uint32_t meleeEnemyCount, uint32_t midRangeEnemyCount);
+		void DrawDebugInstances() const;
+
+		EnemyUpdateLodSettings& GetUpdateLodSettings() { return updateLodSettings_; }
+		const EnemyScalabilityMetrics& GetMetrics() const { return metrics_; }
+		const std::vector<ScalableEnemyData>& GetEnemies() const { return enemies_; }
+		const std::vector<EnemyInstanceData>& GetMeleeEnemyInstanceData() const { return meleeEnemyInstanceData_; }
+		const std::vector<EnemyInstanceData>& GetMidRangeEnemyInstanceData() const { return midRangeEnemyInstanceData_; }
+
+		bool IsSimpleCollisionEnabled() const { return useSimpleCollision_; }
+		void SetSimpleCollisionEnabled(bool enabled) { useSimpleCollision_ = enabled; }
+		bool IsEnemyDebugDrawEnabled() const { return enemyDebugDraw_; }
+		void SetEnemyDebugDrawEnabled(bool enabled) { enemyDebugDraw_ = enabled; }
+
+	private:
+		void SpawnEnemy(uint32_t spawnIndex, ScalableEnemyType enemyType);
+		uint32_t GetUpdateInterval(const ScalableEnemyData& enemy) const;
+		void UpdateEnemy(ScalableEnemyData& enemy, float deltaTime, const Vector3& playerPosition);
+		void UpdateSimpleCollisions(const Vector3& playerPosition);
+		void RebuildInstanceData();
+
+		std::vector<ScalableEnemyData> enemies_{};
+		std::vector<EnemyInstanceData> meleeEnemyInstanceData_{};
+		std::vector<EnemyInstanceData> midRangeEnemyInstanceData_{};
+		EnemyUpdateLodSettings updateLodSettings_{};
+		EnemyScalabilityMetrics metrics_{};
+		uint64_t frameCount_ = 0;
+		bool useSimpleCollision_ = false;
+		bool enemyDebugDraw_ = false;
+	};
+}

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.cpp
@@ -265,6 +265,8 @@ void DebugScene::Update()
 		debugMidRangeEnemy_->Update(deltaTime);
 	}
 
+	enemyScalabilitySystem_.Update(deltaTime, meleeDummyTarget_.GetCenterPosition());
+
 	UpdateDebugBossHitTest();
 
 	UpdateDebugParticleTest();
@@ -344,7 +346,7 @@ void DebugScene::Draw3DObjects()
 	{
 		stage_->Draw();
 		// Stage Debugの茶色ワイヤーはNavigation/Wall用AABBではなくCollider由来OBBで描画する。
-		for (const auto& obstacleObb : stage_->GetWallObstacleOBBs())
+		if (stageBoundsDebugDraw_) for (const auto& obstacleObb : stage_->GetWallObstacleOBBs())
 		{
 			Wireframe::GetInstance()->DrawOBB(obstacleObb, { 0.60f, 0.35f, 0.12f, 0.90f });
 		}
@@ -361,10 +363,11 @@ void DebugScene::Draw3DObjects()
 		Wireframe::GetInstance()->DrawLine(c + Vector3{ 0.0f, -0.2f, 0.0f }, c + Vector3{ 0.0f, 0.2f, 0.0f }, { 0.8f, 1.0f, 0.2f, 1.0f });
 		Wireframe::GetInstance()->DrawLine(c + Vector3{ 0.0f, 0.0f, -0.2f }, c + Vector3{ 0.0f, 0.0f, 0.2f }, { 0.8f, 1.0f, 0.2f, 1.0f });
 	}
-	if (frustumCullingDebug_)
+	if (frustumCullingDebug_ && frustumCullingDebugDraw_)
 	{
 		frustumCullingDebug_->DrawDebug();
 	}
+	enemyScalabilitySystem_.DrawDebugInstances();
 
 	collisionManager_->Draw();
 #endif // _DEBUG
@@ -381,7 +384,7 @@ void DebugScene::DrawShadowObjects()
 	{
 		debugBoss_->DrawShadow();
 	}
-	if (debugMeleeEnemy_)
+	if (debugMeleeEnemy_ && enemyShadowEnabled_)
 	{
 		debugMeleeEnemy_->DrawShadow();
 	}
@@ -431,12 +434,85 @@ void DebugScene::Finalize()
 	dxCommon_ = nullptr;
 }
 
+void DebugScene::DrawEnemyStressTestImGui()
+{
+#ifdef USE_IMGUI
+	K4E::EnemyUpdateLodSettings& settings = enemyScalabilitySystem_.GetUpdateLodSettings();
+	const K4E::EnemyScalabilityMetrics& metrics = enemyScalabilitySystem_.GetMetrics();
+	bool useSimpleCollision = enemyScalabilitySystem_.IsSimpleCollisionEnabled();
+	bool enemyDebugDraw = enemyScalabilitySystem_.IsEnemyDebugDrawEnabled();
+
+	ImGui::Begin("Enemy Stress Test");
+	ImGui::TextWrapped("StressTest enemies use lightweight data only. Normal enemies and the boss remain managed by their existing classes.");
+	ImGui::InputInt("Melee Enemy Count", &stressTestMeleeEnemyCount_);
+	ImGui::InputInt("MidRange Enemy Count", &stressTestMidRangeEnemyCount_);
+	stressTestMeleeEnemyCount_ = std::clamp(stressTestMeleeEnemyCount_, 0, 10000);
+	stressTestMidRangeEnemyCount_ = std::clamp(stressTestMidRangeEnemyCount_, 0, 10000);
+	if (ImGui::Button("Apply"))
+	{
+		enemyScalabilitySystem_.ApplyStressTestCounts(
+			static_cast<uint32_t>(stressTestMeleeEnemyCount_),
+			static_cast<uint32_t>(stressTestMidRangeEnemyCount_));
+		// StressTest 中は大量描画を避けるため、重いデバッグ表示と敵シャドウを既定で無効化する。
+		enemyScalabilitySystem_.SetEnemyDebugDrawEnabled(false);
+		stageBoundsDebugDraw_ = false;
+		frustumCullingDebugDraw_ = false;
+		meleeDummyWireVisible_ = false;
+		enemyShadowEnabled_ = false;
+	}
+	ImGui::SameLine();
+	if (ImGui::Button("Clear"))
+	{
+		enemyScalabilitySystem_.Clear();
+	}
+
+	ImGui::SeparatorText("Update LOD");
+	ImGui::Checkbox("Use Enemy Update LOD", &settings.useEnemyUpdateLod);
+	ImGui::DragFloat("Near Update Distance", &settings.nearUpdateDistance, 1.0f, 0.0f, 1000.0f);
+	ImGui::DragFloat("Mid Update Distance", &settings.midUpdateDistance, 1.0f, settings.nearUpdateDistance, 2000.0f);
+	ImGui::DragFloat("Far Update Distance", &settings.farUpdateDistance, 1.0f, settings.midUpdateDistance, 4000.0f);
+	int nearInterval = static_cast<int>(settings.nearUpdateInterval);
+	int midInterval = static_cast<int>(settings.midUpdateInterval);
+	int farInterval = static_cast<int>(settings.farUpdateInterval);
+	ImGui::DragInt("Near Update Interval", &nearInterval, 1.0f, 1, 120);
+	ImGui::DragInt("Mid Update Interval", &midInterval, 1.0f, 1, 120);
+	ImGui::DragInt("Far Update Interval", &farInterval, 1.0f, 1, 120);
+	settings.nearUpdateInterval = static_cast<uint32_t>(std::max(nearInterval, 1));
+	settings.midUpdateInterval = static_cast<uint32_t>(std::max(midInterval, 1));
+	settings.farUpdateInterval = static_cast<uint32_t>(std::max(farInterval, 1));
+
+	ImGui::SeparatorText("Collision and Debug Draw");
+	if (ImGui::Checkbox("Simple Collision", &useSimpleCollision)) enemyScalabilitySystem_.SetSimpleCollisionEnabled(useSimpleCollision);
+	if (ImGui::Checkbox("Enemy Debug Draw", &enemyDebugDraw)) enemyScalabilitySystem_.SetEnemyDebugDrawEnabled(enemyDebugDraw);
+	ImGui::Checkbox("Stage Bounds Debug Draw", &stageBoundsDebugDraw_);
+	ImGui::Checkbox("Frustum Culling Debug Draw", &frustumCullingDebugDraw_);
+	ImGui::Checkbox("Dummy Target Wire Draw", &meleeDummyWireVisible_);
+	ImGui::Checkbox("Enemy Shadow", &enemyShadowEnabled_);
+
+	ImGui::SeparatorText("Metrics");
+	ImGui::Text("Total Enemy Count: %u", metrics.totalEnemyCount);
+	ImGui::Text("Melee Enemy Count: %u", metrics.meleeEnemyCount);
+	ImGui::Text("MidRange Enemy Count: %u", metrics.midRangeEnemyCount);
+	ImGui::Text("Updated Enemy Count This Frame: %u", metrics.updatedEnemyCountThisFrame);
+	ImGui::Text("Skipped Enemy Count This Frame: %u", metrics.skippedEnemyCountThisFrame);
+	ImGui::Text("Draw Enemy Count: %u", metrics.drawEnemyCount);
+	ImGui::Text("Collision Check Count: %u", metrics.collisionCheckCount);
+	ImGui::Text("FPS: %.1f", ImGui::GetIO().Framerate);
+	ImGui::Text("FrameTime: %.3f ms", ImGui::GetIO().DeltaTime * 1000.0f);
+	ImGui::Text("Enemy Update Time: %.3f ms", metrics.enemyUpdateTimeMs);
+	ImGui::Text("Enemy Draw Submit Time: %.3f ms", metrics.enemyDrawSubmitTimeMs);
+	ImGui::Text("Enemy Collision Time: %.3f ms", metrics.enemyCollisionTimeMs);
+	ImGui::End();
+#endif // USE_IMGUI
+}
+
 void DebugScene::DrawImGui()
 {
 #ifdef USE_IMGUI
 
 	LightManager::GetInstance()->DrawImGui();
 	DrawSkyBoxImGui();
+	DrawEnemyStressTestImGui();
 
 	if (debugBoss_)
 	{

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
@@ -9,6 +9,7 @@
 #include "Derived/GuardianBoss/GuardianBoss.h"
 #include "DisintegrationDebugController.h"
 #include "ApplicationLayer/DebugTools/FrustumCulling/FrustumCullingDebugController.h"
+#include "ApplicationLayer/DebugTools/EnemyScalability/EnemyScalabilitySystem.h"
 #include "Vector3.h"
 #include "Vector4.h"
 #include "Stage.h"
@@ -81,6 +82,7 @@ private: /// ---------- メンバ関数 ---------- ///
 	bool LoadSkyBoxPresets();
 	bool SaveSkyBoxPresets();
 	void DrawSkyBoxImGui();
+	void DrawEnemyStressTestImGui();
 
 	/// -------------------------------------------------------------
 	/// BossHitPart を文字列へ変換
@@ -123,6 +125,14 @@ private: /// ---------- メンバ変数 ---------- ///
 	std::unique_ptr<DisintegrationDebugController> disintegrationDebug_;
 
 	std::unique_ptr<FrustumCullingDebugController> frustumCullingDebug_;
+
+	// 通常 Enemy と混在させない StressTest 専用の軽量敵管理。
+	K4E::EnemyScalabilitySystem enemyScalabilitySystem_{};
+	int stressTestMeleeEnemyCount_ = 100;
+	int stressTestMidRangeEnemyCount_ = 100;
+	bool stageBoundsDebugDraw_ = true;
+	bool frustumCullingDebugDraw_ = true;
+	bool enemyShadowEnabled_ = true;
 
 	// Frustum Culling の挙動確認用 Object3D 群
 	std::vector<std::unique_ptr<K4E::Object3D>> cullingTestObjects_;

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -159,6 +159,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</ExcludedFromBuild>
     </ClCompile>
+    <ClCompile Include="ApplicationLayer\DebugTools\EnemyScalability\EnemyScalabilitySystem.cpp" />
     <ClCompile Include="ApplicationLayer\Scene\DebugScene\DebugScene.cpp" />
     <ClCompile Include="ApplicationLayer\Scene\DebugScene\DisintegrationDebugController.cpp" />
     <ClCompile Include="ApplicationLayer\Character\BaseCharacter\BaseCharacter.cpp">
@@ -749,6 +750,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">false</ExcludedFromBuild>
       <ExcludedFromBuild Condition="'$(Configuration)|$(Platform)'=='Release|x64'">false</ExcludedFromBuild>
     </ClInclude>
+    <ClInclude Include="ApplicationLayer\DebugTools\EnemyScalability\EnemyScalabilitySystem.h" />
     <ClInclude Include="ApplicationLayer\Scene\DebugScene\DebugScene.h" />
     <ClInclude Include="ApplicationLayer\Scene\DebugScene\DisintegrationDebugController.h" />
     <ClInclude Include="ApplicationLayer\Character\BaseCharacter\BaseCharacter.h">

--- a/Project/Ken4lowEngine.vcxproj.filters
+++ b/Project/Ken4lowEngine.vcxproj.filters
@@ -217,6 +217,9 @@
     <ClCompile Include="ApplicationLayer\EffectLayer\BossEnemyVfx.cpp">
       <Filter>ApplicationLayer\EffectLayer</Filter>
     </ClCompile>
+    <ClCompile Include="ApplicationLayer\DebugTools\EnemyScalability\EnemyScalabilitySystem.cpp">
+      <Filter>ApplicationLayer\DebugTools</Filter>
+    </ClCompile>
     <ClCompile Include="ApplicationLayer\Scene\DebugScene\DebugScene.cpp">
       <Filter>ApplicationLayer\Scene\DebugScene</Filter>
     </ClCompile>
@@ -1046,6 +1049,9 @@
     </ClInclude>
     <ClInclude Include="ApplicationLayer\EffectLayer\BossEnemyVfx.h">
       <Filter>ApplicationLayer\EffectLayer</Filter>
+    </ClInclude>
+    <ClInclude Include="ApplicationLayer\DebugTools\EnemyScalability\EnemyScalabilitySystem.h">
+      <Filter>ApplicationLayer\DebugTools</Filter>
     </ClInclude>
     <ClInclude Include="ApplicationLayer\Scene\DebugScene\DebugScene.h">
       <Filter>ApplicationLayer\Scene\DebugScene</Filter>


### PR DESCRIPTION
### Motivation
- 大量の近接／中距離雑魚を扱うために、既存の `Enemy` クラスをそのまま大量生成せずに軽量データ層で検証できる土台を作るため。 
- UE5 の Mass/Instancing/LOD/Culling の考え方を参考に、距離に応じた更新頻度と描画バッチ化の準備を行うため。 
- まずは StressTest 用の独立レーン（通常の敵やボスと混ざらない）で 100〜1000 体規模の計測ができるようにするため。 

### Description
- `Project/ApplicationLayer/DebugTools/EnemyScalability/EnemyScalabilitySystem.h` と `EnemyScalabilitySystem.cpp` を追加し、`ScalableEnemyData`（位置／回転／スケール／速度／型／状態／HP／Active／updateGroupId／距離）と `EnemyInstanceData`（World 行列＋インデックス）を定義しました。 
- 距離ベースの更新 LOD 構成を `EnemyUpdateLodSettings` として実装し、`(updateGroupId + frameCount) % updateInterval` による更新フレーム分散を導入しました。 
- 近距離のみ簡易衝突（球判定）を行う `UpdateSimpleCollisions` を実装し、将来的に Spatial Hash / Uniform Grid へ置換しやすい形で候補抽出を隔離しました。 
- 描画準備として近接用／中距離用で型別の `EnemyInstanceData` 配列を再構築する `RebuildInstanceData` を実装し、将来の `DrawIndexedInstanced` 移行に備えました。 
- `DebugScene` に `Enemy Stress Test` の ImGui パネルを追加し、`Melee/MidRange` 数の `Apply`/`Clear`、LOD パラメータ、`Simple Collision`、デバッグ描画やシャドウのトグル、各種計測値を表示する UI を統合しました（既存の通常敵/ボスの経路を壊さない形で統合）。 
- Visual Studio プロジェクトファイル（`Project/Ken4lowEngine.vcxproj` と `.filters`）へ新規ファイルを登録しました。 

### Testing
- リポジトリ差分チェックのために `git diff --check` と `git diff --cached --check` を実行して差分整合を確認し問題ありませんでした。 
- 新規システムの構文チェックを `clang++ -std=c++20 -fsyntax-only` で行いエラー無しを確認しました。 
- Linux 環境での軽量スモークテストとして、描画/行列の簡易スタブを用いて `/tmp/k4e-stubs/enemy_scalability_smoke` をビルド・実行し、`ApplyStressTestCounts(100,50)`、型別 `InstanceData`、分散更新、`Simple Collision`、`Clear` の挙動を確認しました（実行成功）。 
- `Project/Ken4lowEngine.vcxproj` と `Project/Ken4lowEngine.vcxproj.filters` を Python `xml.etree.ElementTree` でパースして XML 整合性を確認しました。 
- 注記: この Linux コンテナには `dotnet` / MSBuild / Windows SDK / Visual Studio v143 ツールチェーンが無いため、ソリューション全体の Visual Studio ビルド（`dotnet msbuild`）は実行できませんでしたが、該当ソースはプロジェクトへ登録済みです。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e2da18440832daaf3d3d25da42d28)