### PR TITLE
ボス攻撃の当たり判定可変化と敵パラメータ調整ImGuiの追加

### DIFF
--- a/Project/ApplicationLayer/Character/Boss/Attacks/BossAttackDebugSettings.h
+++ b/Project/ApplicationLayer/Character/Boss/Attacks/BossAttackDebugSettings.h
@@ -1,0 +1,43 @@
+#pragma once
+#include <Vector3.h>
+
+namespace K4E = Ken4lowEngine;
+
+/// <summary>
+/// ボス攻撃範囲をJSON保存しやすい単位で分離した設定。
+/// </summary>
+struct BossAttackSettings
+{
+	float attackRadius = 2.75f;
+	float attackDistance = 2.80f;
+	float attackHeight = 1.05f;
+	float attackForwardOffset = 0.0f;
+	float attackActiveStartTime = 0.30f;
+	float attackActiveEndTime = 0.48f;
+	int attackDamage = 20;
+};
+
+/// <summary>
+/// Debug/ImGui専用の表示設定。
+/// </summary>
+struct BossDebugSettings
+{
+#ifdef _DEBUG
+	bool showAttackRange = true;
+#else
+	bool showAttackRange = false;
+#endif
+};
+
+/// <summary>
+/// ボス攻撃の当たり具合をImGuiで確認するための実行時状態。
+/// </summary>
+struct BossDamageDebugState
+{
+	int bossAttackHitCount = 0;
+	float lastPlayerDamage = 0.0f;
+	float playerHp = 0.0f;
+	bool isAttackActive = false;
+	K4E::Vector3 attackCenter{};
+	float distanceToPlayer = 0.0f;
+};

--- a/Project/ApplicationLayer/Character/Boss/Attacks/BossHeavyPunchAttack.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Attacks/BossHeavyPunchAttack.cpp
@@ -1,10 +1,14 @@
 #define NOMINMAX
 #include "BossHeavyPunchAttack.h"
 #include "BossBase.h"
+#include "Player.h"
 
 #ifdef _DEBUG
+#include <Wireframe.h>
+#endif
+
 #include <LogString.h>
-#endif // _DEBUG
+#include <cmath>
 
 #ifdef USE_IMGUI
 #include <imgui.h>
@@ -24,6 +28,15 @@ void BossHeavyPunchAttack::Initialize(BossBase* owner)
 	isActive_ = false;
 	isFinished_ = false;
 	hasHit_ = false;
+	attackHitApplied_ = false;
+	damageDebugState_ = {};
+	attackSettings_.attackRadius = 3.25f;
+	attackSettings_.attackDistance = 3.35f;
+	attackSettings_.attackHeight = 1.10f;
+	attackSettings_.attackForwardOffset = 0.0f;
+	attackSettings_.attackActiveStartTime = 0.67f;
+	attackSettings_.attackActiveEndTime = 0.90f;
+	attackSettings_.attackDamage = 40;
 
 	// フェーズを初期化
 	phase_ = Phase::None;
@@ -46,6 +59,7 @@ void BossHeavyPunchAttack::Start()
 	isActive_ = true;
 	isFinished_ = false;
 	hasHit_ = false;
+	attackHitApplied_ = false;
 
 	// フェーズリセット
 	phase_ = Phase::None;
@@ -68,6 +82,20 @@ void BossHeavyPunchAttack::Update(float deltaTime)
 
 	totalTimer_ += deltaTime;
 	phaseTimer_ += deltaTime;
