### PR TITLE
Fix crystal world-space transform updates

### DIFF
--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/CrystalManager.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/CrystalManager.cpp
@@ -2,6 +2,7 @@
 #include "CrystalManager.h"
 
 #include "CharacterWorld.h"
+#include "CameraManager.h"
 
 #include <algorithm>
 #include <iostream>
@@ -198,9 +199,16 @@ void CrystalManager::DrawImGui()
 		crystal->SetMaxAliveEnemies(maxAliveEnemies);
 	}
 
+	const Ken4lowEngine::Vector3& crystalPosition = crystal->GetPosition();
+	const Ken4lowEngine::Vector3& crystalScale = crystal->GetScale();
+	const Ken4lowEngine::Vector3 cameraPosition = Ken4lowEngine::CameraManager::GetInstance()->GetActiveCameraPosition();
+	ImGui::Text("選択中クリスタル座標: (%.2f, %.2f, %.2f)", crystalPosition.x, crystalPosition.y, crystalPosition.z);
+	ImGui::Text("クリスタルScale: (%.2f, %.2f, %.2f)", crystalScale.x, crystalScale.y, crystalScale.z);
+	ImGui::Text("選択中クリスタルHP: %d", crystal->GetHp());
+	ImGui::Text("生存状態: %s", crystal->IsAlive() ? "生存" : "破壊済み");
+	ImGui::Text("カメラ座標: (%.2f, %.2f, %.2f)", cameraPosition.x, cameraPosition.y, cameraPosition.z);
 	ImGui::Text("選択中クリスタル由来の生存敵数: %d", crystal->GetAliveSpawnedEnemyCount());
 	ImGui::Text("選択中クリスタルの合計スポーン数: %d", crystal->GetTotalSpawnedCount());
