### PR TITLE
Add fan-shaped melee hit angle for Guardian boss attacks

### DIFF
--- a/Project/ApplicationLayer/Character/Boss/Attacks/BossHeavyPunchAttack.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Attacks/BossHeavyPunchAttack.cpp
@@ -284,6 +284,7 @@ void BossHeavyPunchAttack::DrawImGui()
 	ImGui::Text("HitRange          : %.2f", hitRange_);
 	ImGui::Text("HitRadius         : %.2f", hitRadius_);
 	ImGui::Text("HitForwardOffset  : %.2f", hitForwardOffset_);
+	ImGui::Text("HitAngleDeg       : %.2f", hitAngleDeg_);
 	ImGui::Text("Damage            : %.2f", damage_);
 #endif
 }
@@ -293,10 +294,9 @@ void BossHeavyPunchAttack::DrawImGui()
 /// ---------------------------------------------------------------
 void BossHeavyPunchAttack::TryHitPlayer()
 {
-	// 所有者がいないときは何もしない
 	if (owner_ == nullptr) return;
 
-	// 攻撃判定は攻撃開始距離とは別に、ParameterManager由来のリーチ・半径・前方オフセットで計算する。
+	// 攻撃判定は攻撃開始距離とは別に、ParameterManager由来のリーチ・半径・前方オフセット・扇形角度で計算する。
 	const K4E::Vector3 bossCenter = owner_->GetCenterPosition();
 	const float yaw = owner_->GetYaw();
 
@@ -310,20 +310,19 @@ void BossHeavyPunchAttack::TryHitPlayer()
 	const float clampedForwardOffset = std::max(0.0f, hitForwardOffset_);
 	const float clampedHitRange = std::max(clampedForwardOffset, hitRange_);
 	const float clampedHitRadius = std::max(0.0f, hitRadius_);
+	const float clampedHitAngleDeg = std::clamp(hitAngleDeg_, 0.0f, 360.0f);
 
 	K4E::Vector3 attackCenter = bossCenter;
 	attackCenter.x += forward.x * clampedForwardOffset;
 	attackCenter.y += 0.30f;
 	attackCenter.z += forward.z * clampedForwardOffset;
 
-	// -----------------------------------------------------------
-	// 仮のプレイヤー中心
-	// 今は targetPosition_ を使用
-	// -----------------------------------------------------------
 	const K4E::Vector3 targetCenter = owner_->GetTargetPosition();
 
 	const float toTargetX = targetCenter.x - bossCenter.x;
 	const float toTargetZ = targetCenter.z - bossCenter.z;
+	const float horizontalDistanceSq = toTargetX * toTargetX + toTargetZ * toTargetZ;
+	const float horizontalDistance = std::sqrt(horizontalDistanceSq);
 	const float forwardDistance = toTargetX * forward.x + toTargetZ * forward.z;
 	const float closestForwardDistance = std::clamp(forwardDistance, clampedForwardOffset, clampedHitRange);
 
@@ -336,17 +335,26 @@ void BossHeavyPunchAttack::TryHitPlayer()
 	const float dy = targetCenter.y - closestPoint.y;
 	const float dz = targetCenter.z - closestPoint.z;
 
-	// 攻撃判定リーチ上の最近点とターゲット中心の距離で、重攻撃の前方判定を伸ばす。
 	const float distanceSq = dx * dx + dy * dy + dz * dz;
 	const float sumRadius = clampedHitRadius + targetRadius_;
+	const bool isInsideCapsule = distanceSq <= (sumRadius * sumRadius);
 
-	if (distanceSq <= (sumRadius * sumRadius))
+	constexpr float kDegToRad = 3.14159265358979323846f / 180.0f;
+	const float directionDot = (horizontalDistance > 0.0001f) ? (forwardDistance / horizontalDistance) : 1.0f;
+	const float angleCos = std::cos(clampedHitAngleDeg * 0.5f * kDegToRad);
+	const bool isInsideHitAngle = (clampedHitAngleDeg >= 360.0f) || (directionDot >= angleCos);
+	const bool isInsideHitRange = horizontalDistance <= (clampedHitRange + targetRadius_);
+	const bool isInsideHitHeight = std::abs(targetCenter.y - attackCenter.y) <= sumRadius;
+	const bool isInsideFan = isInsideHitRange && isInsideHitAngle && isInsideHitHeight;
+
+	// 細い前方カプセルに加えて扇形条件を許可し、斜め前のプレイヤーにも自然に当たるようにする。
+	if (isInsideCapsule || isInsideFan)
 	{
 #ifdef _DEBUG
 		Log("[BossHeavyPunchAttack] Heavy hit success.\n");
 #endif
 
-		// ボス重攻撃の範囲判定が成立した瞬間だけPlayerへダメージを流す。
+		// ボス近接攻撃の発生フレームで1回だけPlayerへダメージを流す。
 		if (owner_->ApplyDamageToTargetPlayer(damage_, &attackCenter))
 		{
 			Log("[BossHeavyPunchAttack] Player damage applied.\n");
@@ -402,10 +410,11 @@ void BossHeavyPunchAttack::SetValidRange(float minRange, float maxRange)
 /// ---------------------------------------------------------------
 ///					実際の攻撃判定パラメータを設定
 /// ---------------------------------------------------------------
-void BossHeavyPunchAttack::SetHitParameters(float hitRange, float hitRadius, float hitForwardOffset)
+void BossHeavyPunchAttack::SetHitParameters(float hitRange, float hitRadius, float hitForwardOffset, float hitAngleDeg)
 {
-	// ParameterManagerの反映ボタンから、攻撃判定の届く距離だけを実行中攻撃へ差し替える。
+	// ParameterManagerの反映ボタンから、攻撃判定の届く距離・太さ・前方オフセット・扇形角度を実行中攻撃へ差し替える。
 	hitRange_ = std::max(0.0f, hitRange);
 	hitRadius_ = std::max(0.0f, hitRadius);
 	hitForwardOffset_ = std::max(0.0f, hitForwardOffset);
+	hitAngleDeg_ = std::clamp(hitAngleDeg, 0.0f, 360.0f);
 }

--- a/Project/ApplicationLayer/Character/Boss/Attacks/BossHeavyPunchAttack.h
+++ b/Project/ApplicationLayer/Character/Boss/Attacks/BossHeavyPunchAttack.h
@@ -130,6 +130,11 @@ public: /// ---------- デバッグ参照 ---------- ///
 	/// </summary>
 	float GetHitForwardOffset() const { return hitForwardOffset_; }
 
+	/// <summary>
+	/// 攻撃判定角度を取得
+	/// </summary>
+	float GetHitAngleDeg() const { return hitAngleDeg_; }
+
 public: /// ---------- パラメータ反映 ---------- ///
 
 	/// <summary>
@@ -140,7 +145,7 @@ public: /// ---------- パラメータ反映 ---------- ///
 	/// <summary>
 	/// 実際の攻撃判定用パラメータを設定
 	/// </summary>
-	void SetHitParameters(float hitRange, float hitRadius, float hitForwardOffset);
+	void SetHitParameters(float hitRange, float hitRadius, float hitForwardOffset, float hitAngleDeg);
 
 public: /// ---------- 描画 ---------- ///
 
@@ -237,6 +242,7 @@ private: /// ---------- ヒット判定 ---------- ///
 	float hitRange_ = 6.0f;             // ボス正面方向に届く攻撃判定リーチ
 	float hitRadius_ = 2.0f;            // 重攻撃判定の半径
 	float hitForwardOffset_ = 3.0f;     // ボス中心から前方へ判定開始位置をずらす距離
+	float hitAngleDeg_ = 90.0f;         // 正面から左右へ広がる攻撃判定の全角度
 	float targetRadius_ = 0.65f;        // 仮プレイヤー半径
 
 private: /// ---------- クールダウン ---------- ///

--- a/Project/ApplicationLayer/Character/Boss/Attacks/BossPunchAttack.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Attacks/BossPunchAttack.cpp
@@ -266,6 +266,7 @@ void BossPunchAttack::DrawImGui()
 	ImGui::Text("HitRange          : %.2f", hitRange_);
 	ImGui::Text("HitRadius         : %.2f", hitRadius_);
 	ImGui::Text("HitForwardOffset  : %.2f", hitForwardOffset_);
+	ImGui::Text("HitAngleDeg       : %.2f", hitAngleDeg_);
 	ImGui::Text("Damage            : %.2f", damage_);
 #endif
 }
@@ -277,11 +278,10 @@ void BossPunchAttack::TryHitPlayer()
 {
 	if (owner_ == nullptr) return;
 
-	// 攻撃判定は攻撃開始距離とは別に、ParameterManager由来のリーチ・半径・前方オフセットで計算する。
+	// 攻撃判定は攻撃開始距離とは別に、ParameterManager由来のリーチ・半径・前方オフセット・扇形角度で計算する。
 	const K4E::Vector3 bossCenter = owner_->GetCenterPosition();
 	const float yaw = owner_->GetYaw();
 
-	// Yaw から前方ベクトルを計算
 	K4E::Vector3 forward
 	{
 		std::sin(yaw),
@@ -292,18 +292,19 @@ void BossPunchAttack::TryHitPlayer()
 	const float clampedForwardOffset = std::max(0.0f, hitForwardOffset_);
 	const float clampedHitRange = std::max(clampedForwardOffset, hitRange_);
 	const float clampedHitRadius = std::max(0.0f, hitRadius_);
+	const float clampedHitAngleDeg = std::clamp(hitAngleDeg_, 0.0f, 360.0f);
 
-	// 攻撃中心はボス中心から正面方向へオフセットし、見た目の拳位置に寄せる
 	K4E::Vector3 attackCenter = bossCenter;
 	attackCenter.x += forward.x * clampedForwardOffset;
 	attackCenter.y += 0.25f;
 	attackCenter.z += forward.z * clampedForwardOffset;
 
-	// ターゲットの中心座標を取得
 	const K4E::Vector3 targetCenter = owner_->GetTargetPosition();
 
 	const float toTargetX = targetCenter.x - bossCenter.x;
 	const float toTargetZ = targetCenter.z - bossCenter.z;
+	const float horizontalDistanceSq = toTargetX * toTargetX + toTargetZ * toTargetZ;
+	const float horizontalDistance = std::sqrt(horizontalDistanceSq);
 	const float forwardDistance = toTargetX * forward.x + toTargetZ * forward.z;
 	const float closestForwardDistance = std::clamp(forwardDistance, clampedForwardOffset, clampedHitRange);
 
@@ -316,14 +317,22 @@ void BossPunchAttack::TryHitPlayer()
 	const float dy = targetCenter.y - closestPoint.y;
 	const float dz = targetCenter.z - closestPoint.z;
 
-	// 攻撃判定リーチ上の最近点とターゲット中心の距離で、前方に伸びる近接判定を作る
 	const float distanceSq = dx * dx + dy * dy + dz * dz;
 	const float sumRadius = clampedHitRadius + targetRadius_;
+	const bool isInsideCapsule = distanceSq <= (sumRadius * sumRadius);
 
-	if (distanceSq <= (sumRadius * sumRadius))
+	constexpr float kDegToRad = 3.14159265358979323846f / 180.0f;
+	const float directionDot = (horizontalDistance > 0.0001f) ? (forwardDistance / horizontalDistance) : 1.0f;
+	const float angleCos = std::cos(clampedHitAngleDeg * 0.5f * kDegToRad);
+	const bool isInsideHitAngle = (clampedHitAngleDeg >= 360.0f) || (directionDot >= angleCos);
+	const bool isInsideHitRange = horizontalDistance <= (clampedHitRange + targetRadius_);
+	const bool isInsideHitHeight = std::abs(targetCenter.y - attackCenter.y) <= sumRadius;
+	const bool isInsideFan = isInsideHitRange && isInsideHitAngle && isInsideHitHeight;
+
+	// 細い前方カプセルに加えて扇形条件を許可し、斜め前のプレイヤーにも自然に当たるようにする。
+	if (isInsideCapsule || isInsideFan)
 	{
 #ifdef _DEBUG
-		// ヒットしたときのデバッグログ
 		OutputDebugStringA("[BossPunchAttack] Melee hit success.\n");
 #endif
 
@@ -336,7 +345,6 @@ void BossPunchAttack::TryHitPlayer()
 	else
 	{
 #ifdef _DEBUG
-		// ヒットしなかったときのデバッグログ
 		OutputDebugStringA("[BossPunchAttack] Melee hit miss.\n");
 #endif
 	}
@@ -382,10 +390,11 @@ void BossPunchAttack::SetValidRange(float minRange, float maxRange)
 /// ---------------------------------------------------------------
 ///					実際の攻撃判定パラメータを設定
 /// ---------------------------------------------------------------
-void BossPunchAttack::SetHitParameters(float hitRange, float hitRadius, float hitForwardOffset)
+void BossPunchAttack::SetHitParameters(float hitRange, float hitRadius, float hitForwardOffset, float hitAngleDeg)
 {
-	// ParameterManagerの反映ボタンから、攻撃判定の届く距離だけを実行中攻撃へ差し替える。
+	// ParameterManagerの反映ボタンから、攻撃判定の届く距離・太さ・前方オフセット・扇形角度を実行中攻撃へ差し替える。
 	hitRange_ = std::max(0.0f, hitRange);
 	hitRadius_ = std::max(0.0f, hitRadius);
 	hitForwardOffset_ = std::max(0.0f, hitForwardOffset);
+	hitAngleDeg_ = std::clamp(hitAngleDeg, 0.0f, 360.0f);
 }

--- a/Project/ApplicationLayer/Character/Boss/Attacks/BossPunchAttack.h
+++ b/Project/ApplicationLayer/Character/Boss/Attacks/BossPunchAttack.h
@@ -131,6 +131,11 @@ public: /// ---------- デバッグ参照 ---------- ///
 	/// </summary>
 	float GetHitForwardOffset() const { return hitForwardOffset_; }
 
+	/// <summary>
+	/// 攻撃判定角度を取得
+	/// </summary>
+	float GetHitAngleDeg() const { return hitAngleDeg_; }
+
 public: /// ---------- パラメータ反映 ---------- ///
 
 	/// <summary>
@@ -141,7 +146,7 @@ public: /// ---------- パラメータ反映 ---------- ///
 	/// <summary>
 	/// 実際の攻撃判定用パラメータを設定
 	/// </summary>
-	void SetHitParameters(float hitRange, float hitRadius, float hitForwardOffset);
+	void SetHitParameters(float hitRange, float hitRadius, float hitForwardOffset, float hitAngleDeg);
 
 public: /// ---------- 描画 ---------- ///
 
@@ -214,6 +219,7 @@ private: /// ---------- ヒット判定 ---------- ///
 	float hitRange_ = 6.0f;             // ボス正面方向に届く攻撃判定リーチ
 	float hitRadius_ = 2.0f;            // パンチ判定の半径
 	float hitForwardOffset_ = 3.0f;     // ボス中心から前方へ判定開始位置をずらす距離
+	float hitAngleDeg_ = 90.0f;         // 正面から左右へ広がる攻撃判定の全角度
 	float targetRadius_ = 0.65f;        // 仮のプレイヤー半径
 
 private: /// ---------- クールダウン ---------- ///

--- a/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.cpp
@@ -51,6 +51,7 @@ namespace
 		parameters->AddItem(kGuardianBossGroup, "GuardianAttackHitRange", 6.0f, 0.0f, 100.0f);
 		parameters->AddItem(kGuardianBossGroup, "GuardianAttackHitRadius", 2.0f, 0.0f, 30.0f);
 		parameters->AddItem(kGuardianBossGroup, "GuardianAttackForwardOffset", 3.0f, 0.0f, 100.0f);
+		parameters->AddItem(kGuardianBossGroup, "GuardianAttackHitAngleDeg", 90.0f, 0.0f, 360.0f);
 		parameters->AddItem(kGuardianBossGroup, "moveStartDistance", 4.8f, 0.0f, 100.0f);
 		parameters->AddItem(kGuardianBossGroup, "moveStopDistance", 4.8f, 0.0f, 100.0f);
 		parameters->AddItem(kGuardianBossGroup, "attackDuration", 0.85f, 0.0f, 30.0f);
@@ -67,6 +68,7 @@ namespace
 		parameters->SetDisplayName(kGuardianBossGroup, "GuardianAttackHitRange", "攻撃判定リーチ");
 		parameters->SetDisplayName(kGuardianBossGroup, "GuardianAttackHitRadius", "攻撃判定半径");
 		parameters->SetDisplayName(kGuardianBossGroup, "GuardianAttackForwardOffset", "攻撃判定前方オフセット");
+		parameters->SetDisplayName(kGuardianBossGroup, "GuardianAttackHitAngleDeg", "攻撃判定角度");
 		parameters->SetDisplayName(kGuardianBossGroup, "moveStartDistance", "移動開始距離");
 		parameters->SetDisplayName(kGuardianBossGroup, "moveStopDistance", "移動停止距離");
 		parameters->SetDisplayName(kGuardianBossGroup, "attackDuration", "攻撃時間");
@@ -117,6 +119,7 @@ void GuardianBoss::ApplyParameters()
 	attackHitRange_ = GetGuardianParameterOrDefault("GuardianAttackHitRange", attackHitRange_);
 	attackHitRadius_ = GetGuardianParameterOrDefault("GuardianAttackHitRadius", attackHitRadius_);
 	attackForwardOffset_ = GetGuardianParameterOrDefault("GuardianAttackForwardOffset", attackForwardOffset_);
+	attackHitAngleDeg_ = GetGuardianParameterOrDefault("GuardianAttackHitAngleDeg", attackHitAngleDeg_);
 	moveStartDistance_ = GetGuardianParameterOrDefault("moveStartDistance", moveStartDistance_);
 	moveStopDistance_ = GetGuardianParameterOrDefault("moveStopDistance", moveStopDistance_);
 	attackDuration_ = GetGuardianParameterOrDefault("attackDuration", attackDuration_);
@@ -157,6 +160,7 @@ void GuardianBoss::SetupBoss()
 	attackHitRange_ = GetGuardianParameterOrDefault("GuardianAttackHitRange", attackHitRange_); // Guardianの攻撃判定リーチをJSON調整値から復元する
 	attackHitRadius_ = GetGuardianParameterOrDefault("GuardianAttackHitRadius", attackHitRadius_); // Guardianの攻撃判定半径をJSON調整値から復元する
 	attackForwardOffset_ = GetGuardianParameterOrDefault("GuardianAttackForwardOffset", attackForwardOffset_); // Guardianの攻撃判定前方オフセットをJSON調整値から復元する
+	attackHitAngleDeg_ = GetGuardianParameterOrDefault("GuardianAttackHitAngleDeg", attackHitAngleDeg_); // Guardianの攻撃判定角度をJSON調整値から復元する
 	moveStartDistance_ = GetGuardianParameterOrDefault("moveStartDistance", moveStartDistance_); // Guardianの移動開始距離をJSON調整値から復元する
 	moveStopDistance_ = GetGuardianParameterOrDefault("moveStopDistance", moveStopDistance_); // Guardianの移動停止距離をJSON調整値から復元する
 	attackDuration_ = GetGuardianParameterOrDefault("attackDuration", attackDuration_); // Guardianの攻撃時間をJSON調整値から復元する
@@ -659,13 +663,13 @@ void GuardianBoss::ApplyAttackHitParametersToAttacks()
 	if (auto* punch = dynamic_cast<BossPunchAttack*>(GetAttackComponent()->FindAttackByName("Punch")))
 	{
 		punch->SetValidRange(0.0f, attackRange_);
-		punch->SetHitParameters(attackHitRange_, attackHitRadius_, attackForwardOffset_);
+		punch->SetHitParameters(attackHitRange_, attackHitRadius_, attackForwardOffset_, attackHitAngleDeg_);
 	}
 
 	if (auto* heavy = dynamic_cast<BossHeavyPunchAttack*>(GetAttackComponent()->FindAttackByName("HeavyPunch")))
 	{
 		heavy->SetValidRange(0.0f, attackRange_);
-		heavy->SetHitParameters(attackHitRange_, attackHitRadius_, attackForwardOffset_);
+		heavy->SetHitParameters(attackHitRange_, attackHitRadius_, attackForwardOffset_, attackHitAngleDeg_);
 	}
 }
 
@@ -797,6 +801,7 @@ void GuardianBoss::DrawImGui()
 	attackHitTuningChanged |= ImGui::DragFloat("攻撃判定リーチ", &attackHitRange_, 0.01f, 0.0f, 30.0f);
 	attackHitTuningChanged |= ImGui::DragFloat("攻撃判定半径", &attackHitRadius_, 0.01f, 0.0f, 20.0f);
 	attackHitTuningChanged |= ImGui::DragFloat("攻撃判定前方オフセット", &attackForwardOffset_, 0.01f, 0.0f, 30.0f);
+	attackHitTuningChanged |= ImGui::DragFloat("攻撃判定角度", &attackHitAngleDeg_, 0.1f, 0.0f, 360.0f);
 	if (attackHitTuningChanged)
 	{
 		ApplyAttackHitParametersToAttacks(); // GuardianBossデバッグUIで直接変えた値も現在の攻撃判定へ即時反映する。
@@ -933,6 +938,7 @@ void GuardianBoss::DrawImGui()
 		ImGui::Text("AttackHitRange    : %.2f", attackHitRange_);
 		ImGui::Text("AttackHitRadius   : %.2f", attackHitRadius_);
 		ImGui::Text("AttackForwardOff  : %.2f", attackForwardOffset_);
+		ImGui::Text("AttackHitAngleDeg : %.2f", attackHitAngleDeg_);
 
 		if (punch)
 		{

--- a/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.h
+++ b/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.h
@@ -113,6 +113,7 @@ protected: /// ---------- Guardian固有パラメータ ---------- ///
 	float attackHitRange_ = 6.0f;     // 実際の攻撃判定がボス正面へ届く距離
 	float attackHitRadius_ = 2.0f;    // 実際の攻撃判定の太さ
 	float attackForwardOffset_ = 3.0f;// 実際の攻撃判定をボス正面へずらす距離
+	float attackHitAngleDeg_ = 90.0f; // 実際の攻撃判定を正面から左右へ広げる全角度
 	float moveStartDistance_ = 4.8f;  // この距離より離れたら移動開始
 	float moveStopDistance_ = 4.8f;   // この距離より近づいたら移動停止
 

--- a/Project/Resources/ParameterManager/GuardianBoss.json
+++ b/Project/Resources/ParameterManager/GuardianBoss.json
@@ -6,6 +6,7 @@
         "GuardianAttackHitRange": 6.0,
         "GuardianAttackHitRadius": 2.0,
         "GuardianAttackForwardOffset": 3.0,
+        "GuardianAttackHitAngleDeg": 90.0,
         "moveStartDistance": 4.8,
         "moveStopDistance": 4.8,
         "attackDuration": 0.85,


### PR DESCRIPTION
### Motivation
- The existing melee hit used a narrow forward capsule (closest point on a forward line segment vs. player center with sum-of-radii check), which hit well at true front but often missed players standing diagonally in front despite the animation.
- Make the Guardian boss melee attacks hit naturally for diagonal-front players while preserving attack start distance, timings, damage and cooldown, and keep tuning exposed via ParameterManager/ImGui.

### Description
- Added an adjustable fan-shaped (sector) test to both `BossPunchAttack` and `BossHeavyPunchAttack` and combined it with the existing forward-capsule check (OR), using the dot-product / cosine threshold technique to test angle: `dot >= cos(hitAngleDeg * 0.5)`; height and range checks are also applied.
- Introduced `hitAngleDeg_` and updated `SetHitParameters` signatures to accept the angle for both `BossPunchAttack` and `BossHeavyPunchAttack`, and exposed `HitAngleDeg` in their ImGui debug panels.
- Added `GuardianAttackHitAngleDeg` to the Guardian ParameterManager registration and JSON defaults (`Project/Resources/ParameterManager/GuardianBoss.json` with initial value `90.0`), set ImGui display name `攻撃判定角度`, and wired `ApplyParameters` / `ApplyAttackHitParametersToAttacks` to push the angle to registered attacks so it can be changed at runtime.
- Files modified: `BossPunchAttack.{cpp,h}`, `BossHeavyPunchAttack.{cpp,h}`, `GuardianBoss.{cpp,h}`, and `Project/Resources/ParameterManager/GuardianBoss.json`.

### Testing
- Ran `git diff --check` to ensure no whitespace/patch issues (passed).
- Validated the modified JSON with `python3 -m json.tool Project/Resources/ParameterManager/GuardianBoss.json` (passed).
- Performed automated wiring checks (simple Python script / grep) to ensure new symbols and ParameterManager keys are present and applied (passed).
- Attempted to run project builds with `msbuild` / `dotnet msbuild` in this environment but the build tools are not available here, so full compile tests were not run in this environment.
- Static checks (grep/rg) confirmed updated references to `SetHitParameters(..., hitAngleDeg)` and `GuardianAttackHitAngleDeg` are present across the modified files (passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20f66df77c832da8dcdfd28db62bfa)