### PR TITLE
Add runtime enemy type debug spawner

### DIFF
--- a/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.cpp
+++ b/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.cpp
@@ -252,6 +252,22 @@ void CharacterWorld::DrawEnemyDebugImGui()
 #ifdef USE_IMGUI
 	// Enemy DebugにはEnemy Manager相当の一覧と各Enemy個体の詳細をまとめる。
 	ImGui::Text("Enemy Count: %d", static_cast<int>(enemies_.size()));
+
+	// 通常ゲーム側でもFactory接続を確認できるよう、生成する雑魚敵派生を一時的に切り替える。
+	constexpr const char* kEnemyTypeLabels[] = { "Legacy", "Melee", "MidRange" };
+	int debugSpawnEnemyTypeIndex = static_cast<int>(debugSpawnEnemyType_);
+	if (ImGui::Combo("Spawn Enemy Type", &debugSpawnEnemyTypeIndex, kEnemyTypeLabels, IM_ARRAYSIZE(kEnemyTypeLabels)))
+	{
+		debugSpawnEnemyType_ = static_cast<EnemyType>(debugSpawnEnemyTypeIndex);
+	}
+
+	if (player_ && ImGui::Button("Spawn Selected Enemy"))
+	{
+		const K4E::Vector3 spawnPosition = player_->GetCenterPosition() + K4E::Vector3{ 0.0f, 0.0f, 3.0f };
+		SpawnEnemyAt(spawnPosition, debugSpawnEnemyType_);
+	}
+
+	ImGui::Separator();
 	for (size_t i = 0; i < enemies_.size(); ++i)
 	{
 		ImGui::PushID(static_cast<int>(i));

--- a/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.h
+++ b/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.h
@@ -97,5 +97,6 @@ private: /// ---------- メンバ変数 ---------- ///
 private: /// ---------- デバッグ用 ---------- ///
 
 	bool isDebug_ = false;
+	EnemyType debugSpawnEnemyType_ = EnemyType::Legacy;
 
 };


### PR DESCRIPTION
### Motivation
- Provide a unified generation boundary so multiple small enemy derivations can be created via a factory rather than ad-hoc `std::make_unique<Enemy>()` calls. 
- Prepare the normal-game path to accept `MeleeEnemy` and `MidRangeEnemy` while preserving existing behavior for legacy stages. 
- Allow quick runtime verification from the normal-game debug UI to spawn `Legacy`/`Melee`/`MidRange` enemies without editing stage JSON. 
- Keep backward compatibility by treating the existing `Enemy` as `Legacy` to avoid breaking existing stage data.

### Description
- Added a normal-game `EnemyType` enum with `Legacy`, `Melee`, and `MidRange` and `ParseEnemyType()` fallback to `EnemyType::Legacy` when a stage archetype is not specified. 
- Introduced `EnemyFactory::Create(EnemyType)` that returns `std::unique_ptr<EnemyBase>` and constructs `Enemy`/`MeleeEnemy`/`MidRangeEnemy` based on the `EnemyType`. 
- Converted `CharacterWorld` to hold `std::vector<std::unique_ptr<EnemyBase>>`, route enemy creation through `EnemyFactory` in `SpawnEnemy`/`SpawnEnemyAt`, and inject per-enemy dependencies (collision, bullet manager, target) while preserving `Legacy` behavior. 
- Added an ImGui debug UI in `CharacterWorld::DrawEnemyDebugImGui()` with a `Spawn Enemy Type` combo and a `Spawn Selected Enemy` button to spawn the chosen enemy near the player; left `Legacy` as the default so existing stages behave unchanged. 

### Testing
- Ran `git diff --check` and there were no whitespace/conflict issues. (passed)
- Verified `EnemyFactory.cpp`, `EnemyFactory.h`, and `EnemyType.h` are registered in `Project/Ken4lowEngine.vcxproj` and `Project/Ken4lowEngine.vcxproj.filters`. (passed)
- Attempted to build the Visual Studio solution with `msbuild`, but `msbuild` is not installed in the Linux container so the solution build was skipped. (skipped)
- Committed the changes and confirmed a clean working tree and the new commit (`Add runtime enemy type debug spawner`). (passed)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ef9e2664c832db6a7e7a4faee83c6)