### PR TITLE
Add stage JSON enemy type selection for normal wave spawning

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/Core/EnemyType.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/EnemyType.h
@@ -10,13 +10,13 @@ enum class EnemyType
 	MidRange,
 };
 
-inline EnemyType ParseEnemyType(std::string_view archetype)
+inline EnemyType ParseEnemyType(std::string_view enemyType)
 {
-	if (archetype == "Melee" || archetype == "melee")
+	if (enemyType == "Melee" || enemyType == "melee")
 	{
 		return EnemyType::Melee;
 	}
-	if (archetype == "MidRange" || archetype == "midRange" || archetype == "midrange")
+	if (enemyType == "MidRange" || enemyType == "midRange" || enemyType == "midrange")
 	{
 		return EnemyType::MidRange;
 	}

--- a/Project/ApplicationLayer/Scene/GamePlayScene/Core/GamePlayStageContext.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/Core/GamePlayStageContext.cpp
@@ -247,9 +247,10 @@ void GamePlayStageContext::LoadSpawnPointsFromLevel(const std::string& jsonPath)
 				info.wave = (object.spawnProps.wave > 0) ? object.spawnProps.wave : 1;
 				info.group = object.spawnProps.group;
 				info.count = (object.spawnProps.count > 0) ? object.spawnProps.count : 1;
-				if (object.spawnProps.hasArchetype)
+				// stage JSONから敵種別を受け取り、Wave生成時にFactoryへ渡す。
+				if (object.spawnProps.hasEnemyType)
 				{
-					info.enemyType = ParseEnemyType(object.spawnProps.archetype);
+					info.enemyType = ParseEnemyType(object.spawnProps.enemyType);
 				}
 			}
 

--- a/Project/Engine/Scene/Level/LevelData.h
+++ b/Project/Engine/Scene/Level/LevelData.h
@@ -35,6 +35,9 @@ namespace Ken4lowEngine
 
 		std::string archetype;
 		bool hasArchetype = false;
+
+		std::string enemyType; // 通常ゲーム用の敵種別（Legacy / Melee / MidRange）
+		bool hasEnemyType = false;
 	};
 
 	struct IntroCameraProps

--- a/Project/Engine/Scene/Level/LevelLoader.cpp
+++ b/Project/Engine/Scene/Level/LevelLoader.cpp
@@ -249,6 +249,11 @@ namespace Ken4lowEngine
 					objectData->spawnProps.archetype = props["archetype"].get<std::string>();
 					objectData->spawnProps.hasArchetype = true;
 				}
+				if (props.contains("enemyType") && props["enemyType"].is_string())
+				{
+					objectData->spawnProps.enemyType = props["enemyType"].get<std::string>();
+					objectData->spawnProps.hasEnemyType = true;
+				}
 			}
 
 			if (object.contains("props") && object["props"].is_object())


### PR DESCRIPTION
### Motivation
- Enable stage authors to specify normal-game enemy kinds (Legacy / Melee / MidRange) per EnemySpawnPoint and have that choice flow to runtime spawning via the existing wave path. 
- Preserve backward compatibility so existing stage JSON without `enemyType` still spawns Legacy enemies and keep StressTest `ScalableEnemyType` and boss logic unchanged.

### Description
- Added `enemyType` and `hasEnemyType` to `SpawnProps` so LevelLoader can read `EnemySpawnPoint.props.enemyType` from JSON.
- `LevelLoader` now parses `props.enemyType` when present and sets `spawnProps.hasEnemyType`.
- `GamePlayStageContext::LoadSpawnPointsFromLevel()` converts the parsed string to `EnemyType` via `ParseEnemyType()` and stores it in `EnemySpawnInfo::enemyType` (default `EnemyType::Legacy` when absent). A comment was added: `// stage JSONから敵種別を受け取り、Wave生成時にFactoryへ渡す。`.
- `GamePlayStageContext::SetupWaves()` copies `EnemySpawnInfo::enemyType` into `WaveSpawnEntry::enemyType`; `WaveManager::SpawnWave()` passes that `enemyType` to `CharacterWorld::SpawnEnemyAt()`.
- `CharacterWorld::SpawnEnemy()` now uses `EnemyFactory::Create(request.enemyType)` to produce the concrete enemy, and `EnemyFactory` returns `Enemy`/`MeleeEnemy`/`MidRangeEnemy` according to `EnemyType`.
- Kept MidRangeEnemy particle behavior disabled in injection, and kept StressTest `ScalableEnemyType` separate.

### Testing
- Ran a small compiled check program exercising `ParseEnemyType` with `Legacy`, `Melee`, `MidRange`, and an unknown string; it completed successfully (checked via `clang++` and running the binary).
- Performed a syntax-only compile check of `LevelLoader.cpp` with `clang++ -fsyntax-only`; it passed.
- Parsed all stage JSON files under `Project/Resources/JSON/stages/*.json` with Python `json.loads` to validate no JSON was broken; parsing succeeded for all files.
- Executed Python static integration assertions to verify the new loader check, Legacy defaults, wave propagation, factory creation paths, and MidRange particle exclusion; all assertions passed.
- Ran `git diff --check` and local diffs; no issues found.
- Note: full Visual Studio solution build was not executed because `msbuild` / `dotnet` are not available in this container environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1efc960f58832dab4a654bcb6b30ba)