### PR TITLE
Add boss bullet/attack damage and spawn ClearCube on boss death

### DIFF
--- a/Project/ApplicationLayer/Character/Boss/Attacks/BossHeavyPunchAttack.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Attacks/BossHeavyPunchAttack.cpp
@@ -328,15 +328,11 @@ void BossHeavyPunchAttack::TryHitPlayer()
 		Log("[BossHeavyPunchAttack] Heavy hit success.\n");
 #endif
 
-		// -------------------------------------------------------
-		// TODO:
-		// 将来的にここで
-		// - プレイヤーへダメージ
-		// - ノックバック
-		// - ヒットストップ
-		// - 画面揺れ
-		// を追加する
-		// -------------------------------------------------------
+		// ボス重攻撃の範囲判定が成立した瞬間だけPlayerへダメージを流す。
+		if (owner_->ApplyDamageToTargetPlayer(damage_, &attackCenter))
+		{
+			Log("[BossHeavyPunchAttack] Player damage applied.\n");
+		}
 	}
 	else
 	{

--- a/Project/ApplicationLayer/Character/Boss/Attacks/BossPunchAttack.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Attacks/BossPunchAttack.cpp
@@ -312,16 +312,11 @@ void BossPunchAttack::TryHitPlayer()
 		OutputDebugStringA("[BossPunchAttack] Melee hit success.\n");
 #endif
 
-		// -------------------------------------------------------
-		// TODO:
-		// 将来的にはここでプレイヤーへ本当にダメージを与える
-		//
-		// 例:
-		// if (Player* player = owner_->GetTargetPlayer())
-		// {
-		//     player->OnDamaged(damage_);
-		// }
-		// -------------------------------------------------------
+		// ボス近接攻撃の発生フレームで1回だけPlayerへダメージを流す。
+		if (owner_->ApplyDamageToTargetPlayer(damage_, &attackCenter))
+		{
+			DebugLog("[BossPunchAttack] Player damage applied.\n");
+		}
 	}
 	else
 	{

--- a/Project/ApplicationLayer/Character/Boss/Core/BossBase.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Core/BossBase.cpp
@@ -1,5 +1,6 @@
 #include "BossBase.h"
 #include "CollisionTypeIdDef.h"
+#include "Player.h"
 #include <LogString.h>
 
 #include <sstream>
@@ -225,6 +226,32 @@ void BossBase::OnDamaged(float damage)
 		<< ", HP=" << statusComponent_->GetHP() << "/" << statusComponent_->GetMaxHP()
 		<< ", before=" << hpBefore;
 	Log(oss.str() + "\n");
+}
+
+void BossBase::OnBulletDamaged(float damage)
+{
+	OnDamaged(damage);
+}
+
+
+/// -------------------------------------------------------------
+/// ターゲットプレイヤーへのダメージ
+/// -------------------------------------------------------------
+bool BossBase::ApplyDamageToTargetPlayer(float damage, const K4E::Vector3* attackPosition)
+{
+	if (!targetPlayer_ || damage <= 0.0f || IsDead())
+	{
+		return false;
+	}
+
+	targetPlayer_->ApplyDamage(damage, attackPosition);
+	OnTargetPlayerDamaged(damage);
+	return true;
+}
+
+void BossBase::OnTargetPlayerDamaged(float damage)
+{
+	(void)damage;
 }
 
 /// -------------------------------------------------------------

--- a/Project/ApplicationLayer/Character/Boss/Core/BossBase.h
+++ b/Project/ApplicationLayer/Character/Boss/Core/BossBase.h
@@ -49,6 +49,8 @@ struct BossHitResult
 /// -----------------------------------------------------------
 ///					 ボス共通の基底クラス
 /// -----------------------------------------------------------
