### PR TITLE
通常WaveでMelee/MidRangeを生成し旧Enemy利用状況を可視化

### DIFF
--- a/Docs/LegacyEnemyRemovalAssessment.md
+++ b/Docs/LegacyEnemyRemovalAssessment.md
@@ -1,0 +1,57 @@
+# 旧Enemy削除前の確認事項
+
+## 通常ゲームでの生成状況
+
+`fps_stage00.json` の最初のウェーブでは、段階置き換え確認用として近接雑魚敵を3体、中距離雑魚敵を2体生成する。残り7体は `enemyType` 未指定のため、互換動作として旧Enemyを生成する。
+
+| stage JSON | EnemySpawnPoint数 | `enemyType` 指定済み | `enemyType` 未指定（旧Enemy生成） |
+| --- | ---: | ---: | ---: |
+| `fps_stage00.json` | 12 | 5 | 7 |
+| `fps_stage01.json` | 24 | 0 | 24 |
+| `fps_stage02.json` | 21 | 0 | 21 |
+| `fps_stage03.json` | 0 | 0 | 0 |
+| `fps_stage04.json` | 0 | 0 | 0 |
+
+`enemyType` が未指定、未知の文字列、または `Legacy` の場合は、既存stage JSONとの互換性を維持するため旧Enemyを生成する。
+
+## 旧Enemyがまだ必要な理由
+
+- `fps_stage00.json` の未移行7スポーン、`fps_stage01.json` の24スポーン、`fps_stage02.json` の21スポーンが旧Enemyへフォールバックする。
+- 旧Enemyは従来の銃撃雑魚敵として、通常弾の生成、遮蔽利用、射線判定、索敵、後退、回避、スタック解消をまとめて担当している。
+- 中距離雑魚敵は爆弾投射を担当する別アーキタイプであり、旧Enemyの通常銃撃雑魚敵をそのまま置換するものではない。
+
+## 旧Enemyでしかできない処理
+
+- `BulletManager` を利用した通常敵弾の射撃。
+- `CollisionManager` のワールドSegmentCastを利用した射線判定。
+- 旧State群と連携した Idle / CombatMove / Shoot / Search / Dead の状態遷移。
+- 遮蔽選択、低HP時の後退、回避、スタック解消など、旧Enemy内に統合されている戦術行動。
+
+## MeleeEnemy / MidRangeEnemy または新アーキタイプへ移植が必要な処理
+
+- 旧Enemy相当の銃撃雑魚敵を残す場合、通常敵弾、射線判定、索敵、遮蔽、後退、回避、スタック解消を新しい責務へ移す必要がある。
+- stage JSONの `archetype` と `enemyType` の役割を整理し、必要なら銃撃雑魚敵用の新しい `enemyType` を追加する。
+- `CharacterWorld::InjectEnemyDeps` に残る旧Enemy固有の `BulletManager` / `CollisionManager` 注入を、新アーキタイプ側へ移す。
+
+## 削除できそうなEnemyState群
+
+以下は旧Enemyからのみ参照されるため、旧Enemyの生成がゼロになり、旧銃撃処理の移植が完了した後はまとめて削除候補になる。
+
+- `IEnemyState`
+- `EnemyIdleState`
+- `EnemyCombatMoveState`
+- `EnemyShootState`
+- `EnemySearchState`
+- `EnemyDeadState`
+
+## まだ削除してはいけないEnemyState群
+
+現時点では上記State群を削除してはいけない。通常stage JSONに未指定スポーンが残っており、旧EnemyがこれらのState群を実行するためである。
+
+## 次の削除ステップ
+
+1. Enemy Debugの「旧Enemy数」が通常プレイでゼロになるよう、未指定スポーンを段階的に移行する。
+2. 従来の銃撃雑魚敵を廃止するか、新アーキタイプとして再実装するか決定する。
+3. `CharacterWorld::InjectEnemyDeps` の旧Enemy分岐を削除する。
+4. `EnemyFactory` の `Legacy` 生成と互換フォールバックの廃止時期を決定する。
+5. 旧Enemyと旧State群をまとめて削除する。

--- a/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.cpp
+++ b/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.cpp
@@ -16,6 +16,20 @@
 
 using namespace Ken4lowEngine;
 
