### PR TITLE
Releaseデバッグ描画抑制と敵／クリスタルのスポーン安定化

### DIFF
--- a/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.cpp
+++ b/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.cpp
@@ -267,6 +267,21 @@ void CharacterWorld::DrawPlayerDebugImGui()
 void CharacterWorld::DrawEnemyDebugImGui()
 {
 #ifdef USE_IMGUI
+	int totalStuckDetections = 0;
+	int totalStuckRecoveries = 0;
+	for (const auto& enemy : enemies_)
+	{
+		if (!enemy) { continue; }
+		totalStuckDetections += enemy->GetStuckDetectionCount();
+		totalStuckRecoveries += enemy->GetStuckRecoveryCount();
+	}
+	ImGui::Text("スタック検出回数: %d", totalStuckDetections);
+	ImGui::Text("スタック復帰回数: %d", totalStuckRecoveries);
+	if (!enemies_.empty() && enemies_.front())
+	{
+		const Vector3 pos = enemies_.front()->GetCenterPosition();
+		ImGui::Text("敵の現在座標: (%.2f, %.2f, %.2f)", pos.x, pos.y, pos.z);
+	}
 	// 旧Enemyを段階的に置き換えるため、通常ゲーム上の敵種別ごとの生成数を確認する。
 	std::array<int, 3> liveEnemyCounts{};
 	for (const auto& enemy : enemies_)

--- a/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.cpp
@@ -17,6 +17,7 @@
 using namespace Ken4lowEngine;
 
 const std::vector<Ken4lowEngine::AABB>* EnemyBase::g_worldAABBs_ = nullptr;
+const std::vector<Ken4lowEngine::AABB>* EnemyBase::g_floorAABBs_ = nullptr;
 const std::vector<Ken4lowEngine::AABB>* EnemyBase::g_navigationObstacleAABBs_ = nullptr;
 
 namespace
@@ -182,6 +183,11 @@ void EnemyBase::Initialize()
 	worldCol_.half = obbHalf_;
 	worldCol_.centerOffset = { 0, 0, 0 };
 	worldColOverride_ = true;
+	spawnPosition_ = CorrectSpawnPosition(GetCenterPosition());
+	lastSafePosition_ = spawnPosition_;
+	consecutivePushOutFrames_ = 0;
+	stuckDetectionCount_ = 0;
+	stuckRecoveryCount_ = 0;
 }
 
 /// -------------------------------------------------------------
@@ -204,7 +210,60 @@ void EnemyBase::SetCenterPosition(const Vector3& pos)
 /// -------------------------------------------------------------
 void EnemyBase::SetPosition(const Vector3& p)
 {
-	SetCenterPosition(p);
+	// 初期配置で地面や障害物に埋まらないよう、足元と簡易障害物重なりを補正する。
+	spawnPosition_ = CorrectSpawnPosition(p);
+	lastSafePosition_ = spawnPosition_;
+	SetCenterPosition(spawnPosition_);
+}
+
+float EnemyBase::FindGroundY(const Vector3& position) const
+{
+	float groundY = kGroundY;
+	if (!g_floorAABBs_) { return groundY; }
+	for (const AABB& floor : *g_floorAABBs_)
+	{
+		if (position.x >= floor.min.x - obbHalf_.x && position.x <= floor.max.x + obbHalf_.x &&
+			position.z >= floor.min.z - obbHalf_.z && position.z <= floor.max.z + obbHalf_.z &&
+			floor.max.y <= position.y + obbHalf_.y + 0.5f)
+		{
+			groundY = std::max(groundY, floor.max.y);
+		}
+	}
+	return groundY;
+}
+
+bool EnemyBase::OverlapsNavigationObstacle(const Vector3& center) const
+{
+	const auto* obstacles = GetResolvedNavigationObstacleAABBs();
+	if (!obstacles) { return false; }
+	for (const AABB& obstacle : *obstacles)
+	{
+		if (center.x + obbHalf_.x > obstacle.min.x && center.x - obbHalf_.x < obstacle.max.x &&
+			center.y + obbHalf_.y > obstacle.min.y && center.y - obbHalf_.y < obstacle.max.y &&
+			center.z + obbHalf_.z > obstacle.min.z && center.z - obbHalf_.z < obstacle.max.z)
+		{
+			return true;
+		}
+	}
+	return false;
+}
+
+Vector3 EnemyBase::CorrectSpawnPosition(const Vector3& requestedPosition) const
+{
+	constexpr Vector3 offsets[] = {
+		{ 0.0f, 0.0f, 0.0f }, { 2.5f, 0.0f, 0.0f }, { -2.5f, 0.0f, 0.0f },
+		{ 0.0f, 0.0f, 2.5f }, { 0.0f, 0.0f, -2.5f }, { 3.5f, 0.0f, 3.5f },
+		{ -3.5f, 0.0f, 3.5f }, { 3.5f, 0.0f, -3.5f }, { -3.5f, 0.0f, -3.5f }
+	};
+	for (const Vector3& offset : offsets)
+	{
+		Vector3 candidate = requestedPosition + offset;
+		candidate.y = FindGroundY(candidate) + obbHalf_.y;
+		if (!OverlapsNavigationObstacle(candidate)) { return candidate; }
+	}
+	Vector3 fallback = requestedPosition;
+	fallback.y = FindGroundY(fallback) + obbHalf_.y;
+	return fallback;
 }
 
 /// -------------------------------------------------------------
