### PR TITLE
Declare BossBase::ApplyParameters() to match derived overrides

### DIFF
--- a/Project/ApplicationLayer/Character/Boss/Core/BossBase.h
+++ b/Project/ApplicationLayer/Character/Boss/Core/BossBase.h
@@ -91,6 +91,11 @@ public: /// ---------- ライフサイクル ---------- ///
 	/// </summary>
 	virtual void Finalize();
 
+	/// <summary>
+	/// ParameterManager の共通ボス値を実行中のインスタンスへ反映する
+	/// </summary>
+	virtual void ApplyParameters();
+
 public: /// ---------- 衝突 ---------- ///
 
 	/// <summary>


### PR DESCRIPTION
### Motivation
- Fix compilation errors caused by `GuardianBoss::ApplyParameters()` being marked `override` while the base class lacked a virtual declaration, and ensure `ParameterManager` callbacks can call the common applier method on `BossBase` instances.

### Description
- Add `virtual void ApplyParameters();` to `Project/ApplicationLayer/Character/Boss/Core/BossBase.h` so the existing `BossBase::ApplyParameters()` implementation and `GuardianBoss::ApplyParameters() override` are consistent and use only existing members; no other implementation changes or member-name guesses were introduced.

### Testing
- Ran `git diff --check` which produced no whitespace/patch errors; this succeeded.
- Attempted to run `msbuild Project/Ken4lowEngine.sln /p:Configuration=Debug /p:Platform=x64` and `msbuild Project/Ken4lowEngine.sln /p:Configuration=Release /p:Platform=x64` but both could not be executed in this environment because `msbuild` is not installed (builds were not run here).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20efd2eaa8832db034c60cb6420f0c)