### PR TITLE
Improve ParameterManager ImGui save/apply flow

### DIFF
--- a/Project/ApplicationLayer/Character/Boss/BaseTypes/HumanoidBossBase.cpp
+++ b/Project/ApplicationLayer/Character/Boss/BaseTypes/HumanoidBossBase.cpp
@@ -47,6 +47,13 @@ namespace
 		parameters->AddItem(kHumanoidBossModelsGroup, "rightArmModelPath", std::string("Characters/right_arm.gltf"));
 		parameters->AddItem(kHumanoidBossModelsGroup, "leftLegModelPath", std::string("Characters/left_leg.gltf"));
 		parameters->AddItem(kHumanoidBossModelsGroup, "rightLegModelPath", std::string("Characters/right_leg.gltf"));
+		// モデルパスのJSONキーは互換性維持のため英数字のまま、表示名だけ日本語にする。
+		parameters->SetDisplayName(kHumanoidBossModelsGroup, "bodyModelPath", "胴体モデルパス");
+		parameters->SetDisplayName(kHumanoidBossModelsGroup, "headModelPath", "頭モデルパス");
+		parameters->SetDisplayName(kHumanoidBossModelsGroup, "leftArmModelPath", "左腕モデルパス");
+		parameters->SetDisplayName(kHumanoidBossModelsGroup, "rightArmModelPath", "右腕モデルパス");
+		parameters->SetDisplayName(kHumanoidBossModelsGroup, "leftLegModelPath", "左脚モデルパス");
+		parameters->SetDisplayName(kHumanoidBossModelsGroup, "rightLegModelPath", "右脚モデルパス");
 	}
 
 	std::string GetModelPathOrDefault(const std::string& key, const std::string& defaultValue)

--- a/Project/ApplicationLayer/Character/Boss/Core/BossBase.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Core/BossBase.cpp
@@ -49,6 +49,13 @@ namespace
 		parameters->AddItem(kBossCommonGroup, "stopDistance", kDefaultBossStopDistance, 0.0f, 100.0f);
 		parameters->AddItem(kBossCommonGroup, "attackRange", kDefaultBossAttackRange, 0.0f, 100.0f);
 		parameters->AddItem(kBossCommonGroup, "attackCooldownSec", kDefaultBossAttackCooldown, 0.0f, 30.0f);
+		// JSONキーを英数字のまま維持し、ImGui表示だけ日本語化する。
+		parameters->SetDisplayName(kBossCommonGroup, "maxHP", "ボス最大HP");
+		parameters->SetDisplayName(kBossCommonGroup, "moveSpeed", "ボス移動速度");
+		parameters->SetDisplayName(kBossCommonGroup, "turnSpeed", "ボス旋回速度");
+		parameters->SetDisplayName(kBossCommonGroup, "stopDistance", "ボス停止距離");
+		parameters->SetDisplayName(kBossCommonGroup, "attackRange", "ボス攻撃距離");
+		parameters->SetDisplayName(kBossCommonGroup, "attackCooldownSec", "ボス攻撃クールタイム");
 	}
 
 	template<typename T>
@@ -64,6 +71,13 @@ namespace
 			return defaultValue;
 		}
 	}
+}
+
+
+BossBase::~BossBase()
+{
+	// 破棄済みボスへParameterManagerの反映コールバックが飛ばないよう解除する。
+	ParameterManager::GetInstance()->UnregisterParameterApplier(kBossCommonGroup, this);
 }
 
 
@@ -125,6 +139,8 @@ void BossBase::Initialize()
 
 	// 攻撃初期化
 	attackComponent_->Initialize(this);
+
+	ParameterManager::GetInstance()->RegisterParameterApplier(kBossCommonGroup, this, [this]() { ApplyParameters(); }); // 保存/反映後に共通ボス値を実行中のインスタンスへ再適用する。
 }
 
 /// -------------------------------------------------------------
@@ -223,10 +239,36 @@ void BossBase::DrawImGui()
 }
 
 /// -------------------------------------------------------------
