### PR TITLE
Prevent spawn clipping, stabilize death disintegration, and show mid-range bomb as debug cube

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.cpp
@@ -19,6 +19,10 @@ using namespace Ken4lowEngine;
 const std::vector<Ken4lowEngine::AABB>* EnemyBase::g_worldAABBs_ = nullptr;
 const std::vector<Ken4lowEngine::AABB>* EnemyBase::g_floorAABBs_ = nullptr;
 const std::vector<Ken4lowEngine::AABB>* EnemyBase::g_navigationObstacleAABBs_ = nullptr;
+float EnemyBase::s_spawnYOffset_ = 0.15f;
+float EnemyBase::s_deathMaxSpeed_ = 7.0f;
+float EnemyBase::s_deathMaxAngularSpeed_ = 5.0f;
+float EnemyBase::s_deathPieceLifetime_ = 1.8f;
 
 namespace
 {
@@ -56,6 +60,17 @@ namespace
 		// 簡易：立方体→正規化
 		Vector3 v{ RandRange(-1.0f, 1.0f), RandRange(-1.0f, 1.0f), RandRange(-1.0f, 1.0f) };
 		return NormalizeSafe(v, { 0.0f, 1.0f, 0.0f });
+	}
+
+	static Vector3 ClampVectorLength(const Vector3& v, float maxLength)
+	{
+		const float safeMaxLength = std::max(0.0f, maxLength);
+		const float len = Length(v);
+		if (len <= safeMaxLength || len < 1e-6f)
+		{
+			return v;
+		}
+		return v * (safeMaxLength / len);
 	}
 }
 
@@ -258,11 +273,12 @@ Vector3 EnemyBase::CorrectSpawnPosition(const Vector3& requestedPosition) const
 	for (const Vector3& offset : offsets)
 	{
 		Vector3 candidate = requestedPosition + offset;
-		candidate.y = FindGroundY(candidate) + obbHalf_.y;
+		// 地面への埋まりを防ぐため、スポーン時にモデルの高さ分と微小なY補正を足す。
+		candidate.y = FindGroundY(candidate) + obbHalf_.y + s_spawnYOffset_;
 		if (!OverlapsNavigationObstacle(candidate)) { return candidate; }
 	}
 	Vector3 fallback = requestedPosition;
-	fallback.y = FindGroundY(fallback) + obbHalf_.y;
+	fallback.y = FindGroundY(fallback) + obbHalf_.y + s_spawnYOffset_;
 	return fallback;
 }
 
@@ -517,6 +533,26 @@ void EnemyBase::SetGlobalStageNavigationObstacleAABBs(const std::vector<K4E::AAB
 	g_navigationObstacleAABBs_ = aabbs;
 }
 