+	damageDebugState_.attackCenter = CalculateAttackCenter();
+	damageDebugState_.isAttackActive = IsAttackWindowActive();
+	if (owner_)
+	{
+		const K4E::Vector3 targetCenter = owner_->GetTargetPosition();
+		const float dx = targetCenter.x - damageDebugState_.attackCenter.x;
+		const float dy = targetCenter.y - damageDebugState_.attackCenter.y;
+		const float dz = targetCenter.z - damageDebugState_.attackCenter.z;
+		damageDebugState_.distanceToPlayer = std::sqrt(dx * dx + dy * dy + dz * dz);
+		if (auto* player = owner_->GetTargetPlayer())
+		{
+			damageDebugState_.playerHp = player->GetHP();
+		}
+	}
 
 	switch (phase_)
 	{
@@ -193,11 +221,10 @@ void BossHeavyPunchAttack::UpdateActive(float deltaTime)
 	// 今は特に攻撃中の挙動はない想定
 	(void)deltaTime;
 
-	// 発生した瞬間に1回だけヒット判定
-	if (!hasHit_)
+	// 攻撃判定時間内だけヒット判定を試み、命中後はattackHitApplied_で多段ヒットを防ぐ。
+	if (!attackHitApplied_ && IsAttackWindowActive())
 	{
 		TryHitPlayer();
-		hasHit_ = true;
 	}
 
 	// 発生時間が終わったら硬直に移る
@@ -257,9 +284,7 @@ void BossHeavyPunchAttack::ChangePhase(Phase newPhase)
 /// ---------------------------------------------------------------
 void BossHeavyPunchAttack::Draw()
 {
-	// 例:
-	// - Windup/Hold 中は予兆色を出す
-	// - Active 中は攻撃球を描く
+	DrawAttackRangeDebug();
 }
 
 /// ---------------------------------------------------------------
@@ -273,12 +298,26 @@ void BossHeavyPunchAttack::DrawImGui()
 	ImGui::Text("Active            : %s", isActive_ ? "true" : "false");
 	ImGui::Text("Finished          : %s", isFinished_ ? "true" : "false");
 	ImGui::Text("HasHit            : %s", hasHit_ ? "true" : "false");
+	ImGui::Text("attackHitApplied  : %s", attackHitApplied_ ? "true" : "false");
 	ImGui::Text("Phase             : %s", GetPhaseName());
 	ImGui::Text("PhaseTimer        : %.2f", phaseTimer_);
 	ImGui::Text("TotalTimer        : %.2f", totalTimer_);
 	ImGui::Text("CooldownRemaining : %.2f", cooldownRemaining_);
 	ImGui::Text("Range             : %.2f - %.2f", minRange_, maxRange_);
-	ImGui::Text("Damage            : %.2f", damage_);
+	ImGui::Text("攻撃判定中か: %s", damageDebugState_.isAttackActive ? "はい" : "いいえ");
+	ImGui::Text("ボス攻撃ヒット回数: %d", damageDebugState_.bossAttackHitCount);
+	ImGui::Text("最後にプレイヤーへ与えたボスダメージ: %.1f", damageDebugState_.lastPlayerDamage);
+	ImGui::Text("Player HP: %.1f", damageDebugState_.playerHp);
+	ImGui::Text("攻撃判定中心座標: %.2f, %.2f, %.2f", damageDebugState_.attackCenter.x, damageDebugState_.attackCenter.y, damageDebugState_.attackCenter.z);
+	ImGui::Text("プレイヤーとの距離: %.2f", damageDebugState_.distanceToPlayer);
+	ImGui::DragFloat("ボス攻撃半径", &attackSettings_.attackRadius, 0.05f, 0.1f, 20.0f);
+	ImGui::DragFloat("ボス攻撃距離", &attackSettings_.attackDistance, 0.05f, 0.0f, 30.0f);
+	ImGui::DragFloat("ボス攻撃高さ", &attackSettings_.attackHeight, 0.05f, -5.0f, 10.0f);
+	ImGui::DragFloat("ボス攻撃前方オフセット", &attackSettings_.attackForwardOffset, 0.05f, -10.0f, 10.0f);
+	ImGui::DragInt("ボス攻撃ダメージ", &attackSettings_.attackDamage, 1, 0, 999);
+	ImGui::DragFloat("攻撃判定開始時間", &attackSettings_.attackActiveStartTime, 0.01f, 0.0f, 10.0f);
+	ImGui::DragFloat("攻撃判定終了時間", &attackSettings_.attackActiveEndTime, 0.01f, 0.0f, 10.0f);
+	ImGui::Checkbox("ボス攻撃範囲表示", &debugSettings_.showAttackRange);
 #endif
 }
 
@@ -287,40 +326,22 @@ void BossHeavyPunchAttack::DrawImGui()
 /// ---------------------------------------------------------------
 void BossHeavyPunchAttack::TryHitPlayer()
 {
-	// 所有者がいないときは何もしない
-	if (owner_ == nullptr) return;
+	if (owner_ == nullptr || attackHitApplied_ || !IsAttackWindowActive()) return;
 
-	// -----------------------------------------------------------
-	// 攻撃中心
-	// HeavyPunch は Punch より前に届くよう少し伸ばす
-	// -----------------------------------------------------------
-	const K4E::Vector3 armRoot = owner_->GetRightArmRootWorldPosition();
-	const float yaw = owner_->GetYaw();
-
-	K4E::Vector3 forward
-	{
-		std::sin(yaw),
-		0.0f,
-		std::cos(yaw)
-	};
-
-	K4E::Vector3 attackCenter = armRoot;
-	attackCenter.x += forward.x * hitForwardOffset_;
-	attackCenter.y += 0.30f;
-	attackCenter.z += forward.z * hitForwardOffset_;
-
-	// -----------------------------------------------------------
-	// 仮のプレイヤー中心
-	// 今は targetPosition_ を使用
-	// -----------------------------------------------------------
+	// ボス攻撃範囲を調整しやすくするため、前方オフセット付きの球判定としてImGuiから編集できるようにする。
+	const K4E::Vector3 attackCenter = CalculateAttackCenter();
 	const K4E::Vector3 targetCenter = owner_->GetTargetPosition();
 
 	const float dx = targetCenter.x - attackCenter.x;
 	const float dy = targetCenter.y - attackCenter.y;
 	const float dz = targetCenter.z - attackCenter.z;
-
 	const float distanceSq = dx * dx + dy * dy + dz * dz;
-	const float sumRadius = hitRadius_ + targetRadius_;
+	const float distance = std::sqrt(distanceSq);
+	const float sumRadius = attackSettings_.attackRadius + targetRadius_;
+
+	damageDebugState_.attackCenter = attackCenter;
+	damageDebugState_.distanceToPlayer = distance;
+	damageDebugState_.isAttackActive = true;
 
 	if (distanceSq <= (sumRadius * sumRadius))
 	{
@@ -328,9 +349,16 @@ void BossHeavyPunchAttack::TryHitPlayer()
 		Log("[BossHeavyPunchAttack] Heavy hit success.\n");
 #endif
 
-		// ボス重攻撃の範囲判定が成立した瞬間だけPlayerへダメージを流す。
-		if (owner_->ApplyDamageToTargetPlayer(damage_, &attackCenter))
+		if (owner_->ApplyDamageToTargetPlayer(static_cast<float>(attackSettings_.attackDamage), &attackCenter))
 		{
+			attackHitApplied_ = true;
+			hasHit_ = true;
+			++damageDebugState_.bossAttackHitCount;
+			damageDebugState_.lastPlayerDamage = static_cast<float>(attackSettings_.attackDamage);
+			if (auto* player = owner_->GetTargetPlayer())
+			{
+				damageDebugState_.playerHp = player->GetHP();
+			}
 			Log("[BossHeavyPunchAttack] Player damage applied.\n");
 		}
 	}
@@ -340,6 +368,42 @@ void BossHeavyPunchAttack::TryHitPlayer()
 		Log("[BossHeavyPunchAttack] Heavy hit miss.\n");
 #endif
 	}