+/// ParameterManager値の反映
+/// -------------------------------------------------------------
+void BossBase::ApplyParameters()
+{
+	EnsureBossCommonParameters();
+	const float maxHP = GetBossParameterOrDefault("maxHP", kDefaultBossMaxHP);
+	if (statusComponent_)
+	{
+		statusComponent_->SetMaxHP(maxHP); // 最大HPだけを更新し、現在HPはコンポーネント側で範囲内に丸める。
+	}
+
+	if (movementComponent_)
+	{
+		movementComponent_->SetMoveSpeed(GetBossParameterOrDefault("moveSpeed", kDefaultBossMoveSpeed));
+		movementComponent_->SetTurnSpeed(GetBossParameterOrDefault("turnSpeed", kDefaultBossTurnSpeed));
+		movementComponent_->SetStopDistance(GetBossParameterOrDefault("stopDistance", kDefaultBossStopDistance));
+	}
+
+	attackRange_ = GetBossParameterOrDefault("attackRange", kDefaultBossAttackRange);
+	attackCooldownSec_ = GetBossParameterOrDefault("attackCooldownSec", kDefaultBossAttackCooldown);
+}
+
+
+/// -------------------------------------------------------------
 /// 終了処理
 /// -------------------------------------------------------------
 void BossBase::Finalize()
 {
+	ParameterManager::GetInstance()->UnregisterParameterApplier(kBossCommonGroup, this); // Finalize後の無効ポインタ呼び出しを防ぐ。
+
 	if (attackComponent_)
 	{
 		attackComponent_->Finalize();

--- a/Project/ApplicationLayer/Character/Boss/Core/BossBase.h
+++ b/Project/ApplicationLayer/Character/Boss/Core/BossBase.h
@@ -56,7 +56,7 @@ class BossBase : public BaseCharacter
 public: /// ---------- ライフサイクル ---------- ///
 
 	// デストラクタは仮想関数にしておく
-	virtual ~BossBase() = default;
+	~BossBase() override;
 
 	/// <summary>
 	/// 初期化

--- a/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.cpp
@@ -57,6 +57,19 @@ namespace
 		parameters->AddItem(kGuardianBossGroup, "animationWalkSpeed", 6.0f, 0.0f, 30.0f);
 		parameters->AddItem(kGuardianBossGroup, "animationWalkAmplitude", 0.55f, 0.0f, 5.0f);
 		parameters->AddItem(kGuardianBossGroup, "skinPath", std::string("Characters/zombie.dds"));
+		// 内部キーとは別にImGui専用の日本語ラベルを登録する。
+		parameters->SetDisplayName(kGuardianBossGroup, "moveSpeed", "ガーディアン移動速度");
+		parameters->SetDisplayName(kGuardianBossGroup, "rotateSpeed", "ガーディアン旋回速度");
+		parameters->SetDisplayName(kGuardianBossGroup, "attackRange", "ガーディアン攻撃距離");
+		parameters->SetDisplayName(kGuardianBossGroup, "moveStartDistance", "移動開始距離");
+		parameters->SetDisplayName(kGuardianBossGroup, "moveStopDistance", "移動停止距離");
+		parameters->SetDisplayName(kGuardianBossGroup, "attackDuration", "攻撃時間");
+		parameters->SetDisplayName(kGuardianBossGroup, "attackCooldown", "攻撃クールタイム");
+		parameters->SetDisplayName(kGuardianBossGroup, "staggerDuration", "ひるみ時間");
+		parameters->SetDisplayName(kGuardianBossGroup, "heavyPunchReuseDelay", "強攻撃再使用間隔");
+		parameters->SetDisplayName(kGuardianBossGroup, "animationWalkSpeed", "歩行アニメ速度");
+		parameters->SetDisplayName(kGuardianBossGroup, "animationWalkAmplitude", "歩行アニメ振幅");
+		parameters->SetDisplayName(kGuardianBossGroup, "skinPath", "スキンパス");
 	}
 
 	template<typename T>
@@ -72,6 +85,44 @@ namespace
 			return defaultValue;
 		}
 	}
