### PR TITLE
Add crystal-driven capped infinite enemy spawn flow

### DIFF
--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/CrystalManager.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/CrystalManager.cpp
@@ -1,0 +1,144 @@
+#include "CrystalManager.h"
+
+#include "CharacterWorld.h"
+
+#include <algorithm>
+#include <iostream>
+#include <utility>
+
+#ifdef USE_IMGUI
+#include <imgui.h>
+#endif
+
+void CrystalManager::Initialize(const std::vector<CrystalSpawnPoint>& spawnPoints)
+{
+	crystals_.clear();
+	crystals_.reserve(spawnPoints.size());
+	for (const CrystalSpawnPoint& spawnPoint : spawnPoints)
+	{
+		EnemySpawnCrystal crystal;
+		crystal.Initialize(spawnPoint);
+		crystals_.push_back(std::move(crystal));
+	}
+
+	selectedCrystalIndex_ = 0;
+	shouldSpawnBoss_ = false;
+	hasBossSpawned_ = false;
+}
+
+void CrystalManager::Update(CharacterWorld& characters, float deltaTime)
+{
+	for (EnemySpawnCrystal& crystal : crystals_)
+	{
+		crystal.Update(characters, deltaTime);
+	}
+	NotifyBossSpawnIfNeeded();
+}
+
+void CrystalManager::Draw() const
+{
+	for (const EnemySpawnCrystal& crystal : crystals_)
+	{
+		crystal.Draw();
+	}
+}
+
+int CrystalManager::GetAliveCrystalCount() const
+{
+	return static_cast<int>(std::count_if(crystals_.begin(), crystals_.end(),
+		[](const EnemySpawnCrystal& crystal) { return crystal.IsAlive(); }));
+}
+
+bool CrystalManager::AreAllCrystalsDestroyed() const
+{
+	return !crystals_.empty() && GetAliveCrystalCount() == 0;
+}
+
+void CrystalManager::NotifyBossSpawnIfNeeded()
+{
+	if (!AreAllCrystalsDestroyed() || hasBossSpawned_)
+	{
+		return;
+	}
+
+	shouldSpawnBoss_ = true;
+	hasBossSpawned_ = true;
+	// 既存ボス進行へ安全に接続するまでは、全破壊時に一度だけ仮通知する。
+	std::clog << "[CrystalManager] すべてのクリスタルが破壊されました。ボスを出現させます。\n";
+}
+
+EnemySpawnCrystal* CrystalManager::GetSelectedCrystal()
+{
+	return selectedCrystalIndex_ < crystals_.size() ? &crystals_[selectedCrystalIndex_] : nullptr;
+}
+
+const EnemySpawnCrystal* CrystalManager::GetSelectedCrystal() const
+{
+	return selectedCrystalIndex_ < crystals_.size() ? &crystals_[selectedCrystalIndex_] : nullptr;
+}
+
+void CrystalManager::DrawImGui()
+{
+#ifdef USE_IMGUI
+	if (!ImGui::CollapsingHeader("クリスタル デバッグ"))
+	{
+		return;
+	}
+
+	ImGui::Text("クリスタル数: %d", GetCrystalCount());
+	ImGui::Text("生存クリスタル数: %d", GetAliveCrystalCount());
+	ImGui::Text("全クリスタル破壊済み: %s", AreAllCrystalsDestroyed() ? "はい" : "いいえ");
+	ImGui::Text("ボス出現済み: %s", HasBossSpawned() ? "はい" : "いいえ");
+
+	if (crystals_.empty())
+	{
+		ImGui::Text("クリスタル設定がありません。");
+		return;
+	}
+
+	int selectedIndex = static_cast<int>(selectedCrystalIndex_);
+	if (ImGui::SliderInt("選択中クリスタル", &selectedIndex, 0, static_cast<int>(crystals_.size()) - 1))
+	{
+		selectedCrystalIndex_ = static_cast<size_t>(selectedIndex);
+	}
+
+	EnemySpawnCrystal* crystal = GetSelectedCrystal();
+	if (!crystal)
+	{
+		return;
+	}
+
+	bool enableInfiniteSpawn = crystal->IsInfiniteSpawnEnabled();
+	if (ImGui::Checkbox("クリスタル敵スポーン有効", &enableInfiniteSpawn))
+	{
+		crystal->SetInfiniteSpawnEnabled(enableInfiniteSpawn);
+	}
+
+	constexpr const char* enemyTypeLabels[] = { "旧Enemy", "近接雑魚敵", "中距離雑魚敵" };
+	int enemyTypeIndex = static_cast<int>(crystal->GetSpawnEnemyType());
+	if (ImGui::Combo("出現敵タイプ", &enemyTypeIndex, enemyTypeLabels, IM_ARRAYSIZE(enemyTypeLabels)))
+	{
+		crystal->SetSpawnEnemyType(static_cast<EnemyType>(enemyTypeIndex));
+	}
+
+	float spawnInterval = crystal->GetSpawnInterval();
+	if (ImGui::DragFloat("敵出現間隔", &spawnInterval, 0.1f, 0.05f, 60.0f, "%.2f 秒"))
+	{
+		crystal->SetSpawnInterval(spawnInterval);
+	}
+
+	int maxAliveEnemies = crystal->GetMaxAliveEnemies();
+	if (ImGui::DragInt("同時出現上限", &maxAliveEnemies, 1.0f, 0, 100))
+	{
+		crystal->SetMaxAliveEnemies(maxAliveEnemies);
+	}
+
+	ImGui::Text("現在の生存スポーン敵数: %d", crystal->GetAliveSpawnedEnemyCount());
+	ImGui::Text("合計スポーン数: %d", crystal->GetTotalSpawnedCount());
+	ImGui::Text("選択中クリスタルHP: %d", crystal->GetHp());
+	if (ImGui::Button("選択中クリスタルへダメージ"))
+	{
+		crystal->TakeDamage(25);
+	}
+#endif
+}

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/CrystalManager.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/CrystalManager.h
@@ -1,0 +1,35 @@
+#pragma once
+
+#include "EnemySpawnCrystal.h"
+
+#include <cstddef>
+#include <vector>
+
+class CharacterWorld;
+
+/// 複数クリスタルの進行、雑魚敵生成要求、ボス通知を集約する。
+class CrystalManager
+{
+public:
+	void Initialize(const std::vector<CrystalSpawnPoint>& spawnPoints);
+	void Update(CharacterWorld& characters, float deltaTime);
+	void Draw() const;
+	void DrawImGui();
+
+	int GetCrystalCount() const { return static_cast<int>(crystals_.size()); }
+	int GetAliveCrystalCount() const;
+	bool AreAllCrystalsDestroyed() const;
+	bool ShouldSpawnBoss() const { return shouldSpawnBoss_; }
+	bool HasBossSpawned() const { return hasBossSpawned_; }
+
+private:
+	EnemySpawnCrystal* GetSelectedCrystal();
+	const EnemySpawnCrystal* GetSelectedCrystal() const;
+	void NotifyBossSpawnIfNeeded();
+
+private:
+	std::vector<EnemySpawnCrystal> crystals_;
+	size_t selectedCrystalIndex_ = 0;
+	bool shouldSpawnBoss_ = false;
+	bool hasBossSpawned_ = false;
+};

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/EnemySpawnCrystal.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/EnemySpawnCrystal.cpp
@@ -1,0 +1,129 @@
+#include "EnemySpawnCrystal.h"
+
+#include "CharacterWorld.h"
+#include "EnemyBase.h"
+
+#include <algorithm>
+#include <cmath>
+#include <cstdlib>
+
+using namespace Ken4lowEngine;
+
+namespace
+{
+	constexpr float kMinimumSpawnInterval = 0.05f;
+
+	float RandomRange(float minValue, float maxValue)
+	{
+		const float t = static_cast<float>(std::rand()) / static_cast<float>(RAND_MAX);
+		return minValue + (maxValue - minValue) * t;
+	}
+}
+
+void EnemySpawnCrystal::Initialize(const CrystalSpawnPoint& spawnPoint)
+{
+	position_ = spawnPoint.position;
+	isAlive = true;
+	hp = std::max(1, spawnPoint.hp);
+	spawnEnemyType = spawnPoint.spawnEnemyType;
+	spawnInterval = std::max(kMinimumSpawnInterval, spawnPoint.spawnInterval);
+	spawnTimer = 0.0f;
+	spawnRadius = std::max(0.0f, spawnPoint.spawnRadius);
+	maxAliveEnemies = std::max(0, spawnPoint.maxAliveEnemies);
+	totalSpawnedCount = 0;
+	aliveSpawnedEnemyCount = 0;
+	enableInfiniteSpawn = spawnPoint.enableInfiniteSpawn;
+	spawnBossTrigger_ = spawnPoint.spawnBossTrigger;
+	spawnedEnemies_.clear();
+
+	debugCube_ = std::make_unique<Object3D>();
+	debugCube_->Initialize("Test/cube.gltf");
+	debugCube_->SetTranslate(spawnPoint.position);
+	debugCube_->SetRotate(spawnPoint.rotation);
+	debugCube_->SetScale(spawnPoint.scale);
+	debugCube_->SetColor({ 0.25f, 0.85f, 1.0f, 1.0f });
+	debugCube_->Update();
+}
+
+void EnemySpawnCrystal::Update(CharacterWorld& characters, float deltaTime)
+{
+	RemoveInactiveSpawnedEnemies(characters);
+	if (!isAlive || !enableInfiniteSpawn || maxAliveEnemies <= 0)
+	{
+		return;
+	}
+
+	// クリスタルが破壊されるまで一定間隔で敵を出し続ける。
+	spawnTimer += std::max(0.0f, deltaTime);
+	if (spawnTimer < spawnInterval || aliveSpawnedEnemyCount >= maxAliveEnemies)
+	{
+		return;
+	}
+
+	spawnTimer = 0.0f;
+	SpawnEnemy(characters);
+}
+
+void EnemySpawnCrystal::Draw() const
+{
+	if (isAlive && debugCube_)
+	{
+		debugCube_->Draw();
+	}
+}
+
+void EnemySpawnCrystal::TakeDamage(int damage)
+{
+	if (!isAlive || damage <= 0)
+	{
+		return;
+	}
+
+	hp = std::max(0, hp - damage);
+	if (hp <= 0)
+	{
+		isAlive = false;
+		spawnTimer = 0.0f;
+	}
+}
+
+void EnemySpawnCrystal::SetSpawnInterval(float interval)
+{
+	spawnInterval = std::max(kMinimumSpawnInterval, interval);
+}
+
+void EnemySpawnCrystal::SetMaxAliveEnemies(int count)
+{
+	maxAliveEnemies = std::max(0, count);
+}
+
+void EnemySpawnCrystal::RemoveInactiveSpawnedEnemies(const CharacterWorld& characters)
+{
+	const std::vector<EnemyBase*> livingEnemies = characters.GetEnemyRawList();
+	spawnedEnemies_.erase(
+		std::remove_if(spawnedEnemies_.begin(), spawnedEnemies_.end(),
+			[&livingEnemies](const EnemyBase* spawnedEnemy)
+			{
+				const auto it = std::find(livingEnemies.begin(), livingEnemies.end(), spawnedEnemy);
+				return it == livingEnemies.end() || (*it)->IsDead();
+			}),
+		spawnedEnemies_.end());
+	aliveSpawnedEnemyCount = static_cast<int>(spawnedEnemies_.size());
+}
+
+void EnemySpawnCrystal::SpawnEnemy(CharacterWorld& characters)
+{
+	const float angle = RandomRange(0.0f, 6.28318530718f);
+	const float distance = RandomRange(0.0f, spawnRadius);
+	const Vector3 spawnPosition{
+		position_.x + std::cos(angle) * distance,
+		position_.y,
+		position_.z + std::sin(angle) * distance
+	};
+
+	// CharacterWorld 内部で EnemyFactory を経由し、設定された雑魚敵派生を生成する。
+	EnemyBase& enemy = characters.SpawnEnemyAt(spawnPosition, spawnEnemyType);
+	spawnedEnemies_.push_back(&enemy);
+	aliveSpawnedEnemyCount = static_cast<int>(spawnedEnemies_.size());
+	++totalSpawnedCount;
+}

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/EnemySpawnCrystal.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/EnemySpawnCrystal.h
@@ -1,0 +1,77 @@
+#pragma once
+
+#include "EnemyType.h"
+#include "Object3D.h"
+#include "Vector3.h"
+
+#include <memory>
+#include <vector>
+
+class CharacterWorld;
+class EnemyBase;
+
+namespace K4E = ::Ken4lowEngine;
+
+/// Blender のスポーン設定を将来そのまま受け取るためのクリスタル定義。
+struct CrystalSpawnPoint
+{
+	K4E::Vector3 position{};
+	K4E::Vector3 rotation{};
+	K4E::Vector3 scale{ 1.0f, 1.0f, 1.0f };
+	int hp = 100;
+	EnemyType spawnEnemyType = EnemyType::Melee;
+	float spawnInterval = 2.0f;
+	int maxAliveEnemies = 10;
+	float spawnRadius = 3.0f;
+	bool enableInfiniteSpawn = true;
+	bool spawnBossTrigger = true;
+};
+
+/// 破壊されるまで、上限付きで雑魚敵を生成し続ける仮クリスタル。
+class EnemySpawnCrystal
+{
+public:
+	void Initialize(const CrystalSpawnPoint& spawnPoint);
+	void Update(CharacterWorld& characters, float deltaTime);
+	void Draw() const;
+	void TakeDamage(int damage);
+
+	bool IsAlive() const { return isAlive; }
+	int GetHp() const { return hp; }
+	EnemyType GetSpawnEnemyType() const { return spawnEnemyType; }
+	float GetSpawnInterval() const { return spawnInterval; }
+	float GetSpawnRadius() const { return spawnRadius; }
+	int GetMaxAliveEnemies() const { return maxAliveEnemies; }
+	int GetTotalSpawnedCount() const { return totalSpawnedCount; }
+	int GetAliveSpawnedEnemyCount() const { return aliveSpawnedEnemyCount; }
+	bool IsInfiniteSpawnEnabled() const { return enableInfiniteSpawn; }
+	bool IsBossSpawnTrigger() const { return spawnBossTrigger_; }
+	const K4E::Vector3& GetPosition() const { return position_; }
+
+	void SetInfiniteSpawnEnabled(bool enabled) { enableInfiniteSpawn = enabled; }
+	void SetSpawnEnemyType(EnemyType enemyType) { spawnEnemyType = enemyType; }
+	void SetSpawnInterval(float interval);
+	void SetMaxAliveEnemies(int count);
+
+private:
+	void RemoveInactiveSpawnedEnemies(const CharacterWorld& characters);
+	void SpawnEnemy(CharacterWorld& characters);
+
+public: // Blender 読み込み対応時にも維持するランタイム設定値。
+	bool isAlive = true;
+	int hp = 100;
+	EnemyType spawnEnemyType = EnemyType::Melee;
+	float spawnInterval = 2.0f;
+	float spawnTimer = 0.0f;
+	float spawnRadius = 3.0f;
+	int maxAliveEnemies = 10;
+	int totalSpawnedCount = 0;
+	int aliveSpawnedEnemyCount = 0;
+	bool enableInfiniteSpawn = true;
+
+private:
+	K4E::Vector3 position_{};
+	bool spawnBossTrigger_ = true;
+	std::unique_ptr<K4E::Object3D> debugCube_;
+	std::vector<const EnemyBase*> spawnedEnemies_;
+};

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
@@ -143,11 +143,19 @@ void GamePlayWorld::Initialize(GamePlayStageContext& stageContext)
 	prevWaveInProgress_ = false;
 	prevAllWavesCleared_ = false;
 