+class Player;
+
 class BossBase : public BaseCharacter
 {
 public: /// ---------- ライフサイクル ---------- ///
@@ -103,6 +105,11 @@ public: /// ---------- ダメージ / 死亡 ---------- ///
 	/// ダメージを受けたとき
 	/// </summary>
 	virtual void OnDamaged(float damage);
+
+	/// <summary>
+	/// プレイヤー銃弾でダメージを受けたとき
+	/// </summary>
+	virtual void OnBulletDamaged(float damage);
 
 	/// <summary>
 	/// 死亡時
@@ -175,6 +182,11 @@ public: /// ---------- ターゲット情報 ---------- ///
 
 	// ターゲットの位置をセット
 	void SetTargetPosition(const K4E::Vector3& targetPosition) { targetPosition_ = targetPosition; }
+
+	// ボス攻撃が実際にプレイヤーHPへ届くよう、ターゲットPlayer本体も保持する。
+	void SetTargetPlayer(Player* player) { targetPlayer_ = player; }
+	Player* GetTargetPlayer() const { return targetPlayer_; }
+	bool ApplyDamageToTargetPlayer(float damage, const K4E::Vector3* attackPosition = nullptr);
 
 public: /// ---------- 攻撃距離 / 判定補助 ---------- ///
 
@@ -258,6 +270,10 @@ public: /// ---------- 攻撃登録 ---------- ///
 	/// 実体は BossAttackComponent に持たせる
 	/// </summary>
 	void RegisterAttack(std::unique_ptr<IBossAttack> attack);
+
+protected: /// ---------- ダメージ通知 ---------- ///
+
+	virtual void OnTargetPlayerDamaged(float damage);
 
 public: /// ---------- 腕周り補助 ---------- ///
 
@@ -411,6 +427,7 @@ protected: /// ---------- 共通情報群 ---------- ///
 
 	// 追跡対象
 	K4E::Vector3 targetPosition_{};
+	Player* targetPlayer_ = nullptr;
 
 	// 状態
 	BossState state_ = BossState::Intro;

--- a/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.cpp
@@ -30,6 +30,11 @@ void GuardianBoss::SetupBoss()
 	stateTimer_ = 0.0f;
 	attackCooldownTimer_ = 0.0f;
 	hasAppliedAttackHit_ = false;
+	receivedHitCount_ = 0;
+	bulletHitCount_ = 0;
+	bossAttackHitCount_ = 0;
+	lastReceivedDamage_ = 0.0f;
+	lastPlayerDamage_ = 0.0f;
 
 	// HeavyPunch 連打抑制初期化
 	lastSelectedAttack_ = "None";
@@ -111,12 +116,37 @@ void GuardianBoss::OnDead()
 }
 
 /// -------------------------------------------------------------
+/// 銃弾ダメージ
+/// -------------------------------------------------------------
+void GuardianBoss::OnBulletDamaged(float damage)
+{
+	++bulletHitCount_;
+	OnDamaged(damage);
+
+	std::ostringstream oss;
+	oss << "[GuardianBoss] Player bullet hit: damage=" << damage
+		<< ", bulletHitCount=" << bulletHitCount_
+		<< ", HP=" << GetHP() << "/" << GetMaxHP();
+	Log(oss.str() + "\n");
+}
+
+/// -------------------------------------------------------------
 /// 衝突
-/// 今は空実装
 /// -------------------------------------------------------------
 void GuardianBoss::OnCollision(Collider* other)
 {
 	(void)other;
+}
+
+void GuardianBoss::OnTargetPlayerDamaged(float damage)
+{
+	++bossAttackHitCount_;
+	lastPlayerDamage_ = damage;
+
+	std::ostringstream oss;
+	oss << "[GuardianBoss] Boss attack damaged player: damage=" << damage
+		<< ", hitCount=" << bossAttackHitCount_;
+	Log(oss.str() + "\n");
 }
 
 /// -------------------------------------------------------------
@@ -573,8 +603,11 @@ void GuardianBoss::DrawImGui()
 	ImGui::Text("ボスHP: %.1f", GetHP());
 	ImGui::Text("ボス最大HP: %.1f", GetMaxHP());
 	ImGui::Text("ボスHP割合: %.1f%%", GetHPRate() * 100.0f);
-	ImGui::Text("ボス被弾回数: %d", receivedHitCount_);
+	ImGui::Text("近接攻撃ヒット回数: %d", GetMeleeHitCount());
+	ImGui::Text("銃弾ヒット回数: %d", bulletHitCount_);
 	ImGui::Text("最後にボスへ与えたダメージ: %.1f", lastReceivedDamage_);
+	ImGui::Text("ボス攻撃ヒット回数: %d", bossAttackHitCount_);
+	ImGui::Text("最後にプレイヤーが受けたボスダメージ: %.1f", lastPlayerDamage_);
 
 	ImGui::Separator();
 	ImGui::Text("StateTimer      : %.2f", stateTimer_);