+}
+
+K4E::Vector3 BossHeavyPunchAttack::CalculateAttackCenter() const
+{
+	if (!owner_) return {};
+
+	const float yaw = owner_->GetYaw();
+	const K4E::Vector3 forward{ std::sin(yaw), 0.0f, std::cos(yaw) };
+	const float forwardDistance = attackSettings_.attackDistance + attackSettings_.attackForwardOffset;
+	K4E::Vector3 attackCenter = owner_->GetPosition();
+	attackCenter.x += forward.x * forwardDistance;
+	attackCenter.y += attackSettings_.attackHeight;
+	attackCenter.z += forward.z * forwardDistance;
+	return attackCenter;
+}
+
+bool BossHeavyPunchAttack::IsAttackWindowActive() const
+{
+	return isActive_
+		&& totalTimer_ >= attackSettings_.attackActiveStartTime
+		&& totalTimer_ <= attackSettings_.attackActiveEndTime;
+}
+
+void BossHeavyPunchAttack::DrawAttackRangeDebug()
+{
+#ifdef _DEBUG
+	if (!debugSettings_.showAttackRange || !owner_) return;
+
+	auto* wireframe = K4E::Wireframe::GetInstance();
+	if (!wireframe || !wireframe->IsDebugDrawEnabled()) return;
+
+	const K4E::Vector3 center = CalculateAttackCenter();
+	const K4E::Vector4 color = IsAttackWindowActive() ? K4E::Vector4{ 1.0f, 0.05f, 0.05f, 1.0f } : K4E::Vector4{ 1.0f, 0.55f, 0.25f, 0.35f };
+	wireframe->DrawSphere(center, attackSettings_.attackRadius, color);
+	wireframe->DrawLine(owner_->GetPosition(), center, color);
+#endif
 }
 
 /// ---------------------------------------------------------------
@@ -354,7 +418,7 @@ bool BossHeavyPunchAttack::IsTargetInValidRange() const
 	const float distance = owner_->GetDistanceToTargetXZ();
 
 	// 射程内かどうかを判断
-	return (distance >= minRange_ && distance <= maxRange_);
+	return (distance >= minRange_ && distance <= attackSettings_.attackDistance + attackSettings_.attackRadius + targetRadius_);
 }
 
 /// ---------------------------------------------------------------

--- a/Project/ApplicationLayer/Character/Boss/Attacks/BossHeavyPunchAttack.h
+++ b/Project/ApplicationLayer/Character/Boss/Attacks/BossHeavyPunchAttack.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "IBossAttack.h"
+#include "BossAttackDebugSettings.h"
 
 /// ---------- 前方宣言 ---------- ///
 class BossBase;
@@ -161,6 +162,21 @@ private: /// ---------- 内部処理 ---------- ///
 	void TryHitPlayer();
 
 	/// <summary>
+	/// 現在の設定から攻撃中心を計算する
+	/// </summary>
+	K4E::Vector3 CalculateAttackCenter() const;
+
+	/// <summary>
+	/// 攻撃判定時間内か
+	/// </summary>
+	bool IsAttackWindowActive() const;
+
+	/// <summary>
+	/// 攻撃範囲のDebugワイヤーを描画する
+	/// </summary>
+	void DrawAttackRangeDebug();
+
+	/// <summary>
 	/// 攻撃開始可能な距離か
 	/// </summary>
 	bool IsTargetInValidRange() const;
@@ -180,6 +196,7 @@ private: /// ---------- 実行状態 ---------- ///
 	bool isActive_ = false;	  // 実行中か
 	bool isFinished_ = false; // 今回の実行が終わったか
 	bool hasHit_ = false;	  // 発生中にすでにヒット判定を出したか
+	bool attackHitApplied_ = false; // 1回の攻撃で多段ヒットしないようにするためのフラグ
 
 	Phase phase_ = Phase::None; // 現在フェーズ
 	float phaseTimer_ = 0.0f;   // フェーズ内経過時間
@@ -206,9 +223,9 @@ private: /// ---------- フェーズ時間 ---------- ///
 
 private: /// ---------- ヒット判定 ---------- ///
 
-	float damage_ = 40.0f;              // 通常より高威力
-	float hitRadius_ = 1.45f;           // 少し大きめ
-	float hitForwardOffset_ = 1.70f;    // より前に届く
+	BossAttackSettings attackSettings_{}; // 将来JSON保存しやすい攻撃範囲設定
+	BossDebugSettings debugSettings_{};   // Debug表示設定
+	BossDamageDebugState damageDebugState_{}; // ヒット確認用状態
 	float targetRadius_ = 0.65f;        // 仮プレイヤー半径
 
 private: /// ---------- クールダウン ---------- ///

