### PR TITLE
Fix enemy death collapse origin handling

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.cpp
@@ -191,11 +191,18 @@ void EnemyBase::Initialize()
 	deathBreakActive_ = false;
 	deathBreakInitialized_ = false;
 	hasDeathEffectOrigin_ = false;
+	hasDeathPartWorldTransforms_ = false;
+	deathUsesMidRangeSuicideCollapseStyle_ = true;
+	deathEffectInitializeCount_ = 0;
 	deathEnemyPosition_ = GetCenterPosition();
 	deathEffectOrigin_ = deathEnemyPosition_;
 	deathEffectRotation_ = orientation_;
 	deathDebugPlayerPosition_ = s_lastDebugPlayerPosition_;
 	deathDebugAttackCenter_ = s_lastDebugAttackCenter_;
+	deathInitialBodyPosition_ = deathEffectOrigin_;
+	deathInitialBodyRotation_ = deathEffectRotation_;
+	deathInitialPartPositions_.clear();
+	deathInitialPartRotations_.clear();
 	deathTimer_ = 0.0f;
 	deathPieces_.clear();
 	lastHitDir_ = { 0, 0, 0 };
@@ -445,8 +452,17 @@ void EnemyBase::DrawImGui()
 #ifdef USE_IMGUI
 	ImGui::Text("死亡敵座標: %.2f, %.2f, %.2f", deathEnemyPosition_.x, deathEnemyPosition_.y, deathEnemyPosition_.z);
 	ImGui::Text("死亡演出原点: %.2f, %.2f, %.2f", deathEffectOrigin_.x, deathEffectOrigin_.y, deathEffectOrigin_.z);
-	ImGui::Text("プレイヤー座標: %.2f, %.2f, %.2f", deathDebugPlayerPosition_.x, deathDebugPlayerPosition_.y, deathDebugPlayerPosition_.z);
-	ImGui::Text("攻撃判定中心: %.2f, %.2f, %.2f", deathDebugAttackCenter_.x, deathDebugAttackCenter_.y, deathDebugAttackCenter_.z);
+	ImGui::Text("胴体初期座標: %.2f, %.2f, %.2f", deathInitialBodyPosition_.x, deathInitialBodyPosition_.y, deathInitialBodyPosition_.z);
+	const char* deathPartLabels[] = { "頭初期座標", "左腕初期座標", "右腕初期座標", "左脚初期座標", "右脚初期座標" };
+	for (size_t i = 0; i < deathInitialPartPositions_.size() && i < 5; ++i)
+	{
+		const Vector3& p = deathInitialPartPositions_[i];
+		ImGui::Text("%s: %.2f, %.2f, %.2f", deathPartLabels[i], p.x, p.y, p.z);
+	}
+	ImGui::Text("死亡演出初期化回数: %d", deathEffectInitializeCount_);
+	ImGui::Text("中距離自爆崩壊処理を使用中: %s", deathUsesMidRangeSuicideCollapseStyle_ ? "はい" : "いいえ");
+	ImGui::Text("プレイヤー座標(比較のみ): %.2f, %.2f, %.2f", deathDebugPlayerPosition_.x, deathDebugPlayerPosition_.y, deathDebugPlayerPosition_.z);
+	ImGui::Text("攻撃判定中心(比較のみ): %.2f, %.2f, %.2f", deathDebugAttackCenter_.x, deathDebugAttackCenter_.y, deathDebugAttackCenter_.z);
 	ImGui::Text("DeathHitPower: %.2f Up: %.2f", lastHitPower_, lastHitUpPower_);
 	if (body_.object) body_.object->DrawImGui();
 
@@ -686,7 +702,31 @@ void EnemyBase::CaptureDeathEffectOrigin()
 	deathEffectRotation_ = orientation_;
 	deathDebugPlayerPosition_ = s_lastDebugPlayerPosition_;
 	deathDebugAttackCenter_ = s_lastDebugAttackCenter_;
+	CaptureDeathPartWorldTransforms();
 	hasDeathEffectOrigin_ = true;
