### PR TITLE
Apply enemy melee/bomb damage to Player and add hit debug/guards

### DIFF
--- a/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
@@ -1,12 +1,15 @@
 #define NOMINMAX
 #include "MeleeEnemy.h"
 
+#include "ApplicationLayer/Character/Player/Player.h"
+
 #include <cmath>
 #include <algorithm>
 #include <cstdlib>
 #include "Wireframe.h"
 #include "CollisionTypeIdDef.h"
 #include <fstream>
+#include <iostream>
 #include <json.hpp>
 
 #ifdef USE_IMGUI
@@ -757,6 +760,7 @@ if (ImGui::CollapsingHeader("スタック", ImGuiTreeNodeFlags_DefaultOpen)) {
 		}
 		if (ImGui::CollapsingHeader("頭向き", ImGuiTreeNodeFlags_DefaultOpen)) { ImGui::Checkbox("頭をターゲットへ向ける", &headLookSettings_.enabled); ImGui::SliderFloat("ヨー制限", &headLookSettings_.yawLimitDeg, 10.0f, 120.0f); ImGui::SliderFloat("ピッチ最小", &headLookSettings_.pitchMinDeg, -80.0f, 0.0f); ImGui::SliderFloat("ピッチ最大", &headLookSettings_.pitchMaxDeg, 0.0f, 80.0f); ImGui::SliderFloat("補間速度", &headLookSettings_.lerpSpeed, 1.0f, 30.0f); }
 		if (ImGui::CollapsingHeader("状態表示", ImGuiTreeNodeFlags_DefaultOpen)) { ImGui::Text("現在行動: %s", currentBehaviorName_); ImGui::Text("攻撃中: %s", attackController_.IsAttacking() ? "はい" : "いいえ"); ImGui::Text("ターゲット距離: %.2f", GetDistanceToTarget()); }
+		if (ImGui::CollapsingHeader("敵攻撃ダメージ確認", ImGuiTreeNodeFlags_DefaultOpen)) { ImGui::Text("近接攻撃ヒット回数: %d", enemyDamageDebug_.meleeHitCount); ImGui::Text("最後に受けたダメージ: %d", enemyDamageDebug_.lastDamage); ImGui::Text("Player HP: %.1f", enemyDamageDebug_.lastPlayerHp); ImGui::Text("最後の命中種別: %s", enemyDamageDebug_.lastHitSource.c_str()); }
 	}
 	ImGui::End();
 #endif
@@ -1384,9 +1388,25 @@ void MeleeEnemy::ApplyAttackMove(const Vector3& horizontalVelocity)
 	}
 }
 
-void MeleeEnemy::NotifyAttackHit(int, const Vector3&)
+void MeleeEnemy::NotifyAttackHit(int damage, const Vector3&)
 {
-	// TODO: Playerへの実ダメージ処理の接続先が確定したらここで適用する
+	if (damage <= 0 || !target_)
+	{
+		return;
+	}
+
+	if (auto* player = target_->GetOwner<Player>())
+	{
+		const Vector3 attackerPosition = GetCenterPosition();
+		// 近接雑魚敵の攻撃発生中だけプレイヤーとの距離を判定し、命中時にHPを減らす。
+		player->ApplyDamage(static_cast<float>(damage), &attackerPosition);
+		++enemyDamageDebug_.meleeHitCount;
+		enemyDamageDebug_.lastDamage = damage;
+		enemyDamageDebug_.lastPlayerHp = player->GetHP();
+		enemyDamageDebug_.lastHitSource = "近接攻撃";
+		std::cout << "[近接雑魚敵] 近接攻撃ヒット: ダメージ=" << damage
+			<< " Player HP=" << enemyDamageDebug_.lastPlayerHp << std::endl;
+	}
 }
 
 void MeleeEnemy::EvaluateBehavior(float deltaTime)

--- a/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.h
@@ -208,6 +208,14 @@ private: /// ---------- 構造体 ---------- ///
 		bool shouldChase = true; // 攻撃中に追いかけるかどうか
 	};
 