+void EnemyBase::SetSpawnYOffset(float offset)
+{
+	s_spawnYOffset_ = std::clamp(offset, 0.0f, 0.5f);
+}
+
+void EnemyBase::SetDeathMaxSpeed(float speed)
+{
+	s_deathMaxSpeed_ = std::clamp(speed, 0.5f, 20.0f);
+}
+
+void EnemyBase::SetDeathMaxAngularSpeed(float speed)
+{
+	s_deathMaxAngularSpeed_ = std::clamp(speed, 0.5f, 20.0f);
+}
+
+void EnemyBase::SetDeathPieceLifetime(float lifetime)
+{
+	s_deathPieceLifetime_ = std::clamp(lifetime, 0.2f, 5.0f);
+}
+
 void EnemyBase::SpawnHitEffectAt(const K4E::Vector3& worldPos)
 {
 	if (!particleEffectSystem_)
@@ -621,8 +657,14 @@ void EnemyBase::DetachAllPartsToWorldSpace()
 /// -------------------------------------------------------------
 void EnemyBase::StartBreakApartDeath()
 {
+	if (deathBreakActive_ && !deathPieces_.empty())
+	{
+		return;
+	}
+
 	deathPieces_.clear();
 	deathBreakActive_ = true;
+	deathSimDuration_ = s_deathPieceLifetime_;
 	deathTimer_ = deathSimDuration_;
 
 	DetachAllPartsToWorldSpace();
@@ -632,8 +674,9 @@ void EnemyBase::StartBreakApartDeath()
 
 	const Vector3 center = GetCenterPosition();
 	const Vector3 hitDir = NormalizeSafe(lastHitDir_, { 0, 0, 1 });
-	const float power = (lastHitPower_ > 0.0f) ? lastHitPower_ : 1.0f;
-	const float upPower = std::max(0.0f, lastHitUpPower_);
+	const float power = std::clamp((lastHitPower_ > 0.0f) ? lastHitPower_ : 1.0f, 0.2f, 1.2f);
+	const float upPower = std::clamp(lastHitUpPower_, 0.2f, 1.2f);
+	deathGroundY_ = FindGroundY(center) + 0.05f;
 
 	// 体（重め）
 	{
@@ -643,8 +686,8 @@ void EnemyBase::StartBreakApartDeath()
 		const Vector3 fromCenter = NormalizeSafe(body_.transform.translate_ - center);
 		const Vector3 dir = NormalizeSafe(fromCenter + RandomUnit() * 0.35f + hitDir * p.hitBias);
 		const float speed = RandRange(2.0f, 4.5f) * power;
-		p.velocity = dir * speed + Vector3{ 0.0f, RandRange(1.0f, 3.0f) * upPower, 0.0f };
-		p.angularVel = Vector3{ RandRange(-5.0f, 5.0f), RandRange(-7.0f, 7.0f), RandRange(-5.0f, 5.0f) };
+		p.velocity = ClampVectorLength(dir * speed + Vector3{ 0.0f, RandRange(1.0f, 3.0f) * upPower, 0.0f }, s_deathMaxSpeed_);
+		p.angularVel = ClampVectorLength(Vector3{ RandRange(-3.0f, 3.0f), RandRange(-4.0f, 4.0f), RandRange(-3.0f, 3.0f) }, s_deathMaxAngularSpeed_);
 		deathPieces_.push_back(p);
 	}
 
@@ -663,8 +706,8 @@ void EnemyBase::StartBreakApartDeath()
 		const float speed = RandRange(3.0f, 6.5f) * power;
 		const float up = (i == partIndices_.head) ? RandRange(2.0f, 4.0f) : RandRange(1.2f, 3.2f);
 
-		p.velocity = dir * speed + Vector3{ 0.0f, up * upPower, 0.0f };
-		p.angularVel = Vector3{ RandRange(-10.0f, 10.0f), RandRange(-14.0f, 14.0f), RandRange(-10.0f, 10.0f) };
+		p.velocity = ClampVectorLength(dir * speed + Vector3{ 0.0f, up * upPower, 0.0f }, s_deathMaxSpeed_);
+		p.angularVel = ClampVectorLength(Vector3{ RandRange(-4.0f, 4.0f), RandRange(-5.0f, 5.0f), RandRange(-4.0f, 4.0f) }, s_deathMaxAngularSpeed_);
 		deathPieces_.push_back(p);
 	}
 }