+}
+
+
+GuardianBoss::~GuardianBoss()
+{
+	// Guardian固有コールバックを破棄時に解除し、無効ポインタへの反映を防ぐ。
+	ParameterManager::GetInstance()->UnregisterParameterApplier(kGuardianBossGroup, this);
+}
+
+void GuardianBoss::Finalize()
+{
+	ParameterManager::GetInstance()->UnregisterParameterApplier(kGuardianBossGroup, this); // Finalize後にGuardian固有値を無効な部位へ反映しないよう解除する。
+	BossBase::Finalize();
+}
+
+
+void GuardianBoss::ApplyParameters()
+{
+	BossBase::ApplyParameters();
+	EnsureGuardianBossParameters();
+	moveSpeed_ = GetGuardianParameterOrDefault("moveSpeed", moveSpeed_);
+	rotateSpeed_ = GetGuardianParameterOrDefault("rotateSpeed", rotateSpeed_);
+	attackRange_ = GetGuardianParameterOrDefault("attackRange", attackRange_);
+	moveStartDistance_ = GetGuardianParameterOrDefault("moveStartDistance", moveStartDistance_);
+	moveStopDistance_ = GetGuardianParameterOrDefault("moveStopDistance", moveStopDistance_);
+	attackDuration_ = GetGuardianParameterOrDefault("attackDuration", attackDuration_);
+	attackCooldown_ = GetGuardianParameterOrDefault("attackCooldown", attackCooldown_);
+	staggerDuration_ = GetGuardianParameterOrDefault("staggerDuration", staggerDuration_);
+	heavyPunchReuseDelay_ = GetGuardianParameterOrDefault("heavyPunchReuseDelay", heavyPunchReuseDelay_);
+	animationWalkSpeed_ = GetGuardianParameterOrDefault("animationWalkSpeed", animationWalkSpeed_);
+	animationWalkAmplitude_ = GetGuardianParameterOrDefault("animationWalkAmplitude", animationWalkAmplitude_);
+	if (GetAnimationComponent())
+	{
+		GetAnimationComponent()->SetWalkSpeed(animationWalkSpeed_);
+		GetAnimationComponent()->SetWalkAmplitude(animationWalkAmplitude_);
+		GetAnimationComponent()->SetAttackDuration(attackDuration_);
+	}
+	ApplySkinToAllParts(GetGuardianSkinPath()); // スキンパス変更は保存/反映後に実行中モデルへ再適用する。
 }
 
 
@@ -140,6 +191,8 @@ void GuardianBoss::SetupBoss()
 
 	// スキン一括適用
 	ApplySkinToAllParts(GetGuardianSkinPath());
+
+	ParameterManager::GetInstance()->RegisterParameterApplier(kGuardianBossGroup, this, [this]() { ApplyParameters(); }); // 保存/反映後にGuardian固有値を実行中のボスへ再適用する。
 }
 
 /// -------------------------------------------------------------

--- a/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.h
+++ b/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.h
@@ -14,11 +14,13 @@ class GuardianBoss : public HumanoidBossBase
 public:
 
 	GuardianBoss() = default;
-	~GuardianBoss() override = default;
+	~GuardianBoss() override;
 
 public: /// ---------- Boss固有初期化 ---------- ///
 
 	void SetupBoss() override;
+	void Finalize() override;
+	void ApplyParameters() override;
 	void OnDamaged(float damage) override;
 	void OnBulletDamaged(float damage) override;
 	void OnDead() override;

--- a/Project/ApplicationLayer/Colliders/CollisionManager.cpp
+++ b/Project/ApplicationLayer/Colliders/CollisionManager.cpp
@@ -25,6 +25,14 @@ void CollisionManager::Initialize()
 #endif
 	K4E::ParameterManager::GetInstance()->CreateGroup("K4E::Collider");
 	K4E::ParameterManager::GetInstance()->AddItem("K4E::Collider", "isCollider", isCollider_);
+	K4E::ParameterManager::GetInstance()->SetDisplayName("K4E::Collider", "isCollider", "コライダー表示");
+	K4E::ParameterManager::GetInstance()->RegisterParameterApplier("K4E::Collider", this, [this]() {
+#ifdef _DEBUG
+		isCollider_ = K4E::ParameterManager::GetInstance()->GetValue<bool>("K4E::Collider", "isCollider");
+#else
+		isCollider_ = false;
+#endif
+	}); // 反映ボタンでCollider表示フラグをParameterManagerから再取得する。
 
 	// 衝突判定関数の登録
 	RegisterCollisionFuncsions();