--- a/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.h
+++ b/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.h
@@ -1,6 +1,7 @@
 #pragma once
 #include "BaseTypes/HumanoidBossBase.h"
 
+#include <algorithm>
 #include <memory>
 #include <string>
 #include <vector>
@@ -19,9 +20,15 @@ public: /// ---------- Boss固有初期化 ---------- ///
 
 	void SetupBoss() override;
 	void OnDamaged(float damage) override;
+	void OnBulletDamaged(float damage) override;
 	void OnDead() override;
 	void OnCollision(K4E::Collider* other) override;
 	void DrawImGui() override;
+	int GetMeleeHitCount() const { return std::max(0, receivedHitCount_ - bulletHitCount_); }
+	int GetBulletHitCount() const { return bulletHitCount_; }
+	float GetLastReceivedDamage() const { return lastReceivedDamage_; }
+	int GetBossAttackHitCount() const { return bossAttackHitCount_; }
+	float GetLastPlayerDamage() const { return lastPlayerDamage_; }
 
 protected: /// ---------- BossBase override ---------- ///
 
@@ -29,6 +36,7 @@ protected: /// ---------- BossBase override ---------- ///
 	void UpdateMovement(float deltaTime) override;
 	void UpdateAttack(float deltaTime) override;
 	void CheckDeath() override;
+	void OnTargetPlayerDamaged(float damage) override;
 
 	void SetupAttacks() override;
 	void SetupPhaseData() override;
@@ -108,7 +116,10 @@ protected: /// ---------- Guardian固有パラメータ ---------- ///
 	bool hasAppliedAttackHit_ = false;
 
 	int receivedHitCount_ = 0;
+	int bulletHitCount_ = 0;
+	int bossAttackHitCount_ = 0;
 	float lastReceivedDamage_ = 0.0f;
+	float lastPlayerDamage_ = 0.0f;
 
 	/// <summary>
 	/// 最後に選ばれた攻撃名

--- a/Project/ApplicationLayer/Character/Bullet/Bullet.cpp
+++ b/Project/ApplicationLayer/Character/Bullet/Bullet.cpp
@@ -3,6 +3,7 @@
 #include "CollisionTypeIdDef.h"
 #include "CollisionManager.h"
 #include "EnemyBase.h"
+#include "BossBase.h"
 #include "GpuParticleManager.h"
 
 #include <algorithm>
@@ -283,6 +284,10 @@ void Bullet::ApplySplashDamageToType(uint32_t targetType, const K4E::Vector3& ce
 			enemy->TakeDamage(finalDamage, hitDir, 1.8f);
 			enemy->SpawnHitEffectAt(col->GetCenterPosition());
 		}
+		else if (auto* boss = col->GetOwner<BossBase>())
+		{
+			boss->OnBulletDamaged(static_cast<float>(finalDamage));
+		}
 	}
 }
 
@@ -421,6 +426,15 @@ void Bullet::OnCollisionEnter(K4E::Collider* other)
 	const uint32_t otherId = other->GetUniqueID();
 	if (contactRecord_.Check(otherId)) return;
 	contactRecord_.Add(otherId);