@@ -674,6 +717,8 @@ void EnemyBase::StartBreakApartDeath()
 /// -------------------------------------------------------------
 void EnemyBase::UpdateBreakApartDeath(float dt)
 {
+	// 死亡演出が暴れないように、破片の速度と回転速度を制限する。
+	dt = std::clamp(dt, 0.0f, kMaxUpdateDeltaTime);
 	// 念のため：死亡した瞬間に OnKilled が呼ばれない派生があっても演出を走らせる
 	if (!deathBreakActive_)
 	{
@@ -702,12 +747,14 @@ void EnemyBase::UpdateBreakApartDeath(float dt)
 
 		// 重力
 		p.velocity.y -= gravity_ * dt;
+		p.velocity = ClampVectorLength(p.velocity, s_deathMaxSpeed_);
+		p.angularVel = ClampVectorLength(p.angularVel, s_deathMaxAngularSpeed_);
 
 		// 減衰
 		const float linD = std::max(0.0f, 1.0f - deathLinearDamping_ * dt);
 		const float angD = std::max(0.0f, 1.0f - deathAngularDamping_ * dt);
-		p.velocity = p.velocity * linD;
-		p.angularVel = p.angularVel * angD;
+		p.velocity = ClampVectorLength(p.velocity * linD, s_deathMaxSpeed_);
+		p.angularVel = ClampVectorLength(p.angularVel * angD, s_deathMaxAngularSpeed_);
 
 		// 位置・回転
 		p.part->transform.translate_ = p.part->transform.translate_ + p.velocity * dt;

--- a/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.h
@@ -131,6 +131,14 @@ public:
 	static constexpr bool IsGroundSnapEnabled() { return true; }
 	static constexpr bool IsWorldBoundsEnabled() { return true; }
 	static constexpr float GetMaxPushOutPerFrame() { return kMaxPushOutPerFrame; }
+	static float GetSpawnYOffset() { return s_spawnYOffset_; }
+	static void SetSpawnYOffset(float offset);
+	static float GetDeathMaxSpeed() { return s_deathMaxSpeed_; }
+	static void SetDeathMaxSpeed(float speed);
+	static float GetDeathMaxAngularSpeed() { return s_deathMaxAngularSpeed_; }
+	static void SetDeathMaxAngularSpeed(float speed);
+	static float GetDeathPieceLifetime() { return s_deathPieceLifetime_; }
+	static void SetDeathPieceLifetime(float lifetime);
 	int GetStuckDetectionCount() const { return stuckDetectionCount_; }
 	int GetStuckRecoveryCount() const { return stuckRecoveryCount_; }
 
@@ -248,6 +256,11 @@ protected:
 	float deathFriction_ = 0.7f;      // 0..1
 	float deathGroundY_ = 0.0f;       // とりあえず床はY=0想定（必要なら拡張）
 	std::vector<DeathPiece> deathPieces_;
+
+	static float s_spawnYOffset_;
+	static float s_deathMaxSpeed_;
+	static float s_deathMaxAngularSpeed_;
+	static float s_deathPieceLifetime_;
 
 	EnemyParticleEffectSystem* particleEffectSystem_ = nullptr;
 

--- a/Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.cpp
@@ -1212,6 +1212,25 @@ void MidRangeEnemy::DrawImGui()
         ImGui::Text("構え中: %s", bombAttackState_.casting ? "はい" : "いいえ");
         ImGui::Text("クールダウン残り: %.2f", bombAttackState_.cooldownTimer);
         ImGui::Text("現在爆弾数: %d", static_cast<int>(bombs_.size()));
+        bool bombCubeVisible = MidRangeBombProjectile::IsDebugCubeVisible();
+        if (ImGui::Checkbox("爆弾Cube表示", &bombCubeVisible))
+        {
+            MidRangeBombProjectile::SetDebugCubeVisible(bombCubeVisible);
+        }
+        float bombCubeSize = MidRangeBombProjectile::GetDebugCubeSize();
+        if (ImGui::DragFloat("爆弾Cubeサイズ", &bombCubeSize, 0.05f, 0.1f, 2.0f, "%.2f"))
+        {
+            MidRangeBombProjectile::SetDebugCubeSize(bombCubeSize);
+        }
+        if (!bombs_.empty())
+        {
+            const Vector3& bombPosition = bombs_.front()->GetPosition();
+            ImGui::Text("爆弾座標: (%.2f, %.2f, %.2f)", bombPosition.x, bombPosition.y, bombPosition.z);
+        }
+        else
+        {
+            ImGui::Text("爆弾座標: なし");
+        }
         ImGui::Text("経路が見つかったか: %s", pathState_.pathFound ? "はい" : "いいえ");
         ImGui::Text("現在ウェイポイント: (%.2f, %.2f, %.2f)", pathState_.currentWaypoint.x, pathState_.currentWaypoint.y, pathState_.currentWaypoint.z);
     }

--- a/Project/ApplicationLayer/Character/Enemy/Projectile/MidRangeBombProjectile.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Projectile/MidRangeBombProjectile.cpp
@@ -2,9 +2,13 @@
 #include "MidRangeBombProjectile.h"
 #include "Wireframe.h"
 
+#include <algorithm>
 #include <cmath>
 
 using namespace Ken4lowEngine;
+
+bool MidRangeBombProjectile::s_debugCubeVisible_ = true;
+float MidRangeBombProjectile::s_debugCubeSize_ = 0.4f;
 
 void MidRangeBombProjectile::Initialize()
 {
@@ -16,6 +20,11 @@ void MidRangeBombProjectile::Initialize()
     explosionDrawTimer_ = 0.0f;
     exploded_ = false;
     alive_ = false;
+
+    debugCube_ = std::make_unique<Object3D>();
+    debugCube_->Initialize("Test/cube.gltf");
+    debugCube_->SetColor({ 0.15f, 0.02f, 0.22f, 1.0f });
+    UpdateDebugCube();
 }
 
 void MidRangeBombProjectile::Launch(
@@ -47,19 +56,24 @@ void MidRangeBombProjectile::Launch(
         directionXZ = { 0.0f, 0.0f, 1.0f };
     }
 
-    velocity_ = directionXZ * settings_.initialSpeed;
-    velocity_.y = settings_.upwardVelocity;
+    const float maxInitialSpeed = std::max(0.0f, settings_.maxInitialSpeed);
+    velocity_ = directionXZ * std::clamp(settings_.initialSpeed, 0.0f, maxInitialSpeed);
+    velocity_.y = std::clamp(settings_.upwardVelocity, 0.0f, 12.0f);
+    UpdateDebugCube();
 }
 
 void MidRangeBombProjectile::Update(float deltaTime)
 {
     constexpr float kFloorY = 0.0f;
+    constexpr float kMaxDeltaTime = 1.0f / 30.0f;
+    deltaTime = std::clamp(deltaTime, 0.0f, kMaxDeltaTime);
 
     if (alive_)
     {
         lifeTimer_ += deltaTime;
-        velocity_.y -= settings_.gravity * deltaTime;
+        velocity_.y -= std::clamp(settings_.gravity, 0.0f, 30.0f) * deltaTime;
         position_ += velocity_ * deltaTime;
+        UpdateDebugCube();
 
         bool shouldExplode = false;
         if (lifeTimer_ >= settings_.lifeTime)
@@ -68,6 +82,8 @@ void MidRangeBombProjectile::Update(float deltaTime)
         }
         if (position_.y <= kFloorY)
         {
+            position_.y = kFloorY + s_debugCubeSize_ * 0.5f;
+            UpdateDebugCube();
             shouldExplode = true;
         }
 
@@ -90,7 +106,11 @@ void MidRangeBombProjectile::Draw() const
 {
     if (alive_)
     {
-        Wireframe::GetInstance()->DrawSphere(position_, settings_.hitRadius, { 1.0f, 0.4f, 0.1f, 1.0f });
+        // 中距離雑魚敵の爆弾挙動を確認しやすくするため、仮Cubeで描画する。
+        if (s_debugCubeVisible_ && debugCube_)
+        {
+            debugCube_->Draw();
+        }
     }
 
     if (exploded_ && explosionDrawTimer_ > 0.0f)
@@ -112,6 +132,24 @@ void MidRangeBombProjectile::Explode()
     alive_ = false;
     explosionDrawTimer_ = 0.2f;
 }
+void MidRangeBombProjectile::SetDebugCubeSize(float size)
+{
+    s_debugCubeSize_ = std::clamp(size, 0.1f, 2.0f);
+}
+
+void MidRangeBombProjectile::UpdateDebugCube()
+{
+    if (!debugCube_)
+    {
+        return;
+    }
+
+    debugCube_->SetTranslate(position_);
+    debugCube_->SetRotate({ lifeTimer_ * 2.0f, lifeTimer_ * 3.5f, lifeTimer_ * 1.5f });
+    debugCube_->SetScale({ s_debugCubeSize_, s_debugCubeSize_, s_debugCubeSize_ });
+    debugCube_->Update();
+}
+
 bool MidRangeBombProjectile::IsAlive() const
 {
     bool aliveOrExploding = alive_;

--- a/Project/ApplicationLayer/Character/Enemy/Projectile/MidRangeBombProjectile.h
+++ b/Project/ApplicationLayer/Character/Enemy/Projectile/MidRangeBombProjectile.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #include "Vector3.h"
+#include "Object3D.h"
+
+#include <memory>
 struct BombProjectileSettings
 {
     // 追加: 距離に応じた初速調整の基本値。
@@ -41,6 +44,15 @@ public:
     void Explode();
     bool IsAlive() const;
 
+    const Ken4lowEngine::Vector3& GetPosition() const { return position_; }
+    static bool IsDebugCubeVisible() { return s_debugCubeVisible_; }
+    static void SetDebugCubeVisible(bool visible) { s_debugCubeVisible_ = visible; }
+    static float GetDebugCubeSize() { return s_debugCubeSize_; }
+    static void SetDebugCubeSize(float size);
+
+private:
+    void UpdateDebugCube();
+
 private:
     Ken4lowEngine::Vector3 position_{};
     Ken4lowEngine::Vector3 velocity_{};
@@ -50,4 +62,8 @@ private:
     float explosionDrawTimer_ = 0.0f;
     bool exploded_ = false;
     bool alive_ = false;
+    std::unique_ptr<Ken4lowEngine::Object3D> debugCube_;
+
+    static bool s_debugCubeVisible_;
+    static float s_debugCubeSize_;
 };

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/CrystalManager.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/CrystalManager.cpp
@@ -170,6 +170,31 @@ void CrystalManager::DrawImGui()
 	}
 
 	ImGui::Checkbox("クリスタル敵スポーン有効", &enableCrystalEnemySpawn_);
+	float crystalYOffset = EnemySpawnCrystal::GetSpawnYOffset();
+	if (ImGui::DragFloat("クリスタルY補正", &crystalYOffset, 0.01f, 0.0f, 0.5f, "%.2f"))
+	{
+		EnemySpawnCrystal::SetSpawnYOffset(crystalYOffset);
+	}
+	float enemySpawnYOffset = EnemyBase::GetSpawnYOffset();
+	if (ImGui::DragFloat("敵スポーンY補正", &enemySpawnYOffset, 0.01f, 0.0f, 0.5f, "%.2f"))
+	{
+		EnemyBase::SetSpawnYOffset(enemySpawnYOffset);
+	}
+	float deathMaxSpeed = EnemyBase::GetDeathMaxSpeed();
+	if (ImGui::DragFloat("死亡破片 最大速度", &deathMaxSpeed, 0.1f, 0.5f, 20.0f, "%.2f"))
+	{
+		EnemyBase::SetDeathMaxSpeed(deathMaxSpeed);
+	}
+	float deathMaxAngularSpeed = EnemyBase::GetDeathMaxAngularSpeed();
+	if (ImGui::DragFloat("死亡破片 最大回転速度", &deathMaxAngularSpeed, 0.1f, 0.5f, 20.0f, "%.2f"))
+	{
+		EnemyBase::SetDeathMaxAngularSpeed(deathMaxAngularSpeed);
+	}
+	float deathPieceLifetime = EnemyBase::GetDeathPieceLifetime();
+	if (ImGui::DragFloat("死亡破片 寿命", &deathPieceLifetime, 0.1f, 0.2f, 5.0f, "%.2f 秒"))
+	{
+		EnemyBase::SetDeathPieceLifetime(deathPieceLifetime);
+	}
 	ImGui::DragInt("クリスタル由来の最大敵数", &maxTotalCrystalSpawnEnemies_, 1.0f, 0, 100);
 	maxTotalCrystalSpawnEnemies_ = std::max(0, maxTotalCrystalSpawnEnemies_);
 	ImGui::Text("現在のクリスタル由来敵数: %d", GetAliveCrystalSpawnEnemyCount());

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/EnemySpawnCrystal.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/EnemySpawnCrystal.cpp
@@ -12,6 +12,8 @@
 
 using namespace Ken4lowEngine;
 
+float EnemySpawnCrystal::s_spawnYOffset_ = 0.15f;
+
 namespace
 {
 	bool OverlapsObstacle(const Vector3& center, const Vector3& half, const std::vector<AABB>* obstacles)
@@ -26,7 +28,7 @@ namespace
 		return false;
 	}
 
-	Vector3 SnapCrystalPosition(const Vector3& requested, const Vector3& scale, const std::vector<AABB>* floors, const std::vector<AABB>* obstacles)
+	Vector3 SnapCrystalPosition(const Vector3& requested, const Vector3& scale, const std::vector<AABB>* floors, const std::vector<AABB>* obstacles, float spawnYOffset)
 	{
 		const Vector3 half{ std::fabs(scale.x) * 0.5f, std::fabs(scale.y) * 0.5f, std::fabs(scale.z) * 0.5f };
 		const Vector3 offsets[] = { {}, { 2.0f, 0.0f, 0.0f }, { -2.0f, 0.0f, 0.0f }, { 0.0f, 0.0f, 2.0f }, { 0.0f, 0.0f, -2.0f } };
@@ -43,12 +45,22 @@ namespace
 					{ groundY = std::max(groundY, floor.max.y); }
 				}
 			}
-			// Cube仮モデルは中心基準なので、半高さを足して足元を地面へ載せる。
-			candidate.y = groundY + half.y;
+			// Cube仮モデルは中心基準なので、半高さとY補正を足して足元を地面へ載せる。
+			candidate.y = groundY + half.y + spawnYOffset;
 			if (!OverlapsObstacle(candidate, half, obstacles)) { return candidate; }
 		}
 		Vector3 fallback = requested;