+	// Blender 側の設定読み込みを追加するまでは、C++ の仮スポーン地点を使用する。
+	crystalManager_.Initialize({
+		{ { -8.0f, 1.0f, 8.0f }, {}, { 1.5f, 2.5f, 1.5f }, 100, EnemyType::Melee, 2.0f, 10, 4.0f, true, true },
+		{ {  0.0f, 1.0f, 14.0f }, {}, { 1.5f, 2.5f, 1.5f }, 100, EnemyType::MidRange, 3.0f, 6, 4.0f, true, true },
+		{ {  8.0f, 1.0f, 8.0f }, {}, { 1.5f, 2.5f, 1.5f }, 100, EnemyType::Melee, 2.0f, 10, 4.0f, true, true },
+	});
+
 	enemyHpBarManager_.Initialize();
 }
 
 void GamePlayWorld::Finalize()
 {
+	crystalManager_.Initialize({});
 	stageObjectiveManager_.reset();
 	waveManager_.reset();
 	hudManager_.reset();
@@ -178,6 +186,7 @@ void GamePlayWorld::Update(float deltaTime)
 	}
 
 	characters_.Update(deltaTime);
+	crystalManager_.Update(characters_, deltaTime);
 	if (auto* player = characters_.GetPlayer())
 	{
 		itemManager_.Update(player, deltaTime);
@@ -356,6 +365,8 @@ void GamePlayWorld::Draw3D(bool hideCharactersDuringIntro)
 		stage_->DrawChunkDebug();
 	}
 
