### PR TITLE
Fix enemy death part world transforms and add Draw-time debug info

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.cpp
@@ -208,6 +208,9 @@ void EnemyBase::Initialize()
 	deathInitialBodyRotation_ = deathEffectRotation_;
 	deathInitialPartPositions_.clear();
 	deathInitialPartRotations_.clear();
+	deathInitialPartLocalOffsets_.clear();
+	deathDrawBodyPosition_ = deathEffectOrigin_;
+	deathDrawPartPositions_.clear();
 	deathTimer_ = 0.0f;
 	deathPieces_.clear();
 	lastHitDir_ = { 0, 0, 0 };
@@ -437,13 +440,20 @@ void EnemyBase::Draw()
 
 	if (body_.active && body_.object)
 	{
+		deathDrawBodyPosition_ = body_.object->GetTranslate();
 		body_.object->Draw();
 	}
 
-	for (const auto& part : parts_)
+	if (deathDrawPartPositions_.size() != parts_.size())
 	{
+		deathDrawPartPositions_.assign(parts_.size(), {});
+	}
+	for (size_t i = 0; i < parts_.size(); ++i)
+	{
+		const auto& part = parts_[i];
 		if (part.active && part.object)
 		{
+			deathDrawPartPositions_[i] = part.object->GetTranslate();
 			part.object->Draw();
 		}
 	}
@@ -458,11 +468,20 @@ void EnemyBase::DrawImGui()
 	ImGui::Text("敵死亡座標: %.2f, %.2f, %.2f", deathEnemyPosition_.x, deathEnemyPosition_.y, deathEnemyPosition_.z);
 	ImGui::Text("死亡演出原点: %.2f, %.2f, %.2f", deathEffectOrigin_.x, deathEffectOrigin_.y, deathEffectOrigin_.z);
 	ImGui::Text("胴体初期座標: %.2f, %.2f, %.2f", deathInitialBodyPosition_.x, deathInitialBodyPosition_.y, deathInitialBodyPosition_.z);
-	const char* deathPartLabels[] = { "頭初期座標", "左腕初期座標", "右腕初期座標", "左脚初期座標", "右脚初期座標" };
+	ImGui::SeparatorText("死亡部位 Draw直前WorldTransform.translation");
+	ImGui::Text("deathOrigin: %.2f, %.2f, %.2f", deathEffectOrigin_.x, deathEffectOrigin_.y, deathEffectOrigin_.z);
+	ImGui::Text("body.worldTransform.translation: %.2f, %.2f, %.2f", deathDrawBodyPosition_.x, deathDrawBodyPosition_.y, deathDrawBodyPosition_.z);
+	const char* deathPartLabels[] = { "head", "leftArm", "rightArm", "leftLeg", "rightLeg" };
+	for (size_t i = 0; i < deathDrawPartPositions_.size() && i < 5; ++i)
+	{
+		const Vector3& p = deathDrawPartPositions_[i];
+		ImGui::Text("%s.worldTransform.translation: %.2f, %.2f, %.2f", deathPartLabels[i], p.x, p.y, p.z);
+	}
+	ImGui::SeparatorText("死亡部位 初期World座標");
 	for (size_t i = 0; i < deathInitialPartPositions_.size() && i < 5; ++i)
 	{
 		const Vector3& p = deathInitialPartPositions_[i];
-		ImGui::Text("%s: %.2f, %.2f, %.2f", deathPartLabels[i], p.x, p.y, p.z);
+		ImGui::Text("%s初期座標: %.2f, %.2f, %.2f", deathPartLabels[i], p.x, p.y, p.z);
 	}
 	ImGui::Text("死亡演出初期化回数: %d", deathEffectInitializeCount_);
 	ImGui::Text("中距離自爆崩壊処理を使用中: %s", deathUsesMidRangeSuicideCollapseStyle_ ? "はい" : "いいえ");
@@ -744,18 +763,22 @@ void EnemyBase::CaptureDeathPartWorldTransforms()
 		return;
 	}
 
