### PR TITLE
敵の移動安全処理とクリスタル破壊判定を追加

### DIFF
--- a/Project/ApplicationLayer/Character/Bullet/Bullet.cpp
+++ b/Project/ApplicationLayer/Character/Bullet/Bullet.cpp
@@ -400,12 +400,13 @@ void Bullet::OnCollisionEnter(K4E::Collider* other)
 	const uint32_t kEnemy = static_cast<uint32_t>(CollisionTypeIdDef::kEnemy);
 	const uint32_t kBoss = static_cast<uint32_t>(CollisionTypeIdDef::kBoss);
 	const uint32_t kWorld = static_cast<uint32_t>(CollisionTypeIdDef::kWorld);
+	const uint32_t kCrystal = static_cast<uint32_t>(CollisionTypeIdDef::kCrystal);
 
 	bool shouldHit = false;
 	if (selfType == static_cast<uint32_t>(CollisionTypeIdDef::kBullet))
 	{
-		// プレイヤー弾：敵/ボス/ワールド
-		shouldHit = (otherType == kEnemy || otherType == kBoss || otherType == kWorld);
+		// プレイヤー弾：敵/ボス/クリスタル/ワールド
+		shouldHit = (otherType == kEnemy || otherType == kBoss || otherType == kCrystal || otherType == kWorld);
 	}
 	else if (selfType == static_cast<uint32_t>(CollisionTypeIdDef::kEnemyBullet) ||
 		selfType == static_cast<uint32_t>(CollisionTypeIdDef::kBossBullet))