-		fallback.y = half.y;
+		float fallbackGroundY = 0.0f;
+		if (floors)
+		{
+			for (const AABB& floor : *floors)
+			{
+				if (fallback.x >= floor.min.x - half.x && fallback.x <= floor.max.x + half.x &&
+					fallback.z >= floor.min.z - half.z && fallback.z <= floor.max.z + half.z && floor.max.y <= requested.y + half.y + 0.5f)
+				{ fallbackGroundY = std::max(fallbackGroundY, floor.max.y); }
+			}
+		}
+		fallback.y = fallbackGroundY + half.y + spawnYOffset;
 		return fallback;
 	}
 
@@ -61,7 +73,7 @@ namespace
 
 void EnemySpawnCrystal::Initialize(const CrystalSpawnPoint& spawnPoint, const std::vector<AABB>* floorAABBs, const std::vector<AABB>* obstacleAABBs)
 {
-	position_ = SnapCrystalPosition(spawnPoint.position, spawnPoint.scale, floorAABBs, obstacleAABBs);
+	position_ = SnapCrystalPosition(spawnPoint.position, spawnPoint.scale, floorAABBs, obstacleAABBs, s_spawnYOffset_);
 	rotation_ = spawnPoint.rotation;
 	scale_ = spawnPoint.scale;
 	isAlive = true;
@@ -153,6 +165,11 @@ bool EnemySpawnCrystal::CanSpawnEnemy() const
 void EnemySpawnCrystal::SetMaxAliveEnemies(int count)
 {
 	maxAliveEnemies = std::max(0, count);
+}
+
+void EnemySpawnCrystal::SetSpawnYOffset(float offset)
+{
+	s_spawnYOffset_ = std::clamp(offset, 0.0f, 0.5f);
 }
 
 void EnemySpawnCrystal::RemoveInactiveSpawnedEnemies(const CharacterWorld& characters)

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/EnemySpawnCrystal.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/EnemySpawnCrystal.h
@@ -57,6 +57,8 @@ public:
 	const K4E::Vector3& GetPosition() const { return position_; }
 	const K4E::Vector3& GetScale() const { return scale_; }
 	static constexpr bool IsGroundSnapEnabled() { return true; }
+	static float GetSpawnYOffset() { return s_spawnYOffset_; }
+	static void SetSpawnYOffset(float offset);
 
 	void SetInfiniteSpawnEnabled(bool enabled) { enableInfiniteSpawn = enabled; }
 	void SetSpawnEnemyType(EnemyType enemyType) { spawnEnemyType = enemyType; }
@@ -83,4 +85,5 @@ private:
 	int hitCount_ = 0;
 	std::unique_ptr<K4E::Object3D> debugCube_;
 	std::vector<const EnemyBase*> spawnedEnemies_;
+	static float s_spawnYOffset_;
 };