+	struct EnemyDamageDebugState
+	{
+		int meleeHitCount = 0;
+		int lastDamage = 0;
+		float lastPlayerHp = 0.0f;
+		std::string lastHitSource = "なし";
+	};
+
 	// 攻撃選択の設定
 	struct AttackSelectSettings
 	{
@@ -710,6 +718,9 @@ private: /// ---------- メンバ変数 ---------- //
 
 	// 攻撃の状態管理
 	AttackState attackState_{};
+
+	// 敵攻撃がPlayerへ届いたかをImGui/ログで確認するための状態
+	EnemyDamageDebugState enemyDamageDebug_{};
 
 	// 攻撃選択の設定
 	AttackSelectSettings attackSelectSettings_{};

--- a/Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.cpp
@@ -1,6 +1,7 @@
 #define NOMINMAX
 #include "MidRangeEnemy.h"
 
+#include "ApplicationLayer/Character/Player/Player.h"
 #include "Wireframe.h"
 
 #include <imgui.h>
@@ -9,6 +10,7 @@
 #include <algorithm>
 #include <cmath>
 #include <fstream>
+#include <iostream>
 
 using namespace Ken4lowEngine;
 
@@ -200,6 +202,34 @@ void MidRangeEnemy::Update(float deltaTime)
     for (auto& bomb : bombs_)
     {
         bomb->Update(deltaTime);
+        if (targetCollider_)
+        {
+            if (auto* player = targetCollider_->GetOwner<Player>())
+            {
+                const MidRangeBombProjectile::PlayerHitResult hitResult = bomb->TryApplyPlayerDamage(*player);
+                if (hitResult != MidRangeBombProjectile::PlayerHitResult::None)
+                {
+                    ++enemyDamageDebug_.midRangeHitCount;
+                    enemyDamageDebug_.lastPlayerHp = player->GetHP();
+                    if (hitResult == MidRangeBombProjectile::PlayerHitResult::Direct || hitResult == MidRangeBombProjectile::PlayerHitResult::DirectAndExplosion)
+                    {
+                        ++enemyDamageDebug_.bombDirectHitCount;
+                        enemyDamageDebug_.lastDamage = bombProjectile_.directHitDamage;
+                        enemyDamageDebug_.lastHitSource = "爆弾直撃";
+                        std::cout << "[中距離雑魚敵] 爆弾直撃: ダメージ=" << bombProjectile_.directHitDamage
+                            << " Player HP=" << enemyDamageDebug_.lastPlayerHp << std::endl;
+                    }
+                    if (hitResult == MidRangeBombProjectile::PlayerHitResult::Explosion || hitResult == MidRangeBombProjectile::PlayerHitResult::DirectAndExplosion)
+                    {
+                        ++enemyDamageDebug_.bombExplosionHitCount;
+                        enemyDamageDebug_.lastDamage = bombProjectile_.explosionDamage;
+                        enemyDamageDebug_.lastHitSource = (hitResult == MidRangeBombProjectile::PlayerHitResult::DirectAndExplosion) ? "爆弾直撃+爆発" : "爆弾爆発";
+                        std::cout << "[中距離雑魚敵] 爆弾爆発ヒット: ダメージ=" << bombProjectile_.explosionDamage
+                            << " Player HP=" << enemyDamageDebug_.lastPlayerHp << std::endl;
+                    }
+                }
+            }
+        }
     }
 
     bombs_.erase(
@@ -571,7 +601,18 @@ void MidRangeEnemy::ExplodeSuicideBomb(const std::string& reason)
         const float distanceToTarget = LengthXZ(targetState_.position - suicideBombState_.explosionPosition);
         if (distanceToTarget <= suicideBomb_.explosionRadius)
         {
-            // 追加: TODO 既存のプレイヤーダメージ接続先が確定したら範囲ダメージを適用する。
+            if (auto* player = targetCollider_ ? targetCollider_->GetOwner<Player>() : nullptr)
+            {
+                // 中距離雑魚敵の自爆範囲内にプレイヤーがいる場合のみHPを減らす。
+                player->ApplyDamage(static_cast<float>(suicideBomb_.explosionDamage), &suicideBombState_.explosionPosition);
+                ++enemyDamageDebug_.midRangeHitCount;
+                ++enemyDamageDebug_.suicideHitCount;
+                enemyDamageDebug_.lastDamage = suicideBomb_.explosionDamage;
+                enemyDamageDebug_.lastPlayerHp = player->GetHP();
+                enemyDamageDebug_.lastHitSource = "自爆";
+                std::cout << "[中距離雑魚敵] 自爆ヒット: ダメージ=" << suicideBomb_.explosionDamage
+                    << " Player HP=" << enemyDamageDebug_.lastPlayerHp << std::endl;
+            }
             behaviorState_.lastReason = "自爆範囲内";
         }
     }
@@ -1081,6 +1122,16 @@ void MidRangeEnemy::DrawImGui()
             suicideBombState_.explosionDrawTimer = drawTime;
             suicideBombState_.lastReason = "DebugExplosionDrawOnly";
         }