-	// 死亡部位が別座標へ飛ばないよう、死亡瞬間のWorld座標を保存して崩壊演出に使用する。
+	// localOffsetをWorld座標として使わず、死亡瞬間のdeathOriginからDraw用World座標を再構築する。
 	UpdateVisualHierarchy();
 	deathInitialBodyPosition_ = body_.transform.worldTranslate_;
 	deathInitialBodyRotation_ = body_.transform.worldRotate_;
 	deathInitialPartPositions_.clear();
 	deathInitialPartRotations_.clear();
+	deathInitialPartLocalOffsets_.clear();
 	deathInitialPartPositions_.reserve(parts_.size());
 	deathInitialPartRotations_.reserve(parts_.size());
+	deathInitialPartLocalOffsets_.reserve(parts_.size());
 	for (auto& part : parts_)
 	{
-		deathInitialPartPositions_.push_back(part.transform.worldTranslate_);
-		deathInitialPartRotations_.push_back(part.transform.worldRotate_);
+		const Vector3 localOffset = part.transform.parent_ ? part.transform.translate_ : (part.transform.translate_ - deathEffectOrigin_);
+		deathInitialPartLocalOffsets_.push_back(localOffset);
+		deathInitialPartPositions_.push_back(BuildDeathPartWorldPosition(localOffset));
+		deathInitialPartRotations_.push_back(deathEffectRotation_ + part.transform.rotate_);
 	}
 	hasDeathPartWorldTransforms_ = true;
 }
@@ -764,6 +787,11 @@ Vector3 EnemyBase::RotateLocalOffsetByDeathRotation(const Vector3& localOffset) 
 {
 	const Matrix4x4 rotationMatrix = Matrix4x4::MakeRotateMatrix(deathEffectRotation_);
 	return Matrix4x4::Transform(localOffset, rotationMatrix);
+}
+
+Vector3 EnemyBase::BuildDeathPartWorldPosition(const Vector3& localOffset) const
+{
+	return deathEffectOrigin_ + RotateLocalOffsetByDeathRotation(localOffset);
 }
 
 /// -------------------------------------------------------------
