### PR TITLE
Player melee can hit Boss; register Boss collider, apply damage, add logs/ImGui

### DIFF
--- a/Project/ApplicationLayer/Character/Boss/Core/BossBase.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Core/BossBase.cpp
@@ -1,5 +1,9 @@
 #include "BossBase.h"
 #include "CollisionTypeIdDef.h"
+#include <LogString.h>
+
+#include <sstream>
+#include <string>
 
 using namespace Ken4lowEngine;
 
@@ -10,7 +14,9 @@ void BossBase::Initialize()
 {
 	// コライダータイプの設定
 	Collider::SetTypeID(static_cast<uint32_t>(CollisionTypeIdDef::kBoss));
-	Collider::SetOBBHalfSize({ 1.0f, 1.0f, 1.0f }); // 仮。後でボスごとに差し替え
+	Collider::SetOwner<BossBase>(this);
+	// プレイヤー近接攻撃が胴体を拾えるように、ボス本体を覆う大きめのOBBを登録する。
+	Collider::SetOBBHalfSize({ 1.25f, 1.75f, 1.25f });
 
 	// ボス用部位を構築
 	BuildBossParts();
@@ -103,7 +109,8 @@ void BossBase::Update(float deltaTime)
 	// 死亡確認
 	CheckDeath();
 
-	Collider::SetCenterPosition(GetBody().object->GetTranslate());
+	Collider::SetCenterPosition(GetCenterPosition());
+	Collider::SetOrientation({ 0.0f, GetYaw(), 0.0f });
 
 	// 最後に部位階層更新
 	BaseCharacter::Update(deltaTime);
@@ -210,7 +217,14 @@ void BossBase::OnDamaged(float damage)
 		return;
 	}
 
+	const float hpBefore = statusComponent_->GetHP();
 	statusComponent_->ApplyDamage(damage);
+
+	std::ostringstream oss;
+	oss << "[GuardianBoss] TakeDamage: damage=" << damage
+		<< ", HP=" << statusComponent_->GetHP() << "/" << statusComponent_->GetMaxHP()
+		<< ", before=" << hpBefore;
+	Log(oss.str() + "\n");
 }
 
 /// -------------------------------------------------------------

--- a/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.cpp
@@ -3,9 +3,12 @@
 #include "BossPunchAttack.h"
 #include "BossHeavyPunchAttack.h"
 #include <LinearInterpolation.h>
+#include <LogString.h>
 
 #include <algorithm>
 #include <cmath>
+#include <sstream>
+#include <string>
 
 #ifdef USE_IMGUI
 #include <imgui.h>
@@ -67,8 +70,24 @@ void GuardianBoss::OnDamaged(float damage)
 		return;
 	}
 
+	const float hpBefore = GetHP();
+
 	// HP減算は基底側に任せる
 	BossBase::OnDamaged(damage);
+
+	if (GetHP() < hpBefore)
+	{
+		++receivedHitCount_;
+		lastReceivedDamage_ = damage;
+	}
+
+	{
+		std::ostringstream oss;
+		oss << "[GuardianBoss] HP=" << GetHP() << "/" << GetMaxHP()
+			<< ", hitCount=" << receivedHitCount_
+			<< ", lastDamage=" << lastReceivedDamage_;
+		Log(oss.str() + "\n");
+	}
 
 	// 生きていたらひるみへ
 	if (!IsDead())
@@ -547,6 +566,15 @@ void GuardianBoss::DrawImGui()
 	ImGui::Text("State: %d", static_cast<int>(GetState()));
 	ImGui::Text("HP: %.1f / %.1f", GetHP(), GetMaxHP());
 	ImGui::Text("DistanceToTargetXZ: %.2f", GetDistanceToTargetXZ());
