### PR TITLE
クリスタル由来の敵スポーンにステージ全体制限と間隔制御を追加

### DIFF
--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/CrystalManager.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/CrystalManager.cpp
@@ -10,6 +10,11 @@
 #include <imgui.h>
 #endif
 
+namespace
+{
+	constexpr float kMinimumSpawnInterval = 0.05f;
+}
+
 void CrystalManager::Initialize(const std::vector<CrystalSpawnPoint>& spawnPoints)
 {
 	crystals_.clear();
@@ -22,6 +27,12 @@ void CrystalManager::Initialize(const std::vector<CrystalSpawnPoint>& spawnPoint
 	}
 
 	selectedCrystalIndex_ = 0;
+	nextSpawnCrystalIndex_ = 0;
+	enableCrystalEnemySpawn_ = true;
+	maxTotalCrystalSpawnEnemies_ = 9;
+	globalSpawnInterval_ = 5.0f;
+	globalSpawnTimer_ = 0.0f;
+	maxSpawnPerInterval_ = 1;
 	shouldSpawnBoss_ = false;
 	hasBossSpawned_ = false;
 }
@@ -30,9 +41,35 @@ void CrystalManager::Update(CharacterWorld& characters, float deltaTime)
 {
 	for (EnemySpawnCrystal& crystal : crystals_)
 	{
-		crystal.Update(characters, deltaTime);
+		crystal.Update(characters);
 	}
+
 	NotifyBossSpawnIfNeeded();
+	if (!enableCrystalEnemySpawn_ || AreAllCrystalsDestroyed() || GetAliveCrystalCount() <= 0 ||
+		GetAliveCrystalSpawnEnemyCount() >= maxTotalCrystalSpawnEnemies_)
+	{
+		globalSpawnTimer_ = 0.0f;
+		return;
+	}
+
+	globalSpawnTimer_ += std::max(0.0f, deltaTime);
+	if (globalSpawnTimer_ < globalSpawnInterval_)
+	{
+		return;
+	}
+
+	globalSpawnTimer_ = 0.0f;
+	// 敵が増えすぎないよう、クリスタル由来の生存敵数がステージ全体の上限未満のときだけ補充する。
+	for (int spawnedCount = 0; spawnedCount < maxSpawnPerInterval_ &&
+		GetAliveCrystalSpawnEnemyCount() < maxTotalCrystalSpawnEnemies_; ++spawnedCount)
+	{
+		EnemySpawnCrystal* crystal = FindNextSpawnableCrystal();
+		if (!crystal)
+		{
+			break;
+		}
+		crystal->SpawnEnemy(characters);
+	}
 }
 
 void CrystalManager::Draw() const
@@ -47,6 +84,16 @@ int CrystalManager::GetAliveCrystalCount() const
 {
 	return static_cast<int>(std::count_if(crystals_.begin(), crystals_.end(),
 		[](const EnemySpawnCrystal& crystal) { return crystal.IsAlive(); }));
+}
+
+int CrystalManager::GetAliveCrystalSpawnEnemyCount() const
+{
+	int totalCount = 0;
+	for (const EnemySpawnCrystal& crystal : crystals_)
+	{
+		totalCount += crystal.GetAliveSpawnedEnemyCount();
+	}
+	return totalCount;
 }
 
 bool CrystalManager::AreAllCrystalsDestroyed() const
@@ -77,6 +124,20 @@ const EnemySpawnCrystal* CrystalManager::GetSelectedCrystal() const
 	return selectedCrystalIndex_ < crystals_.size() ? &crystals_[selectedCrystalIndex_] : nullptr;
 }
 
+EnemySpawnCrystal* CrystalManager::FindNextSpawnableCrystal()
+{
+	for (size_t offset = 0; offset < crystals_.size(); ++offset)
+	{
+		const size_t crystalIndex = (nextSpawnCrystalIndex_ + offset) % crystals_.size();
+		if (crystals_[crystalIndex].CanSpawnEnemy())
+		{
+			nextSpawnCrystalIndex_ = (crystalIndex + 1) % crystals_.size();
+			return &crystals_[crystalIndex];
+		}
+	}
+	return nullptr;
+}
+
 void CrystalManager::DrawImGui()
 {
 #ifdef USE_IMGUI
@@ -85,6 +146,15 @@ void CrystalManager::DrawImGui()
 		return;
 	}
 