-	ImGui::Text("選択中クリスタルHP: %d", crystal->GetHp());
 	if (ImGui::Button("選択中クリスタルへダメージ"))
 	{
 		crystal->TakeDamage(25);

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/EnemySpawnCrystal.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/EnemySpawnCrystal.cpp
@@ -22,6 +22,8 @@ namespace
 void EnemySpawnCrystal::Initialize(const CrystalSpawnPoint& spawnPoint)
 {
 	position_ = spawnPoint.position;
+	rotation_ = spawnPoint.rotation;
+	scale_ = spawnPoint.scale;
 	isAlive = true;
 	hp = std::max(1, spawnPoint.hp);
 	spawnEnemyType = spawnPoint.spawnEnemyType;
@@ -35,9 +37,9 @@ void EnemySpawnCrystal::Initialize(const CrystalSpawnPoint& spawnPoint)
 
 	debugCube_ = std::make_unique<Object3D>();
 	debugCube_->Initialize("Test/cube.gltf");
-	debugCube_->SetTranslate(spawnPoint.position);
-	debugCube_->SetRotate(spawnPoint.rotation);
-	debugCube_->SetScale(spawnPoint.scale);
+	debugCube_->SetTranslate(position_);
+	debugCube_->SetRotate(rotation_);
+	debugCube_->SetScale(scale_);
 	debugCube_->SetColor({ 0.25f, 0.85f, 1.0f, 1.0f });
 	debugCube_->Update();
 }
@@ -45,6 +47,15 @@ void EnemySpawnCrystal::Initialize(const CrystalSpawnPoint& spawnPoint)
 void EnemySpawnCrystal::Update(const CharacterWorld& characters)
 {
 	RemoveInactiveSpawnedEnemies(characters);
+
+	if (debugCube_)
+	{
+		// クリスタルはカメラ基準ではなく、ステージ上の固定ワールド座標に配置する。
+		debugCube_->SetTranslate(position_);
+		debugCube_->SetRotate(rotation_);
+		debugCube_->SetScale(scale_);
+		debugCube_->Update();
+	}
 }
 
 void EnemySpawnCrystal::Draw() const

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/EnemySpawnCrystal.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/EnemySpawnCrystal.h
@@ -48,6 +48,7 @@ public:
 	bool IsInfiniteSpawnEnabled() const { return enableInfiniteSpawn; }
 	bool IsBossSpawnTrigger() const { return spawnBossTrigger_; }
 	const K4E::Vector3& GetPosition() const { return position_; }
+	const K4E::Vector3& GetScale() const { return scale_; }
 
 	void SetInfiniteSpawnEnabled(bool enabled) { enableInfiniteSpawn = enabled; }
 	void SetSpawnEnemyType(EnemyType enemyType) { spawnEnemyType = enemyType; }
@@ -68,6 +69,8 @@ private:
 
 private:
 	K4E::Vector3 position_{};
+	K4E::Vector3 rotation_{};
+	K4E::Vector3 scale_{ 1.0f, 1.0f, 1.0f };
 	bool spawnBossTrigger_ = true;
 	std::unique_ptr<K4E::Object3D> debugCube_;
 	std::vector<const EnemyBase*> spawnedEnemies_;

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
@@ -143,11 +143,11 @@ void GamePlayWorld::Initialize(GamePlayStageContext& stageContext)
 	prevWaveInProgress_ = false;
 	prevAllWavesCleared_ = false;
 
-	// Blender 側の設定読み込みを追加するまでは、C++ の仮スポーン地点を使用する。
+	// Blender 側の設定読み込みを追加するまでは、C++ でステージ上の固定ワールド座標へ仮配置する。
 	crystalManager_.Initialize({
-		{ { -8.0f, 1.0f, 8.0f }, {}, { 1.5f, 2.5f, 1.5f }, 100, EnemyType::Melee, 2.0f, 10, 4.0f, true, true },
-		{ {  0.0f, 1.0f, 14.0f }, {}, { 1.5f, 2.5f, 1.5f }, 100, EnemyType::MidRange, 3.0f, 6, 4.0f, true, true },
-		{ {  8.0f, 1.0f, 8.0f }, {}, { 1.5f, 2.5f, 1.5f }, 100, EnemyType::Melee, 2.0f, 10, 4.0f, true, true },
+		{ {   0.0f, 2.0f, 20.0f }, {}, { 1.5f, 2.5f, 1.5f }, 100, EnemyType::Melee, 2.0f, 10, 4.0f, true, true },
+		{ {  10.0f, 2.0f, 30.0f }, {}, { 1.5f, 2.5f, 1.5f }, 100, EnemyType::MidRange, 3.0f, 6, 4.0f, true, true },
+		{ { -10.0f, 2.0f, 30.0f }, {}, { 1.5f, 2.5f, 1.5f }, 100, EnemyType::Melee, 2.0f, 10, 4.0f, true, true },
 	});
 
 	enemyHpBarManager_.Initialize();


### PR DESCRIPTION
### Motivation
- Crystals were visually attached to the camera because their Object3D WVP remained initialized and was not refreshed when the camera moved. 
- The change ensures crystals are stored and drawn as world-space objects so camera movement does not change their world position. 

### Description
- Persisted per-crystal world parameters (`position_`, `rotation_`, `scale_`) in `EnemySpawnCrystal` and applied them to the owned `Object3D` every frame in `EnemySpawnCrystal::Update()` before calling `debugCube_->Update()` so the object's `WorldTransform` and WVP are recalculated with the current camera. 
- Set fixed stage spawn coordinates in `GamePlayWorld::Initialize()` to explicit world positions: `{0.0f,2.0f,20.0f}`, `{10.0f,2.0f,30.0f}`, `{-10.0f,2.0f,30.0f}`. 
- Added Japanese ImGui diagnostics in `CrystalManager::DrawImGui()` showing selected crystal position, scale, HP, alive state, and active camera position so runtime verification is possible. 
- Kept existing spawn logic and the normal `Object3D::Draw()` path unchanged; no camera-relative placement or screen-space debug draw was introduced. 

### Testing
- Passed: `git diff --check` with no whitespace/errors reported. 
- Passed: static scans using `rg` confirmed there are no camera-relative crystal placement assignments and that per-frame `SetTranslate/SetRotate/SetScale` + `debugCube_->Update()` and ImGui labels were added. 
- Not run: full Visual Studio/MSBuild solution build (`msbuild Project/Ken4lowEngine.sln`) could not be executed in the Linux container because `msbuild` is not available; runtime verification on Windows is recommended and the new ImGui fields can be used to confirm crystal positions remain fixed while moving the camera.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f0fa5b284832d9868bdce11cb3d64)