--- a/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.cpp
+++ b/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.cpp
@@ -174,10 +174,11 @@ void CharacterWorld::Update(float dt)
 {
 	if (player_) player_->Update(dt);
 
+	const float enemyDeltaTime = std::clamp(dt, 0.0f, EnemyBase::GetMaxUpdateDeltaTime());
 	for (auto& e : enemies_)
 	{
 		const bool wasAlreadyNotified = notifiedKilledEnemies_.contains(e.get());
-		e->Update(dt);
+		e->Update(enemyDeltaTime);
 
 		// 衝突更新で死亡した敵も次フレームに1回だけ通知して、ドロップ生成の取り逃しを防ぐ。
 		if (!wasAlreadyNotified && e->IsDead())

--- a/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.cpp
@@ -236,6 +236,9 @@ void EnemyBase::Update(float deltaTime)
 {
 	if (removable_) return;
 
+	// フレーム落ち時の移動暴走を防ぐため、敵更新用deltaTimeを制限する。
+	deltaTime = std::clamp(deltaTime, 0.0f, kMaxUpdateDeltaTime);
+
 	// 死亡演出
 	if (isDead_)
 	{
@@ -274,6 +277,19 @@ void EnemyBase::Update(float deltaTime)
 		grounded_ = res.grounded;
 		newPos = res.fixedCenter + s.centerOffset;
 	}
+
+	// 仮の安全処理として、敵の足元が基準床Yより下なら地面上へ戻す。
+	const float minimumCenterY = kGroundY + obbHalf_.y;
+	if (newPos.y < minimumCenterY)
+	{
+		newPos.y = minimumCenterY;
+		velocity_.y = 0.0f;
+		grounded_ = true;
+	}
+
+	// ステージ外へ落ち続けないよう、生存中の敵XZ座標を安全範囲へ制限する。
+	newPos.x = std::clamp(newPos.x, kWorldBoundsMinX, kWorldBoundsMaxX);
+	newPos.z = std::clamp(newPos.z, kWorldBoundsMinZ, kWorldBoundsMaxZ);
 
 	SetCenterPosition(newPos);
 	UpdateHitFlash(deltaTime);

--- a/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.h
@@ -126,6 +126,9 @@ public:
 
 	static void SetGlobalStageWorldAABBs(const std::vector<K4E::AABB>* aabbs);
 	static void SetGlobalStageNavigationObstacleAABBs(const std::vector<K4E::AABB>* aabbs);
+	static constexpr float GetMaxUpdateDeltaTime() { return kMaxUpdateDeltaTime; }
+	static constexpr bool IsGroundSnapEnabled() { return true; }
+	static constexpr bool IsWorldBoundsEnabled() { return true; }
 
 	// 参照用
 	BodyPart& GetBody() { return body_; }
@@ -175,6 +178,13 @@ protected:
 	std::vector<BodyPart> parts_;
 	PartIndices partIndices_{};
 	K4E::Vector3 orientation_{ 0.0f, 0.0f, 0.0f };
+
+	static constexpr float kMaxUpdateDeltaTime = 1.0f / 30.0f;
+	static constexpr float kGroundY = 0.0f;
+	static constexpr float kWorldBoundsMinX = -100.0f;
+	static constexpr float kWorldBoundsMaxX = 100.0f;
+	static constexpr float kWorldBoundsMinZ = -100.0f;
+	static constexpr float kWorldBoundsMaxZ = 100.0f;
 
 	// HP
 	int maxHp_ = 240;

--- a/Project/ApplicationLayer/Character/Player/Component/PlayerMeleeComponent.cpp
+++ b/Project/ApplicationLayer/Character/Player/Component/PlayerMeleeComponent.cpp
@@ -4,6 +4,8 @@
 #include "CollisionTypeIdDef.h"
 #include "Collider.h"
 #include "EnemyBase.h"
+#include "EnemySpawnCrystal.h"
+#include "BossBase.h"
 
 namespace
 {
@@ -91,6 +93,7 @@ void PlayerMeleeComponent::EvaluateHit(const K4E::Vector3& playerPos)
 
 	K4E::Collider* enemyHit = nullptr;
 	K4E::Collider* bossHit = nullptr;
+	K4E::Collider* crystalHit = nullptr;
 
 	const bool hitEnemy = collisionManager_->SegmentCast(
 		static_cast<uint32_t>(CollisionTypeIdDef::kEnemy), seg, &enemyHit);
@@ -98,30 +101,34 @@ void PlayerMeleeComponent::EvaluateHit(const K4E::Vector3& playerPos)
 	const bool hitBoss = collisionManager_->SegmentCast(
 		static_cast<uint32_t>(CollisionTypeIdDef::kBoss), seg, &bossHit);
 
-	K4E::Collider* bestHit = nullptr;
+	const bool hitCrystal = collisionManager_->SegmentCast(
+		static_cast<uint32_t>(CollisionTypeIdDef::kCrystal), seg, &crystalHit);
 
-	if (hitEnemy && enemyHit && hitBoss && bossHit)
-	{
-		const float enemyDist = DistSq(enemyHit->GetCenterPosition(), start);
-		const float bossDist = DistSq(bossHit->GetCenterPosition(), start);
-		bestHit = (enemyDist <= bossDist) ? enemyHit : bossHit;
-	}
-	else if (hitEnemy && enemyHit)
-	{
-		bestHit = enemyHit;
-	}
-	else if (hitBoss && bossHit)
-	{
-		bestHit = bossHit;
-	}
+	K4E::Collider* bestHit = nullptr;
+	float bestDist = 0.0f;
+	auto selectNearest = [&](bool hit, K4E::Collider* candidate)
+		{
+			if (!hit || !candidate) return;
+			const float dist = DistSq(candidate->GetCenterPosition(), start);
+			if (!bestHit || dist < bestDist)
+			{
+				bestHit = candidate;
+				bestDist = dist;
+			}
+		};
+
+	selectNearest(hitEnemy, enemyHit);
+	selectNearest(hitBoss, bossHit);
+	selectNearest(hitCrystal, crystalHit);
 
 	if (!bestHit)
 	{
 		return;
 	}
 
-	if (auto* enemyBase = bestHit->GetOwner<EnemyBase>())
+	if (bestHit->GetTypeID() == static_cast<uint32_t>(CollisionTypeIdDef::kEnemy))
 	{
+		auto* enemyBase = bestHit->GetOwner<EnemyBase>();
 		const bool wasDead = enemyBase->IsDead();
 
 		// 近接ヒット位置
@@ -149,5 +156,16 @@ void PlayerMeleeComponent::EvaluateHit(const K4E::Vector3& playerPos)
 		{
 			onHit_();
 		}
+	}
+	else if (bestHit->GetTypeID() == static_cast<uint32_t>(CollisionTypeIdDef::kCrystal))
+	{
+		// 敵だけでなく、近接攻撃の最寄り対象がクリスタルならHPを減らす。
+		bestHit->GetOwner<EnemySpawnCrystal>()->ApplyDamage(damage_);
+		if (onHit_) onHit_();
+	}
+	else if (bestHit->GetTypeID() == static_cast<uint32_t>(CollisionTypeIdDef::kBoss))
+	{
+		bestHit->GetOwner<BossBase>()->OnDamaged(static_cast<float>(damage_));
+		if (onHit_) onHit_();
 	}
 }

--- a/Project/ApplicationLayer/Character/Player/Component/PlayerMeleeComponent.h
+++ b/Project/ApplicationLayer/Character/Player/Component/PlayerMeleeComponent.h
@@ -9,6 +9,7 @@ namespace K4E = ::Ken4lowEngine;
 class CollisionManager;
 class PlayerViewComponent;
 class EnemyBase;
+class EnemySpawnCrystal;
 
 class PlayerMeleeComponent
 {

--- a/Project/ApplicationLayer/Colliders/CollisionManager.cpp
+++ b/Project/ApplicationLayer/Colliders/CollisionManager.cpp
@@ -97,6 +97,7 @@ void CollisionManager::CheckAllCollisions()
 	const CId kBossBullet = static_cast<CId>(CollisionTypeIdDef::kBossBullet);
 	const CId kItem = static_cast<CId>(CollisionTypeIdDef::kItem);
 	const CId kWorld = static_cast<CId>(CollisionTypeIdDef::kWorld);
+	const CId kCrystal = static_cast<CId>(CollisionTypeIdDef::kCrystal);
 
 	// --- スナップショット（イベント中の追加/削除に備える） ---
 	std::vector<K4E::Collider*> snapshot = all_;
@@ -138,6 +139,7 @@ void CollisionManager::CheckAllCollisions()
 	pairLoop(kBoss, kPlayer);
 	pairLoop(kEnemy, kPlayer);
 	pairLoop(kBullet, kEnemy);
+	pairLoop(kBullet, kCrystal);
 	pairLoop(kBoss, kBullet);
 	pairLoop(kEnemyBullet, kPlayer);
 	pairLoop(kPlayer, kBossBullet);
@@ -288,6 +290,7 @@ void CollisionManager::RegisterCollisionFuncsions()
 	constexpr CollisionType kItem = static_cast<CollisionType>(CollisionTypeIdDef::kItem);
 	constexpr CollisionType kBoss = static_cast<CollisionType>(CollisionTypeIdDef::kBoss);
 	constexpr CollisionType kWorld = static_cast<CollisionType>(CollisionTypeIdDef::kWorld);
+	constexpr CollisionType kCrystal = static_cast<CollisionType>(CollisionTypeIdDef::kCrystal);
 
 	auto AddCollisionFunc = [&](CollisionType a, CollisionType b, const CollisionFunc& func) {
 		collisionTable_[{a, b}] = func;
@@ -323,6 +326,7 @@ void CollisionManager::RegisterCollisionFuncsions()
 	//  - 弾は Segment、キャラ/ワールドは OBB として扱う
 	for (auto [seg, obb] : std::initializer_list<std::pair<CollisionType, CollisionType>>{
 		{kBullet, kEnemy},
+		{kBullet, kCrystal},
 		{kBullet, kBoss},
 		{kBullet, kWorld},
 		{kEnemyBullet, kPlayer},

--- a/Project/ApplicationLayer/Colliders/CollisionTypeIdDef.h
+++ b/Project/ApplicationLayer/Colliders/CollisionTypeIdDef.h
@@ -16,4 +16,5 @@ enum class CollisionTypeIdDef : uint32_t
 	kBossBullet,	 // ボス弾ID 9
 	kWorld,			 // ワールドID 10
 	kTragetLock,	 // ターゲットロック用ID 11
+	kCrystal,		 // 敵スポーンクリスタルID 12
 };

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/CrystalManager.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/CrystalManager.cpp
@@ -3,6 +3,8 @@
 
 #include "CharacterWorld.h"
 #include "CameraManager.h"
+#include "CollisionManager.h"
+#include "EnemyBase.h"
 
 #include <algorithm>
 #include <iostream>
@@ -17,15 +19,32 @@ namespace
 	constexpr float kMinimumSpawnInterval = 0.05f;
 }
 
-void CrystalManager::Initialize(const std::vector<CrystalSpawnPoint>& spawnPoints)
+void CrystalManager::Initialize(const std::vector<CrystalSpawnPoint>& spawnPoints, CollisionManager* collisionManager)
 {
+	if (collisionManager_)
+	{
+		for (EnemySpawnCrystal& crystal : crystals_)
+		{
+			collisionManager_->RemoveCollider(&crystal);
+		}
+	}
+
 	crystals_.clear();
+	collisionManager_ = collisionManager;
 	crystals_.reserve(spawnPoints.size());
 	for (const CrystalSpawnPoint& spawnPoint : spawnPoints)
 	{
 		EnemySpawnCrystal crystal;
 		crystal.Initialize(spawnPoint);
 		crystals_.push_back(std::move(crystal));
+	}
+
+	if (collisionManager_)
+	{
+		for (EnemySpawnCrystal& crystal : crystals_)
+		{
+			collisionManager_->AddCollider(&crystal);
+		}
 	}
 
 	selectedCrystalIndex_ = 0;
@@ -54,7 +73,9 @@ void CrystalManager::Update(CharacterWorld& characters, float deltaTime)
 		return;
 	}
 
-	globalSpawnTimer_ += std::max(0.0f, deltaTime);
+	// フレーム落ち時にスポーン更新が一気に進まないよう、Crystal更新用deltaTimeを制限する。
+	const float safeDeltaTime = std::clamp(deltaTime, 0.0f, kMaxUpdateDeltaTime);
+	globalSpawnTimer_ += safeDeltaTime;
 	if (globalSpawnTimer_ < globalSpawnInterval_)
 	{
 		return;
@@ -161,6 +182,9 @@ void CrystalManager::DrawImGui()
 	ImGui::Text("生存クリスタル数: %d", GetAliveCrystalCount());
 	ImGui::Text("全クリスタル破壊済み: %s", AreAllCrystalsDestroyed() ? "はい" : "いいえ");
 	ImGui::Text("ボス出現済み: %s", HasBossSpawned() ? "はい" : "いいえ");
+	ImGui::Text("更新用deltaTime上限: %.4f 秒", kMaxUpdateDeltaTime);
+	ImGui::Text("敵のGround Snap有効: %s", EnemyBase::IsGroundSnapEnabled() ? "はい" : "いいえ");
+	ImGui::Text("敵の場外制限有効: %s", EnemyBase::IsWorldBoundsEnabled() ? "はい" : "いいえ");
 
 	if (crystals_.empty())
 	{
@@ -206,12 +230,22 @@ void CrystalManager::DrawImGui()
 	ImGui::Text("クリスタルScale: (%.2f, %.2f, %.2f)", crystalScale.x, crystalScale.y, crystalScale.z);
 	ImGui::Text("選択中クリスタルHP: %d", crystal->GetHp());
 	ImGui::Text("生存状態: %s", crystal->IsAlive() ? "生存" : "破壊済み");
+	ImGui::Text("クリスタル破壊済み: %s", crystal->IsDestroyed() ? "はい" : "いいえ");
+	ImGui::Text("クリスタルCollider有効: %s", crystal->IsColliderEnabled() ? "はい" : "いいえ");
+	ImGui::Text("クリスタル被弾回数: %d", crystal->GetHitCount());
 	ImGui::Text("カメラ座標: (%.2f, %.2f, %.2f)", cameraPosition.x, cameraPosition.y, cameraPosition.z);
 	ImGui::Text("選択中クリスタル由来の生存敵数: %d", crystal->GetAliveSpawnedEnemyCount());
 	ImGui::Text("選択中クリスタルの合計スポーン数: %d", crystal->GetTotalSpawnedCount());
-	if (ImGui::Button("選択中クリスタルへダメージ"))
+	if (ImGui::Button("選択中クリスタルに10ダメージ"))
 	{
-		crystal->TakeDamage(25);
+		crystal->ApplyDamage(10);
+	}
+	if (ImGui::Button("全クリスタルに10ダメージ"))
+	{
+		for (EnemySpawnCrystal& target : crystals_)
+		{
+			target.ApplyDamage(10);
+		}
 	}
 #endif
 }

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/CrystalManager.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/CrystalManager.h
@@ -6,12 +6,13 @@
 #include <vector>
 
 class CharacterWorld;
+class CollisionManager;
 
 /// 複数クリスタルの進行、雑魚敵生成要求、ボス通知を集約する。
 class CrystalManager
 {
 public:
-	void Initialize(const std::vector<CrystalSpawnPoint>& spawnPoints);
+	void Initialize(const std::vector<CrystalSpawnPoint>& spawnPoints, CollisionManager* collisionManager = nullptr);
 	void Update(CharacterWorld& characters, float deltaTime);
 	void Draw() const;
 	void DrawImGui();
@@ -22,6 +23,7 @@ public:
 	bool AreAllCrystalsDestroyed() const;
 	bool ShouldSpawnBoss() const { return shouldSpawnBoss_; }
 	bool HasBossSpawned() const { return hasBossSpawned_; }
+	static constexpr float GetMaxUpdateDeltaTime() { return kMaxUpdateDeltaTime; }
 
 private:
 	EnemySpawnCrystal* GetSelectedCrystal();
@@ -30,7 +32,9 @@ private:
 	void NotifyBossSpawnIfNeeded();
 
 private:
+	static constexpr float kMaxUpdateDeltaTime = 1.0f / 30.0f;
 	std::vector<EnemySpawnCrystal> crystals_;
+	CollisionManager* collisionManager_ = nullptr;
 	size_t selectedCrystalIndex_ = 0;
 	size_t nextSpawnCrystalIndex_ = 0;
 	bool enableCrystalEnemySpawn_ = true;

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/EnemySpawnCrystal.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/EnemySpawnCrystal.cpp
@@ -3,6 +3,8 @@
 
 #include "CharacterWorld.h"
 #include "EnemyBase.h"
+#include "Bullet.h"
+#include "CollisionTypeIdDef.h"
 
 #include <algorithm>
 #include <cmath>
@@ -34,6 +36,13 @@ void EnemySpawnCrystal::Initialize(const CrystalSpawnPoint& spawnPoint)
 	enableInfiniteSpawn = spawnPoint.enableInfiniteSpawn;
 	spawnBossTrigger_ = spawnPoint.spawnBossTrigger;
 	spawnedEnemies_.clear();
+	hitCount_ = 0;
+
+	SetTypeID(static_cast<uint32_t>(CollisionTypeIdDef::kCrystal));
+	SetOwner(this);
+	SetCenterPosition(position_);
+	SetOBBHalfSize(scale_);
+	SetOrientation(rotation_);
 
 	debugCube_ = std::make_unique<Object3D>();
 	debugCube_->Initialize("Test/cube.gltf");
@@ -66,17 +75,35 @@ void EnemySpawnCrystal::Draw() const
 	}
 }
 
-void EnemySpawnCrystal::TakeDamage(int damage)
+void EnemySpawnCrystal::ApplyDamage(int damage)
 {
 	if (!isAlive || damage <= 0)
 	{
 		return;
 	}
 
+	// プレイヤー攻撃でクリスタルを破壊できるよう、被弾回数とHPを一か所で更新する。
+	++hitCount_;
 	hp = std::max(0, hp - damage);
 	if (hp <= 0)
 	{
 		isAlive = false;
+		// 破壊後のColliderが近接攻撃や弾を遮らないよう、判定だけを場外へ退避する。
+		SetCenterPosition({ 1.0e9f, 1.0e9f, 1.0e9f });
+	}
+}
+
+
+void EnemySpawnCrystal::OnCollisionEnter(K4E::Collider* other)
+{
+	if (!isAlive || !other || other->GetTypeID() != static_cast<uint32_t>(CollisionTypeIdDef::kBullet))
+	{
+		return;
+	}
+
+	if (auto* bullet = other->GetOwner<Bullet>())
+	{
+		ApplyDamage(bullet->GetDamage());
 	}
 }
 
@@ -106,6 +133,11 @@ void EnemySpawnCrystal::RemoveInactiveSpawnedEnemies(const CharacterWorld& chara
 
 void EnemySpawnCrystal::SpawnEnemy(CharacterWorld& characters)
 {
+	if (!CanSpawnEnemy())
+	{
+		return;
+	}
+
 	const float angle = RandomRange(0.0f, 6.28318530718f);
 	const float distance = RandomRange(0.0f, spawnRadius);
 	const Vector3 spawnPosition{

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/EnemySpawnCrystal.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/EnemySpawnCrystal.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "EnemyType.h"
+#include "Collider.h"
 #include "Object3D.h"
 #include "Vector3.h"
 
@@ -28,17 +29,22 @@ struct CrystalSpawnPoint
 };
 
 /// 破壊されるまで、上限付きで雑魚敵を生成し続ける仮クリスタル。
-class EnemySpawnCrystal
+class EnemySpawnCrystal : public K4E::Collider
 {
 public:
 	void Initialize(const CrystalSpawnPoint& spawnPoint);
 	void Update(const CharacterWorld& characters);
 	void Draw() const;
-	void TakeDamage(int damage);
+	void ApplyDamage(int damage);
+	void TakeDamage(int damage) { ApplyDamage(damage); }
+	void OnCollisionEnter(K4E::Collider* other) override;
 	bool CanSpawnEnemy() const;
 	void SpawnEnemy(CharacterWorld& characters);
 
 	bool IsAlive() const { return isAlive; }
+	bool IsDestroyed() const { return !isAlive; }
+	bool IsColliderEnabled() const { return isAlive; }
+	int GetHitCount() const { return hitCount_; }
 	int GetHp() const { return hp; }
 	EnemyType GetSpawnEnemyType() const { return spawnEnemyType; }
 	float GetSpawnRadius() const { return spawnRadius; }
@@ -72,6 +78,7 @@ private:
 	K4E::Vector3 rotation_{};
 	K4E::Vector3 scale_{ 1.0f, 1.0f, 1.0f };
 	bool spawnBossTrigger_ = true;
+	int hitCount_ = 0;
 	std::unique_ptr<K4E::Object3D> debugCube_;
 	std::vector<const EnemyBase*> spawnedEnemies_;
 };

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
@@ -148,14 +148,14 @@ void GamePlayWorld::Initialize(GamePlayStageContext& stageContext)
 		{ {   0.0f, 2.0f, 20.0f }, {}, { 1.5f, 2.5f, 1.5f }, 100, EnemyType::Melee, 2.0f, 10, 4.0f, true, true },
 		{ {  10.0f, 2.0f, 30.0f }, {}, { 1.5f, 2.5f, 1.5f }, 100, EnemyType::MidRange, 3.0f, 6, 4.0f, true, true },
 		{ { -10.0f, 2.0f, 30.0f }, {}, { 1.5f, 2.5f, 1.5f }, 100, EnemyType::Melee, 2.0f, 10, 4.0f, true, true },
-	});
+	}, collisionManager_.get());
 
 	enemyHpBarManager_.Initialize();
 }
 
 void GamePlayWorld::Finalize()
 {
-	crystalManager_.Initialize({});
+	crystalManager_.Initialize({}, nullptr);
 	stageObjectiveManager_.reset();
 	waveManager_.reset();
 	hudManager_.reset();


### PR DESCRIPTION
### Motivation
- フレーム落ち時に敵が一フレームで大きく移動して床下や場外へ落ちる問題を最低限の安全処理で防ぐため。 
- クリスタルがプレイヤーの攻撃（近接・弾）でダメージを受けず破壊されない問題を修正するため。 
- 破壊済みクリスタルから敵が湧き続けるなどゲームが破綻する挙動を防止するため。 

### Description
- 敵更新の `deltaTime` を制限するため `EnemyBase` に `kMaxUpdateDeltaTime = 1.0f/30.0f` を追加し、`EnemyBase::Update()` と `CharacterWorld::Update()` で更新用 delta を `std::clamp` して利用するようにしました（`EnemyBase::GetMaxUpdateDeltaTime()` を使用）。
- 敵の最低限の Ground Snap と World Bounds を追加し、床下に落ちた場合は基準床 `kGroundY` に戻し、XZ を `kWorldBoundsMin/Max` でクランプする安全処理を `EnemyBase::Update()` に入れました。 
- `EnemySpawnCrystal` を `Collider` 派生に変更し、`ApplyDamage(int)` / `OnCollisionEnter(K4E::Collider*)` / 被弾回数と `IsDestroyed()` などの API を追加して弾と近接攻撃でダメージを受け破壊状態になるようにし、破壊時は描画停止かつ判定を場外へ退避して以後スポーンを行わないようにしました。 
- `CollisionTypeIdDef` に `kCrystal` を追加し、`CollisionManager` に弾 vs クリスタルのペアを登録、`CrystalManager` が `CollisionManager` にクリスタルを登録するよう `CrystalManager::Initialize(..., CollisionManager*)` を拡張、`GamePlayWorld` 側で `collisionManager_` を渡す変更を行いました。 
- 近接攻撃判定 (`PlayerMeleeComponent`) を Enemy/Boss/Crystal の最寄りヒット選択に変更し、クリスタルに当たったら `ApplyDamage()` が呼ばれるようにしました。 
- 弾 (`Bullet`) 側をプレイヤー弾が `kCrystal` をヒット対象に含むよう修正し、着弾時に `EnemySpawnCrystal::ApplyDamage()` を呼ぶ流れをつなぎました。 
- デバッグUI（ImGui）へクリスタルの HP / 生存数 / 選択中 HP / 破壊済み表示 / Collider 有効表示 / 被弾回数 / 敵の Ground Snap 有効 / 場外制限有効 / 更新用 deltaTime 上限 を追加し、選択中クリスタルに `10` ダメージ、全クリスタルに `10` ダメージを与えるデバッグボタンを追加しました。 

### Testing
- `git diff --check` を実行して差分に重大な whitespace/merge 問題がないことを確認しました（成功）。
- リポジトリ内の Visual Studio プロジェクト XML を Python スクリプトで解析し、クリスタル関連の Collider 登録・衝突ペア・近接攻撃配線・破壊後スポーン停止・敵 deltaTime 制限・ImGui 項目など計 12 項目の静的配線チェックを実行して検証しました（成功）。
- `dotnet msbuild` によるソリューションビルドは、実行環境に `dotnet` / `msbuild` が存在しないため実行できずビルドは未完了（環境依存で未実行）。
- `clang++ -fsyntax-only` による簡易構文チェックは試行しましたが、コンテナに Windows DirectX SDK ヘッダ（`d3d12.h`）や一部外部ヘッダが存在しないため完走できず構文チェックは未完了（環境制約による）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f13dbbce4832d8c58228b8d7e96bb)