@@ -275,7 +334,41 @@ void EnemyBase::Update(float deltaTime)
 
 		velocity_.y = vy;
 		grounded_ = res.grounded;
-		newPos = res.fixedCenter + s.centerOffset;
+		const Vector3 resolvedPos = res.fixedCenter + s.centerOffset;
+		Vector3 pushOut = resolvedPos - newPos;
+		pushOut.y = 0.0f; // 地面補正はY、壁・障害物の押し出しはXZとして分離する。
+		const float pushOutLength = std::sqrt(pushOut.x * pushOut.x + pushOut.z * pushOut.z);
+		if (pushOutLength > kMaxPushOutPerFrame)
+		{
+			// 押し出し暴走を防ぐため、1フレームのXZ補正量を制限する。
+			const float scale = kMaxPushOutPerFrame / pushOutLength;
+			pushOut.x *= scale;
+			pushOut.z *= scale;
+		}
+		newPos.x += pushOut.x;
+		newPos.z += pushOut.z;
+		newPos.y = resolvedPos.y;
+
+		if (pushOutLength > 0.0001f)
+		{
+			++consecutivePushOutFrames_;
+			++stuckDetectionCount_;
+			velocity_.x = 0.0f;
+			velocity_.z = 0.0f;
+		}
+		else
+		{
+			consecutivePushOutFrames_ = 0;
+			lastSafePosition_ = newPos;
+		}
+	}
+
+	if (consecutivePushOutFrames_ >= kStuckRecoveryThreshold)
+	{
+		newPos = !OverlapsNavigationObstacle(lastSafePosition_) ? lastSafePosition_ : spawnPosition_;
+		velocity_ = {};
+		consecutivePushOutFrames_ = 0;
+		++stuckRecoveryCount_;
 	}
 
 	// 仮の安全処理として、敵の足元が基準床Yより下なら地面上へ戻す。
@@ -412,6 +505,11 @@ void EnemyBase::TakeDamage(int amount, const Vector3& hitDir, float hitPower)
 void EnemyBase::SetGlobalStageWorldAABBs(const std::vector<K4E::AABB>* aabbs)
 {
 	g_worldAABBs_ = aabbs;
+}
+
+void EnemyBase::SetGlobalStageFloorAABBs(const std::vector<K4E::AABB>* aabbs)
+{
+	g_floorAABBs_ = aabbs;
 }
 
 void EnemyBase::SetGlobalStageNavigationObstacleAABBs(const std::vector<K4E::AABB>* aabbs)

--- a/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.h
@@ -125,10 +125,14 @@ public:
 	void OnCollisionExit(K4E::Collider* other) override { (void)other; }
 
 	static void SetGlobalStageWorldAABBs(const std::vector<K4E::AABB>* aabbs);
+	static void SetGlobalStageFloorAABBs(const std::vector<K4E::AABB>* aabbs);
 	static void SetGlobalStageNavigationObstacleAABBs(const std::vector<K4E::AABB>* aabbs);
 	static constexpr float GetMaxUpdateDeltaTime() { return kMaxUpdateDeltaTime; }
 	static constexpr bool IsGroundSnapEnabled() { return true; }
 	static constexpr bool IsWorldBoundsEnabled() { return true; }