+	crystalManager_.Draw();
+
 	if (bulletManager_)
 	{
 		bulletManager_->Draw();
@@ -425,6 +436,7 @@ void GamePlayWorld::DrawGameDebugImGui()
 	}
 	ImGui::Text("Player Dead: %s", IsPlayerDead() ? "true" : "false");
 	ImGui::Text("Enemies: %d", characters_.GetEnemyCount());
+	crystalManager_.DrawImGui();
 
 	const float fps = K4E::GameTimer::GetInstance()->GetFPS();
 	const auto* particleManager = K4E::ParticleManager::GetInstance();

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.h
@@ -10,6 +10,7 @@
 #include "DataAssetPresets.h"
 #include "EnemyHPBarManager.h"
 #include "ItemManager.h"
+#include "CrystalManager.h"
 
 #include <memory>
 
@@ -98,6 +99,7 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	EnemyHPBarManager enemyHpBarManager_;
 	ItemManager itemManager_;
+	CrystalManager crystalManager_;
 
 	int prevWaveNumber_ = 0;
 	bool prevWaveInProgress_ = false;

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -147,6 +147,8 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClCompile Include="ApplicationLayer\Character\Enemy\AI\MeleeAttackController.cpp" />
     <ClCompile Include="ApplicationLayer\Character\Enemy\Core\EnemyBase.cpp" />
     <ClCompile Include="ApplicationLayer\Character\CharacterWorld\CharacterWorld.cpp" />