+
+	ImGui::SeparatorText("ボス被弾確認");
+	ImGui::Text("ボス出現済み: はい");
+	ImGui::Text("ボス生存中: %s", IsAlive() ? "はい" : "いいえ");
+	ImGui::Text("ボスHP: %.1f", GetHP());
+	ImGui::Text("ボス最大HP: %.1f", GetMaxHP());
+	ImGui::Text("ボスHP割合: %.1f%%", GetHPRate() * 100.0f);
+	ImGui::Text("ボス被弾回数: %d", receivedHitCount_);
+	ImGui::Text("最後にボスへ与えたダメージ: %.1f", lastReceivedDamage_);
 
 	ImGui::Separator();
 	ImGui::Text("StateTimer      : %.2f", stateTimer_);

--- a/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.h
+++ b/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.h
@@ -107,6 +107,9 @@ protected: /// ---------- Guardian固有パラメータ ---------- ///
 
 	bool hasAppliedAttackHit_ = false;
 
+	int receivedHitCount_ = 0;
+	float lastReceivedDamage_ = 0.0f;
+
 	/// <summary>
 	/// 最後に選ばれた攻撃名
 	/// HeavyPunch 連打抑制にも使う

--- a/Project/ApplicationLayer/Character/Player/Component/PlayerMeleeComponent.cpp
+++ b/Project/ApplicationLayer/Character/Player/Component/PlayerMeleeComponent.cpp
@@ -6,6 +6,12 @@
 #include "EnemyBase.h"
 #include "EnemySpawnCrystal.h"
 #include "BossBase.h"
+#include <LogString.h>
+
+#include <algorithm>
+#include <cmath>
+#include <sstream>
+#include <string>
 
 namespace
 {
@@ -15,6 +21,27 @@ namespace
 		const float dy = a.y - b.y;
 		const float dz = a.z - b.z;
 		return dx * dx + dy * dy + dz * dz;
+	}
+
+	float DistancePointToSegmentSq(const K4E::Vector3& point, const K4E::Segment& seg)
+	{
+		const float lenSq = seg.diff.x * seg.diff.x + seg.diff.y * seg.diff.y + seg.diff.z * seg.diff.z;
+		if (lenSq <= 0.0001f)
+		{
+			return DistSq(point, seg.origin);
+		}
+
+		const K4E::Vector3 toPoint = point - seg.origin;
+		float t = (toPoint.x * seg.diff.x + toPoint.y * seg.diff.y + toPoint.z * seg.diff.z) / lenSq;
+		t = std::clamp(t, 0.0f, 1.0f);
+
+		const K4E::Vector3 nearest = seg.origin + seg.diff * t;
+		return DistSq(point, nearest);
+	}
+
+	void LogPlayerAttack(const std::string& message)
+	{
+		Log(message + "\n");
 	}
 }
 
@@ -29,6 +56,7 @@ void PlayerMeleeComponent::StartAttack(const K4E::Vector3& /*playerPos*/)
 	isAttacking_ = true;
 	activeHitDone_ = false;
 	timer_ = 0.0f;
+	hitColliderIds_.clear();
 }
 
 void PlayerMeleeComponent::Tick(float dt, const K4E::Vector3& playerPos)
@@ -99,8 +127,37 @@ void PlayerMeleeComponent::EvaluateHit(const K4E::Vector3& playerPos)
 	const bool hitEnemy = collisionManager_->SegmentCast(
 		static_cast<uint32_t>(CollisionTypeIdDef::kEnemy), seg, &enemyHit);
 