+}
+
+void EnemyBase::CaptureDeathPartWorldTransforms()
+{
+	if (hasDeathPartWorldTransforms_)
+	{
+		return;
+	}
+
+	// 死亡部位が別座標へ飛ばないよう、死亡瞬間のWorld座標を保存して崩壊演出に使用する。
+	UpdateVisualHierarchy();
+	deathInitialBodyPosition_ = body_.transform.worldTranslate_;
+	deathInitialBodyRotation_ = body_.transform.worldRotate_;
+	deathInitialPartPositions_.clear();
+	deathInitialPartRotations_.clear();
+	deathInitialPartPositions_.reserve(parts_.size());
+	deathInitialPartRotations_.reserve(parts_.size());
+	for (auto& part : parts_)
+	{
+		deathInitialPartPositions_.push_back(part.transform.worldTranslate_);
+		deathInitialPartRotations_.push_back(part.transform.worldRotate_);
+	}
+	hasDeathPartWorldTransforms_ = true;
 }
 
 Vector3 EnemyBase::RotateLocalOffsetByDeathRotation(const Vector3& localOffset) const
@@ -706,16 +746,21 @@ void EnemyBase::StartBreakApartDeath()
 	}
 
 	CaptureDeathEffectOrigin();
+	if (!hasDeathPartWorldTransforms_)
+	{
+		CaptureDeathPartWorldTransforms();
+	}
 	deathPieces_.clear();
 	deathBreakActive_ = true;
 	deathBreakInitialized_ = true;
+	++deathEffectInitializeCount_;
 	deathSimDuration_ = s_deathPieceLifetime_;
 	deathTimer_ = deathSimDuration_;
 
-	// 四肢分解演出は攻撃者位置ではなく、敵が死亡したワールド座標を基準に生成する。
+	// 通常死亡も中距離雑魚敵の自爆崩壊と同じ座標基準でその場に崩す。
 	body_.transform.parent_ = nullptr;
-	body_.transform.translate_ = deathEffectOrigin_;
-	body_.transform.rotate_ = deathEffectRotation_;
+	body_.transform.translate_ = deathInitialBodyPosition_;
+	body_.transform.rotate_ = deathInitialBodyRotation_;
 	body_.transform.Update();
 	if (body_.object)
 	{
@@ -724,12 +769,20 @@ void EnemyBase::StartBreakApartDeath()
 		body_.object->Update();
 	}
 