--- a/Project/ApplicationLayer/Character/Boss/Attacks/BossPunchAttack.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Attacks/BossPunchAttack.cpp
@@ -1,6 +1,11 @@
 #define NOMINMAX
 #include "BossPunchAttack.h"
 #include "BossBase.h"
+#include "Player.h"
+
+#ifdef _DEBUG
+#include <Wireframe.h>
+#endif
 
 #include <Windows.h>
 #include <cmath>
@@ -33,6 +38,8 @@ void BossPunchAttack::Initialize(BossBase* owner)
 	isActive_ = false;
 	isFinished_ = false;
 	hasHit_ = false;
+	attackHitApplied_ = false;
+	damageDebugState_ = {};
 
 	// フェーズを初期化
 	phase_ = Phase::None;
@@ -55,6 +62,7 @@ void BossPunchAttack::Start()
 	isActive_ = true;
 	isFinished_ = false;
 	hasHit_ = false;
+	attackHitApplied_ = false;
 
 	// フェーズリセット
 	phase_ = Phase::None;
@@ -78,6 +86,21 @@ void BossPunchAttack::Update(float deltaTime)
 
 	totalTimer_ += deltaTime; // 攻撃開始からの総時間
 	phaseTimer_ += deltaTime; // 現在フェーズに入ってからの時間
+	damageDebugState_.attackCenter = CalculateAttackCenter();
+	damageDebugState_.isAttackActive = IsAttackWindowActive();
+	if (owner_)
+	{
+		const K4E::Vector3 targetCenter = owner_->GetTargetPosition();
+		const float dx = targetCenter.x - damageDebugState_.attackCenter.x;
+		const float dy = targetCenter.y - damageDebugState_.attackCenter.y;
+		const float dz = targetCenter.z - damageDebugState_.attackCenter.z;
+		damageDebugState_.distanceToPlayer = std::sqrt(dx * dx + dy * dy + dz * dz);
+		if (auto* player = owner_->GetTargetPlayer())
+		{
+			damageDebugState_.playerHp = player->GetHP();
+		}
+	}
+
 
 	// フェーズごとに更新
 	switch (phase_)
@@ -180,11 +203,10 @@ void BossPunchAttack::UpdateActive(float deltaTime)
 	// 今は特に発生中の挙動はないので、時間だけ進める
 	(void)deltaTime;
 
-	// 発生中に一度だけヒット判定
-	if (!hasHit_)
+	// 攻撃判定時間内だけヒット判定を試み、命中後はattackHitApplied_で多段ヒットを防ぐ。
+	if (!attackHitApplied_ && IsAttackWindowActive())
 	{
-		TryHitPlayer(); // ヒット判定を試みる
-		hasHit_ = true; // これ以降はヒット判定しない
+		TryHitPlayer();
 	}
 
 	// 発生時間を過ぎたら硬直へ
@@ -240,10 +262,7 @@ void BossPunchAttack::ChangePhase(Phase newPhase)
 /// ---------------------------------------------------------------
 void BossPunchAttack::Draw()
 {
-	// 例:
-	// - Windup 中に拳の前に予兆球
-	// - Active 中に当たり判定球を赤で表示
-	// 今は未実装
+	DrawAttackRangeDebug();
 }
 
 /// ---------------------------------------------------------------
@@ -257,12 +276,26 @@ void BossPunchAttack::DrawImGui()
 	ImGui::Text("Active            : %s", isActive_ ? "true" : "false");
 	ImGui::Text("Finished          : %s", isFinished_ ? "true" : "false");
 	ImGui::Text("HasHit            : %s", hasHit_ ? "true" : "false");
+	ImGui::Text("attackHitApplied  : %s", attackHitApplied_ ? "true" : "false");
 	ImGui::Text("Phase             : %s", GetPhaseName());
 	ImGui::Text("PhaseTimer        : %.2f", phaseTimer_);
 	ImGui::Text("TotalTimer        : %.2f", totalTimer_);
 	ImGui::Text("CooldownRemaining : %.2f", cooldownRemaining_);
 	ImGui::Text("Range             : %.2f - %.2f", minRange_, maxRange_);