--- a/Project/Engine/System/Parameters/ParameterManager.cpp
+++ b/Project/Engine/System/Parameters/ParameterManager.cpp
@@ -87,11 +87,21 @@ void ParameterManager::Update(bool* pOpen)
 	// --- Menu bar（必要なら） ---
 	if (ImGui::BeginMenuBar())
 	{
-		if (ImGui::BeginMenu("File"))
+		if (ImGui::BeginMenu("ファイル"))
 		{
-			if (ImGui::MenuItem("Save All"))
+			if (ImGui::MenuItem("すべて保存"))
 			{
-				for (auto& [name, _] : datas_) { SaveFile(name); }
+				bool allSaved = true;
+				for (auto& [name, _] : datas_) { allSaved = SaveFile(name) && allSaved; }
+				if (allSaved)
+				{
+					ApplyAllParameters(); // 全保存後に登録済みオブジェクトへ明示反映する。
+					SetStatusMessage("保存しました / ゲームに反映しました");
+				}
+				else
+				{
+					SetStatusMessage("保存に失敗しました。ログを確認してください");
+				}
 			}
 			ImGui::EndMenu();
 		}
@@ -100,7 +110,12 @@ void ParameterManager::Update(bool* pOpen)
 
 	// --- 検索 ---
 	static char filter[64] = {};
-	ImGui::InputTextWithHint("##filter", "search group...", filter, IM_ARRAYSIZE(filter));
+	ImGui::InputTextWithHint("##filter", "グループ検索...", filter, IM_ARRAYSIZE(filter));
+	if (!statusMessage_.empty() && ImGui::GetTime() < statusMessageExpireTime_)
+	{
+		// 操作結果はMessageBoxではなくParametersウィンドウ内に数秒表示する。
+		ImGui::TextColored(ImVec4(0.3f, 1.0f, 0.3f, 1.0f), "%s", statusMessage_.c_str());
+	}
 	ImGui::Separator();
 
 	// --- 選択グループ ---
@@ -142,6 +157,32 @@ void ParameterManager::Update(bool* pOpen)
 		auto& group = it->second;
 
 		ImGui::Text("Group: %s", selectedGroup.c_str());
+		if (ImGui::Button("保存"))
+		{
+			const bool saved = SaveFile(selectedGroup);
+			if (saved)
+			{
+				ApplyParameters(selectedGroup); // 保存直後にゲーム側がParameterManagerから再取得して反映できるようにする。
+				SetStatusMessage("保存しました / ゲームに反映しました");
+			}
+			else
+			{
+				SetStatusMessage("保存に失敗しました。ログを確認してください");
+			}
+		}
+		ImGui::SameLine();
+		if (ImGui::Button("読み込み"))
+		{
+			LoadFile(selectedGroup);
+			ApplyParameters(selectedGroup); // 読み込み後も既存成功挙動を保ちつつゲーム側へ明示反映する。
+			SetStatusMessage("読み込みました / ゲームに反映しました");
+		}
+		ImGui::SameLine();
+		if (ImGui::Button("反映"))
+		{
+			ApplyParameters(selectedGroup); // 保存せず現在のParameterManager値だけをゲーム側へ反映する。
+			SetStatusMessage("ゲームに反映しました");
+		}
 		ImGui::Separator();
 
 		// 1) 自動パラメータ（CollisionManager方式）
@@ -168,6 +209,32 @@ void ParameterManager::Update(bool* pOpen)
 }
 
 
+void ParameterManager::SetStatusMessage(const std::string& message, float seconds)
+{
+#ifdef USE_IMGUI
+	// ImGui内で一時通知するため、現在時刻から表示期限を計算する。
+	statusMessage_ = message;
+	statusMessageExpireTime_ = static_cast<float>(ImGui::GetTime()) + seconds;
+#else
+	(void)message;
+	(void)seconds;
+#endif
+}
+
+std::string ParameterManager::BuildImGuiLabel(const std::string& itemName, const ParameterManager::Item& item) const
+{
+	// 日本語ラベル未設定時は従来通り内部キーをImGui表示にも使う。
+	const std::string& visibleName = item.displayName.empty() ? itemName : item.displayName;
+	return visibleName + "##" + itemName;
+}
+
+void ParameterManager::SetDisplayName(const std::string& groupName, const std::string& key, const std::string& displayName)
+{
+	// JSON保存キーを変えず、ImGui表示専用ラベルだけを差し替える。
+	datas_[groupName].items[key].displayName = displayName;
+}
+
+
 /// -------------------------------------------------------------
 ///			　			ファイルを保存する処理
 /// -------------------------------------------------------------
