### PR TITLE
クリスタルHPバー追加と全破壊後のGuardianBoss出現制御実装

### DIFF
--- a/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.cpp
+++ b/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.cpp
@@ -156,6 +156,25 @@ EnemyBase& CharacterWorld::SpawnEnemyAt(const K4E::Vector3& position, EnemyType 
 	return SpawnEnemy(request);
 }
 
+int CharacterWorld::GetAliveNormalEnemyCount() const
+{
+	int aliveCount = 0;
+	for (const auto& enemy : enemies_)
+	{
+		if (!enemy || enemy->IsDead())
+		{
+			continue;
+		}
+
+		// ボスやクリスタルはCharacterWorldの雑魚敵配列に入れず、近接/中距離雑魚敵だけを進行条件に使う。
+		if (dynamic_cast<const MeleeEnemy*>(enemy.get()) || dynamic_cast<const MidRangeEnemy*>(enemy.get()))
+		{
+			++aliveCount;
+		}
+	}
+	return aliveCount;
+}
+
 void CharacterWorld::ClearEnemies()
 {
 	notifiedKilledEnemies_.clear();

--- a/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.h
+++ b/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.h
@@ -72,6 +72,7 @@ public: /// ---------- メンバ関数 ---------- ///
 	void SetEnemyKilledCallback(std::function<void(const K4E::Vector3&)> callback) { onEnemyKilled_ = std::move(callback); }
 
 	int GetEnemyCount() const { return static_cast<int>(enemies_.size()); }
+	int GetAliveNormalEnemyCount() const;
 
 public: /// ---------- デバッグ用 ---------- ///
 

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/CrystalManager.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/CrystalManager.cpp
@@ -5,10 +5,12 @@
 #include "CameraManager.h"
 #include "CollisionManager.h"
 #include "EnemyBase.h"
+#include "EnemyHPBarProjector.h"
 
 #include <algorithm>
-#include <iostream>
+#include <cmath>
 #include <utility>
+#include <string>
 
 #ifdef USE_IMGUI
 #include <imgui.h>
@@ -54,8 +56,10 @@ void CrystalManager::Initialize(const std::vector<CrystalSpawnPoint>& spawnPoint
 	globalSpawnInterval_ = 5.0f;
 	globalSpawnTimer_ = 0.0f;
 	maxSpawnPerInterval_ = 1;
-	shouldSpawnBoss_ = false;
-	hasBossSpawned_ = false;
+	debugAliveNormalEnemyCount_ = 0;
+	debugBossSpawnConditionMet_ = false;
+	debugBossSpawned_ = false;
+	debugBossSpawnPosition_ = {};
 }
 
 void CrystalManager::Update(CharacterWorld& characters, float deltaTime)
@@ -65,7 +69,6 @@ void CrystalManager::Update(CharacterWorld& characters, float deltaTime)
 		crystal.Update(characters);
 	}
 
-	NotifyBossSpawnIfNeeded();
 	if (!enableCrystalEnemySpawn_ || AreAllCrystalsDestroyed() || GetAliveCrystalCount() <= 0 ||
 		GetAliveCrystalSpawnEnemyCount() >= maxTotalCrystalSpawnEnemies_)
 	{
@@ -103,6 +106,53 @@ void CrystalManager::Draw() const
 	}
 }
 