-	for (auto& part : parts_)
+	for (size_t i = 0; i < parts_.size(); ++i)
 	{
-		const Vector3 localOffset = part.transform.translate_;
+		auto& part = parts_[i];
 		part.transform.parent_ = nullptr;
-		part.transform.translate_ = deathEffectOrigin_ + RotateLocalOffsetByDeathRotation(localOffset);
-		part.transform.rotate_ = deathEffectRotation_;
+		if (i < deathInitialPartPositions_.size())
+		{
+			part.transform.translate_ = deathInitialPartPositions_[i];
+		}
+		else
+		{
+			const Vector3 localOffset = part.transform.translate_;
+			part.transform.translate_ = deathEffectOrigin_ + RotateLocalOffsetByDeathRotation(localOffset);
+		}
+		part.transform.rotate_ = (i < deathInitialPartRotations_.size()) ? deathInitialPartRotations_[i] : deathEffectRotation_;
 		part.transform.Update();
 		if (part.object)
 		{
@@ -743,41 +796,40 @@ void EnemyBase::StartBreakApartDeath()
 	SetVisualColorAll(baseColor_);
 
 	const Vector3 center = deathEffectOrigin_;
-	const float power = std::clamp((lastHitPower_ > 0.0f) ? lastHitPower_ : 1.0f, 0.2f, 1.0f);
-	const float upPower = std::clamp(lastHitUpPower_, 0.2f, 1.0f);
 	deathGroundY_ = FindGroundY(center) + 0.05f;
 
-	// 体（重め）
-	{
+	auto makeCollapsePiece = [this, &center](BodyPart* part, bool isHead, float scatterScale, float liftMin, float liftMax, float speedMin, float speedMax) {
 		DeathPiece p{};
-		p.part = &body_;
-		p.hitBias = 0.75f;
-		const Vector3 fromCenter = NormalizeSafe(body_.transform.translate_ - center);
-		const Vector3 dir = NormalizeSafe(fromCenter + RandomUnit() * 0.25f);
-		const float speed = RandRange(1.4f, 2.8f) * power;
-		p.velocity = ClampVectorLength(dir * speed + Vector3{ 0.0f, RandRange(0.8f, 1.8f) * upPower, 0.0f }, s_deathMaxSpeed_);
-		p.angularVel = ClampVectorLength(Vector3{ RandRange(-3.0f, 3.0f), RandRange(-4.0f, 4.0f), RandRange(-3.0f, 3.0f) }, s_deathMaxAngularSpeed_);
-		deathPieces_.push_back(p);
-	}
+		p.part = part;
+		if (!part)
+		{
+			return p;
+		}
 
-	// 手足/頭
+		Vector3 fromCenter = part->transform.translate_ - center;
+		fromCenter.y = 0.0f;
+		Vector3 outward = NormalizeSafe(fromCenter, { 0.0f, 0.0f, 1.0f });
+		Vector3 jitter = RandomUnit();
+		jitter.y = 0.0f;
+		jitter = NormalizeSafe(jitter, outward);
+		const Vector3 dir = NormalizeSafe(outward * 0.85f + jitter * 0.15f, outward);
+		const float speed = RandRange(speedMin, speedMax) * scatterScale;
+		const float lift = RandRange(liftMin, liftMax);
+		p.velocity = ClampVectorLength(dir * speed + Vector3{ 0.0f, lift, 0.0f }, s_deathMaxSpeed_);
+		const float angular = isHead ? 1.15f : 0.85f;
+		p.angularVel = ClampVectorLength(Vector3{
+			RandRange(-1.2f, 1.2f) * angular,
+			RandRange(-1.6f, 1.6f) * angular,
+			RandRange(-1.2f, 1.2f) * angular }, s_deathMaxAngularSpeed_);
+		return p;
+	};
+
+	// 自爆崩壊と同じ「現在位置を原点に小さく持ち上げて落とす」考え方に寄せ、攻撃者方向の爆散は使わない。
+	deathPieces_.push_back(makeCollapsePiece(&body_, false, 0.55f, 0.45f, 0.85f, 0.25f, 0.65f));
 	for (size_t i = 0; i < parts_.size(); ++i)
 	{
-		DeathPiece p{};
-		p.part = &parts_[i];
-
-		// 部位ごとに少し差
-		p.hitBias = (i == partIndices_.head) ? 0.9f : 0.55f;
-
-		const Vector3 fromCenter = NormalizeSafe(parts_[i].transform.translate_ - center);
-		const Vector3 dir = NormalizeSafe(fromCenter + RandomUnit() * 0.35f);
-
-		const float speed = RandRange(1.8f, 3.4f) * power;
-		const float up = (i == partIndices_.head) ? RandRange(1.2f, 2.2f) : RandRange(0.9f, 1.9f);
-
-		p.velocity = ClampVectorLength(dir * speed + Vector3{ 0.0f, up * upPower, 0.0f }, s_deathMaxSpeed_);
-		p.angularVel = ClampVectorLength(Vector3{ RandRange(-4.0f, 4.0f), RandRange(-5.0f, 5.0f), RandRange(-4.0f, 4.0f) }, s_deathMaxAngularSpeed_);
-		deathPieces_.push_back(p);
+		const bool isHead = (i == partIndices_.head);
+		deathPieces_.push_back(makeCollapsePiece(&parts_[i], isHead, 0.75f, isHead ? 0.65f : 0.45f, isHead ? 1.05f : 0.85f, 0.35f, 0.95f));
 	}
 }
 
@@ -826,7 +878,9 @@ void EnemyBase::UpdateBreakApartDeath(float dt)
 		p.angularVel = ClampVectorLength(p.angularVel * angD, s_deathMaxAngularSpeed_);
 
 		// 位置・回転
-		p.part->transform.translate_ = p.part->transform.translate_ + p.velocity * dt;
+		Vector3 frameMove = p.velocity * dt;
+		frameMove = ClampVectorLength(frameMove, deathMaxMovePerFrame_);
+		p.part->transform.translate_ = p.part->transform.translate_ + frameMove;
 		p.part->transform.rotate_ = p.part->transform.rotate_ + p.angularVel * dt;
 
 		// 簡易床

--- a/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.h
@@ -188,6 +188,7 @@ private:
 	void UpdateBreakApartDeath(float dt);
 	void DetachAllPartsToWorldSpace();
 	void CaptureDeathEffectOrigin();
+	void CaptureDeathPartWorldTransforms();
 	K4E::Vector3 RotateLocalOffsetByDeathRotation(const K4E::Vector3& localOffset) const;
 
 protected:
@@ -252,11 +253,18 @@ protected:
 	bool deathBreakActive_ = false;
 	bool deathBreakInitialized_ = false;
 	bool hasDeathEffectOrigin_ = false;
+	bool hasDeathPartWorldTransforms_ = false;
+	bool deathUsesMidRangeSuicideCollapseStyle_ = true;
+	int deathEffectInitializeCount_ = 0;
 	K4E::Vector3 deathEnemyPosition_{};
 	K4E::Vector3 deathEffectOrigin_{};
 	K4E::Vector3 deathEffectRotation_{};
 	K4E::Vector3 deathDebugPlayerPosition_{};
 	K4E::Vector3 deathDebugAttackCenter_{};
+	K4E::Vector3 deathInitialBodyPosition_{};
+	K4E::Vector3 deathInitialBodyRotation_{};
+	std::vector<K4E::Vector3> deathInitialPartPositions_{};
+	std::vector<K4E::Vector3> deathInitialPartRotations_{};
 	float deathTimer_ = 0.0f;
 	float deathSimDuration_ = 1.8f;   // 破片が残る時間
 	float deathFadeDuration_ = 0.6f;  // 最後にフェードする時間
@@ -265,6 +273,7 @@ protected:
 	float deathBounce_ = 0.25f;       // 0..1
 	float deathFriction_ = 0.7f;      // 0..1
 	float deathGroundY_ = 0.0f;       // とりあえず床はY=0想定（必要なら拡張）
+	float deathMaxMovePerFrame_ = 0.25f;
 	std::vector<DeathPiece> deathPieces_;
 
 	static float s_spawnYOffset_;

--- a/Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.cpp
@@ -607,6 +607,7 @@ void MidRangeEnemy::KillBySuicideExplosion()
     Vector3 breakApartDirection = CalculateSuicideBreakApartDirection();
     lastSuicideBreakApartDirection_ = breakApartDirection;
     usedEnemyBaseDeathForSuicide_ = true;
+    // 追加: 自爆崩壊も通常死亡と同じEnemyBaseのその場崩れ処理へ集約する。
     EnemyBase::TakeDamage(lethalDamage, breakApartDirection, suicideBomb_.breakApartPower);
 }
 