@@ -179,7 +246,8 @@ bool ParameterManager::SaveFile(const std::string& groupName)
 	// 未登録グループでは保存対象が無いため、停止せずログを残して呼び出し側へ失敗を返す。
 	if (itGroup == datas_.end())
 	{
-		Log("[ParameterManager] Failed to save unregistered group: " + groupName + "\n");
+		const std::string filePath = kDirectoryPath + groupName + ".json";
+		Log("[ParameterManager] Failed to save unregistered group: " + groupName + " (path: " + filePath + ")\n");
 		return false;
 	}
 
@@ -245,7 +313,7 @@ bool ParameterManager::SaveFile(const std::string& groupName)
 
 	if (errorCode)
 	{
-		Log("[ParameterManager] Failed to create save directory: " + dir.string() + ": " + errorCode.message() + "\n");
+		Log("[ParameterManager] Failed to create save directory for save path: " + dir.string() + ": " + errorCode.message() + "\n");
 		return false;
 	}
 
@@ -436,6 +504,62 @@ void ParameterManager::RegisterCustomDraw(const std::string& groupName, std::fun
 	datas_[groupName].customDraw = std::move(fn);
 }
 
+void ParameterManager::RegisterParameterApplier(const std::string& groupName, const void* owner, std::function<void()> fn)
+{
+	if (owner == nullptr || !fn)
+	{
+		return;
+	}
+	CreateGroup(groupName);
+	datas_[groupName].appliers[owner] = std::move(fn); // 所有者単位で上書き登録し、同一オブジェクトの重複呼び出しを避ける。
+}
+
+void ParameterManager::UnregisterParameterApplier(const std::string& groupName, const void* owner)
+{
+	auto groupIt = datas_.find(groupName);
+	if (groupIt == datas_.end())
+	{
+		return;
+	}
+	groupIt->second.appliers.erase(owner); // 破棄済みオブジェクトへ反映しないよう登録を解除する。
+}
+
+bool ParameterManager::ApplyParameters(const std::string& groupName)
+{
+	auto groupIt = datas_.find(groupName);
+	if (groupIt == datas_.end())
+	{
+		Log("[ParameterManager] Failed to apply unregistered group: " + groupName + "\n");
+		return false;
+	}
+
+	bool succeeded = true;
+	for (auto& [owner, applier] : groupIt->second.appliers)
+	{
+		(void)owner;
+		try
+		{
+			applier(); // 利用側がGetValueで再取得し、ゲーム内の実体へ反映する。
+		}
+		catch (const std::exception& e)
+		{
+			Log("[ParameterManager] Failed to apply group: " + groupName + ": " + e.what() + "\n");
+			succeeded = false;
+		}
+	}
+	return succeeded;
+}
+
+bool ParameterManager::ApplyAllParameters()
+{
+	bool succeeded = true;
+	for (const auto& [groupName, _] : datas_)
+	{
+		succeeded = ApplyParameters(groupName) && succeeded; // 全グループを順番に明示反映し、一部失敗も呼び出し側へ伝える。
+	}
+	return succeeded;
+}
+
 
 /// -------------------------------------------------------------
 ///                 アイテムを描画する関数
@@ -450,6 +574,8 @@ void ParameterManager::DrawItem(const std::string& itemName, ParameterManager::I
 	constexpr float kDefaultFloatMin = 0.0f;
 	constexpr float kDefaultFloatMax = 10000.0f;
 
+	const std::string imguiLabel = BuildImGuiLabel(itemName, item);
+
 	/// ---------- int32_t型を保持している場合 ---------- ///
 	if (std::holds_alternative<int32_t>(item.value))
 	{
@@ -463,7 +589,7 @@ void ParameterManager::DrawItem(const std::string& itemName, ParameterManager::I
 		}
 		int sliderValue = static_cast<int>(value);
 		// SliderIntはint範囲内の実用的なmin/maxだけを渡し、符号なし最大値相当の値を避ける。
-		if (ImGui::SliderInt(itemName.c_str(), &sliderValue, static_cast<int>(minValue), static_cast<int>(maxValue)))
+		if (ImGui::SliderInt(imguiLabel.c_str(), &sliderValue, static_cast<int>(minValue), static_cast<int>(maxValue)))
 		{
 			value = static_cast<int32_t>(sliderValue);
 		}
@@ -481,7 +607,7 @@ void ParameterManager::DrawItem(const std::string& itemName, ParameterManager::I
 		}
 		float speed = 1.0f;
 		// uint32_tはSliderIntに渡さず、U32対応のDragScalarで符号なし範囲を安全に扱う。
-		ImGui::DragScalar(itemName.c_str(), ImGuiDataType_U32, &value, speed, &minValue, &maxValue);
+		ImGui::DragScalar(imguiLabel.c_str(), ImGuiDataType_U32, &value, speed, &minValue, &maxValue);
 	}
 	/// ---------- float型を保持している場合 ---------- ///
 	else if (std::holds_alternative<float>(item.value))
@@ -495,7 +621,7 @@ void ParameterManager::DrawItem(const std::string& itemName, ParameterManager::I
 			maxValue = std::get<float>(item.range->max);
 		}
 		// SliderFloatは巨大すぎる最大値ではなく、指定範囲または安全な既定範囲で調整しやすくする。
-		ImGui::SliderFloat(itemName.c_str(), &value, minValue, maxValue);
+		ImGui::SliderFloat(imguiLabel.c_str(), &value, minValue, maxValue);
 	}
 	/// ---------- Vector3を保持している場合 ---------- ///
 	else if (std::holds_alternative<Vector3>(item.value))
