### PR TITLE
Fix ParameterManager save failure handling

### DIFF
--- a/Project/Engine/System/Parameters/ParameterManager.cpp
+++ b/Project/Engine/System/Parameters/ParameterManager.cpp
@@ -3,6 +3,43 @@
 #include <fstream>
 #include <LogString.h>
 #include <exception>
+#include <filesystem>
+#include <system_error>
+
+
+namespace
+{
+
+bool HasInvalidFileNameChars(const std::string& fileName)
+{
+	for (unsigned char c : fileName)
+	{
+		if (c < 0x20)
+		{
+			return true;
+		}
+
+		switch (c)
+		{
+		case '<':
+		case '>':
+		case ':':
+		case '"':
+		case '/':
+		case '\\':
+		case '|':
+		case '?':
+		case '*':
+			return true;
+		default:
+			break;
+		}
+	}
+
+	return false;
+}
+
+} // namespace
 
 namespace Ken4lowEngine
 {
@@ -133,13 +170,17 @@ void ParameterManager::Update(bool* pOpen)
 /// -------------------------------------------------------------
 ///			　			ファイルを保存する処理
 /// -------------------------------------------------------------
-void ParameterManager::SaveFile(const std::string& groupName)
+bool ParameterManager::SaveFile(const std::string& groupName)
 {
 	// グループ検索
 	auto itGroup = datas_.find(groupName);
 
-	// 未登録チェック
-	assert(itGroup != datas_.end());
+	// 未登録グループでは保存対象が無いため、停止せずログを残して呼び出し側へ失敗を返す。
+	if (itGroup == datas_.end())
+	{
+		Log("[ParameterManager] Failed to save unregistered group: " + groupName + "\n");
+		return false;
+	}
 
 	// JSONオブジェクト作成
 	json root = json::object();
@@ -193,29 +234,58 @@ void ParameterManager::SaveFile(const std::string& groupName)
 		}
 	}
 
-	// ディレクトリの作成（存在しない場合）
+	// 親ディレクトリが無い環境でも保存できるよう、保存先ディレクトリを再帰的に作成する。
 	std::filesystem::path dir(kDirectoryPath);
-	if (!std::filesystem::exists(kDirectoryPath))
+	std::error_code errorCode;
+	if (!std::filesystem::exists(dir, errorCode))
 	{
-		std::filesystem::create_directory(kDirectoryPath);
+		std::filesystem::create_directories(dir, errorCode);
+	}
+
+	if (errorCode)
+	{
+		Log("[ParameterManager] Failed to create save directory: " + dir.string() + ": " + errorCode.message() + "\n");
+		return false;
+	}
+
+	if (!std::filesystem::is_directory(dir, errorCode))
+	{
+		Log("[ParameterManager] Save path is not a directory: " + dir.string() + "\n");
+		return false;
 	}
 
 	// JSONファイルのパス
 	std::string filePath = kDirectoryPath + groupName + ".json";
 
-	// ファイルストリームで書き込み
+	if (HasInvalidFileNameChars(groupName))
+	{
+		Log("[ParameterManager] Warning: groupName contains characters that may be invalid for a file name: " + groupName + " (path: " + filePath + ")\n");
+	}
+
+	// ファイルを開けない場合も停止せず、保存できなかったパスをログに残す。
 	std::ofstream ofs(filePath);
 	if (ofs.fail())
 	{
-		std::string message = "Failed to open data file for write";
-		MessageBoxA(nullptr, message.c_str(), "GlobalVariables", 0);
-		assert(0);
-		return;
+		Log("[ParameterManager] Failed to open data file for write: " + filePath + "\n");
+		return false;
 	}
 
 	// JSONデータをファイルに書き込む
 	ofs << std::setw(4) << root << std::endl;
+	if (ofs.fail())
+	{
+		Log("[ParameterManager] Failed to write data file: " + filePath + "\n");
+		return false;
+	}
+
 	ofs.close();
+	if (ofs.fail())
+	{
+		Log("[ParameterManager] Failed to close data file after write: " + filePath + "\n");
+		return false;
+	}
+
+	return true;
 }
 
 

--- a/Project/Engine/System/Parameters/ParameterManager.h
+++ b/Project/Engine/System/Parameters/ParameterManager.h
@@ -57,7 +57,8 @@ public: /// ---------- メンバ関数 ---------- ///
 	/// ファイルに書き出し
 	/// </summary>
 	/// <param name="groupName">グループ名</param>
-	void SaveFile(const std::string& groupName);
+	/// <returns>保存できた場合はtrue、失敗時はfalse</returns>
+	bool SaveFile(const std::string& groupName);
 
 	/// <summary>
 	/// ディレクトリの全ファイル読み込み


### PR DESCRIPTION
### Motivation

- 保存に失敗した際に `MessageBoxA` と `assert(0)` によってアプリがクラッシュする問題を防ぐための修正です。 
- 保存に失敗したパスや失敗理由をログに残して調査できるようにするための変更です。 
- 影響範囲を `ParameterManager` 周辺に限定し、保存成功時の挙動は変えないことを優先しました。 

### Description

- `SaveFile` の戻り値を `void` から `bool` に変更し、成功時は `true`、失敗時は `false` を返すようにしました（ヘッダのドキュメントコメントも追加）。
- `std::ofstream` が開けなかったときの `MessageBoxA` / `assert(0)` を削除し、代わりに `Log(...)` で失敗した `filePath` を出力して `false` を返すようにしました（クラッシュを防止）。
- 保存先ディレクトリの作成を `std::filesystem::create_directories` に切り替え、`std::error_code` を用いたエラーチェックを追加して親ディレクトリが無い環境にも対応するようにしました。作成失敗時はログを残して `false` を返します。
- `groupName` がファイル名として問題になり得る文字を含むかを判定する `HasInvalidFileNameChars` 関数を追加し、不正文字が検出された場合はパス付きで警告ログを出すようにしました。
- 必要な `#include`（`<filesystem>`, `<system_error>`）を追加し、書き込み／フラッシュ／クローズの失敗時にもパス付きでログを残して `false` を返すようにしました。
- 変更は `Project/Engine/System/Parameters/ParameterManager.cpp` とヘッダのみで行い、既存の保存成功時の挙動は維持しています（`Save All` 等で戻り値を無視して呼ぶコードはそのまま動作します）。

### Testing

- `git diff --check` を実行して差分の基本チェックを行い、問題は報告されませんでした（成功）。
- コード内の痕跡確認として `rg` を使い `MessageBoxA` / `assert(0)` / `create_directory` 等の検索を行い、置換・修正が適切に行われていることを確認しました（成功）。
- `msbuild Project/Ken4lowEngine.sln /p:Configuration=Debug /p:Platform=x64` および `msbuild ... /p:Configuration=Release` を実行しましたが、この環境に `msbuild` が無くビルドは実行できませんでした（失敗／環境依存）。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20e664fcdc832d82e8e2301a146673)