+	ImGui::Checkbox("クリスタル敵スポーン有効", &enableCrystalEnemySpawn_);
+	ImGui::DragInt("クリスタル由来の最大敵数", &maxTotalCrystalSpawnEnemies_, 1.0f, 0, 100);
+	maxTotalCrystalSpawnEnemies_ = std::max(0, maxTotalCrystalSpawnEnemies_);
+	ImGui::Text("現在のクリスタル由来敵数: %d", GetAliveCrystalSpawnEnemyCount());
+	ImGui::DragFloat("スポーン間隔", &globalSpawnInterval_, 0.1f, kMinimumSpawnInterval, 60.0f, "%.2f 秒");
+	globalSpawnInterval_ = std::max(kMinimumSpawnInterval, globalSpawnInterval_);
+	ImGui::Text("スポーンタイマー: %.2f / %.2f 秒", globalSpawnTimer_, globalSpawnInterval_);
+	ImGui::DragInt("1回の最大スポーン数", &maxSpawnPerInterval_, 1.0f, 1, 9);
+	maxSpawnPerInterval_ = std::max(1, maxSpawnPerInterval_);
 	ImGui::Text("クリスタル数: %d", GetCrystalCount());
 	ImGui::Text("生存クリスタル数: %d", GetAliveCrystalCount());
 	ImGui::Text("全クリスタル破壊済み: %s", AreAllCrystalsDestroyed() ? "はい" : "いいえ");
@@ -109,7 +179,7 @@ void CrystalManager::DrawImGui()
 	}
 
 	bool enableInfiniteSpawn = crystal->IsInfiniteSpawnEnabled();
-	if (ImGui::Checkbox("クリスタル敵スポーン有効", &enableInfiniteSpawn))
+	if (ImGui::Checkbox("選択中クリスタルの敵スポーン有効", &enableInfiniteSpawn))
 	{
 		crystal->SetInfiniteSpawnEnabled(enableInfiniteSpawn);
 	}
@@ -121,20 +191,14 @@ void CrystalManager::DrawImGui()
 		crystal->SetSpawnEnemyType(static_cast<EnemyType>(enemyTypeIndex));
 	}
 
-	float spawnInterval = crystal->GetSpawnInterval();
-	if (ImGui::DragFloat("敵出現間隔", &spawnInterval, 0.1f, 0.05f, 60.0f, "%.2f 秒"))
-	{
-		crystal->SetSpawnInterval(spawnInterval);
-	}
-
 	int maxAliveEnemies = crystal->GetMaxAliveEnemies();
-	if (ImGui::DragInt("同時出現上限", &maxAliveEnemies, 1.0f, 0, 100))
+	if (ImGui::DragInt("選択中クリスタルの同時出現上限", &maxAliveEnemies, 1.0f, 0, 100))
 	{
 		crystal->SetMaxAliveEnemies(maxAliveEnemies);
 	}
 