### PR DESCRIPTION
### Motivation

- クリスタルや敵が地面に少し埋まる問題を解消して見た目を安定させるため、スポーンYを微小に持ち上げられるようにする。  
- 死亡時の四肢分解演出が高速で暴れたり地面に埋まったりする不安定挙動を抑制して見た目を自然化する。  
- 中距離雑魚の投擲爆弾が分かりにくいため、まずは仮Cubeで軌道が視認できるようにする。

### Description

- クリスタルおよび敵スポーンY補正を追加しました。`EnemySpawnCrystal::SnapCrystalPosition` に `s_spawnYOffset_` を導入し、`EnemySpawnCrystal::Initialize` で使用します。敵側は `EnemyBase::CorrectSpawnPosition` に `s_spawnYOffset_` を足して、足元が地面に載るように補正しています（参照: `EnemySpawnCrystal`, `EnemyBase` の該当関数）。

- 死亡時の四肢分解処理を安全化しました。原因として初速度/回転速度の未制限、`deltaTime` 暴走、地面補正不足、二重初期化などを確認したため、以下を実装しています: 初期化ガード（多重初期化防止）、`lastHitPower`/上方向力のクランプ、破片の最大線速度・角速度を `ClampVectorLength` で制限、`dt` を `kMaxUpdateDeltaTime` でクランプ、床Yへ微小補正、破片寿命（`deathSimDuration_` を設定可能に）およびフェード。該当ロジックは `EnemyBase::StartBreakApartDeath` / `EnemyBase::UpdateBreakApartDeath` に組み込みました。