-	const bool hitBoss = collisionManager_->SegmentCast(
+	bool hitBoss = collisionManager_->SegmentCast(
 		static_cast<uint32_t>(CollisionTypeIdDef::kBoss), seg, &bossHit);
+
+	int bossCandidateCount = 0;
+	const auto& bossColliders = collisionManager_->GetCollidersByType(static_cast<uint32_t>(CollisionTypeIdDef::kBoss));
+	for (K4E::Collider* bossCollider : bossColliders)
+	{
+		if (!bossCollider) continue;
+
+		const K4E::Vector3 halfSize = bossCollider->GetOBBHalfSize();
+		const float bossRadius = std::max({ halfSize.x, halfSize.y, halfSize.z });
+		const float hitRadius = radius_ + bossRadius;
+		if (DistancePointToSegmentSq(bossCollider->GetCenterPosition(), seg) > hitRadius * hitRadius)
+		{
+			continue;
+		}
+
+		++bossCandidateCount;
+		if (!bossHit || DistSq(bossCollider->GetCenterPosition(), start) < DistSq(bossHit->GetCenterPosition(), start))
+		{
+			bossHit = bossCollider;
+		}
+	}
+	hitBoss = hitBoss || bossHit != nullptr;
+	{
+		std::ostringstream oss;
+		oss << "[PlayerAttack] Boss candidate count = " << bossCandidateCount
+			<< ", registered = " << bossColliders.size()
+			<< ", segmentHit = " << (hitBoss ? "true" : "false");
+		LogPlayerAttack(oss.str());
+	}
 
 	const bool hitCrystal = collisionManager_->SegmentCast(
 		static_cast<uint32_t>(CollisionTypeIdDef::kCrystal), seg, &crystalHit);
@@ -127,9 +184,17 @@ void PlayerMeleeComponent::EvaluateHit(const K4E::Vector3& playerPos)
 		return;
 	}
 
+	if (hitColliderIds_.find(bestHit->GetUniqueID()) != hitColliderIds_.end())
+	{
+		LogPlayerAttack("[PlayerAttack] Same collider already hit in this attack. Skip.");
+		return;
+	}
+
 	if (bestHit->GetTypeID() == static_cast<uint32_t>(CollisionTypeIdDef::kEnemy))
 	{
 		auto* enemyBase = bestHit->GetOwner<EnemyBase>();
+		if (!enemyBase) return;
+		hitColliderIds_.insert(bestHit->GetUniqueID());
 		EnemyBase::SetDeathDebugComparePositions(playerPos, attackCenter);
 		const bool wasDead = enemyBase->IsDead();
 
@@ -162,12 +227,27 @@ void PlayerMeleeComponent::EvaluateHit(const K4E::Vector3& playerPos)
 	else if (bestHit->GetTypeID() == static_cast<uint32_t>(CollisionTypeIdDef::kCrystal))
 	{
 		// 敵だけでなく、近接攻撃の最寄り対象がクリスタルならHPを減らす。
-		bestHit->GetOwner<EnemySpawnCrystal>()->ApplyDamage(damage_);
+		auto* crystal = bestHit->GetOwner<EnemySpawnCrystal>();
+		if (!crystal) return;
+		hitColliderIds_.insert(bestHit->GetUniqueID());
+		crystal->ApplyDamage(damage_);
 		if (onHit_) onHit_();
 	}
 	else if (bestHit->GetTypeID() == static_cast<uint32_t>(CollisionTypeIdDef::kBoss))
 	{
-		bestHit->GetOwner<BossBase>()->OnDamaged(static_cast<float>(damage_));
+		// ボス出現後もプレイヤー攻撃対象に含めるため、BossColliderへのヒット判定を追加する。
+		auto* boss = bestHit->GetOwner<BossBase>();
+		if (!boss || boss->IsDead()) return;
+		hitColliderIds_.insert(bestHit->GetUniqueID());
+		const BossHitResult bossPartHit = boss->CheckDebugHitSphere(attackCenter, radius_);
+		const float bossDamage = bossPartHit.isHit ? static_cast<float>(damage_) * bossPartHit.damageMultiplier : static_cast<float>(damage_);
+		{
+			std::ostringstream oss;
+			oss << "[PlayerAttack] Boss hit damage=" << bossDamage
+				<< ", hpBefore=" << boss->GetHP() << "/" << boss->GetMaxHP();
+			LogPlayerAttack(oss.str());
+		}
+		boss->OnDamaged(bossDamage);
 		if (onHit_) onHit_();
 	}
 }

--- a/Project/ApplicationLayer/Character/Player/Component/PlayerMeleeComponent.h
+++ b/Project/ApplicationLayer/Character/Player/Component/PlayerMeleeComponent.h
@@ -1,6 +1,6 @@
 #pragma once
 #include <functional>
-#include <unordered_map>
+#include <unordered_set>
 #include <Vector3.h>
 #include <Segment.h>
 
@@ -47,4 +47,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	int damage_ = 35;
 
 	std::function<void()> onHit_;