+    <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\World\EnemySpawnCrystal.cpp" />
+    <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\World\CrystalManager.cpp" />
     <ClCompile Include="ApplicationLayer\OverlaySystem\BaseOverlay.cpp" />
     <ClCompile Include="ApplicationLayer\OverlaySystem\ConfirmQuitOverlay.cpp" />
     <ClCompile Include="ApplicationLayer\OverlaySystem\PauseOverlay.cpp" />
@@ -737,6 +739,8 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="ApplicationLayer\Character\Enemy\AI\MeleeAttackPattern.h" />
     <ClInclude Include="ApplicationLayer\Character\Enemy\Core\EnemyBase.h" />
     <ClInclude Include="ApplicationLayer\Character\CharacterWorld\CharacterWorld.h" />
+    <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\World\EnemySpawnCrystal.h" />
+    <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\World\CrystalManager.h" />
     <ClInclude Include="ApplicationLayer\OverlaySystem\BaseOverlay.h" />
     <ClInclude Include="ApplicationLayer\OverlaySystem\ConfirmQuitOverlay.h" />
     <ClInclude Include="ApplicationLayer\OverlaySystem\PauseOverlay.h" />

--- a/Project/Ken4lowEngine.vcxproj.filters
+++ b/Project/Ken4lowEngine.vcxproj.filters
@@ -253,6 +253,12 @@
     <ClCompile Include="ApplicationLayer\Character\Player\PlayerHurtbox.cpp">
       <Filter>ApplicationLayer\Character\Player</Filter>
     </ClCompile>