-	ImGui::Text("Damage            : %.2f", damage_);
+	ImGui::Text("攻撃判定中か: %s", damageDebugState_.isAttackActive ? "はい" : "いいえ");
+	ImGui::Text("ボス攻撃ヒット回数: %d", damageDebugState_.bossAttackHitCount);
+	ImGui::Text("最後にプレイヤーへ与えたボスダメージ: %.1f", damageDebugState_.lastPlayerDamage);
+	ImGui::Text("Player HP: %.1f", damageDebugState_.playerHp);
+	ImGui::Text("攻撃判定中心座標: %.2f, %.2f, %.2f", damageDebugState_.attackCenter.x, damageDebugState_.attackCenter.y, damageDebugState_.attackCenter.z);
+	ImGui::Text("プレイヤーとの距離: %.2f", damageDebugState_.distanceToPlayer);
+	ImGui::DragFloat("ボス攻撃半径", &attackSettings_.attackRadius, 0.05f, 0.1f, 20.0f);
+	ImGui::DragFloat("ボス攻撃距離", &attackSettings_.attackDistance, 0.05f, 0.0f, 30.0f);
+	ImGui::DragFloat("ボス攻撃高さ", &attackSettings_.attackHeight, 0.05f, -5.0f, 10.0f);
+	ImGui::DragFloat("ボス攻撃前方オフセット", &attackSettings_.attackForwardOffset, 0.05f, -10.0f, 10.0f);
+	ImGui::DragInt("ボス攻撃ダメージ", &attackSettings_.attackDamage, 1, 0, 999);
+	ImGui::DragFloat("攻撃判定開始時間", &attackSettings_.attackActiveStartTime, 0.01f, 0.0f, 10.0f);
+	ImGui::DragFloat("攻撃判定終了時間", &attackSettings_.attackActiveEndTime, 0.01f, 0.0f, 10.0f);
+	ImGui::Checkbox("ボス攻撃範囲表示", &debugSettings_.showAttackRange);
 #endif
 }
 
@@ -271,60 +304,84 @@ void BossPunchAttack::DrawImGui()
 /// ---------------------------------------------------------------
 void BossPunchAttack::TryHitPlayer()
 {
-	if (owner_ == nullptr) return;
+	if (owner_ == nullptr || attackHitApplied_ || !IsAttackWindowActive()) return;
 
-	// 攻撃の中心座標を計算する
-	const K4E::Vector3 armRoot = owner_->GetRightArmRootWorldPosition();
-	const float yaw = owner_->GetYaw();
-
-	// Yaw から前方ベクトルを計算
-	K4E::Vector3 forward
-	{
-		std::sin(yaw),
-		0.0f,
-		std::cos(yaw)
-	};
-
-	// 攻撃中心は腕の根元から前方に少しオフセットした位置
-	K4E::Vector3 attackCenter = armRoot;
-	attackCenter.x += forward.x * hitForwardOffset_;
-	attackCenter.y += 0.25f;
-	attackCenter.z += forward.z * hitForwardOffset_;
-
-	// ターゲットの中心座標を取得
+	// ボス攻撃範囲を調整しやすくするため、前方オフセット付きの球判定としてImGuiから編集できるようにする。
+	const K4E::Vector3 attackCenter = CalculateAttackCenter();
 	const K4E::Vector3 targetCenter = owner_->GetTargetPosition();
 
-	const float dx = targetCenter.x - attackCenter.x; // XZ 平面での距離を計算
-	const float dy = targetCenter.y - attackCenter.y; // Y 軸の距離も考慮する場合はこれも使う
-	const float dz = targetCenter.z - attackCenter.z; // XZ 平面での距離を計算
-
-	// 攻撃中心とターゲット中心の距離の二乗を計算
+	const float dx = targetCenter.x - attackCenter.x;
+	const float dy = targetCenter.y - attackCenter.y;
+	const float dz = targetCenter.z - attackCenter.z;
 	const float distanceSq = dx * dx + dy * dy + dz * dz;
+	const float distance = std::sqrt(distanceSq);
+	const float sumRadius = attackSettings_.attackRadius + targetRadius_;
 
-	// 攻撃の当たり判定半径とターゲットの半径を足した値の二乗と比較してヒット判定
-	const float sumRadius = hitRadius_ + targetRadius_;
+	damageDebugState_.attackCenter = attackCenter;
+	damageDebugState_.distanceToPlayer = distance;
+	damageDebugState_.isAttackActive = true;
 
-	// 距離の二乗が半径の二乗以下ならヒットと判定
 	if (distanceSq <= (sumRadius * sumRadius))
 	{
 #ifdef _DEBUG
-		// ヒットしたときのデバッグログ
 		OutputDebugStringA("[BossPunchAttack] Melee hit success.\n");
 #endif
 
-		// ボス近接攻撃の発生フレームで1回だけPlayerへダメージを流す。
-		if (owner_->ApplyDamageToTargetPlayer(damage_, &attackCenter))
+		if (owner_->ApplyDamageToTargetPlayer(static_cast<float>(attackSettings_.attackDamage), &attackCenter))
 		{
+			attackHitApplied_ = true;
+			hasHit_ = true;
+			++damageDebugState_.bossAttackHitCount;
+			damageDebugState_.lastPlayerDamage = static_cast<float>(attackSettings_.attackDamage);
+			if (auto* player = owner_->GetTargetPlayer())
+			{
+				damageDebugState_.playerHp = player->GetHP();
+			}
 			DebugLog("[BossPunchAttack] Player damage applied.\n");
 		}
 	}
 	else
 	{
 #ifdef _DEBUG
-		// ヒットしなかったときのデバッグログ
 		OutputDebugStringA("[BossPunchAttack] Melee hit miss.\n");
 #endif
 	}
+}
+
+K4E::Vector3 BossPunchAttack::CalculateAttackCenter() const
+{
+	if (!owner_) return {};
+
+	const float yaw = owner_->GetYaw();
+	const K4E::Vector3 forward{ std::sin(yaw), 0.0f, std::cos(yaw) };
+	const float forwardDistance = attackSettings_.attackDistance + attackSettings_.attackForwardOffset;
+	K4E::Vector3 attackCenter = owner_->GetPosition();
+	attackCenter.x += forward.x * forwardDistance;
+	attackCenter.y += attackSettings_.attackHeight;
+	attackCenter.z += forward.z * forwardDistance;
+	return attackCenter;
+}
+
+bool BossPunchAttack::IsAttackWindowActive() const
+{
+	return isActive_
+		&& totalTimer_ >= attackSettings_.attackActiveStartTime
+		&& totalTimer_ <= attackSettings_.attackActiveEndTime;
+}
+
+void BossPunchAttack::DrawAttackRangeDebug()
+{
+#ifdef _DEBUG
+	if (!debugSettings_.showAttackRange || !owner_) return;
+
+	auto* wireframe = K4E::Wireframe::GetInstance();
+	if (!wireframe || !wireframe->IsDebugDrawEnabled()) return;
+
+	const K4E::Vector3 center = CalculateAttackCenter();
+	const K4E::Vector4 color = IsAttackWindowActive() ? K4E::Vector4{ 1.0f, 0.05f, 0.05f, 1.0f } : K4E::Vector4{ 1.0f, 0.55f, 0.25f, 0.35f };
+	wireframe->DrawSphere(center, attackSettings_.attackRadius, color);
+	wireframe->DrawLine(owner_->GetPosition(), center, color);
+#endif
 }
 
 /// ---------------------------------------------------------------