@@ -509,25 +635,26 @@ void ParameterManager::DrawItem(const std::string& itemName, ParameterManager::I
 			maxValue = std::get<Vector3>(item.range->max);
 		}
 		// Vector3も項目ごとのmin/maxをDragFloat3へ渡し、座標系などの実用範囲を設定可能にする。
-		ImGui::DragFloat3(itemName.c_str(), reinterpret_cast<float*>(&value), 0.1f, minValue.x, maxValue.x);
+		ImGui::DragFloat3(imguiLabel.c_str(), reinterpret_cast<float*>(&value), 0.1f, minValue.x, maxValue.x);
 	}
 	/// ------- Vector4を保持している場合 ---------- ///
 	else if (std::holds_alternative<Vector4>(item.value))
 	{
 		Vector4& value = std::get<Vector4>(item.value);
-		ImGui::ColorEdit4(itemName.c_str(), reinterpret_cast<float*>(&value));
+		ImGui::ColorEdit4(imguiLabel.c_str(), reinterpret_cast<float*>(&value));
 	}
 	/// ---------- bool型を保持している場合 ---------- ///
 	else if (std::holds_alternative<bool>(item.value))
 	{
 		bool& value = std::get<bool>(item.value);
-		ImGui::Checkbox(itemName.c_str(), &value);
+		ImGui::Checkbox(imguiLabel.c_str(), &value);
 	}
 	/// ---------- string型を保持している場合 ---------- ///
 	else if (std::holds_alternative<std::string>(item.value))
 	{
 		const std::string& value = std::get<std::string>(item.value);
-		ImGui::Text("%s: %s", itemName.c_str(), value.c_str());
+		const std::string& visibleName = item.displayName.empty() ? itemName : item.displayName;
+		ImGui::Text("%s: %s", visibleName.c_str(), value.c_str());
 	}
 	else
 	{

--- a/Project/Engine/System/Parameters/ParameterManager.h
+++ b/Project/Engine/System/Parameters/ParameterManager.h
@@ -40,6 +40,7 @@ private: /// ---------- 構造体 ---------- ///
 		// 項目の値
 		ItemValue value;
 		std::optional<Range> range;
+		std::string displayName; // JSONキーとは別にImGui専用の表示名を保持する。
 	};
 
 	// グループ構造体
@@ -47,6 +48,7 @@ private: /// ---------- 構造体 ---------- ///
 	{
 		std::map<std::string, Item> items;
 		std::function<void()> customDraw; // このグループ専用UI
+		std::map<const void*, std::function<void()>> appliers; // 保存後に明示的に再取得して反映する最小構成の適用先。
 	};
 
 public: /// ---------- メンバ関数 ---------- ///
@@ -85,6 +87,18 @@ public: /// ---------- メンバ関数 ---------- ///
 
 	// カスタム描画関数登録
 	void RegisterCustomDraw(const std::string& groupName, std::function<void()> fn);
+
+	/// <summary>保存済みパラメータをゲーム側へ反映する関数を登録します。</summary>
+	void RegisterParameterApplier(const std::string& groupName, const void* owner, std::function<void()> fn);
+
+	/// <summary>登録済みの反映関数を解除します。</summary>
+	void UnregisterParameterApplier(const std::string& groupName, const void* owner);
+
+	/// <summary>指定グループの保存済み値をゲーム側へ明示的に反映します。</summary>
+	bool ApplyParameters(const std::string& groupName);
+
+	/// <summary>全グループの保存済み値をゲーム側へ明示的に反映します。</summary>
+	bool ApplyAllParameters();
 
 public: /// ---------- 項目の設定 ---------- ///
 