+void CrystalManager::DrawHpBars(const Ken4lowEngine::Matrix4x4& viewMatrix, const Ken4lowEngine::Matrix4x4& projMatrix, float screenWidth, float screenHeight) const
+{
+#ifdef USE_IMGUI
+	ImDrawList* drawList = ImGui::GetBackgroundDrawList();
+	if (!drawList)
+	{
+		return;
+	}
+
+	for (const EnemySpawnCrystal& crystal : crystals_)
+	{
+		if (crystal.IsDestroyed())
+		{
+			continue;
+		}
+
+		const Ken4lowEngine::Vector3& pos = crystal.GetPosition();
+		const Ken4lowEngine::Vector3& scale = crystal.GetScale();
+		const Ken4lowEngine::Vector3 hpBarWorldPos{ pos.x, pos.y + std::abs(scale.y) * 0.65f + 0.35f, pos.z };
+		const HpBarProjectResult projected = ProjectWorldToScreen(hpBarWorldPos, viewMatrix, projMatrix, screenWidth, screenHeight);
+		if (!projected.inFront || !projected.inScreen)
+		{
+			continue;
+		}
+
+		const float hpRate = std::clamp(crystal.GetHpRate(), 0.0f, 1.0f);
+		const ImVec2 barSize{ 82.0f, 9.0f };
+		const ImVec2 barMin{ projected.screenPos.x - barSize.x * 0.5f, projected.screenPos.y - 20.0f };
+		const ImVec2 barMax{ barMin.x + barSize.x, barMin.y + barSize.y };
+		const ImVec2 fillMax{ barMin.x + barSize.x * hpRate, barMax.y };
+
+		drawList->AddRectFilled(barMin, barMax, IM_COL32(25, 25, 25, 210), 3.0f);
+		drawList->AddRectFilled(barMin, fillMax, IM_COL32(60, 220, 255, 235), 3.0f);
+		drawList->AddRect(barMin, barMax, IM_COL32(255, 255, 255, 230), 3.0f);
+
+		const std::string hpText = std::to_string(crystal.GetHp()) + "/" + std::to_string(crystal.GetMaxHp());
+		const ImVec2 textSize = ImGui::CalcTextSize(hpText.c_str());
+		drawList->AddText({ projected.screenPos.x - textSize.x * 0.5f, barMin.y - textSize.y - 2.0f }, IM_COL32(255, 255, 255, 255), hpText.c_str());
+	}
+#else
+	(void)viewMatrix;
+	(void)projMatrix;
+	(void)screenWidth;
+	(void)screenHeight;
+#endif
+}
+
 int CrystalManager::GetAliveCrystalCount() const
 {
 	return static_cast<int>(std::count_if(crystals_.begin(), crystals_.end(),
@@ -124,17 +174,12 @@ bool CrystalManager::AreAllCrystalsDestroyed() const
 	return !crystals_.empty() && GetAliveCrystalCount() == 0;
 }
 
-void CrystalManager::NotifyBossSpawnIfNeeded()
+void CrystalManager::SetProgressDebugStatus(int aliveNormalEnemyCount, bool bossSpawnConditionMet, bool bossSpawned, const Ken4lowEngine::Vector3& bossSpawnPosition)
 {
-	if (!AreAllCrystalsDestroyed() || hasBossSpawned_)
-	{
-		return;
-	}
-
-	shouldSpawnBoss_ = true;
-	hasBossSpawned_ = true;
-	// 既存ボス進行へ安全に接続するまでは、全破壊時に一度だけ仮通知する。
-	std::clog << "[CrystalManager] すべてのクリスタルが破壊されました。ボスを出現させます。\n";
+	debugAliveNormalEnemyCount_ = aliveNormalEnemyCount;
+	debugBossSpawnConditionMet_ = bossSpawnConditionMet;
+	debugBossSpawned_ = bossSpawned;
+	debugBossSpawnPosition_ = bossSpawnPosition;
 }
 
 EnemySpawnCrystal* CrystalManager::GetSelectedCrystal()
@@ -221,7 +266,11 @@ void CrystalManager::DrawImGui()
 	ImGui::Text("クリスタル数: %d", GetCrystalCount());
 	ImGui::Text("生存クリスタル数: %d", GetAliveCrystalCount());
 	ImGui::Text("全クリスタル破壊済み: %s", AreAllCrystalsDestroyed() ? "はい" : "いいえ");
-	ImGui::Text("ボス出現済み: %s", HasBossSpawned() ? "はい" : "いいえ");
+	ImGui::Text("クリスタル敵スポーン有効(実効): %s", (enableCrystalEnemySpawn_ && !AreAllCrystalsDestroyed()) ? "はい" : "いいえ");
+	ImGui::Text("生存雑魚敵数: %d", debugAliveNormalEnemyCount_);
+	ImGui::Text("ボス出現条件成立: %s", debugBossSpawnConditionMet_ ? "はい" : "いいえ");
+	ImGui::Text("ボス出現済み: %s", debugBossSpawned_ ? "はい" : "いいえ");
+	ImGui::Text("ボス出現位置: (%.2f, %.2f, %.2f)", debugBossSpawnPosition_.x, debugBossSpawnPosition_.y, debugBossSpawnPosition_.z);
 	ImGui::Text("更新用deltaTime上限: %.4f 秒", kMaxUpdateDeltaTime);
 	ImGui::Text("敵Ground Snap有効: %s", EnemyBase::IsGroundSnapEnabled() ? "はい" : "いいえ");
 	ImGui::Text("クリスタルGround Snap有効: %s", EnemySpawnCrystal::IsGroundSnapEnabled() ? "はい" : "いいえ");
@@ -271,6 +320,8 @@ void CrystalManager::DrawImGui()
 	ImGui::Text("選択中クリスタル座標: (%.2f, %.2f, %.2f)", crystalPosition.x, crystalPosition.y, crystalPosition.z);
 	ImGui::Text("クリスタルScale: (%.2f, %.2f, %.2f)", crystalScale.x, crystalScale.y, crystalScale.z);
 	ImGui::Text("選択中クリスタルHP: %d", crystal->GetHp());
+	ImGui::Text("選択中クリスタル最大HP: %d", crystal->GetMaxHp());
+	ImGui::Text("選択中クリスタルHP割合: %.2f", crystal->GetHpRate());
 	ImGui::Text("生存状態: %s", crystal->IsAlive() ? "生存" : "破壊済み");
 	ImGui::Text("クリスタル破壊済み: %s", crystal->IsDestroyed() ? "はい" : "いいえ");
 	ImGui::Text("クリスタルCollider有効: %s", crystal->IsColliderEnabled() ? "はい" : "いいえ");

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/CrystalManager.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/CrystalManager.h
@@ -5,6 +5,8 @@
 #include <cstddef>
 #include <vector>
 
+#include "Matrix4x4.h"
+
 class CharacterWorld;
 class CollisionManager;
 
@@ -15,21 +17,21 @@ public:
 	void Initialize(const std::vector<CrystalSpawnPoint>& spawnPoints, CollisionManager* collisionManager = nullptr, const std::vector<K4E::AABB>* floorAABBs = nullptr, const std::vector<K4E::AABB>* obstacleAABBs = nullptr);
 	void Update(CharacterWorld& characters, float deltaTime);
 	void Draw() const;
+	void DrawHpBars(const K4E::Matrix4x4& viewMatrix, const K4E::Matrix4x4& projMatrix, float screenWidth, float screenHeight) const;
 	void DrawImGui();
 
 	int GetCrystalCount() const { return static_cast<int>(crystals_.size()); }
 	int GetAliveCrystalCount() const;
 	int GetAliveCrystalSpawnEnemyCount() const;
 	bool AreAllCrystalsDestroyed() const;
-	bool ShouldSpawnBoss() const { return shouldSpawnBoss_; }
-	bool HasBossSpawned() const { return hasBossSpawned_; }
+	bool IsCrystalEnemySpawnEnabled() const { return enableCrystalEnemySpawn_; }
+	void SetProgressDebugStatus(int aliveNormalEnemyCount, bool bossSpawnConditionMet, bool bossSpawned, const K4E::Vector3& bossSpawnPosition);
 	static constexpr float GetMaxUpdateDeltaTime() { return kMaxUpdateDeltaTime; }
 
 private:
 	EnemySpawnCrystal* GetSelectedCrystal();
 	const EnemySpawnCrystal* GetSelectedCrystal() const;
 	EnemySpawnCrystal* FindNextSpawnableCrystal();
-	void NotifyBossSpawnIfNeeded();
 
 private:
 	static constexpr float kMaxUpdateDeltaTime = 1.0f / 30.0f;
@@ -42,6 +44,8 @@ private:
 	float globalSpawnInterval_ = 5.0f;
 	float globalSpawnTimer_ = 0.0f;
 	int maxSpawnPerInterval_ = 1;
-	bool shouldSpawnBoss_ = false;
-	bool hasBossSpawned_ = false;
+	int debugAliveNormalEnemyCount_ = 0;
+	bool debugBossSpawnConditionMet_ = false;
+	bool debugBossSpawned_ = false;
+	K4E::Vector3 debugBossSpawnPosition_{};
 };

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/EnemySpawnCrystal.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/EnemySpawnCrystal.cpp
@@ -77,7 +77,8 @@ void EnemySpawnCrystal::Initialize(const CrystalSpawnPoint& spawnPoint, const st
 	rotation_ = spawnPoint.rotation;
 	scale_ = spawnPoint.scale;
 	isAlive = true;
-	hp = std::max(1, spawnPoint.hp);
+	maxHp = std::max(1, spawnPoint.hp);
+	hp = maxHp;
 	spawnEnemyType = spawnPoint.spawnEnemyType;
 	spawnRadius = std::max(0.0f, spawnPoint.spawnRadius);
 	maxAliveEnemies = std::max(0, spawnPoint.maxAliveEnemies);
@@ -132,7 +133,7 @@ void EnemySpawnCrystal::ApplyDamage(int damage)
 		return;
 	}
 
-	// プレイヤー攻撃でクリスタルを破壊できるよう、被弾回数とHPを一か所で更新する。
+	// クリスタルの残りHPを確認できるよう、HP割合を表示用に公開する。
 	++hitCount_;
 	hp = std::max(0, hp - damage);
 	if (hp <= 0)

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/EnemySpawnCrystal.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/EnemySpawnCrystal.h
@@ -21,6 +21,7 @@ struct CrystalSpawnPoint
 	K4E::Vector3 rotation{};
 	K4E::Vector3 scale{ 1.0f, 1.0f, 1.0f };
 	int hp = 100;
+	int maxHp = 100;
 	EnemyType spawnEnemyType = EnemyType::Melee;
 	float spawnInterval = 5.0f; // 互換性維持用。生成間隔は CrystalManager がステージ全体で管理する。
 	int maxAliveEnemies = 9;
@@ -47,6 +48,8 @@ public:
 	bool IsColliderEnabled() const { return isAlive; }
 	int GetHitCount() const { return hitCount_; }
 	int GetHp() const { return hp; }
+	int GetMaxHp() const { return maxHp; }
+	float GetHpRate() const { return maxHp > 0 ? static_cast<float>(hp) / static_cast<float>(maxHp) : 0.0f; }
 	EnemyType GetSpawnEnemyType() const { return spawnEnemyType; }
 	float GetSpawnRadius() const { return spawnRadius; }
 	int GetMaxAliveEnemies() const { return maxAliveEnemies; }
@@ -67,6 +70,7 @@ public:
 public: // Blender 読み込み対応時にも維持するランタイム設定値。
 	bool isAlive = true;
 	int hp = 100;
+	int maxHp = 100;
 	EnemyType spawnEnemyType = EnemyType::Melee;
 	float spawnRadius = 3.0f;
 	int maxAliveEnemies = 9;

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
@@ -143,6 +143,14 @@ void GamePlayWorld::Initialize(GamePlayStageContext& stageContext)
 	prevWaveNumber_ = 0;
 	prevWaveInProgress_ = false;
 	prevAllWavesCleared_ = false;
+	bossSpawnPosition_ = stageContext.HasBossSpawnPoint() ? stageContext.GetBossSpawnPoint() : K4E::Vector3{ 0.0f, 2.25f, 30.0f };
+	if (!stageContext.HasBossSpawnPoint())
+	{
+		// Blender側BossSpawnPointが未設定の間は、DebugSceneと同じ仮固定座標を使う。
+		bossSpawnPosition_ = { 0.0f, 2.25f, 30.0f };
+	}
+	bossSpawned_ = false;
+	bossSpawnConditionMet_ = false;
 
 	// Blender 側の設定読み込みを追加するまでは、C++ でステージ上の固定ワールド座標へ仮配置する。
 	crystalManager_.Initialize({
@@ -150,12 +158,18 @@ void GamePlayWorld::Initialize(GamePlayStageContext& stageContext)
 		{ {  10.0f, 2.0f, 30.0f }, {}, { 1.5f, 2.5f, 1.5f }, 100, EnemyType::MidRange, 3.0f, 6, 4.0f, true, true },
 		{ { -10.0f, 2.0f, 30.0f }, {}, { 1.5f, 2.5f, 1.5f }, 100, EnemyType::Melee, 2.0f, 10, 4.0f, true, true },
 	}, collisionManager_.get(), &stage_->GetFloorAABBs(), &stage_->GetNavigationObstacleAABBs());
+	crystalManager_.SetProgressDebugStatus(characters_.GetAliveNormalEnemyCount(), bossSpawnConditionMet_, bossSpawned_, bossSpawnPosition_);
 
 	enemyHpBarManager_.Initialize();
 }
 
 void GamePlayWorld::Finalize()
 {
+	if (guardianBoss_ && collisionManager_)
+	{
+		collisionManager_->RemoveCollider(guardianBoss_.get());
+	}
+	guardianBoss_.reset();
 	crystalManager_.Initialize({}, nullptr);
 	stageObjectiveManager_.reset();
 	waveManager_.reset();
@@ -189,6 +203,16 @@ void GamePlayWorld::Update(float deltaTime)
 
 	characters_.Update(deltaTime);
 	crystalManager_.Update(characters_, deltaTime);
+	UpdateCrystalBossSpawnProgress();
+	if (guardianBoss_)
+	{
+		if (auto* player = characters_.GetPlayer())
+		{
+			guardianBoss_->SetTargetPosition(player->GetCenterPosition());
+		}
+		guardianBoss_->Update(deltaTime);
+	}
+	crystalManager_.SetProgressDebugStatus(characters_.GetAliveNormalEnemyCount(), bossSpawnConditionMet_, bossSpawned_, bossSpawnPosition_);
 	if (auto* player = characters_.GetPlayer())
 	{
 		itemManager_.Update(player, deltaTime);
@@ -205,6 +229,10 @@ void GamePlayWorld::Update(float deltaTime)
 		stage_->UpdateShadowMatrix(shadowLightViewProjection_);
 	}
 	characters_.UpdateShadowMatrix(shadowLightViewProjection_);
+	if (guardianBoss_)
+	{
+		guardianBoss_->UpdateShadowMatrix(shadowLightViewProjection_);
+	}
 
 	if (bulletManager_)
 	{
@@ -359,6 +387,10 @@ void GamePlayWorld::Draw3D(bool hideCharactersDuringIntro)
 	if (!hideCharactersDuringIntro)
 	{
 		characters_.Draw();
+		if (guardianBoss_)
+		{
+			guardianBoss_->Draw();
+		}
 	}
 
 	if (stage_)
@@ -401,6 +433,10 @@ void GamePlayWorld::DrawShadow(bool hideCharactersDuringIntro)
 	if (!hideCharactersDuringIntro)
 	{
 		characters_.DrawShadow();
+		if (guardianBoss_)
+		{
+			guardianBoss_->DrawShadow();
+		}
 	}
 }
 
@@ -409,6 +445,17 @@ void GamePlayWorld::DrawHUD(bool hideDuringIntro)
 	if (hideDuringIntro) { return; }
 
 	enemyHpBarManager_.Draw();
+	if (auto* player = characters_.GetPlayer())
+	{
+		if (auto* camera = player->GetCamera())
+		{
+			crystalManager_.DrawHpBars(
+				camera->GetViewMatrix(),
+				camera->GetProjectionMatrix(),
+				static_cast<float>(K4E::GameViewportConstants::Width),
+				static_cast<float>(K4E::GameViewportConstants::Height));
+		}
+	}
 
 	if (hudManager_)
 	{
@@ -555,6 +602,41 @@ bool GamePlayWorld::IsPlayerDead()
 {
 	const auto* player = characters_.GetPlayer();
 	return player && player->GetHP() <= 0;
+}
+
+void GamePlayWorld::UpdateCrystalBossSpawnProgress()
+{
+	const int aliveNormalEnemyCount = characters_.GetAliveNormalEnemyCount();
+	bossSpawnConditionMet_ = crystalManager_.AreAllCrystalsDestroyed() && aliveNormalEnemyCount == 0 && !bossSpawned_;
+
+	// 全クリスタル破壊後、残った雑魚敵がいなくなったタイミングでボスを1回だけ出現させる。
+	if (bossSpawnConditionMet_)
+	{
+		SpawnGuardianBoss();
+	}
+}
+
+void GamePlayWorld::SpawnGuardianBoss()
+{
+	if (bossSpawned_)
+	{
+		return;
+	}
+
+	guardianBoss_ = std::make_unique<GuardianBoss>();
+	guardianBoss_->Initialize();
+	guardianBoss_->SetPosition(bossSpawnPosition_);
+	guardianBoss_->SetYaw(3.141592f);
+	if (auto* player = characters_.GetPlayer())
+	{
+		guardianBoss_->SetTargetPosition(player->GetCenterPosition());
+	}
+	guardianBoss_->Update(0.0f);
+	if (collisionManager_)
+	{
+		collisionManager_->AddCollider(guardianBoss_.get());
+	}
+	bossSpawned_ = true;
 }
 
 bool GamePlayWorld::IsAllWavesCleared() const

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.h
@@ -11,6 +11,7 @@
 #include "EnemyHPBarManager.h"
 #include "ItemManager.h"
 #include "CrystalManager.h"
+#include "Derived/GuardianBoss/GuardianBoss.h"
 
 #include <memory>
 
@@ -83,6 +84,8 @@ private: /// ---------- メンバ関数 ---------- ///
 	void UpdateShadowLightViewProjection();
 	bool TryGetDirectionalLightFromManager(K4E::Vector3& outDirection) const;
 	bool IsSightBlocked(const K4E::Segment& seg) const;
+	void UpdateCrystalBossSpawnProgress();
+	void SpawnGuardianBoss();
 
 
 private: /// ---------- メンバ変数 ---------- ///
@@ -100,6 +103,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	EnemyHPBarManager enemyHpBarManager_;
 	ItemManager itemManager_;
 	CrystalManager crystalManager_;
+	std::unique_ptr<GuardianBoss> guardianBoss_;
 
 	int prevWaveNumber_ = 0;
 	bool prevWaveInProgress_ = false;
@@ -118,4 +122,7 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	float lastBulletUpdateMs_ = 0.0f;
 	float lastCollisionUpdateMs_ = 0.0f;
+	K4E::Vector3 bossSpawnPosition_{ 0.0f, 2.25f, 30.0f };
+	bool bossSpawned_ = false;
+	bool bossSpawnConditionMet_ = false;
 };


### PR DESCRIPTION
### Motivation
- クリスタルを攻撃した際に残りHPを視認できるようにし、ゲーム進行として「全クリスタル破壊 → 残存雑魚0 → ボス出現」というフローを実装するため。
- ボスの二重出現やクリスタル破壊後のスポーン継続を防ぎ、デバッグで進行状態を確認できるようにするため。

### Description
- `EnemySpawnCrystal` に `maxHp` を保持するようにし、`GetMaxHp()` と `GetHpRate()` を追加してHP割合を取得可能にした（`hp` は初期化時に `maxHp` を設定）。
- `CrystalManager` に `DrawHpBars(...)` を追加して、カメラ行列と画面サイズを受け取り生存中のクリスタルの上にImGuiベースの3D→スクリーン投影HPバーを描画するようにしたとともに、デバッグ用の状態表示フィールドと `SetProgressDebugStatus(...)` を追加した。
- `CharacterWorld` に `GetAliveNormalEnemyCount()` を追加し、ボス出現条件判定で `MeleeEnemy` / `MidRangeEnemy` の生存数だけをカウントするようにした。
- `GamePlayWorld` に `guardianBoss_` 保持、`bossSpawnPosition_` と出現フラグ、`UpdateCrystalBossSpawnProgress()` と `SpawnGuardianBoss()` を実装し、条件（`CrystalManager::AreAllCrystalsDestroyed()` && `GetAliveNormalEnemyCount() == 0` && `!bossSpawned_`）で `GuardianBoss` を一度だけ生成してコリジョン登録・初期化・更新/描画に接続した。ボス位置は `stageContext.GetBossSpawnPoint()` を優先し未設定時はデバッグ用固定座標へフォールバックする。
- デバッグUI（ImGui）を拡張して以下を表示可能にした：`クリスタル数` / `生存クリスタル数` / `全クリスタル破壊済み` / `クリスタル敵スポーン有効(実効)` / `生存雑魚敵数` / `ボス出現条件成立` / `ボス出現済み` / `ボス出現位置` および選択中クリスタルの `HP/MaxHP/HP割合` と「選択中に10ダメージ」「全クリスタルに10ダメージ」ボタン。

### Testing
- `git diff --check` を実行し問題なしを確認した（成功）。
- ソリューションビルドは環境内で `dotnet` が利用できなかったため実行できなかった（`dotnet build` はコンテナに存在せず実行不能）。
- 変更はローカルでコミット済み（`Add crystal HP bars and boss spawn gate`）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a200cc82844832da48d16712dc3626a)