@@ -337,7 +394,7 @@ bool BossPunchAttack::IsTargetInValidRange() const
 
 	// ターゲットまでの距離を取得して、有効距離内か判定
 	const float distance = owner_->GetDistanceToTargetXZ();
-	return (distance >= minRange_ && distance <= maxRange_);
+	return (distance >= minRange_ && distance <= attackSettings_.attackDistance + attackSettings_.attackRadius + targetRadius_);
 }
 
 /// ---------------------------------------------------------------

--- a/Project/ApplicationLayer/Character/Boss/Attacks/BossPunchAttack.h
+++ b/Project/ApplicationLayer/Character/Boss/Attacks/BossPunchAttack.h
@@ -1,5 +1,6 @@
 #pragma once
 #include "IBossAttack.h"
+#include "BossAttackDebugSettings.h"
 
 /// ---------- 前方宣言 ---------- ///
 class BossBase;
@@ -142,6 +143,21 @@ private: /// ---------- 内部処理 ---------- ///
 	void TryHitPlayer();
 
 	/// <summary>
+	/// 現在の設定から攻撃中心を計算する
+	/// </summary>
+	K4E::Vector3 CalculateAttackCenter() const;
+
+	/// <summary>
+	/// 攻撃判定時間内か
+	/// </summary>
+	bool IsAttackWindowActive() const;
+
+	/// <summary>
+	/// 攻撃範囲のDebugワイヤーを描画する
+	/// </summary>
+	void DrawAttackRangeDebug();
+
+	/// <summary>
 	/// 攻撃開始条件に必要な距離内か
 	/// </summary>
 	bool IsTargetInValidRange() const;
@@ -160,6 +176,7 @@ private: /// ---------- 実行状態 ---------- ///
 	bool isActive_ = false;     // 実行中か
 	bool isFinished_ = false;   // 今回の実行が終わったか
 	bool hasHit_ = false;       // 今回すでにヒットを出したか
+	bool attackHitApplied_ = false; // 1回の攻撃で多段ヒットしないようにするためのフラグ
 
 	Phase phase_ = Phase::None; // 現在フェーズ
 	float phaseTimer_ = 0.0f;   // フェーズ内経過時間
@@ -183,9 +200,9 @@ private: /// ---------- フェーズ時間 ---------- ///
 
 private: /// ---------- ヒット判定 ---------- ///
 
-	float damage_ = 20.0f;              // 将来プレイヤーに与えるダメージ
-	float hitRadius_ = 1.15f;           // パンチ球の半径
-	float hitForwardOffset_ = 1.35f;    // 右腕根本から前方へずらす距離
+	BossAttackSettings attackSettings_{}; // 将来JSON保存しやすい攻撃範囲設定
+	BossDebugSettings debugSettings_{};   // Debug表示設定
+	BossDamageDebugState damageDebugState_{}; // ヒット確認用状態
 	float targetRadius_ = 0.65f;        // 仮のプレイヤー半径
 
 private: /// ---------- クールダウン ---------- ///

--- a/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.cpp
+++ b/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.cpp
@@ -357,6 +357,60 @@ void CharacterWorld::DrawEnemyDebugImGui()
 #endif
 }
 