+    }
+    if (ImGui::CollapsingHeader("敵攻撃ダメージ確認", ImGuiTreeNodeFlags_DefaultOpen))
+    {
+        ImGui::Text("中距離攻撃ヒット回数: %d", enemyDamageDebug_.midRangeHitCount);
+        ImGui::Text("爆弾直撃ヒット回数: %d", enemyDamageDebug_.bombDirectHitCount);
+        ImGui::Text("爆弾爆発ヒット回数: %d", enemyDamageDebug_.bombExplosionHitCount);
+        ImGui::Text("自爆ヒット回数: %d", enemyDamageDebug_.suicideHitCount);
+        ImGui::Text("最後に受けたダメージ: %d", enemyDamageDebug_.lastDamage);
+        ImGui::Text("Player HP: %.1f", enemyDamageDebug_.lastPlayerHp);
+        ImGui::Text("最後の命中種別: %s", enemyDamageDebug_.lastHitSource.c_str());
     }
     if (ImGui::CollapsingHeader("爆弾Projectile"))
     {

--- a/Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.h
@@ -256,6 +256,17 @@ private:
         std::string lastReason = "None";
     };
 
+    struct EnemyDamageDebugState
+    {
+        int midRangeHitCount = 0;
+        int bombDirectHitCount = 0;
+        int bombExplosionHitCount = 0;
+        int suicideHitCount = 0;
+        int lastDamage = 0;
+        float lastPlayerHp = 0.0f;
+        std::string lastHitSource = "なし";
+    };
+
 public:
     void Initialize() override;
     void Update(float deltaTime) override;
@@ -333,6 +344,7 @@ private:
     DeathAnimationState deathAnimationState_{};
     TuningIoState tuningIo_{};
     BehaviorState behaviorState_{};
+    EnemyDamageDebugState enemyDamageDebug_{};
     bool usedEnemyBaseDeathForSuicide_ = false;
     K4E::Vector3 lastSuicideBreakApartDirection_{ 0.0f, 0.0f, 1.0f };
     // 使用中の雑魚敵だけを残し、大量敵対応に向けてEnemy周りの責務を整理する。

--- a/Project/ApplicationLayer/Character/Enemy/Projectile/MidRangeBombProjectile.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Projectile/MidRangeBombProjectile.cpp
@@ -1,5 +1,7 @@
 #define NOMINMAX
 #include "MidRangeBombProjectile.h"
+
+#include "ApplicationLayer/Character/Player/Player.h"
 #include "Wireframe.h"
 
 #include <algorithm>
@@ -20,6 +22,8 @@ void MidRangeBombProjectile::Initialize()
     explosionDrawTimer_ = 0.0f;
     exploded_ = false;
     alive_ = false;
+    directDamageApplied_ = false;
+    explosionDamageApplied_ = false;
 
     debugCube_ = std::make_unique<Object3D>();
     debugCube_->Initialize("Test/cube.gltf");