### PR DESCRIPTION
### Motivation
- 通常死亡時の四肢が振り向きなどで別座標へ飛ぶ不自然な挙動を解消するため、死亡時の座標基準を中距離雑魚敵の自爆崩壊と同じ「その場で崩れる」方式へ寄せる。
- 部位の初期位置を死亡瞬間のWorld座標で確定してから演出を行い、プレイヤー座標や攻撃判定中心、親Transformの後続参照を使わないようにする。
- 破片の速度・角速度・1フレーム移動量に上限を設け、二重初期化や演出暴走を防止する。

### Description
- 追加: `CaptureDeathPartWorldTransforms()` を導入して死亡瞬間に `deathInitialBodyPosition_` / `deathInitialPartPositions_` と回転を保存する実装を追加した。
- 修正: `StartBreakApartDeath()` を保存済みWorld座標を優先して部位を配置するよう変更し、従来の攻撃者方向ベースの爆散ではなく中距離自爆に合わせた「その場で少し外側へずらして持ち上げる」崩壊ロジックへ置き換えた（内部で `makeCollapsePiece` を採用）。
- 制御: 速度・角速度の上限に加え、1フレーム最大移動量を制限する `deathMaxMovePerFrame_` を導入して `UpdateBreakApartDeath()` で `frameMove` をクランプするようにした。
- デバッグ/安全: `hasDeathPartWorldTransforms_`, `deathEffectInitializeCount_`, `deathUsesMidRangeSuicideCollapseStyle_` 等のフラグ/カウンタを追加し、ImGuiへ初期部位位置・初期化回数・使用方式フラグ等を表示するようにした。
- 共通化: 中距離雑魚の自爆経路はこれまで通り `KillBySuicideExplosion()` → `EnemyBase::TakeDamage()` に集約されており、通常死亡も `EnemyBase` の保存済みWorld座標ベースの崩壊処理を使うことで挙動を統一した（`MidRangeEnemy::KillBySuicideExplosion()` に説明コメントを追加）。

### Testing
- 実行したチェックとして `git diff --check` を実行して差分の基本整合性を確認した（成功）。
- 文法的な静的構文チェックとして `clang++ -std=c++20 -fsyntax-only` を用いたが、環境に Windows DirectX ヘッダ `d3d12.h` が存在しないため完全なパースは行えなかった（ローカル/Windows ビルド環境でのビルド確認を推奨）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fae10b5cc832dbd4a5be1c8059617)