+void CharacterWorld::DrawEnemyTuningImGui()
+{
+#ifdef USE_IMGUI
+	MeleeEnemy* representativeMelee = nullptr;
+	MidRangeEnemy* representativeMidRange = nullptr;
+	EnemyBase* representativeLegacy = nullptr;
+
+	for (const auto& enemy : enemies_)
+	{
+		if (!enemy) { continue; }
+
+		if (!representativeMelee)
+		{
+			representativeMelee = dynamic_cast<MeleeEnemy*>(enemy.get());
+		}
+		if (!representativeMidRange)
+		{
+			representativeMidRange = dynamic_cast<MidRangeEnemy*>(enemy.get());
+		}
+		if (!representativeLegacy && !dynamic_cast<MeleeEnemy*>(enemy.get()) && !dynamic_cast<MidRangeEnemy*>(enemy.get()))
+		{
+			representativeLegacy = enemy.get();
+		}
+	}
+
+	// GamePlaySceneから各敵のパラメータ調整ImGuiを呼び出せるようにする。
+	ImGui::SeparatorText("近接雑魚敵パラメータ");
+	if (representativeMelee)
+	{
+		representativeMelee->DrawImGui();
+	}
+	else
+	{
+		ImGui::TextUnformatted("近接雑魚敵の代表個体がいません。");
+	}
+
+	ImGui::SeparatorText("中距離雑魚敵パラメータ");
+	if (representativeMidRange)
+	{
+		representativeMidRange->DrawImGui();
+	}
+	else
+	{
+		ImGui::TextUnformatted("中距離雑魚敵の代表個体がいません。");
+	}
+
+	if (representativeLegacy)
+	{
+		ImGui::SeparatorText("旧Enemy代表パラメータ");
+		representativeLegacy->DrawImGui();
+	}
+#endif
+}
+
 void CharacterWorld::DrawShadow()
 {
 	if (player_) { player_->DrawShadow(); }

--- a/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.h
+++ b/Project/ApplicationLayer/Character/CharacterWorld/CharacterWorld.h
@@ -51,6 +51,7 @@ public: /// ---------- メンバ関数 ---------- ///
 	void DrawImGui();
 	void DrawPlayerDebugImGui();
 	void DrawEnemyDebugImGui();
+	void DrawEnemyTuningImGui();
 
 	void DrawShadow();
 

--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.cpp
@@ -644,6 +644,8 @@ void GamePlayScene::DrawImGui()
 		ImGui::End();
 	}
 
+	DrawEnemyTuningImGui();
+
 	if (hpPostEffectController_ && editorWindowState.showPlayerDebug)
 	{
 		// Player DebugへHP/Damage系ポストエフェクト調整を追加し、単独浮遊ウィンドウを出さない。
@@ -655,6 +657,24 @@ void GamePlayScene::DrawImGui()
 		ImGui::End();
 	}
 #endif // USE_IMGUI
+}
+
+void GamePlayScene::DrawEnemyTuningImGui()
+{
+#ifdef USE_IMGUI
+	auto& editorWindowState = K4E::EditorWindowManager::GetInstance()->GetWindowState();
+	if (!editorWindowState.showEnemyDebug || !world_)
+	{
+		return;
+	}
+
+	ImGui::SetNextWindowSize(ImVec2(560.0f, 620.0f), ImGuiCond_FirstUseEver);
+	if (ImGui::Begin("Enemy Parameter Tuning", &editorWindowState.showEnemyDebug))
+	{
+		world_->DrawEnemyTuningImGui();
+	}
+	ImGui::End();
+#endif
 }
 
 void GamePlayScene::StartLoad()

--- a/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/GamePlayScene.h
@@ -93,6 +93,9 @@ private: /// ---------- 初期化 / 終了系 ---------- ///
 	// HP連動ポストエフェクトを初期化して被弾通知を接続する
 	void InitializeHealthPostEffectController();
 
+	// GamePlaySceneから敵パラメータ調整ImGuiをまとめて開く。
+	void DrawEnemyTuningImGui();
+
 	// 生成済みオブジェクトの破棄
 	void ReleaseGameplayObjects();
 

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.cpp
@@ -733,6 +733,41 @@ void GamePlayWorld::DrawEnemyDebugImGui()
 #endif
 }
 