@@ -41,6 +45,8 @@ void MidRangeBombProjectile::Launch(
     explosionDrawTimer_ = 0.0f;
     exploded_ = false;
     alive_ = true;
+    directDamageApplied_ = false;
+    explosionDamageApplied_ = false;
 
     Vector3 directionXZ = target - start;
     directionXZ.y = 0.0f;
@@ -148,6 +154,53 @@ void MidRangeBombProjectile::UpdateDebugCube()
     debugCube_->SetRotate({ lifeTimer_ * 2.0f, lifeTimer_ * 3.5f, lifeTimer_ * 1.5f });
     debugCube_->SetScale({ s_debugCubeSize_, s_debugCubeSize_, s_debugCubeSize_ });
     debugCube_->Update();
+}
+
+
+MidRangeBombProjectile::PlayerHitResult MidRangeBombProjectile::TryApplyPlayerDamage(Player& player)
+{
+    auto* playerTransform = player.GetWorldTransform();
+    if (!playerTransform)
+    {
+        return PlayerHitResult::None;
+    }
+
+    PlayerHitResult result = PlayerHitResult::None;
+    const Vector3 playerPosition = playerTransform->translate_;
+
+    if (alive_ && !directDamageApplied_)
+    {
+        const float directDistance = Vector3::Length(playerPosition - position_);
+        if (directDistance <= settings_.hitRadius)
+        {
+            // 中距離雑魚敵の爆弾Cubeがプレイヤーへ直撃した瞬間だけHPを減らす。
+            player.ApplyDamage(static_cast<float>(settings_.directHitDamage), &position_);
+            directDamageApplied_ = true;
+            result = PlayerHitResult::Direct;
+            Explode();
+        }
+    }
+
+    if (exploded_ && !explosionDamageApplied_)
+    {
+        const float explosionDistance = Vector3::Length(playerPosition - explosionPosition_);
+        if (explosionDistance <= settings_.explosionRadius)
+        {
+            if (result != PlayerHitResult::Direct || settings_.directHitAlsoExplosionDamage)
+            {
+                // 中距離雑魚敵の爆弾範囲内にプレイヤーが入った場合のみダメージを与える。
+                player.ApplyDamage(static_cast<float>(settings_.explosionDamage), &explosionPosition_);
+                explosionDamageApplied_ = true;
+                result = (result == PlayerHitResult::Direct) ? PlayerHitResult::DirectAndExplosion : PlayerHitResult::Explosion;
+            }
+            else
+            {
+                explosionDamageApplied_ = true;
+            }
+        }
+    }
+
+    return result;
 }
 
 bool MidRangeBombProjectile::IsAlive() const

--- a/Project/ApplicationLayer/Character/Enemy/Projectile/MidRangeBombProjectile.h
+++ b/Project/ApplicationLayer/Character/Enemy/Projectile/MidRangeBombProjectile.h
@@ -4,6 +4,9 @@
 #include "Object3D.h"
 
 #include <memory>