-	ImGui::Text("現在の生存スポーン敵数: %d", crystal->GetAliveSpawnedEnemyCount());
-	ImGui::Text("合計スポーン数: %d", crystal->GetTotalSpawnedCount());
+	ImGui::Text("選択中クリスタル由来の生存敵数: %d", crystal->GetAliveSpawnedEnemyCount());
+	ImGui::Text("選択中クリスタルの合計スポーン数: %d", crystal->GetTotalSpawnedCount());
 	ImGui::Text("選択中クリスタルHP: %d", crystal->GetHp());
 	if (ImGui::Button("選択中クリスタルへダメージ"))
 	{

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/CrystalManager.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/CrystalManager.h
@@ -18,6 +18,7 @@ public:
 
 	int GetCrystalCount() const { return static_cast<int>(crystals_.size()); }
 	int GetAliveCrystalCount() const;
+	int GetAliveCrystalSpawnEnemyCount() const;
 	bool AreAllCrystalsDestroyed() const;
 	bool ShouldSpawnBoss() const { return shouldSpawnBoss_; }
 	bool HasBossSpawned() const { return hasBossSpawned_; }
@@ -25,11 +26,18 @@ public:
 private:
 	EnemySpawnCrystal* GetSelectedCrystal();
 	const EnemySpawnCrystal* GetSelectedCrystal() const;
+	EnemySpawnCrystal* FindNextSpawnableCrystal();
 	void NotifyBossSpawnIfNeeded();
 
 private:
 	std::vector<EnemySpawnCrystal> crystals_;
 	size_t selectedCrystalIndex_ = 0;
+	size_t nextSpawnCrystalIndex_ = 0;
+	bool enableCrystalEnemySpawn_ = true;
+	int maxTotalCrystalSpawnEnemies_ = 9;
+	float globalSpawnInterval_ = 5.0f;
+	float globalSpawnTimer_ = 0.0f;
+	int maxSpawnPerInterval_ = 1;
 	bool shouldSpawnBoss_ = false;
 	bool hasBossSpawned_ = false;
 };

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/EnemySpawnCrystal.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/EnemySpawnCrystal.cpp
@@ -12,8 +12,6 @@ using namespace Ken4lowEngine;
 
 namespace
 {
-	constexpr float kMinimumSpawnInterval = 0.05f;
-
 	float RandomRange(float minValue, float maxValue)
 	{
 		const float t = static_cast<float>(std::rand()) / static_cast<float>(RAND_MAX);
@@ -27,8 +25,6 @@ void EnemySpawnCrystal::Initialize(const CrystalSpawnPoint& spawnPoint)
 	isAlive = true;
 	hp = std::max(1, spawnPoint.hp);
 	spawnEnemyType = spawnPoint.spawnEnemyType;
-	spawnInterval = std::max(kMinimumSpawnInterval, spawnPoint.spawnInterval);
-	spawnTimer = 0.0f;
 	spawnRadius = std::max(0.0f, spawnPoint.spawnRadius);
 	maxAliveEnemies = std::max(0, spawnPoint.maxAliveEnemies);
 	totalSpawnedCount = 0;
@@ -46,23 +42,9 @@ void EnemySpawnCrystal::Initialize(const CrystalSpawnPoint& spawnPoint)
 	debugCube_->Update();
 }
 
-void EnemySpawnCrystal::Update(CharacterWorld& characters, float deltaTime)
+void EnemySpawnCrystal::Update(const CharacterWorld& characters)
 {
 	RemoveInactiveSpawnedEnemies(characters);
-	if (!isAlive || !enableInfiniteSpawn || maxAliveEnemies <= 0)
-	{
-		return;
-	}
-
-	// クリスタルが破壊されるまで一定間隔で敵を出し続ける。
-	spawnTimer += std::max(0.0f, deltaTime);
-	if (spawnTimer < spawnInterval || aliveSpawnedEnemyCount >= maxAliveEnemies)
-	{
-		return;
-	}
-
-	spawnTimer = 0.0f;
-	SpawnEnemy(characters);
 }
 
 void EnemySpawnCrystal::Draw() const
@@ -84,13 +66,12 @@ void EnemySpawnCrystal::TakeDamage(int damage)
 	if (hp <= 0)
 	{
 		isAlive = false;
-		spawnTimer = 0.0f;
 	}
 }
 
-void EnemySpawnCrystal::SetSpawnInterval(float interval)
+bool EnemySpawnCrystal::CanSpawnEnemy() const
 {
-	spawnInterval = std::max(kMinimumSpawnInterval, interval);
+	return isAlive && enableInfiniteSpawn && aliveSpawnedEnemyCount < maxAliveEnemies;
 }
 
 void EnemySpawnCrystal::SetMaxAliveEnemies(int count)

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/EnemySpawnCrystal.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/EnemySpawnCrystal.h
@@ -20,8 +20,8 @@ struct CrystalSpawnPoint
 	K4E::Vector3 scale{ 1.0f, 1.0f, 1.0f };
 	int hp = 100;
 	EnemyType spawnEnemyType = EnemyType::Melee;
-	float spawnInterval = 2.0f;
-	int maxAliveEnemies = 10;
+	float spawnInterval = 5.0f; // 互換性維持用。生成間隔は CrystalManager がステージ全体で管理する。
+	int maxAliveEnemies = 9;
 	float spawnRadius = 3.0f;
 	bool enableInfiniteSpawn = true;
 	bool spawnBossTrigger = true;