@@ -788,10 +816,11 @@ void EnemyBase::StartBreakApartDeath(const Vector3& deathOrigin, const Vector3& 
 	deathSimDuration_ = s_deathPieceLifetime_;
 	deathTimer_ = deathSimDuration_;
 
-	// 通常死亡も中距離雑魚敵の自爆崩壊と同じ座標基準でその場に崩す。
+	// 死亡部位の最終描画座標が原点へ戻らないよう、deathOriginから各部位のWorldTransformを直接構築する。
 	body_.transform.parent_ = nullptr;
-	body_.transform.translate_ = deathInitialBodyPosition_;
+	body_.transform.translate_ = deathEffectOrigin_;
 	body_.transform.rotate_ = deathInitialBodyRotation_;
+	deathInitialBodyPosition_ = body_.transform.translate_;
 	body_.transform.Update();
 	if (body_.object)
 	{
@@ -804,15 +833,8 @@ void EnemyBase::StartBreakApartDeath(const Vector3& deathOrigin, const Vector3& 
 	{
 		auto& part = parts_[i];
 		part.transform.parent_ = nullptr;
-		if (i < deathInitialPartPositions_.size())
-		{
-			part.transform.translate_ = deathInitialPartPositions_[i];
-		}
-		else
-		{
-			const Vector3 localOffset = part.transform.translate_;
-			part.transform.translate_ = deathEffectOrigin_ + RotateLocalOffsetByDeathRotation(localOffset);
-		}
+		const Vector3 localOffset = (i < deathInitialPartLocalOffsets_.size()) ? deathInitialPartLocalOffsets_[i] : part.transform.translate_;
+		part.transform.translate_ = BuildDeathPartWorldPosition(localOffset);
 		part.transform.rotate_ = (i < deathInitialPartRotations_.size()) ? deathInitialPartRotations_[i] : deathEffectRotation_;
 		part.transform.Update();
 		if (part.object)

--- a/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.h
@@ -191,6 +191,7 @@ private:
 	K4E::Vector3 ResolveDeathOrigin(const K4E::Vector3& requestedOrigin);
 	void CaptureDeathPartWorldTransforms();
 	K4E::Vector3 RotateLocalOffsetByDeathRotation(const K4E::Vector3& localOffset) const;
+	K4E::Vector3 BuildDeathPartWorldPosition(const K4E::Vector3& localOffset) const;
 
 protected:
 	// ----- humanoid visual -----
@@ -266,6 +267,9 @@ protected:
 	K4E::Vector3 deathInitialBodyRotation_{};
 	std::vector<K4E::Vector3> deathInitialPartPositions_{};
 	std::vector<K4E::Vector3> deathInitialPartRotations_{};
+	std::vector<K4E::Vector3> deathInitialPartLocalOffsets_{};
+	K4E::Vector3 deathDrawBodyPosition_{};
+	std::vector<K4E::Vector3> deathDrawPartPositions_{};
 	float deathTimer_ = 0.0f;
 	float deathSimDuration_ = 1.8f;   // 破片が残る時間
 	float deathFadeDuration_ = 0.6f;  // 最後にフェードする時間

--- a/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
@@ -81,6 +81,12 @@ void MeleeEnemy::Initialize()
 
 void MeleeEnemy::Update(float deltaTime)
 {
+	if (IsDead())
+	{
+		EnemyBase::Update(deltaTime);
+		return;
+	}
+
 	const Vector3 beforePos = GetCenterPosition();
 	attackController_.Update(*this, deltaTime);
 	// 被ダメージリアクションと死亡演出のタイマー更新を先に行う。
@@ -95,6 +101,10 @@ void MeleeEnemy::Update(float deltaTime)
 	// 優先度の高い行動から順に評価して近接敵の行動を決定する
 	EvaluateBehavior(deltaTime);
 	EnemyBase::Update(deltaTime);
+	if (IsDead())
+	{
+		return;
+	}
 
 	collision_.usingWorldAABBCount = GetResolvedWorldAABBs() ? static_cast<int>(GetResolvedWorldAABBs()->size()) : 0;
 	collision_.usingObstacleAABBCount = GetResolvedNavigationObstacleAABBs() ? static_cast<int>(GetResolvedNavigationObstacleAABBs()->size()) : 0;


### PR DESCRIPTION
### Motivation
- 死亡時の四肢が `deathOrigin` 周辺ではなく原点や別地点に出るため、Draw直前の最終座標と座標生成元を追跡して原因を特定し修正する必要がある。
- `deathOrigin` を計算しても最終的な `WorldTransform.translation` に到達していない経路を塞ぎ、全パーツが同一基準で崩れるようにする。

### Description
- Draw直前の実際に描画される座標を保存するメンバー `deathDrawBodyPosition_` / `deathDrawPartPositions_` を追加し、ImGuiで `deathOrigin` と各部位の `worldTransform.translation` を表示するようにした（`EnemyBase::Draw` / `EnemyBase::DrawImGui`）。
- 死亡時に部位のローカルオフセットを `deathInitialPartLocalOffsets_` に保存し、`BuildDeathPartWorldPosition()` を追加して `deathEffectOrigin_ + RotateLocalOffsetByDeathRotation(localOffset)` で Draw 用の World 座標を再構築するようにした（`CaptureDeathPartWorldTransforms` / `StartBreakApartDeath`）。
- `StartBreakApartDeath` で各部位の `transform.translate_` を `deathEffectOrigin` 基準で直接構築し、直後に `transform.Update()` と `object->Update()` を呼ぶことで最終的な World 行列を確実に更新するようにした。
- 近接敵で死亡後も生存時の階層更新が続き死亡用の Transform を上書きしてしまう経路があったため、`MeleeEnemy::Update` に死亡判定で早期 return を追加して `EnemyBase` の死亡崩壊処理のみを実行するようにした。
- 変更点には「localOffset をそのまま World 座標として使わない」旨のコメントを追加した。

### Testing
- `git diff --check` を実行し問題なし（成功）。
- `cmake --build Project` を実行したが、この環境では CMake キャッシュが未生成のため `Error: could not load cache` でビルドは実行できなかった（環境依存）。
- `msbuild Project/Ken4lowEngine.sln` はこの Linux 環境で `msbuild` が無いため実行できなかった（未実行）。
- `g++ -fsyntax-only` による構文チェックは試行したが、プラットフォーム固有ヘッダー（例: `d3d12.h`）が存在しないため完全な静的検査は行えなかった（環境制約）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fb281ba38832d9fff36fcde51378a)