+
+class Player;
+
 struct BombProjectileSettings
 {
     // 追加: 距離に応じた初速調整の基本値。
@@ -31,6 +34,14 @@ struct BombProjectileSettings
 class MidRangeBombProjectile
 {
 public:
+    enum class PlayerHitResult
+    {
+        None,
+        Direct,
+        Explosion,
+        DirectAndExplosion,
+    };
+
     void Initialize();
 
     void Launch(
@@ -42,6 +53,7 @@ public:
     void Update(float deltaTime);
     void Draw() const;
     void Explode();
+    PlayerHitResult TryApplyPlayerDamage(Player& player);
     bool IsAlive() const;
 
     const Ken4lowEngine::Vector3& GetPosition() const { return position_; }
@@ -62,6 +74,8 @@ private:
     float explosionDrawTimer_ = 0.0f;
     bool exploded_ = false;
     bool alive_ = false;
+    bool directDamageApplied_ = false;
+    bool explosionDamageApplied_ = false;
     std::unique_ptr<Ken4lowEngine::Object3D> debugCube_;
 
     static bool s_debugCubeVisible_;

--- a/Project/ApplicationLayer/Character/Player/Component/PlayerDamageComponent.cpp
+++ b/Project/ApplicationLayer/Character/Player/Component/PlayerDamageComponent.cpp
@@ -237,6 +237,72 @@ PlayerDamageComponent::DamageFeedback PlayerDamageComponent::ApplyFallDamage(
 	return fb;
 }
 
+
+PlayerDamageComponent::DamageFeedback PlayerDamageComponent::ApplyDamage(
+	Player& player,
+	float damage,
+	PlayerViewComponent& view,
+	PlayerWeaponController& weaponController,
+	PlayerDeathComponent& death,
+	InputSnapshot& inputSnap,
+	bool& runCarry,
+	std::function<void()> onHitSE,
+	std::function<void()> onDeathSE)
+{
+	DamageFeedback fb{};
+	fb.hpAfter = state_.hp;
+	fb.maxHp = state_.maxHp;
+
+	if (death.IsActive() || damage <= 0.0f || state_.hp <= 0.0f)
+	{
+		return fb;
+	}
+
+	const bool wasAlive = (state_.hp > 0.0f);
+	state_.hp -= damage;
+	if (state_.hp < 0.0f)
+	{
+		state_.hp = 0.0f;
+	}
+
+	fb.tookDamage = true;
+	fb.hpChanged = true;
+	fb.notifyPlayerHit = true;
+	fb.damage = damage;
+	fb.hpAfter = state_.hp;
+	fb.maxHp = state_.maxHp;
+	fb.hitStrength01 = CalcHitStrength01(damage);
+
+	if (onHitSE)
+	{
+		onHitSE();
+	}
+
+	if (wasAlive && state_.hp <= 0.0f)
+	{
+		if (onDeathSE)
+		{
+			onDeathSE();
+		}
+
+		K4E::Vector3 launchDir = { 0.0f, 0.0f, -1.0f };
+		if (auto* cam = view.GetCamera())
+		{
+			launchDir = -cam->GetForward();
+			launchDir.y = 0.0f;
+			if (K4E::Vector3::Length(launchDir) > 0.0001f)
+			{
+				launchDir = K4E::Vector3::Normalize(launchDir);
+			}
+		}
+
+		StartDeath(player, view, weaponController, death, inputSnap, runCarry, launchDir);
+		fb.startedDeath = true;
+	}
+
+	return fb;
+}
+
 void PlayerDamageComponent::StartDeath(
 	Player& player,
 	PlayerViewComponent& view,

--- a/Project/ApplicationLayer/Character/Player/Component/PlayerDamageComponent.h
+++ b/Project/ApplicationLayer/Character/Player/Component/PlayerDamageComponent.h
@@ -87,6 +87,17 @@ public:
 		bool& runCarry,
 		std::function<void()> onDeathSE);
 
+	DamageFeedback ApplyDamage(
+		Player& player,
+		float damage,
+		PlayerViewComponent& view,
+		PlayerWeaponController& weaponController,
+		PlayerDeathComponent& death,
+		InputSnapshot& inputSnap,
+		bool& runCarry,
+		std::function<void()> onHitSE,
+		std::function<void()> onDeathSE);
+
 	float GetHP() const { return state_.hp; }
 	float GetMaxHP() const { return state_.maxHp; }
 	void Heal(float amount);

--- a/Project/ApplicationLayer/Character/Player/Player.cpp
+++ b/Project/ApplicationLayer/Character/Player/Player.cpp
@@ -600,6 +600,52 @@ void Player::OnHitByEnemyBullet(K4E::Collider* bullet, PlayerHitPart part, float
 		cameraRight);
 }
 
+
+void Player::ApplyDamage(float amount, const K4E::Vector3* attackerPosition)
+{
+	// 敵の近接・爆弾攻撃は既存のHP/死亡フィードバック経路へ集約して処理する。
+	const auto fb = damage_.ApplyDamage(
+		*this,
+		amount,
+		view_,
+		weaponController_,
+		death_,
+		inputSnap_,
+		runtime_.runCarry,
+		audio_.onHit,
+		audio_.onDeath);
+
+	ApplyDamageFeedback(fb);
+
+	if (!fb.tookDamage || !refs_.hudManager || !attackerPosition)
+	{
+		return;
+	}
+
+	auto* cam = view_.GetCamera();
+	if (!cam)
+	{
+		return;
+	}
+
+	K4E::Vector3 playerPos = GetWorldTransform()->translate_;
+	K4E::Vector3 cameraForward = cam->GetForward();
+	cameraForward.y = 0.0f;
+	const float forwardLenSq = cameraForward.x * cameraForward.x + cameraForward.z * cameraForward.z;
+	if (forwardLenSq <= 0.0001f)
+	{
+		cameraForward = { 0.0f, 0.0f, 1.0f };
+	}
+	else
+	{
+		cameraForward = K4E::Vector3::Normalize(cameraForward);
+	}
+	K4E::Vector3 cameraRight = { cameraForward.z, 0.0f, -cameraForward.x };
+	cameraRight = K4E::Vector3::Normalize(cameraRight);
+
+	refs_.hudManager->AddDamageIndicator(playerPos, *attackerPosition, cameraForward, cameraRight);
+}
+
 void Player::NotifyEnemyHitUI(bool isHeadshot)
 {
 	if (refs_.hudManager)

--- a/Project/ApplicationLayer/Character/Player/Player.h
+++ b/Project/ApplicationLayer/Character/Player/Player.h
@@ -128,6 +128,7 @@ public: /// ---------- メンバ関数 ---------- ///
 
 	float GetHP() const { return damage_.GetHP(); }
 	float GetMaxHP() const { return damage_.GetMaxHP(); }
+	void ApplyDamage(float amount, const K4E::Vector3* attackerPosition = nullptr);
 	void Heal(float amount) { damage_.Heal(amount); }
 	int AddReserveAmmo(int amount) { return weapon_.AddReserveAmmo(amount); }
 	int GetCurrentWeaponMagazineAmmo() const { return weapon_.GetMagazineAmmo(); }


### PR DESCRIPTION
### Motivation
- Fix cases where melee and mid-range enemy attacks didn’t reduce the Player HP while keeping existing Player HP / lives / GameOver logic intact.  
- Ensure attacks only deal damage during attack-hit windows (no per-frame multi-damage).  
- Make attack hits observable via logs/ImGui so QA can verify hits during scalability tests.  

### Description
- Add `Player::ApplyDamage` and `PlayerDamageComponent::ApplyDamage` as a unified entry that reuses HUD/VFX/SE/death flows to apply damage to the player.  
- Wire melee hits to player damage by calling `player->ApplyDamage(...)` from `MeleeEnemy::NotifyAttackHit` when an attack step hits.  
- Add `MidRangeBombProjectile::TryApplyPlayerDamage` to evaluate direct-hit and explosion-hit, with `directDamageApplied_` and `explosionDamageApplied_` guards to ensure each event deals damage only once; call it from `MidRangeEnemy` update loop.  
- Implement suicide-explosion damage application in `MidRangeEnemy::ExplodeSuicideBomb` without changing enemy death/collapse handling, and add Japanese ImGui displays + std::cout logs for melee and mid-range hit counts, last damage, last hit source and last observed Player HP.  

### Testing
- Ran `git diff --check` to validate whitespace/patch integrity, which reported no issues.  
- Attempted to build with `msbuild Project/Ken4lowEngine.sln /p:Configuration=Debug /p:Platform=x64` but the environment lacked `msbuild` so the build could not be executed.  
- Performed a local syntax-only compile check using `clang++ -std=c++20 -fsyntax-only ... PlayerDamageComponent.cpp MidRangeBombProjectile.cpp`; that check aborted due to the environment missing Windows SDK headers (`d3d12.h`), not due to changes in the modify files.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fbfb4b5f0832dbe974f4c93cba839)