@@ -32,14 +32,15 @@ class EnemySpawnCrystal
 {
 public:
 	void Initialize(const CrystalSpawnPoint& spawnPoint);
-	void Update(CharacterWorld& characters, float deltaTime);
+	void Update(const CharacterWorld& characters);
 	void Draw() const;
 	void TakeDamage(int damage);
+	bool CanSpawnEnemy() const;
+	void SpawnEnemy(CharacterWorld& characters);
 
 	bool IsAlive() const { return isAlive; }
 	int GetHp() const { return hp; }
 	EnemyType GetSpawnEnemyType() const { return spawnEnemyType; }
-	float GetSpawnInterval() const { return spawnInterval; }
 	float GetSpawnRadius() const { return spawnRadius; }
 	int GetMaxAliveEnemies() const { return maxAliveEnemies; }
 	int GetTotalSpawnedCount() const { return totalSpawnedCount; }
@@ -50,24 +51,20 @@ public:
 
 	void SetInfiniteSpawnEnabled(bool enabled) { enableInfiniteSpawn = enabled; }
 	void SetSpawnEnemyType(EnemyType enemyType) { spawnEnemyType = enemyType; }
-	void SetSpawnInterval(float interval);
 	void SetMaxAliveEnemies(int count);
-
-private:
-	void RemoveInactiveSpawnedEnemies(const CharacterWorld& characters);
-	void SpawnEnemy(CharacterWorld& characters);
 
 public: // Blender 読み込み対応時にも維持するランタイム設定値。
 	bool isAlive = true;
 	int hp = 100;
 	EnemyType spawnEnemyType = EnemyType::Melee;
-	float spawnInterval = 2.0f;
-	float spawnTimer = 0.0f;
 	float spawnRadius = 3.0f;
-	int maxAliveEnemies = 10;
+	int maxAliveEnemies = 9;
 	int totalSpawnedCount = 0;
 	int aliveSpawnedEnemyCount = 0;
 	bool enableInfiniteSpawn = true;
+
+private:
+	void RemoveInactiveSpawnedEnemies(const CharacterWorld& characters);
 
 private:
 	K4E::Vector3 position_{};


### PR DESCRIPTION
### Motivation
- クリスタルが独立タイマーで無制限に大量湧きしてしまう問題を抑制し、ステージ全体で雑魚敵の同時上限を設けて安定した難易度にするため。 
- 敵が倒されたときのみ補充し、短時間で大量に湧かないようにスポーン間隔と1回あたりの生成数を導入するため。 
- すべてのクリスタル破壊時は補充処理を停止して既存のボス遷移処理へ安全に接続するため。 
- ImGuiでデザイナ/デバッグが設定と現在状態を確認・調整できるようにするため。 

### Description
- 全生成ロジックを`CrystalManager`へ集約し、ステージ全体の上限を管理するようにした（新規フィールド：`maxTotalCrystalSpawnEnemies_ = 9`、`globalSpawnInterval_ = 5.0f`、`maxSpawnPerInterval_ = 1`）。
- クリスタル単位の独立タイマーを撤廃し、各`EnemySpawnCrystal`は自分由来の生存敵を追跡する責務と`CanSpawnEnemy()`/`SpawnEnemy()`を提供するように変更した。 
- `CrystalManager::Update()`でグローバルタイマーと合算した生存クリスタル由来敵数を評価してから、ラウンドロビンで生成元クリスタルを選び1体ずつ補充する仕組みにした（大量同時生成を防止）。
- 破壊済みクリスタルを生成候補から除外し、すべて破壊されたら補充処理を停止して既存のボス通知フローへ進むようにした。 
- ImGuiに日本語項目を追加して、`クリスタル敵スポーン有効`、`クリスタル由来の最大敵数`、`現在のクリスタル由来敵数`、`スポーン間隔`、`スポーンタイマー`、`1回の最大スポーン数`、`生存クリスタル数`、`全クリスタル破壊済み`などを表示/編集可能にした。 
- 既存の`EnemyScalabilitySystem`/`StressTest`や`MidRangeEnemy`本体、ボス処理には変更を加えていません。 

### Testing
- 自動静的チェックとして `git diff --check` を実行し問題なしを確認しました。 (成功)
- リポジトリ内のスクリプトで `maxTotalCrystalSpawnEnemies_ == 9`、`globalSpawnInterval_ == 5.0f`、`maxSpawnPerInterval_ == 1`、破壊済みクリスタルの除外、クリスタル由来敵追跡、およびImGuiラベルの存在を確認する静的検証を実行しました。 (成功)
- ワークツリーはクリーンでブランチは `feature/enemy-scalability-system` にコミット済みであることを確認しました。 (成功)
- ソリューションビルドはCIがWindows/MSBuild前提であるためローカルコンテナでは `msbuild` が存在せず実行できませんでした（CI上の `windows-2022` ジョブでのビルドを推奨）。 (実行不可)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f0c2c6884832d9c19f0791db5ca71)