+
+	// 同じ攻撃中に同一Colliderへ複数回ダメージが入らないようにする。
+	std::unordered_set<uint32_t> hitColliderIds_;
 };

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
@@ -14,6 +14,7 @@
 #include "GpuParticleManager.h"
 #include "ParticleManager.h"
 #include "CollisionTypeIdDef.h"
+#include <LogString.h>
 
 #include <chrono>
 #include <cmath>
@@ -528,6 +529,23 @@ void GamePlayWorld::DrawGameDebugImGui()
 	}
 	ImGui::Text("Player Dead: %s", IsPlayerDead() ? "true" : "false");
 	ImGui::Text("Enemies: %d", characters_.GetEnemyCount());
+	ImGui::SeparatorText("ボス状態");
+	ImGui::Text("ボス出現済み: %s", bossSpawned_ ? "はい" : "いいえ");
+	if (guardianBoss_)
+	{
+		ImGui::Text("ボス生存中: %s", guardianBoss_->IsAlive() ? "はい" : "いいえ");
+		ImGui::Text("ボスHP: %.1f", guardianBoss_->GetHP());
+		ImGui::Text("ボス最大HP: %.1f", guardianBoss_->GetMaxHP());
+		ImGui::Text("ボスHP割合: %.1f%%", guardianBoss_->GetHPRate() * 100.0f);
+		guardianBoss_->DrawImGui();
+	}
+	else
+	{
+		ImGui::Text("ボス生存中: いいえ");
+		ImGui::Text("ボスHP: 0.0");
+		ImGui::Text("ボス最大HP: 0.0");
+		ImGui::Text("ボスHP割合: 0.0%%");
+	}
 	crystalManager_.DrawImGui();
 
 	auto* wireframe = K4E::Wireframe::GetInstance();
@@ -676,6 +694,7 @@ void GamePlayWorld::SpawnGuardianBoss()
 	if (collisionManager_)
 	{
 		collisionManager_->AddCollider(guardianBoss_.get());
+		Log("[GuardianBoss] Collider registered as kBoss.\n");
 	}
 	bossSpawned_ = true;
 }


### PR DESCRIPTION
### Motivation
- Players' melee attacks were not affecting the boss because the boss collider wasn't correctly registered/owned and there was no robust hit dispatch from the player melee flow. 
- Add visibility and safeguards (logs, ImGui, per-attack de-dup) to help debug and verify boss hit behavior without breaking existing enemy/crystal logic.

### Description
- Register boss collider owner and enlarge the body OBB in `BossBase::Initialize()` and keep collider center/orientation synced with the boss in `BossBase::Update()` so player melee can hit the boss (`Project/ApplicationLayer/Character/Boss/Core/BossBase.cpp`).
- Extend `PlayerMeleeComponent::EvaluateHit()` to include `kBoss` candidate scanning (segment cast + distance-to-segment fallback), pick nearest candidate, compute boss-part multiplier via `BossBase::CheckDebugHitSphere()`, call boss damage (`OnDamaged`) and emit detailed logs; also add per-attack hit de-dup (`hitColliderIds_`) to avoid multi-hits (`Project/ApplicationLayer/Character/Player/Component/PlayerMeleeComponent.*`).
- Add damage/HP logging inside `BossBase::OnDamaged()` and record/display hit count and last received damage in `GuardianBoss` with ImGui fields for Japanese UI (boss spawned, alive, HP, max HP, HP percent, hit count, last damage) to confirm hits at runtime (`GuardianBoss.cpp/.h`, `GamePlayWorld.cpp`).
- Add small debug log at boss spawn when registering the collider and include `LogString` usage for the new messages; keep all existing enemy/crystal branches intact and null-check owners before applying damage.

### Testing
- Ran `git diff --check` to validate no whitespace errors (passed). 
- Attempted to build with `msbuild Project/Ken4lowEngine.sln /p:Configuration=Debug /p:Platform=x64` but `msbuild` was not available in the environment so a local Visual Studio build was not executed here (build should be confirmed on Windows CI/developer machine).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a201abf4fe0832d900c8c767eae9ae4)