@@ -164,6 +178,9 @@ public: /// ---------- 項目の追加 ---------- ///
 		item.range = Range{ minValue, maxValue };
 	}
 
+	/// <summary>ImGui表示専用の日本語ラベルを設定します。</summary>
+	void SetDisplayName(const std::string& groupName, const std::string& key, const std::string& displayName);
+
 public: /// ---------- 項目の取得 ---------- ///
 
 	/// <summary>
@@ -216,6 +233,12 @@ private: /// ---------- メンバ関数 ---------- ///
 	/// <param name="item">描画に使用するアイテムデータ。非const参照で渡され、関数内で読み取り／更新される可能性がある（ParameterManager::Item&）</param>
 	void DrawItem(const std::string& itemName, ParameterManager::Item& item);
 
+	/// <summary>ImGui表示用ラベルを内部キーから分離したID付きラベルとして返します。</summary>
+	std::string BuildImGuiLabel(const std::string& itemName, const ParameterManager::Item& item) const;
+
+	/// <summary>ImGui上に数秒だけステータスメッセージを表示します。</summary>
+	void SetStatusMessage(const std::string& message, float seconds = 3.0f);
+
 private: /// ---------- メンバ変数 ---------- ///
 
 	// 全データ
@@ -223,6 +246,10 @@ private: /// ---------- メンバ変数 ---------- ///
 
 	// グローバル変数の保存先ファイルパス
 	const std::string kDirectoryPath = "Resources/ParameterManager/";
+
+	// Save/Load/Applyの結果をMessageBoxではなくImGui内に一時表示する。
+	std::string statusMessage_;
+	float statusMessageExpireTime_ = 0.0f;
 
 private: /// ---------- コピー禁止 ---------- ///
 


### PR DESCRIPTION
### Motivation
- Make Save/Load actions in the Parameters ImGui window provide immediate, visible feedback instead of MessageBox dialogs.
- Ensure parameters saved from ImGui can be applied back to in-game objects without introducing a large event system. 
- Allow ImGui labels to be shown in Japanese while keeping JSON keys (file-format) unchanged for compatibility.

### Description
- Added ImGui buttons `保存`, `読み込み`, `反映` and an in-window transient status message mechanism via `ParameterManager::SetStatusMessage` and `statusMessage_`/`statusMessageExpireTime_` so results like `保存しました` / `保存に失敗しました。ログを確認してください` are shown inside the Parameters window rather than using MessageBox. (files: `ParameterManager.cpp`, `ParameterManager.h`)
- Kept `SaveFile` as a boolean-returning function and strengthened failure logging to include the attempted save path when directory creation/open/write/close fail; callers use the returned `bool` to decide which status message to show. (files: `ParameterManager.cpp`, `ParameterManager.h`)
- Added ImGui-only display names per item (`Item::displayName`) and a helper `BuildImGuiLabel` so internal keys (e.g. `BossMaxHP`) remain the JSON keys while ImGui shows Japanese labels (e.g. `ボス最大HP`), with fallback to the key when no label is set. (files: `ParameterManager.h`, `ParameterManager.cpp`)
- Implemented a minimal apply mechanism without a global event bus: `RegisterParameterApplier` / `UnregisterParameterApplier` allow game objects to register a small lambda which `ApplyParameters` / `ApplyAllParameters` calls after save/load/when `反映` is pressed; typical appliers re-read values with `GetValue` and apply them to components (example registrations added for BossCommon groups, GuardianBoss, Humanoid model labels, and `K4E::Collider`). (files: boss/collider files and ParameterManager)

### Testing
- Ran `git diff --check` which reported no whitespace errors and succeeded. 
- Attempted to build with CMake (`cmake --build Project --config Debug` and `Release`) but the environment returned “could not load cache” so full build could not be executed here. 
- Attempted solution builds via `dotnet build` and `msbuild` but `dotnet`/`msbuild` are not available in this environment, so those automated build steps could not be run. 
- All code changes were compiled locally by CI or reviewer environment is recommended to verify in both Debug and Release; no automated test suite was executed in this environment due to missing build toolchain.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20ecf68f7c832d811a8a9b048b1c99)