### PR TITLE
Add EnemyFactory and EnemyType to enable Melee/MidRange wave spawning

### DIFF
--- a/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.cpp
+++ b/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.cpp
@@ -1,6 +1,10 @@
 #include "CharacterWorld.h"
 #include "CollisionManager.h"
 #include "BulletManager.h"
+#include "EnemyFactory.h"
+#include "Enemy.h"
+#include "MeleeEnemy.h"
+#include "MidRangeEnemy.h"
 #include <algorithm>
 
 #ifdef USE_IMGUI
@@ -74,16 +78,27 @@ void CharacterWorld::InjectPlayerDeps(Player& p)
 		});
 }
 
-void CharacterWorld::InjectEnemyDeps(Enemy& e)
+void CharacterWorld::InjectEnemyDeps(EnemyBase& e)
 {
-	e.SetCollisionManager(ctx_.collisionManager_);
-	e.SetBulletManager(ctx_.bulletManager_);
-
-	e.SetParticleEffectSystem(&enemyParticleEffectSystem_);
-
-	if (player_)
+	// MidRangeEnemy固有パーティクルは復活させず、既存方針を維持する。
+	if (dynamic_cast<MidRangeEnemy*>(&e) == nullptr)
 	{
-		e.SetTarget(player_.get());
+		e.SetParticleEffectSystem(&enemyParticleEffectSystem_);
+	}
+
+	if (auto* legacyEnemy = dynamic_cast<Enemy*>(&e))
+	{
+		legacyEnemy->SetCollisionManager(ctx_.collisionManager_);
+		legacyEnemy->SetBulletManager(ctx_.bulletManager_);
+		if (player_) { legacyEnemy->SetTarget(player_.get()); }
+	}
+	else if (auto* meleeEnemy = dynamic_cast<MeleeEnemy*>(&e))
+	{
+		if (player_) { meleeEnemy->SetTarget(player_.get()); }
+	}
+	else if (auto* midRangeEnemy = dynamic_cast<MidRangeEnemy*>(&e))
+	{
+		if (player_) { midRangeEnemy->SetTarget(player_.get()); }
 	}
 }
 
@@ -100,9 +115,10 @@ std::vector<EnemyBase*> CharacterWorld::GetEnemyRawList() const
 	return result;
 }
 
-Enemy& CharacterWorld::SpawnEnemy(const EnemySpawnRequest& request)
+EnemyBase& CharacterWorld::SpawnEnemy(const EnemySpawnRequest& request)
 {
-	auto e = std::make_unique<Enemy>();
+	// 通常ゲームでも近接・中距離雑魚敵を生成できるよう、EnemyFactory経由で敵を作成する。
+	auto e = EnemyFactory::Create(request.enemyType);
 	InjectEnemyDeps(*e);
 	e->Initialize();
 	e->SetPosition(request.position);
@@ -116,10 +132,11 @@ Enemy& CharacterWorld::SpawnEnemy(const EnemySpawnRequest& request)
 	return *enemies_.back();
 }
 
-Enemy& CharacterWorld::SpawnEnemyAt(const K4E::Vector3& position)
+EnemyBase& CharacterWorld::SpawnEnemyAt(const K4E::Vector3& position, EnemyType enemyType)
 {
 	EnemySpawnRequest request{};
 	request.position = position;
+	request.enemyType = enemyType;
 	return SpawnEnemy(request);
 }
 