+    <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\World\EnemySpawnCrystal.cpp">
+      <Filter>ApplicationLayer\Scene\GamePlayScene\World</Filter>
+    </ClCompile>
+    <ClCompile Include="ApplicationLayer\Scene\GamePlayScene\World\CrystalManager.cpp">
+      <Filter>ApplicationLayer\Scene\GamePlayScene\World</Filter>
+    </ClCompile>
     <ClCompile Include="ApplicationLayer\Character\CharacterWorld\CharacterWorld.cpp">
       <Filter>ApplicationLayer\Character\CharacterWorld</Filter>
     </ClCompile>
@@ -1094,6 +1100,12 @@
     </ClInclude>
     <ClInclude Include="ApplicationLayer\Character\Player\PlayerHurtbox.h">
       <Filter>ApplicationLayer\Character\Player</Filter>
+    </ClInclude>
+    <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\World\EnemySpawnCrystal.h">
+      <Filter>ApplicationLayer\Scene\GamePlayScene\World</Filter>
+    </ClInclude>
+    <ClInclude Include="ApplicationLayer\Scene\GamePlayScene\World\CrystalManager.h">
+      <Filter>ApplicationLayer\Scene\GamePlayScene\World</Filter>
     </ClInclude>
     <ClInclude Include="ApplicationLayer\Character\CharacterWorld\CharacterWorld.h">
       <Filter>ApplicationLayer\Character\CharacterWorld</Filter>