+
+	if (otherType == kBoss)
+	{
+		if (auto* boss = other->GetOwner<BossBase>())
+		{
+			// プレイヤー銃弾がボスへ当たったら、非貫通弾として1回だけダメージを与える。
+			boss->OnBulletDamaged(static_cast<float>(damage_));
+		}
+	}
 
 	if (HasSplashDamage())
 	{

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
@@ -27,6 +27,85 @@
 
 using namespace Ken4lowEngine;
 
+
+void BossClearItem::Initialize(const K4E::Vector3& position)
+{
+	K4E::Vector3 spawnPosition = position;
+	spawnPosition.y += 1.25f;
+
+	position_ = spawnPosition;
+	basePosition_ = spawnPosition;
+	rotation_ = {};
+	floatTimer_ = 0.0f;
+	spawned_ = true;
+	collected_ = false;
+
+	SetTypeID(static_cast<uint32_t>(CollisionTypeIdDef::kItem));
+	SetOwner<BossClearItem>(this);
+	SetOBBHalfSize(halfSize_);
+	SetCenterPosition(position_);
+
+	object3d_ = std::make_unique<K4E::Object3D>();
+	object3d_->Initialize("Test/cube.gltf");
+	object3d_->SetScale({ 1.8f, 1.8f, 1.8f });
+	object3d_->SetTranslate(position_);
+	object3d_->SetColor({ 1.0f, 0.85f, 0.05f, 1.0f });
+	object3d_->Update();
+}
+
+void BossClearItem::Update(float deltaTime)
+{
+	if (!spawned_ || collected_)
+	{
+		return;
+	}
+
+	floatTimer_ += deltaTime * 3.0f;
+	position_ = basePosition_;
+	position_.y += std::sinf(floatTimer_) * 0.25f;
+	rotation_.y += deltaTime * 1.2f;
+
+	SetCenterPosition(position_);
+	SetOrientation(rotation_);
+
+	if (object3d_)
+	{
+		object3d_->SetTranslate(position_);
+		object3d_->SetRotate(rotation_);
+		object3d_->Update();
+	}
+}
+
+void BossClearItem::Draw()
+{
+	if (spawned_ && !collected_ && object3d_)
+	{
+		object3d_->Draw();
+	}
+}
+
+bool BossClearItem::CheckPickup(const Player& player) const
+{
+	if (!spawned_ || collected_)
+	{
+		return false;
+	}
+
+	const K4E::Vector3 diff = position_ - player.GetCenterPosition();
+	return K4E::Vector3::Length(diff) <= pickupRadius_;
+}
+
+void BossClearItem::MarkCollected()
+{
+	collected_ = true;
+	SetCenterPosition({ 1.0e9f, 1.0e9f, 1.0e9f });
+}
+
+void BossClearItem::OnCollision(K4E::Collider* other)
+{
+	(void)other;
+}
+
 void GamePlayWorld::Initialize(GamePlayStageContext& stageContext)
 {
 	const auto stageAssets = stageContext.GetCurrentStageAssets();
@@ -153,6 +232,11 @@ void GamePlayWorld::Initialize(GamePlayStageContext& stageContext)
 	}
 	bossSpawned_ = false;
 	bossSpawnConditionMet_ = false;
+	bossDefeated_ = false;
+	clearItemSpawned_ = false;
+	clearItemCollected_ = false;
+	isGameClear_ = false;
+	clearItem_.reset();
 
 	// C++側の仮クリスタル配置を明示的なvectorにして、初期化型の不一致を防ぐ。
 	std::vector<CrystalSpawnPoint> crystalSpawnPoints;
@@ -210,7 +294,12 @@ void GamePlayWorld::Finalize()
 	{
 		collisionManager_->RemoveCollider(guardianBoss_.get());
 	}
+	if (clearItem_ && collisionManager_)
+	{
+		collisionManager_->RemoveCollider(clearItem_.get());
+	}
 	guardianBoss_.reset();
+	clearItem_.reset();
 	const std::vector<CrystalSpawnPoint> emptyCrystalSpawnPoints;
 	crystalManager_.Initialize(emptyCrystalSpawnPoints, nullptr);
 	stageObjectiveManager_.reset();
@@ -251,9 +340,11 @@ void GamePlayWorld::Update(float deltaTime)
 		if (auto* player = characters_.GetPlayer())
 		{
 			guardianBoss_->SetTargetPosition(player->GetCenterPosition());
+			guardianBoss_->SetTargetPlayer(player);
 		}
 		guardianBoss_->Update(deltaTime);
 	}
+	UpdateBossClearProgress(deltaTime);
 	crystalManager_.SetProgressDebugStatus(characters_.GetAliveNormalEnemyCount(), bossSpawnConditionMet_, bossSpawned_, bossSpawnPosition_);
 	if (auto* player = characters_.GetPlayer())
 	{
@@ -451,6 +542,10 @@ void GamePlayWorld::Draw3D(bool hideCharactersDuringIntro)
 	}
 
 	itemManager_.Draw();
+	if (clearItem_)
+	{
+		clearItem_->Draw();
+	}
 
 #ifdef _DEBUG
 	if (collisionManager_)