@@ -161,7 +178,7 @@ void CharacterWorld::Update(float dt)
 	{
 		enemies_.erase(
 			std::remove_if(enemies_.begin(), enemies_.end(),
-				[&](const std::unique_ptr<Enemy>& e)
+				[&](const std::unique_ptr<EnemyBase>& e)
 				{
 					if (e && e->IsRemovable())
 					{

--- a/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.h
+++ b/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.h
@@ -6,7 +6,8 @@
 #include <unordered_set>
 
 #include "Player.h"
-#include "Enemy.h"
+#include "EnemyBase.h"
+#include "EnemyType.h"
 #include "EnemyParticleEffectSystem.h"
 
 // 前方宣言
@@ -33,6 +34,7 @@ private: /// ---------- 構造体 ---------- ///
 		K4E::Vector3 position = {};
 		float yawRad = 0.0f;
 		float maxHp = 240.0f;
+		EnemyType enemyType = EnemyType::Legacy;
 	};
 
 public: /// ---------- メンバ関数 ---------- ///
@@ -55,14 +57,14 @@ public: /// ---------- メンバ関数 ---------- ///
 
 	Player* GetPlayer() { return player_.get(); }
 	const Player* GetPlayer() const { return player_.get(); }
-	const std::vector<std::unique_ptr<Enemy>>& GetEnemies() const { return enemies_; }
+	const std::vector<std::unique_ptr<EnemyBase>>& GetEnemies() const { return enemies_; }
 
 	// HPバーやロックオンみたいな「EnemyBase* 配列」が欲しい処理用
 	std::vector<EnemyBase*> GetEnemyRawList() const;
 
 	// 生成
-	Enemy& SpawnEnemy(const EnemySpawnRequest& request);
-	Enemy& SpawnEnemyAt(const K4E::Vector3& position);
+	EnemyBase& SpawnEnemy(const EnemySpawnRequest& request);
+	EnemyBase& SpawnEnemyAt(const K4E::Vector3& position, EnemyType enemyType = EnemyType::Legacy);
 
 	// 全消し
 	void ClearEnemies();
@@ -78,19 +80,19 @@ public: /// ---------- デバッグ用 ---------- ///
 private: /// ---------- 内部処理 ---------- ///
 
 	void InjectPlayerDeps(Player& p);
-	void InjectEnemyDeps(Enemy& e);
+	void InjectEnemyDeps(EnemyBase& e);
 
 private: /// ---------- メンバ変数 ---------- ///
 
 	GameContext ctx_{}; // ポインタ保持しない（Scene側ローカルctxの寿命問題を避ける）
 
 	std::unique_ptr<Player> player_;
-	std::vector<std::unique_ptr<Enemy>> enemies_;
+	std::vector<std::unique_ptr<EnemyBase>> enemies_;
 
 	// 敵の被弾エフェクトシステム
 	EnemyParticleEffectSystem enemyParticleEffectSystem_;
 	std::function<void(const K4E::Vector3&)> onEnemyKilled_{};
-	std::unordered_set<const Enemy*> notifiedKilledEnemies_;
+	std::unordered_set<const EnemyBase*> notifiedKilledEnemies_;
 
 private: /// ---------- デバッグ用 ---------- ///
 

--- a/Project/ApplicationLayer/Character/Enemy/Core/EnemyFactory.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/EnemyFactory.cpp
@@ -1,0 +1,19 @@
+#include "EnemyFactory.h"
+
+#include "Enemy.h"
+#include "MeleeEnemy.h"
+#include "MidRangeEnemy.h"
+
+std::unique_ptr<EnemyBase> EnemyFactory::Create(EnemyType enemyType)
+{
+	switch (enemyType)
+	{
+	case EnemyType::Melee:
+		return std::make_unique<MeleeEnemy>();
+	case EnemyType::MidRange:
+		return std::make_unique<MidRangeEnemy>();
+	case EnemyType::Legacy:
+	default:
+		return std::make_unique<Enemy>();
+	}
+}

--- a/Project/ApplicationLayer/Character/Enemy/Core/EnemyFactory.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/EnemyFactory.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "EnemyType.h"
+
+#include <memory>
+
+class EnemyBase;
+
+/// 通常ゲーム用の雑魚敵を生成し、Legacy Enemyの置き換え境界を集約する。
+class EnemyFactory
+{
+public:
+	static std::unique_ptr<EnemyBase> Create(EnemyType enemyType);
+};

--- a/Project/ApplicationLayer/Character/Enemy/Core/EnemyType.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/EnemyType.h
@@ -1,0 +1,24 @@
+#pragma once
+
+#include <string_view>
+
+/// 通常ゲームで生成する雑魚敵の種類。StressTest専用のScalableEnemyTypeとは分離して扱う。
+enum class EnemyType
+{
+	Legacy,
+	Melee,
+	MidRange,
+};
+
+inline EnemyType ParseEnemyType(std::string_view archetype)
+{
+	if (archetype == "Melee" || archetype == "melee")
+	{
+		return EnemyType::Melee;
+	}
+	if (archetype == "MidRange" || archetype == "midRange" || archetype == "midrange")
+	{
+		return EnemyType::MidRange;
+	}
+	return EnemyType::Legacy;
+}

--- a/Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.cpp
@@ -1560,6 +1560,13 @@ bool MidRangeEnemy::LoadTuningFromJson(const std::filesystem::path& path, std::s
 
 void MidRangeEnemy::UpdateTargetState()
 {
+    // 通常ゲームでは移動するプレイヤーの最新位置をCollider参照から追跡する。
+    if (targetCollider_)
+    {
+        targetState_.position = targetCollider_->GetCenterPosition();
+        targetState_.hasTarget = true;
+    }
+
     // 追加: ターゲット情報更新を通常行動と時限爆弾で共通化する。
     if (!targetState_.hasTarget)
     {

--- a/Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.h
@@ -262,6 +262,7 @@ public:
     void Draw() override;
     void DrawImGui() override;
     void SetTarget(const K4E::Vector3& target);
+    void SetTarget(K4E::Collider* target) { targetCollider_ = target; }
 
     void SetFloorAABBs(const std::vector<K4E::AABB>* aabbs)
     {
@@ -325,6 +326,7 @@ private:
     SuicideBombState suicideBombState_{};
     WanderState wanderState_{};
     TargetState targetState_{};
+    K4E::Collider* targetCollider_ = nullptr;
     AnimationStateData animationState_{};
     HeadLookState headLookState_{};
     HitReactionState hitReactionState_{};

--- a/Project/ApplicationLayer/Character/Player/Component/PlayerMeleeComponent.cpp
+++ b/Project/ApplicationLayer/Character/Player/Component/PlayerMeleeComponent.cpp
@@ -4,7 +4,6 @@
 #include "CollisionTypeIdDef.h"
 #include "Collider.h"
 #include "EnemyBase.h"
-#include "Enemy.h"
 
 namespace
 {
@@ -145,13 +144,6 @@ void PlayerMeleeComponent::EvaluateHit(const K4E::Vector3& playerPos)
 			enemyBase->SetVelocity(knock);
 		}
 
-		if (auto* enemy = bestHit->GetOwner<Enemy>())
-		{
-			if (!enemy->IsDead())
-			{
-				//enemy->RequestStun(0.18f);
-			}
-		}
 
 		if (!wasDead && onHit_)
 		{

--- a/Project/ApplicationLayer/Scene/GamePlayScene/Core/GamePlayStageContext.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/Core/GamePlayStageContext.cpp
@@ -247,6 +247,10 @@ void GamePlayStageContext::LoadSpawnPointsFromLevel(const std::string& jsonPath)
 				info.wave = (object.spawnProps.wave > 0) ? object.spawnProps.wave : 1;
 				info.group = object.spawnProps.group;
 				info.count = (object.spawnProps.count > 0) ? object.spawnProps.count : 1;
+				if (object.spawnProps.hasArchetype)
+				{
+					info.enemyType = ParseEnemyType(object.spawnProps.archetype);
+				}
 			}
 
 			enemySpawnInfos_.push_back(info);
@@ -353,6 +357,7 @@ void GamePlayStageContext::SetupWaves(WaveManager* waveManager) const
 
 			WaveSpawnEntry entry{};
 			entry.position = spawn.position;
+			entry.enemyType = spawn.enemyType;
 
 			const int spawnCount = std::max(1, spawn.count);
 			for (int i = 0; i < spawnCount; ++i)

--- a/Project/ApplicationLayer/Scene/GamePlayScene/Core/GamePlayStageContext.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/Core/GamePlayStageContext.h
@@ -49,6 +49,7 @@ public: /// ---------- 構造体 ---------- ///
 		int wave = 1;
 		int group = 0;
 		int count = 1;
+		EnemyType enemyType = EnemyType::Legacy;
 	};
 
 	struct IntroCameraPointInfo

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/WaveManager.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/WaveManager.cpp
@@ -81,7 +81,7 @@ int WaveManager::SpawnWave(CharacterWorld& characters, const WaveDefinition& wav
 
 	for (const auto& entry : wave.enemies)
 	{
-		characters.SpawnEnemyAt(entry.position);
+		characters.SpawnEnemyAt(entry.position, entry.enemyType);
 		++spawnedCount;
 	}
 

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/WaveManager.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/WaveManager.h
@@ -2,6 +2,7 @@
 #include <vector>
 #include <algorithm>
 #include "Vector3.h"
+#include "EnemyType.h"
 
 namespace K4E = ::Ken4lowEngine;
 
@@ -12,6 +13,7 @@ class CharacterWorld;
 struct WaveSpawnEntry
 {
 	K4E::Vector3 position = { 0.0f, 0.0f, 0.0f }; // スポーン位置
+	EnemyType enemyType = EnemyType::Legacy; // 未指定の既存ステージは従来Enemyを生成
 };
 
 /// ---------- 1ウェーブ分の定義 ---------- ///

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -140,6 +140,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="ApplicationLayer\Character\Bullet\Bullet.cpp" />
     <ClCompile Include="ApplicationLayer\Character\Bullet\BulletManager.cpp" />
     <ClCompile Include="ApplicationLayer\Character\Enemy\Core\Enemy.cpp" />
+    <ClCompile Include="ApplicationLayer\Character\Enemy\Core\EnemyFactory.cpp" />
     <ClCompile Include="ApplicationLayer\Character\Enemy\Core\MeleeEnemy.cpp" />
     <ClCompile Include="ApplicationLayer\Character\Enemy\Core\MidRangeEnemy.cpp" />
     <ClCompile Include="ApplicationLayer\Character\Enemy\Projectile\MidRangeBombProjectile.cpp" />
@@ -727,6 +728,8 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="ApplicationLayer\Character\Bullet\Bullet.h" />
     <ClInclude Include="ApplicationLayer\Character\Bullet\BulletManager.h" />
     <ClInclude Include="ApplicationLayer\Character\Enemy\Core\Enemy.h" />
+    <ClInclude Include="ApplicationLayer\Character\Enemy\Core\EnemyFactory.h" />
+    <ClInclude Include="ApplicationLayer\Character\Enemy\Core\EnemyType.h" />
     <ClInclude Include="ApplicationLayer\Character\Enemy\Core\MeleeEnemy.h" />
     <ClInclude Include="ApplicationLayer\Character\Enemy\Core\MidRangeEnemy.h" />
     <ClInclude Include="ApplicationLayer\Character\Enemy\Projectile\MidRangeBombProjectile.h" />

--- a/Project/Ken4lowEngine.vcxproj.filters
+++ b/Project/Ken4lowEngine.vcxproj.filters
@@ -415,6 +415,9 @@
     <ClCompile Include="ApplicationLayer\Character\Enemy\Core\Enemy.cpp">
       <Filter>ApplicationLayer\Character\Enemy\Core</Filter>
     </ClCompile>
+    <ClCompile Include="ApplicationLayer\Character\Enemy\Core\EnemyFactory.cpp">
+      <Filter>ApplicationLayer\Character\Enemy\Core</Filter>
+    </ClCompile>
     <ClCompile Include="ApplicationLayer\Character\Enemy\Core\MeleeEnemy.cpp">
       <Filter>ApplicationLayer\Character\Enemy\Core</Filter>
     </ClCompile>
@@ -1285,6 +1288,12 @@
       <Filter>ApplicationLayer\Character\Player</Filter>
     </ClInclude>
     <ClInclude Include="ApplicationLayer\Character\Enemy\Core\Enemy.h">
+      <Filter>ApplicationLayer\Character\Enemy\Core</Filter>
+    </ClInclude>
+    <ClInclude Include="ApplicationLayer\Character\Enemy\Core\EnemyFactory.h">
+      <Filter>ApplicationLayer\Character\Enemy\Core</Filter>
+    </ClInclude>
+    <ClInclude Include="ApplicationLayer\Character\Enemy\Core\EnemyType.h">
       <Filter>ApplicationLayer\Character\Enemy\Core</Filter>
     </ClInclude>
     <ClInclude Include="ApplicationLayer\Character\Enemy\Core\MeleeEnemy.h">


### PR DESCRIPTION
### Motivation
- Prepare the game to spawn non-legacy small enemies from normal gameplay waves by centralizing runtime creation behind a factory and separating normal-game enemy types from StressTest scalability types.
- Keep the old `Enemy` implementation as a Legacy variant to allow incremental refactor and safe rollback while making it easier to remove later.
- Avoid direct `std::make_unique<Enemy>()` in `CharacterWorld` so future changes to enemy responsibilities (LOD, collisions, refactor) can be applied per-type via the factory.

### Description
- Added `EnemyType` enum with values `Legacy`, `Melee`, and `MidRange`, plus `ParseEnemyType()` to map optional level `archetype` strings to types and default unknown/unspecified values to `Legacy`.
- Added `EnemyFactory` that returns `std::unique_ptr<EnemyBase>` and creates `Enemy` (Legacy), `MeleeEnemy`, or `MidRangeEnemy` depending on `EnemyType`.
- Changed `CharacterWorld` to store `std::vector<std::unique_ptr<EnemyBase>>`, updated `SpawnEnemy`/`SpawnEnemyAt` to use `EnemyFactory::Create()`, and adjusted dependency injection to assign per-derived dependencies (collision, bullet manager, player target) without hardcoding `Enemy` construction.
- Propagated `EnemyType` through stage/wave parsing: extended `EnemySpawnInfo` and `WaveSpawnEntry` to include `EnemyType` and set `entry.enemyType = EnemyType::Legacy` by default so existing stage JSON remains compatible; when level JSON contains `props.archetype` it is parsed and applied.
- Made `MidRangeEnemy` follow the live player via a `Collider*` target API in addition to the existing snapshot API so it works correctly in normal gameplay.
- Removed an unnecessary `Enemy*` downcast from `PlayerMeleeComponent` and switched melee hit handling to operate on `EnemyBase*` (hit effects, damage, knockback remain applied to `EnemyBase`).
- Registered new source/header files in Visual Studio project and filters so the new factory and types are included in the project files.
- Kept StressTest `ScalableEnemyType` and associated systems untouched and ensured they remain separate from the normal-game `EnemyType` additions.

### Testing
- Ran a focused smoke build/test of the parsing helper by compiling and running a small test for `ParseEnemyType()` which succeeded.
- Ran repository static assertions and greps to confirm the new enum variants, factory mappings, `EnemyBase` storage, factory usage from `CharacterWorld`, wave propagation of `EnemyType`, and optional archetype parsing; those checks passed.
- Validated Visual Studio project XML modifications by parsing `Project/Ken4lowEngine.vcxproj` and the `.filters` file with Python `xml.etree.ElementTree` which succeeded.
- Ran `git diff --cached --check` and other whitespace/diff checks which passed.
- Attempted a broader syntax-only compile for platform-specific files but the environment lacks Windows DirectX headers and `msbuild`, therefore a full Visual Studio build could not be run in the Linux container; this is an environment limitation and not a code regression (project file entries were added and XML validated).
- Notes: gameplay integration items that remain and require follow-up (not test failures) are connecting `MeleeEnemy::NotifyAttackHit` and MidRange bomb/explosion effects to the player damage/collision pipeline before removing Legacy `Enemy`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ef7327598832d968ecbcfd531ca29)