### PR DESCRIPTION
### Motivation
- ゲーム進行を「クリスタル破壊」に据え、クリスタルが生存している間は雑魚を継続的に（ただし同時出現数で上限をかけて）出し、全破壊後にボス出現トリガを立てるための基盤をC++側で仮実装しました。
- 将来的にBlenderからスポーン設定を読み込めるよう、データ構造を用意しておくことを目的としています。

### Description
- 追加したデータ／クラス：`CrystalSpawnPoint`（Blender互換構造）、`EnemySpawnCrystal`（個別クリスタルの状態・生成ロジック・デバッグ描画）、`CrystalManager`（複数クリスタルの管理・全破壊判定・ImGuiデバッグ）。
- 敵生成は既存の経路を利用しており、`EnemySpawnCrystal` は `CharacterWorld::SpawnEnemyAt()` を呼び出して `EnemyFactory` 経由で `Melee` / `MidRange` を生成します（将来切替可能）。
- クリスタル側は指定のランタイム項目（`isAlive`, `hp`, `spawnEnemyType`, `spawnInterval`, `spawnTimer`, `spawnRadius`, `maxAliveEnemies`, `totalSpawnedCount`, `aliveSpawnedEnemyCount`, `enableInfiniteSpawn`）を保持し、`maxAliveEnemies` によって同時出現を制限します。コメントとして「クリスタルが破壊されるまで一定間隔で敵を出し続ける。」を追加しています。
- `GamePlayWorld` に `CrystalManager` を統合し、現時点ではC++側の仮スポーン3点（左右Melee・中央MidRange）を初期設定として追加し、更新／描画／ImGui（日本語ラベル）と連携しています。ボス出現は一次的に `shouldSpawnBoss_` / `hasBossSpawned_` フラグとログ出力のみ実装し既存ボス処理を壊さない形にしています。
- 追加ファイルを Visual Studio プロジェクト（`Project/Ken4lowEngine.vcxproj` とフィルター）へ登録しました。

### Testing
- `git diff --cached --check` を実行して差分の問題を確認しました（問題なし）。
- `Project/Ken4lowEngine.vcxproj` と `Project/Ken4lowEngine.vcxproj.filters` を Python `xml.etree.ElementTree` でパースして XML 構文の妥当性を確認しました（OK）。
- Python スクリプトで新規クラス/メンバの存在チェックを行い、必要な宣言があることを検証しました（OK）。
- `dotnet msbuild` による実ビルドはこの Linux コンテナに `dotnet` / `msbuild` / Windows C++ コンパイラが無いため実行できませんでした（環境上の制約）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f0737ee3c832d9854f969a17dafb0)