- 中距離雑魚の爆弾を仮Cubeで描画するようにしました。`MidRangeBombProjectile` に `debugCube_` を追加し `Initialize`/`Launch`/`Update` で `UpdateDebugCube()` を呼びワールド座標に追従して描画します（回転・スケールも更新）。描画は `Draw()` で行います。爆弾の振る舞いは破綻しないよう `deltaTime` の上限や `gravity` のクランプも導入しました。

- ImGui に調整項目を追加しました: `CrystalManager::DrawImGui` に `クリスタルY補正` / `敵スポーンY補正` / `死亡破片 最大速度` / `死亡破片 最大回転速度` / `死亡破片 寿命` を追加しランタイム調整可能にしました。`MidRangeEnemy::DrawImGui` に `爆弾Cube表示` / `爆弾Cubeサイズ` / `爆弾座標` を追加しました。

- 既存のスポーン経路やシステムを壊さないよう `CharacterWorld::SpawnEnemyAt` 経由の生成フローはそのまま維持しています。

- 主要変更ファイル: `Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.*`, `Project/ApplicationLayer/Scene/GamePlayScene/World/EnemySpawnCrystal.*`, `Project/ApplicationLayer/Scene/GamePlayScene/World/CrystalManager.cpp`, `Project/ApplicationLayer/Character/Enemy/Projectile/MidRangeBombProjectile.*`, `Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.cpp`.

- 次に正式モデル（アセット）へ差し替える手順: `MidRangeBombProjectile::Initialize()` の `debugCube_->Initialize("Test/cube.gltf")` を正式モデルのパスに変更し、`SetColor`/`s_debugCubeSize_` を正式見た目に合わせて調整するだけでワールド追従は `UpdateDebugCube()` を流用できます。

### Testing

- 実行した自動チェック: `git diff --check` は問題なし。  
- Releaseビルド試行: `msbuild Project/Ken4lowEngine.sln /p:Configuration=Release /p:Platform=x64` を試みましたが、この実行環境に `msbuild` が無く実行できませんでした（環境依存のためここではビルド未実行）。

No other automated tests were executed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fa2810a54832d90f815f7ec25dc8e)