@@ -537,7 +632,11 @@ void GamePlayWorld::DrawGameDebugImGui()
 		ImGui::Text("ボスHP: %.1f", guardianBoss_->GetHP());
 		ImGui::Text("ボス最大HP: %.1f", guardianBoss_->GetMaxHP());
 		ImGui::Text("ボスHP割合: %.1f%%", guardianBoss_->GetHPRate() * 100.0f);
-		guardianBoss_->DrawImGui();
+		ImGui::Text("近接攻撃ヒット回数: %d", guardianBoss_->GetMeleeHitCount());
+		ImGui::Text("銃弾ヒット回数: %d", guardianBoss_->GetBulletHitCount());
+		ImGui::Text("最後にボスへ与えたダメージ: %.1f", guardianBoss_->GetLastReceivedDamage());
+		ImGui::Text("ボス攻撃ヒット回数: %d", guardianBoss_->GetBossAttackHitCount());
+		ImGui::Text("最後にプレイヤーが受けたボスダメージ: %.1f", guardianBoss_->GetLastPlayerDamage());
 	}
 	else
 	{
@@ -545,6 +644,31 @@ void GamePlayWorld::DrawGameDebugImGui()
 		ImGui::Text("ボスHP: 0.0");
 		ImGui::Text("ボス最大HP: 0.0");
 		ImGui::Text("ボスHP割合: 0.0%%");
+		ImGui::Text("近接攻撃ヒット回数: 0");
+		ImGui::Text("銃弾ヒット回数: 0");
+		ImGui::Text("最後にボスへ与えたダメージ: 0.0");
+		ImGui::Text("ボス攻撃ヒット回数: 0");
+		ImGui::Text("最後にプレイヤーが受けたボスダメージ: 0.0");
+	}
+	if (auto* player = characters_.GetPlayer())
+	{
+		ImGui::Text("Player HP: %.1f / %.1f", player->GetHP(), player->GetMaxHP());
+	}
+	else
+	{
+		ImGui::Text("Player HP: 0.0 / 0.0");
+	}
+
+	ImGui::SeparatorText("クリアCube状態");
+	ImGui::Text("クリアCube出現済み: %s", clearItemSpawned_ ? "はい" : "いいえ");
+	ImGui::Text("クリアCube取得済み: %s", clearItemCollected_ ? "はい" : "いいえ");
+	const K4E::Vector3 clearPos = clearItem_ ? clearItem_->GetPosition() : K4E::Vector3{};
+	ImGui::Text("クリアCube座標: %.2f, %.2f, %.2f", clearPos.x, clearPos.y, clearPos.z);
+	ImGui::Text("ゲームクリア判定: %s", isGameClear_ ? "はい" : "いいえ");
+	ImGui::Text("ボス撃破済み: %s", bossDefeated_ ? "はい" : "いいえ");
+	if (guardianBoss_)
+	{
+		guardianBoss_->DrawImGui();
 	}
 	crystalManager_.DrawImGui();
 
@@ -689,6 +813,7 @@ void GamePlayWorld::SpawnGuardianBoss()
 	if (auto* player = characters_.GetPlayer())
 	{
 		guardianBoss_->SetTargetPosition(player->GetCenterPosition());
+		guardianBoss_->SetTargetPlayer(player);
 	}
 	guardianBoss_->Update(0.0f);
 	if (collisionManager_)
@@ -699,6 +824,78 @@ void GamePlayWorld::SpawnGuardianBoss()
 	bossSpawned_ = true;
 }
 