+	static constexpr float GetMaxPushOutPerFrame() { return kMaxPushOutPerFrame; }
+	int GetStuckDetectionCount() const { return stuckDetectionCount_; }
+	int GetStuckRecoveryCount() const { return stuckRecoveryCount_; }
 
 	// 参照用
 	BodyPart& GetBody() { return body_; }
@@ -152,6 +156,9 @@ protected:
 	void UpdateVisualHierarchy();
 	void SetVisualColorAll(const K4E::Vector4& color);
 	void MoveVisualFar(const K4E::Vector3& pos);
+	K4E::Vector3 CorrectSpawnPosition(const K4E::Vector3& requestedPosition) const;
+	float FindGroundY(const K4E::Vector3& position) const;
+	bool OverlapsNavigationObstacle(const K4E::Vector3& center) const;
 
 private:
 	// コライダーだけ無効化（見た目は残す）
@@ -181,6 +188,8 @@ protected:
 
 	static constexpr float kMaxUpdateDeltaTime = 1.0f / 30.0f;
 	static constexpr float kGroundY = 0.0f;
+	static constexpr float kMaxPushOutPerFrame = 0.45f;
+	static constexpr int kStuckRecoveryThreshold = 45;
 	static constexpr float kWorldBoundsMinX = -100.0f;
 	static constexpr float kWorldBoundsMaxX = 100.0f;
 	static constexpr float kWorldBoundsMinZ = -100.0f;
@@ -217,6 +226,11 @@ protected:
 	bool worldColOverride_ = false;
 	bool useWorldResolve_ = true;
 	bool grounded_ = false;
+	K4E::Vector3 spawnPosition_{};
+	K4E::Vector3 lastSafePosition_{};
+	int consecutivePushOutFrames_ = 0;
+	int stuckDetectionCount_ = 0;
+	int stuckRecoveryCount_ = 0;
 
 	// ---- last hit info (for death impulse) ----
 	K4E::Vector3 lastHitDir_{ 0.0f, 0.0f, 0.0f };
@@ -239,5 +253,6 @@ protected:
 
 private:
 	static const std::vector<K4E::AABB>* g_worldAABBs_;
+	static const std::vector<K4E::AABB>* g_floorAABBs_;
 	static const std::vector<K4E::AABB>* g_navigationObstacleAABBs_;
 };