+void GamePlayWorld::DrawEnemyTuningImGui()
+{
+#ifdef USE_IMGUI
+	if (ImGui::CollapsingHeader("近接雑魚敵・中距離雑魚敵パラメータ", ImGuiTreeNodeFlags_DefaultOpen))
+	{
+		characters_.DrawEnemyTuningImGui();
+	}
+
+	if (ImGui::CollapsingHeader("ボスパラメータ", ImGuiTreeNodeFlags_DefaultOpen))
+	{
+		if (guardianBoss_)
+		{
+			guardianBoss_->DrawImGui();
+		}
+		else
+		{
+			ImGui::TextUnformatted("ボスはまだ出現していません。");
+		}
+	}
+
+	if (ImGui::CollapsingHeader("クリスタル状態", ImGuiTreeNodeFlags_DefaultOpen))
+	{
+		crystalManager_.DrawImGui();
+	}
+
+	if (ImGui::CollapsingHeader("ボス戦状態", ImGuiTreeNodeFlags_DefaultOpen))
+	{
+		ImGui::Text("ボス出現済み: %s", bossSpawned_ ? "はい" : "いいえ");
+		ImGui::Text("ボス撃破済み: %s", bossDefeated_ ? "はい" : "いいえ");
+		ImGui::Text("クリアCube出現済み: %s", clearItemSpawned_ ? "はい" : "いいえ");
+		ImGui::Text("クリアCube取得済み: %s", clearItemCollected_ ? "はい" : "いいえ");
+	}
+#endif
+}
+
 void GamePlayWorld::DrawCollisionDebugImGui()
 {
 #ifdef USE_IMGUI

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/GamePlayWorld.h
@@ -70,6 +70,7 @@ public: /// ---------- メンバ関数 ---------- ///
 	void DrawGameDebugImGui();
 	void DrawCollisionDebugImGui();
 	void DrawEnemyDebugImGui();
+	void DrawEnemyTuningImGui();
 
 	void SyncAfterPlayerSpawn();
 	void StartWaves();

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -719,6 +719,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="ApplicationLayer\Character\Boss\BehaviorTree\BTSelectorNode.h" />
     <ClInclude Include="ApplicationLayer\Character\Boss\BehaviorTree\BTSequenceNode.h" />
     <ClInclude Include="ApplicationLayer\Character\Boss\Attacks\BossPunchAttack.h" />
+    <ClInclude Include="ApplicationLayer\Character\Boss\Attacks\BossAttackDebugSettings.h" />
     <ClInclude Include="ApplicationLayer\Character\Boss\Core\BossTypes.h" />
     <ClInclude Include="ApplicationLayer\Character\Boss\Attacks\BossHeavyPunchAttack.h" />
     <ClInclude Include="ApplicationLayer\Character\Boss\Animations\BossPunchAttackAnimation.h" />

--- a/Project/Ken4lowEngine.vcxproj.filters
+++ b/Project/Ken4lowEngine.vcxproj.filters
@@ -1263,6 +1263,9 @@
     <ClInclude Include="ApplicationLayer\Character\Boss\Attacks\BossPunchAttack.h">
       <Filter>ApplicationLayer\Character\Boss\Attacks</Filter>
     </ClInclude>
+    <ClInclude Include="ApplicationLayer\Character\Boss\Attacks\BossAttackDebugSettings.h">
+      <Filter>ApplicationLayer\Character\Boss\Attacks</Filter>
+    </ClInclude>
     <ClInclude Include="ApplicationLayer\Character\Boss\Core\BossTypes.h">
       <Filter>ApplicationLayer\Character\Boss\Core</Filter>
     </ClInclude>


### PR DESCRIPTION
### Motivation
- ボス攻撃アニメは再生されるが判定中心/半径が小さくプレイヤーに当たっていなかったため、判定を調整可能にして当たりを確実にする。 
- 開発中に調整しやすいようImGuiで攻撃範囲・タイミング・ダメージをチューニングできるようにする。 
- 攻撃判定は攻撃アニメの指定時間窓のみ有効にし、1回の攻撃で多段ヒットしないようにする。 
- Debugビルドでワイヤーフレーム表示して視覚的に確認できるようにする。 

### Description
- 追加: `BossAttackDebugSettings.h` に `BossAttackSettings` / `BossDebugSettings` / `BossDamageDebugState` を導入して将来のJSON保存に備えた設定分離を行った。 
- 近接/重パンチ攻撃の改修: `BossPunchAttack` / `BossHeavyPunchAttack` のヘッダ/実装を変更し、攻撃中心を `attackCenter = bossPosition + forward * (attackDistance + attackForwardOffset); attackCenter.y += attackHeight;` の方式で計算するようにした。 
- 攻撃時間窓と単一ヒット制御: `attackActiveStartTime`/`attackActiveEndTime` をUIで変更可能にし、判定は `IsAttackWindowActive()` が true の間のみ行い、命中後は `attackHitApplied_` フラグで多段を防止する。 
- ダメージ伝搬: 判定成立時に `owner_->ApplyDamageToTargetPlayer(...)` を呼びプレイヤーHPを減らし、ヒット回数・最後に与えたダメージ・Player HP を `BossDamageDebugState` に保存してImGuiで表示する。 
- Debugワイヤー描画: DebugビルドでImGuiの「ボス攻撃範囲表示」がONかつ `Wireframe::IsDebugDrawEnabled()` の時に攻撃中心の球とボス位置→攻撃中心の線を描画し、Active中は赤、非Activeは薄色で表示する。 
- ImGui: 日本語ラベルで以下を追加・公開した: 「ボス攻撃半径」「ボス攻撃距離」「ボス攻撃高さ」「ボス攻撃前方オフセット」「ボス攻撃ダメージ」「攻撃判定開始時間」「攻撃判定終了時間」「ボス攻撃範囲表示」およびヒット統計表示。 
- GamePlayScene連携: `CharacterWorld::DrawEnemyTuningImGui()` / `GamePlayWorld::DrawEnemyTuningImGui()` / `GamePlayScene::DrawEnemyTuningImGui()` を追加し、代表1体の近接・中距離敵の `DrawImGui()` とボス調整・クリスタル/ボス戦状態をGamePlayScene側から開けるようにした。 
- プロジェクト: 新しいヘッダをVisual Studioプロジェクトファイルに登録してエディタからも参照できるようにした（vcxproj/filters更新）。 
- 実装上の補助関数追加: `CalculateAttackCenter()`, `IsAttackWindowActive()`, `DrawAttackRangeDebug()` を攻撃クラスに実装。 

### Testing
- 自動チェック: `git diff --check` を実行して差分チェックは問題無し（成功）。
- 構文バランス: ブレース整合（簡易スクリプト）を実行し、編集ファイルのブレースバランスは問題無し（成功）。
- コンパイル静的チェック: `clang++ -fsyntax-only` を用いた構文チェックを試行したが、コンテナ環境にWindows DirectX ヘッダ（`d3d12.h` 等）が無いため失敗した（環境依存のためWindows/MSBuild環境でのビルド確認をお願いします）。
- その他: 変更はImGui/Debug表示に依存するため、Debugビルド・エディタ上での実動確認（攻撃窓・ワイヤー表示・ApplyDamageの動作確認）をWindows環境で行ってください。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2025d541d4832d9ed5955e9a92dd34)