+
+void GamePlayWorld::UpdateBossClearProgress(float deltaTime)
+{
+	if (guardianBoss_ && guardianBoss_->IsDead() && !bossDefeated_)
+	{
+		bossDefeated_ = true;
+		SetBossDefeated(false);
+	}
+
+	if (bossDefeated_ && !clearItemSpawned_ && guardianBoss_)
+	{
+		SpawnClearItem(guardianBoss_->GetPosition());
+	}
+
+	if (clearItem_ && !clearItemCollected_)
+	{
+		clearItem_->Update(deltaTime);
+		if (auto* player = characters_.GetPlayer())
+		{
+			if (clearItem_->CheckPickup(*player))
+			{
+				CollectClearItem();
+			}
+		}
+	}
+}
+
+void GamePlayWorld::SpawnClearItem(const K4E::Vector3& bossPosition)
+{
+	if (clearItemSpawned_)
+	{
+		return;
+	}
+
+	K4E::Vector3 spawnPosition = bossPosition;
+	spawnPosition.z -= 2.0f;
+	spawnPosition.y = std::max(spawnPosition.y, 0.75f);
+
+	clearItem_ = std::make_unique<BossClearItem>();
+	clearItem_->Initialize(spawnPosition);
+	if (collisionManager_)
+	{
+		collisionManager_->AddCollider(clearItem_.get());
+	}
+
+	clearItemSpawned_ = true;
+	Log("[GameClear] BossClearItem spawned.\n");
+}
+
+void GamePlayWorld::CollectClearItem()
+{
+	if (clearItemCollected_ || isGameClear_)
+	{
+		return;
+	}
+
+	clearItemCollected_ = true;
+	isGameClear_ = true;
+	if (clearItem_)
+	{
+		clearItem_->MarkCollected();
+		if (collisionManager_)
+		{
+			collisionManager_->RemoveCollider(clearItem_.get());
+		}
+	}
+
+	// ボス撃破後に出現するクリアCubeを取得したらゲームクリアへ進める。
+	SetBossDefeated(true);
+	Log("[GameClear] Clear item collected.\n");
+}
+
 bool GamePlayWorld::IsAllWavesCleared() const
 {
 	return waveManager_ && waveManager_->IsAllWavesCleared();
@@ -706,7 +903,7 @@ bool GamePlayWorld::IsAllWavesCleared() const
 
 bool GamePlayWorld::IsStageObjectiveCleared() const
 {
-	return stageObjectiveManager_ && stageObjectiveManager_->IsStageObjectiveCleared(IsAllWavesCleared());
+	return isGameClear_ || (stageObjectiveManager_ && stageObjectiveManager_->IsStageObjectiveCleared(IsAllWavesCleared()));
 }
 
 bool GamePlayWorld::IsStageObjectiveFailed() const

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.h
@@ -12,10 +12,42 @@
 #include "ItemManager.h"
 #include "CrystalManager.h"
 #include "Derived/GuardianBoss/GuardianBoss.h"
+#include "Object3D.h"
 
 #include <memory>
 
 namespace K4E = ::Ken4lowEngine;
+
+class Player;
+
+class BossClearItem : public K4E::Collider
+{
+public:
+	void Initialize(const K4E::Vector3& position);
+	void Update(float deltaTime);
+	void Draw();
+	bool CheckPickup(const Player& player) const;
+	void MarkCollected();
+
+	bool IsSpawned() const { return spawned_; }
+	bool IsCollected() const { return collected_; }
+	const K4E::Vector3& GetPosition() const { return position_; }
+
+	void OnCollision(K4E::Collider* other) override;
+	K4E::Vector3 GetCenterPosition() const override { return position_; }
+	void SetCenterPosition(const K4E::Vector3& pos) override { position_ = pos; }
+
+private:
+	std::unique_ptr<K4E::Object3D> object3d_;
+	K4E::Vector3 position_{};
+	K4E::Vector3 basePosition_{};
+	K4E::Vector3 rotation_{};
+	K4E::Vector3 halfSize_{ 0.9f, 0.9f, 0.9f };
+	float pickupRadius_ = 2.1f;
+	float floatTimer_ = 0.0f;
+	bool spawned_ = false;
+	bool collected_ = false;
+};
 
 class GamePlayWorld
 {
@@ -47,6 +79,7 @@ public: /// ---------- メンバ関数 ---------- ///
 
 	bool IsStageObjectiveCleared() const;
 	bool IsStageObjectiveFailed() const;
+	bool IsGameClearRequested() const { return isGameClear_; }
 
 	void SetDebugCameraEnabled(bool enabled);
 
@@ -86,6 +119,9 @@ private: /// ---------- メンバ関数 ---------- ///
 	bool IsSightBlocked(const K4E::Segment& seg) const;
 	void UpdateCrystalBossSpawnProgress();
 	void SpawnGuardianBoss();
+	void UpdateBossClearProgress(float deltaTime);
+	void SpawnClearItem(const K4E::Vector3& bossPosition);
+	void CollectClearItem();
 
 
 private: /// ---------- メンバ変数 ---------- ///
@@ -104,6 +140,7 @@ private: /// ---------- メンバ変数 ---------- ///
 	ItemManager itemManager_;
 	CrystalManager crystalManager_;
 	std::unique_ptr<GuardianBoss> guardianBoss_;
+	std::unique_ptr<BossClearItem> clearItem_;
 
 	int prevWaveNumber_ = 0;
 	bool prevWaveInProgress_ = false;
@@ -125,4 +162,8 @@ private: /// ---------- メンバ変数 ---------- ///
 	K4E::Vector3 bossSpawnPosition_{ 0.0f, 2.25f, 30.0f };
 	bool bossSpawned_ = false;
 	bool bossSpawnConditionMet_ = false;
+	bool bossDefeated_ = false;
+	bool clearItemSpawned_ = false;
+	bool clearItemCollected_ = false;
+	bool isGameClear_ = false;
 };


### PR DESCRIPTION
### Motivation
- ボス戦を成立させるため、プレイヤー銃弾でボスにダメージを与えられるようにし、ボス攻撃がプレイヤーにダメージを与える経路を実装する。
- ボス撃破時にクリア用のアイテムを生成してプレイヤーが取得するとステージクリアへ遷移する仕組みを追加する。
- 既存の雑魚・クリスタル・近接攻撃処理を壊さずに拡張する。

### Description
- 弾の当たり判定からボスへダメージを流すようにし、範囲攻撃（スプラッシュ）でも `kBoss` を対象にダメージを送るようにした（`Bullet::OnCollisionEnter` / `Bullet::ApplySplashDamageToType` に `BossBase` 分岐を追加）。
- ボス基底にプレイヤー参照と Player へダメージを適用する API を追加した（`BossBase::SetTargetPlayer` / `BossBase::ApplyDamageToTargetPlayer` / `BossBase::OnBulletDamaged` / `BossBase::OnTargetPlayerDamaged`）。
- ボス近接攻撃のヒット処理で実際にプレイヤーへダメージを与えるようにした（`BossPunchAttack::TryHitPlayer` / `BossHeavyPunchAttack::TryHitPlayer` で `ApplyDamageToTargetPlayer` を呼ぶ）。
- GuardianBoss 側に銃弾ヒット回数・近接ヒット回数・ボス攻撃ヒット回数・直近ダメージのカウンタを追加し、ImGui デバッグ表示へ日本語で出力するようにした（`GuardianBoss` のメンバと `DrawImGui` を拡張）。
- ボス撃破後に一度だけ生成される仮クリアアイテム `BossClearItem` を追加し、見やすい大きめの Cube モデルで描画、Y補正・浮遊アニメ・取得判定を実装した（`GamePlayWorld::SpawnClearItem` / `UpdateBossClearProgress` / `CollectClearItem`）。
- クリアアイテム取得で内部フラグ `isGameClear_` を立て、既存のステージクリア判定経路に乗せるようにした（`GamePlayWorld::IsStageObjectiveCleared` を `isGameClear_` を見るよう変更）。
- 既存の多段ヒット防止ロジックや弾の消去（非貫通挙動）は維持している。注釈コメントを追加し動作意図を明記。 

主に編集したクラス/関数（抜粋）: `Bullet::OnCollisionEnter`, `Bullet::ApplySplashDamageToType`, `BossBase::ApplyDamageToTargetPlayer`, `BossBase::OnBulletDamaged`, `GuardianBoss::OnBulletDamaged`, `BossPunchAttack::TryHitPlayer`, `BossHeavyPunchAttack::TryHitPlayer`, `GamePlayWorld::SpawnClearItem`, `GamePlayWorld::UpdateBossClearProgress`, `GamePlayWorld::CollectClearItem`, `GuardianBoss::DrawImGui`。

### Testing
- 実行した自動チェック: `git diff --check` はエラー無しで通過。 (成功)
- ビルド: `cmake --build Project` を実行しましたが、この Visual Studio 用プロジェクトのチェックアウト環境では CMake キャッシュが無く `Error: could not load cache` によりビルドを行えませんでした（環境依存）。 (失敗/実行不可)

注: ローカル環境／CI 上でフルビルドを実行して動作確認を行ってください。特にボス周り（銃弾命中、近接攻撃でのプレイヤー被弾、クリアCube生成・取得、ImGui 表示）が期待通りかを確認することを推奨します。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a201f86cb08832da29e8fa78100eabc)