--- a/Project/ApplicationLayer/Colliders/CollisionManager.cpp
+++ b/Project/ApplicationLayer/Colliders/CollisionManager.cpp
@@ -18,7 +18,11 @@ namespace K4E = ::Ken4lowEngine;
 /// -------------------------------------------------------------
 void CollisionManager::Initialize()
 {
+#ifdef _DEBUG
 	isCollider_ = true;
+#else
+	isCollider_ = false;
+#endif
 	K4E::ParameterManager::GetInstance()->CreateGroup("K4E::Collider");
 	K4E::ParameterManager::GetInstance()->AddItem("K4E::Collider", "isCollider", isCollider_);
 
@@ -31,7 +35,12 @@ void CollisionManager::Initialize()
 /// -------------------------------------------------------------
 void CollisionManager::Update()
 {
+#ifdef _DEBUG
 	isCollider_ = K4E::ParameterManager::GetInstance()->GetValue<bool>("K4E::Collider", "isCollider");
+#else
+	// Releaseビルドでは保存済みパラメータがtrueでもColliderワイヤーを復活させない。
+	isCollider_ = false;
+#endif
 
 	// Collider 本体の Update はデバッグ用（Wireframeなど）
 	for (K4E::Collider* collider : all_) collider->Update();
@@ -42,6 +51,9 @@ void CollisionManager::Update()
 /// -------------------------------------------------------------
 void CollisionManager::Draw()
 {
+#ifndef _DEBUG
+	return;
+#endif
 	if (!isCollider_) return;
 
 	for (K4E::Collider* collider : all_)

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/CrystalManager.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/CrystalManager.cpp
@@ -19,7 +19,7 @@ namespace
 	constexpr float kMinimumSpawnInterval = 0.05f;
 }
 
-void CrystalManager::Initialize(const std::vector<CrystalSpawnPoint>& spawnPoints, CollisionManager* collisionManager)
+void CrystalManager::Initialize(const std::vector<CrystalSpawnPoint>& spawnPoints, CollisionManager* collisionManager, const std::vector<Ken4lowEngine::AABB>* floorAABBs, const std::vector<Ken4lowEngine::AABB>* obstacleAABBs)
 {
 	if (collisionManager_)
 	{
@@ -35,7 +35,7 @@ void CrystalManager::Initialize(const std::vector<CrystalSpawnPoint>& spawnPoint
 	for (const CrystalSpawnPoint& spawnPoint : spawnPoints)
 	{
 		EnemySpawnCrystal crystal;
-		crystal.Initialize(spawnPoint);
+		crystal.Initialize(spawnPoint, floorAABBs, obstacleAABBs);
 		crystals_.push_back(std::move(crystal));
 	}
 
@@ -183,7 +183,9 @@ void CrystalManager::DrawImGui()
 	ImGui::Text("全クリスタル破壊済み: %s", AreAllCrystalsDestroyed() ? "はい" : "いいえ");
 	ImGui::Text("ボス出現済み: %s", HasBossSpawned() ? "はい" : "いいえ");
 	ImGui::Text("更新用deltaTime上限: %.4f 秒", kMaxUpdateDeltaTime);
-	ImGui::Text("敵のGround Snap有効: %s", EnemyBase::IsGroundSnapEnabled() ? "はい" : "いいえ");
+	ImGui::Text("敵Ground Snap有効: %s", EnemyBase::IsGroundSnapEnabled() ? "はい" : "いいえ");
+	ImGui::Text("クリスタルGround Snap有効: %s", EnemySpawnCrystal::IsGroundSnapEnabled() ? "はい" : "いいえ");
+	ImGui::Text("最大押し出し量: %.2f", EnemyBase::GetMaxPushOutPerFrame());
 	ImGui::Text("敵の場外制限有効: %s", EnemyBase::IsWorldBoundsEnabled() ? "はい" : "いいえ");
 
 	if (crystals_.empty())

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/CrystalManager.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/CrystalManager.h
@@ -12,7 +12,7 @@ class CollisionManager;
 class CrystalManager
 {
 public:
-	void Initialize(const std::vector<CrystalSpawnPoint>& spawnPoints, CollisionManager* collisionManager = nullptr);
+	void Initialize(const std::vector<CrystalSpawnPoint>& spawnPoints, CollisionManager* collisionManager = nullptr, const std::vector<K4E::AABB>* floorAABBs = nullptr, const std::vector<K4E::AABB>* obstacleAABBs = nullptr);
 	void Update(CharacterWorld& characters, float deltaTime);
 	void Draw() const;
 	void DrawImGui();

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/EnemySpawnCrystal.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/EnemySpawnCrystal.cpp
@@ -14,6 +14,44 @@ using namespace Ken4lowEngine;
 
 namespace
 {
+	bool OverlapsObstacle(const Vector3& center, const Vector3& half, const std::vector<AABB>* obstacles)
+	{
+		if (!obstacles) { return false; }
+		for (const AABB& obstacle : *obstacles)
+		{
+			if (center.x + half.x > obstacle.min.x && center.x - half.x < obstacle.max.x &&
+				center.y + half.y > obstacle.min.y && center.y - half.y < obstacle.max.y &&
+				center.z + half.z > obstacle.min.z && center.z - half.z < obstacle.max.z) { return true; }
+		}
+		return false;
+	}
+
+	Vector3 SnapCrystalPosition(const Vector3& requested, const Vector3& scale, const std::vector<AABB>* floors, const std::vector<AABB>* obstacles)
+	{
+		const Vector3 half{ std::fabs(scale.x) * 0.5f, std::fabs(scale.y) * 0.5f, std::fabs(scale.z) * 0.5f };
+		constexpr Vector3 offsets[] = { {}, { 2.0f, 0.0f, 0.0f }, { -2.0f, 0.0f, 0.0f }, { 0.0f, 0.0f, 2.0f }, { 0.0f, 0.0f, -2.0f } };
+		for (const Vector3& offset : offsets)
+		{
+			Vector3 candidate = requested + offset;
+			float groundY = 0.0f;
+			if (floors)
+			{
+				for (const AABB& floor : *floors)
+				{
+					if (candidate.x >= floor.min.x - half.x && candidate.x <= floor.max.x + half.x &&
+						candidate.z >= floor.min.z - half.z && candidate.z <= floor.max.z + half.z && floor.max.y <= requested.y + half.y + 0.5f)
+					{ groundY = std::max(groundY, floor.max.y); }
+				}
+			}
+			// Cube仮モデルは中心基準なので、半高さを足して足元を地面へ載せる。
+			candidate.y = groundY + half.y;
+			if (!OverlapsObstacle(candidate, half, obstacles)) { return candidate; }
+		}
+		Vector3 fallback = requested;
+		fallback.y = half.y;
+		return fallback;
+	}
+
 	float RandomRange(float minValue, float maxValue)
 	{
 		const float t = static_cast<float>(std::rand()) / static_cast<float>(RAND_MAX);
@@ -21,9 +59,9 @@ namespace
 	}
 }
 
-void EnemySpawnCrystal::Initialize(const CrystalSpawnPoint& spawnPoint)
+void EnemySpawnCrystal::Initialize(const CrystalSpawnPoint& spawnPoint, const std::vector<AABB>* floorAABBs, const std::vector<AABB>* obstacleAABBs)
 {
-	position_ = spawnPoint.position;
+	position_ = SnapCrystalPosition(spawnPoint.position, spawnPoint.scale, floorAABBs, obstacleAABBs);
 	rotation_ = spawnPoint.rotation;
 	scale_ = spawnPoint.scale;
 	isAlive = true;
@@ -41,7 +79,7 @@ void EnemySpawnCrystal::Initialize(const CrystalSpawnPoint& spawnPoint)
 	SetTypeID(static_cast<uint32_t>(CollisionTypeIdDef::kCrystal));
 	SetOwner(this);
 	SetCenterPosition(position_);
-	SetOBBHalfSize(scale_);
+	SetOBBHalfSize({ std::fabs(scale_.x) * 0.5f, std::fabs(scale_.y) * 0.5f, std::fabs(scale_.z) * 0.5f });
 	SetOrientation(rotation_);
 
 	debugCube_ = std::make_unique<Object3D>();

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/EnemySpawnCrystal.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/EnemySpawnCrystal.h
@@ -4,6 +4,7 @@
 #include "Collider.h"
 #include "Object3D.h"
 #include "Vector3.h"
+#include "AABB.h"
 
 #include <memory>
 #include <vector>
@@ -32,7 +33,7 @@ struct CrystalSpawnPoint
 class EnemySpawnCrystal : public K4E::Collider
 {
 public:
-	void Initialize(const CrystalSpawnPoint& spawnPoint);
+	void Initialize(const CrystalSpawnPoint& spawnPoint, const std::vector<K4E::AABB>* floorAABBs = nullptr, const std::vector<K4E::AABB>* obstacleAABBs = nullptr);
 	void Update(const CharacterWorld& characters);
 	void Draw() const;
 	void ApplyDamage(int damage);
@@ -55,6 +56,7 @@ public:
 	bool IsBossSpawnTrigger() const { return spawnBossTrigger_; }
 	const K4E::Vector3& GetPosition() const { return position_; }
 	const K4E::Vector3& GetScale() const { return scale_; }
+	static constexpr bool IsGroundSnapEnabled() { return true; }
 
 	void SetInfiniteSpawnEnabled(bool enabled) { enableInfiniteSpawn = enabled; }
 	void SetSpawnEnemyType(EnemyType enemyType) { spawnEnemyType = enemyType; }

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
@@ -80,6 +80,7 @@ void GamePlayWorld::Initialize(GamePlayStageContext& stageContext)
 	stage_->Update();
 
 	EnemyBase::SetGlobalStageWorldAABBs(&stage_->GetWorldAABBs());
+	EnemyBase::SetGlobalStageFloorAABBs(&stage_->GetFloorAABBs());
 	EnemyBase::SetGlobalStageNavigationObstacleAABBs(&stage_->GetNavigationObstacleAABBs());
 
 	if (auto* player = characters_.GetPlayer())
@@ -148,7 +149,7 @@ void GamePlayWorld::Initialize(GamePlayStageContext& stageContext)
 		{ {   0.0f, 2.0f, 20.0f }, {}, { 1.5f, 2.5f, 1.5f }, 100, EnemyType::Melee, 2.0f, 10, 4.0f, true, true },
 		{ {  10.0f, 2.0f, 30.0f }, {}, { 1.5f, 2.5f, 1.5f }, 100, EnemyType::MidRange, 3.0f, 6, 4.0f, true, true },
 		{ { -10.0f, 2.0f, 30.0f }, {}, { 1.5f, 2.5f, 1.5f }, 100, EnemyType::Melee, 2.0f, 10, 4.0f, true, true },
-	}, collisionManager_.get());
+	}, collisionManager_.get(), &stage_->GetFloorAABBs(), &stage_->GetNavigationObstacleAABBs());
 
 	enemyHpBarManager_.Initialize();
 }
@@ -161,6 +162,7 @@ void GamePlayWorld::Finalize()
 	hudManager_.reset();
 
 	EnemyBase::SetGlobalStageWorldAABBs(nullptr);
+	EnemyBase::SetGlobalStageFloorAABBs(nullptr);
 	EnemyBase::SetGlobalStageNavigationObstacleAABBs(nullptr);
 	itemManager_.Clear();
 
@@ -362,7 +364,9 @@ void GamePlayWorld::Draw3D(bool hideCharactersDuringIntro)
 	if (stage_)
 	{
 		stage_->Draw();
+#ifdef _DEBUG
 		stage_->DrawChunkDebug();
+#endif
 	}
 
 	crystalManager_.Draw();
@@ -437,6 +441,18 @@ void GamePlayWorld::DrawGameDebugImGui()
 	ImGui::Text("Player Dead: %s", IsPlayerDead() ? "true" : "false");
 	ImGui::Text("Enemies: %d", characters_.GetEnemyCount());
 	crystalManager_.DrawImGui();
+
+	auto* wireframe = K4E::Wireframe::GetInstance();
+	bool debugDrawEnabled = wireframe->IsDebugDrawEnabled();
+#ifdef _DEBUG
+	if (ImGui::Checkbox("デバッグ描画有効", &debugDrawEnabled))
+	{
+		wireframe->SetDebugDrawEnabled(debugDrawEnabled);
+	}
+#else
+	ImGui::Text("デバッグ描画有効: いいえ");
+#endif
+	ImGui::Text("Release時デバッグ描画無効: %s", K4E::Wireframe::IsDebugDrawSupported() ? "Debugビルド" : "はい");
 
 	const float fps = K4E::GameTimer::GetInstance()->GetFPS();
 	const auto* particleManager = K4E::ParticleManager::GetInstance();

--- a/Project/Engine/Graphics/Renderer/Wireframe/Wireframe.cpp
+++ b/Project/Engine/Graphics/Renderer/Wireframe/Wireframe.cpp
@@ -145,6 +145,12 @@ namespace Ken4lowEngine
 	/// -------------------------------------------------------------
 	void Wireframe::Draw()
 	{
+		if (!debugDrawEnabled_)
+		{
+			Reset();
+			return;
+		}
+
 		auto commandList = dxCommon_->GetCommandManager()->GetCommandList();
 
 #pragma region ---------- 線の描画 ----------
@@ -188,6 +194,16 @@ namespace Ken4lowEngine
 	/// -------------------------------------------------------------
 	///				　	          リセット処理
 	/// -------------------------------------------------------------
+	void Wireframe::SetDebugDrawEnabled(bool enabled)
+	{
+#ifdef _DEBUG
+		debugDrawEnabled_ = enabled;
+#else
+		(void)enabled;
+		debugDrawEnabled_ = false;
+#endif
+	}
+
 	void Wireframe::Reset()
 	{
 		triangleIndex_ = 0;

--- a/Project/Engine/Graphics/Renderer/Wireframe/Wireframe.h
+++ b/Project/Engine/Graphics/Renderer/Wireframe/Wireframe.h
@@ -121,6 +121,18 @@ public: /// ---------- メンバ関数 ---------- ///
 	/// </summary>
 	void Reset();
 
+	/// Releaseビルドではゲームプレイに不要なデバッグワイヤーを描画しない。
+	void SetDebugDrawEnabled(bool enabled);
+	bool IsDebugDrawEnabled() const { return debugDrawEnabled_; }
+	static constexpr bool IsDebugDrawSupported()
+	{
+#ifdef _DEBUG
+		return true;
+#else
+		return false;
+#endif
+	}
+
 public: /// ---------- 2D用の線の描画 ---------- ///
 
 	/// <summary>
@@ -665,6 +677,11 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	// デバッグカメラの有無
 	bool isDebugCamera_ = false;
+#ifdef _DEBUG
+	bool debugDrawEnabled_ = true;
+#else
+	bool debugDrawEnabled_ = false;
+#endif
 
 	// 三角形
 	uint32_t triangleIndex_ = 0; // 三角形のインデックス


### PR DESCRIPTION
### Motivation
- Release ビルドでデバッグワイヤー／コライダー等のデバッグ表示が残っていたため、ゲームプレイ中に不要なワイヤーが表示されてしまっていた問題を解決するため。 
- 敵やクリスタルが初期配置で地面や障害物にめり込み、その後の押し出しで高速移動やスタックが発生していたため、スポーン補正と押し出し制御を追加するため。

### Description
- 描画制御: `Wireframe` にビルド依存のデバッグフラグを追加し、`SetDebugDrawEnabled` / `IsDebugDrawEnabled` を実装して Release ではデフォルト OFF にした（`Wireframe` 側で最終遮断）。
- Collision/Stage: `CollisionManager` の Collider 表示を Release で強制 OFF にし、`Stage::DrawChunkDebug()` 呼び出しを `_DEBUG` で保護して Release 側の Bounds/Chunk デバッグ呼び出しを止めた。 
- 敵の初期配置補正: 敵生成/配置で `CorrectSpawnPosition` を導入し、床 AABB を使った `FindGroundY`（足元を地面に合わせる）と簡易障害物重なり判定 `OverlapsNavigationObstacle` を行い、重なり回避の候補を順次試すようにした。 
- 押し出し制御とスタック復帰: 衝突解決結果を Y 補正（床）と XZ 押し出し（壁）に分離し、XZ 押し出し量を `kMaxPushOutPerFrame`（既定 0.45f）でクリップ、連続押し出し検出で速度をリセットし近傍の安全位置／スポーン位置へ戻す復帰処理を追加した。 
- クリスタル補正: クリスタルの仮 Cube は中心基準のため、スポーン時に `half = scale * 0.5f` を考慮して `position.y = groundY + half.y` に補正し、OBB 半サイズも半高さで設定するよう変更した。 
- CrystalManager/World: `CrystalManager::Initialize` と `GamePlayWorld` の初期化で床 AABB と障害物 AABB を渡すようにし、クリスタルスポーンも補正対象にした。 
- ImGui: `GamePlayWorld` / `CrystalManager` / `CharacterWorld` のデバッグ UI に、デバッグ描画の有効切替や「Release時デバッグ描画無効」「敵/クリスタル Ground Snap」「最大押し出し量」「スタック検出回数／復帰回数」「座標表示」などの確認項目を追加した。 
- コメント: Release の動作意図と補正・制限ロジックの説明コメントをソースへ追加。 

### Testing
- 静的チェック: `git diff --check` を実行して差分の basic check を実行し問題なしを確認（エラーなし）。
- 自動スクリプト検証: Python スクリプトで変更箇所の静的検証を実行し、以下を検証・合格: Wireframe の Release デフォルト OFF、Wireframe の Release 側強制 OFF、Stage Chunk 呼び出しの Debug 限定化、CollisionManager の Release 強制 OFF、敵の Ground Snap/障害物チェック、押し出しクランプ、スタック復帰、クリスタル半高さ補正、vcxproj の XML パース。 
- リポジトリ整合性: 変更ファイル一覧とヘッダー/プリプロセッサバランスを確認し不整合なしを確認。 
- ビルド注意: 実環境の Windows/MSBuild による Debug/Release ビルドはこのコンテナ環境に `msbuild` が無いため実行できなかったため、CI（Windows）でのビルド確認を推奨。 

（補足）MidRangeEnemy のパーティクルやクリスタル破壊／敵スポーンの既存ロジックは破壊していません。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f18ad26b8832d90c43876a066d54d)