+namespace
+{
+	size_t ToEnemyTypeIndex(EnemyType enemyType)
+	{
+		switch (enemyType)
+		{
+		case EnemyType::Melee: return 1;
+		case EnemyType::MidRange: return 2;
+		case EnemyType::Legacy:
+		default: return 0;
+		}
+	}
+}
+
 void CharacterWorld::Initialize(GameContext& ctx)
 {
 	ctx_ = ctx;
@@ -38,6 +52,7 @@ void CharacterWorld::Initialize(GameContext& ctx)
 
 	enemies_.clear();
 	notifiedKilledEnemies_.clear();
+	spawnedEnemyCounts_.fill(0);
 }
 
 void CharacterWorld::Finalize()
@@ -129,6 +144,7 @@ EnemyBase& CharacterWorld::SpawnEnemy(const EnemySpawnRequest& request)
 	}
 
 	enemies_.push_back(std::move(e));
+	++spawnedEnemyCounts_[ToEnemyTypeIndex(request.enemyType)];
 	return *enemies_.back();
 }
 
@@ -250,18 +266,43 @@ void CharacterWorld::DrawPlayerDebugImGui()
 void CharacterWorld::DrawEnemyDebugImGui()
 {
 #ifdef USE_IMGUI
-	// Enemy DebugにはEnemy Manager相当の一覧と各Enemy個体の詳細をまとめる。
-	ImGui::Text("Enemy Count: %d", static_cast<int>(enemies_.size()));
+	// 旧Enemyを段階的に置き換えるため、通常ゲーム上の敵種別ごとの生成数を確認する。
+	std::array<int, 3> liveEnemyCounts{};
+	for (const auto& enemy : enemies_)
+	{
+		if (dynamic_cast<const MeleeEnemy*>(enemy.get()))
+		{
+			++liveEnemyCounts[ToEnemyTypeIndex(EnemyType::Melee)];
+		}
+		else if (dynamic_cast<const MidRangeEnemy*>(enemy.get()))
+		{
+			++liveEnemyCounts[ToEnemyTypeIndex(EnemyType::MidRange)];
+		}
+		else
+		{
+			++liveEnemyCounts[ToEnemyTypeIndex(EnemyType::Legacy)];
+		}
+	}
+
+	ImGui::Text("現在の敵数: %d", static_cast<int>(enemies_.size()));
+	ImGui::Text("現在の旧Enemy数: %d", liveEnemyCounts[ToEnemyTypeIndex(EnemyType::Legacy)]);
+	ImGui::Text("現在の近接雑魚敵数: %d", liveEnemyCounts[ToEnemyTypeIndex(EnemyType::Melee)]);
+	ImGui::Text("現在の中距離雑魚敵数: %d", liveEnemyCounts[ToEnemyTypeIndex(EnemyType::MidRange)]);
+	ImGui::Separator();
+	ImGui::Text("生成済み敵数: %d", spawnedEnemyCounts_[0] + spawnedEnemyCounts_[1] + spawnedEnemyCounts_[2]);
+	ImGui::Text("旧Enemy数: %d", spawnedEnemyCounts_[ToEnemyTypeIndex(EnemyType::Legacy)]);
+	ImGui::Text("近接雑魚敵数: %d", spawnedEnemyCounts_[ToEnemyTypeIndex(EnemyType::Melee)]);
+	ImGui::Text("中距離雑魚敵数: %d", spawnedEnemyCounts_[ToEnemyTypeIndex(EnemyType::MidRange)]);
 
 	// 通常ゲーム側でもFactory接続を確認できるよう、生成する雑魚敵派生を一時的に切り替える。
-	constexpr const char* kEnemyTypeLabels[] = { "Legacy", "Melee", "MidRange" };
+	constexpr const char* kEnemyTypeLabels[] = { "旧Enemy", "近接雑魚敵", "中距離雑魚敵" };
 	int debugSpawnEnemyTypeIndex = static_cast<int>(debugSpawnEnemyType_);
-	if (ImGui::Combo("Spawn Enemy Type", &debugSpawnEnemyTypeIndex, kEnemyTypeLabels, IM_ARRAYSIZE(kEnemyTypeLabels)))
+	if (ImGui::Combo("敵種別", &debugSpawnEnemyTypeIndex, kEnemyTypeLabels, IM_ARRAYSIZE(kEnemyTypeLabels)))
 	{
 		debugSpawnEnemyType_ = static_cast<EnemyType>(debugSpawnEnemyTypeIndex);
 	}
 
-	if (player_ && ImGui::Button("Spawn Selected Enemy"))
+	if (player_ && ImGui::Button("選択した敵を生成"))
 	{
 		const K4E::Vector3 spawnPosition = player_->GetCenterPosition() + K4E::Vector3{ 0.0f, 0.0f, 3.0f };
 		SpawnEnemyAt(spawnPosition, debugSpawnEnemyType_);

--- a/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.h
+++ b/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.h
@@ -1,4 +1,5 @@
 #pragma once
+#include <array>
 #include <functional>
 #include <memory>
 #include <vector>
@@ -93,6 +94,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	EnemyParticleEffectSystem enemyParticleEffectSystem_;
 	std::function<void(const K4E::Vector3&)> onEnemyKilled_{};
 	std::unordered_set<const EnemyBase*> notifiedKilledEnemies_;
+	std::array<int, 3> spawnedEnemyCounts_{}; // 通常ゲーム中に生成した敵種別ごとの累計
 
 private: /// ---------- デバッグ用 ---------- ///
 

--- a/Project/Resources/JSON/stages/fps_stage00.json
+++ b/Project/Resources/JSON/stages/fps_stage00.json
@@ -1551,7 +1551,8 @@
                 "wave": 1,
                 "group": 0,
                 "count": 1,
-                "archetype": "RifleGrunt"
+                "archetype": "RifleGrunt",
+                "enemyType": "Melee"
             }
         },
         {
@@ -1582,7 +1583,8 @@
                 "wave": 1,
                 "group": 0,
                 "count": 1,
-                "archetype": "RifleGrunt"
+                "archetype": "RifleGrunt",
+                "enemyType": "Melee"
             }
         },
         {
@@ -1613,7 +1615,8 @@
                 "wave": 1,
                 "group": 0,
                 "count": 1,
-                "archetype": "RifleGrunt"
+                "archetype": "RifleGrunt",
+                "enemyType": "Melee"
             }
         },
         {
@@ -1644,7 +1647,8 @@
                 "wave": 1,
                 "group": 0,
                 "count": 1,
-                "archetype": "Scout"
+                "archetype": "Scout",
+                "enemyType": "MidRange"
             }
         },
         {
@@ -1675,7 +1679,8 @@
                 "wave": 1,
                 "group": 0,
                 "count": 1,
-                "archetype": "Scout"
+                "archetype": "Scout",
+                "enemyType": "MidRange"
             }
         },
         {


### PR DESCRIPTION
### Motivation
- 通常ステージのWave定義から直接 `MeleeEnemy` / `MidRangeEnemy` を出せるようにし、Legacy Enemy に依存しない移行可否を確認するため。 
- 旧 Enemy の段階的削除を進めるために、通常ゲーム上での敵種別ごとの生成数や現存数を可視化して判断材料を揃えるため。

### Description
- `Project/Resources/JSON/stages/fps_stage00.json` の通常Waveに `enemyType` を追加して、`EnemySpawn_001`〜`EnemySpawn_003` を `Melee`、`EnemySpawn_004`〜`EnemySpawn_005` を `MidRange` に設定しました。 
- `CharacterWorld` に `spawnedEnemyCounts_`（種別ごとの累計）を追加し、`SpawnEnemy` 呼び出し直後に該当種別のカウンタをインクリメントするようにしました（`ToEnemyTypeIndex` 補助関数を追加）。 
- Enemy Debug GUI を日本語化して「現在の旧Enemy数」「現在の近接雑魚敵数」「現在の中距離雑魚敵数」および生成済み累計を表示する項目を追加し、手動生成UIラベルも日本語化しました。 
- MidRangeEnemy 固有のパーティクル復活は行わず既存方針を維持し、旧 Enemy 削除前の依存・移植項目を `Docs/LegacyEnemyRemovalAssessment.md` にまとめました。 

### Testing
- `fps_stage00.json` の変更を Python スクリプトで検証して `EnemySpawn_001`〜`EnemySpawn_005` がそれぞれ `Melee,Melee,Melee,MidRange,MidRange` になっていることと未指定スポーン数が 7 であることを確認しました（成功）。
- 通常ゲームのパイプライン接続（Stage → Wave → SpawnEnemyAt → EnemyFactory → CollisionManager 登録 → Update/Draw/DrawShadow → PlayerMelee からの `EnemyBase::TakeDamage`）をソース上の静的チェックで確認しました（成功）。
- `git diff --check` を実行して差分の問題がないことを確認しました（成功）。
- Visual Studio ソリューションのフルビルドはコンテナに `msbuild` が存在しないため実行できませんでした（未実行）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f017438f0832d8738b0a4c12eb538)