### PR TITLE
Restore Guardian boss animation & direction control

### DIFF
--- a/Project/ApplicationLayer/Character/Boss/Attacks/BossChargeAttack.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Attacks/BossChargeAttack.cpp
@@ -134,18 +134,8 @@ void BossChargeAttack::LockChargeDirection()
 	}
 
 	startPosition_ = owner_->GetPosition();
-	Vector3 toTarget{ owner_->GetTargetPosition().x - startPosition_.x, 0.0f, owner_->GetTargetPosition().z - startPosition_.z };
-	const float lenSq = toTarget.x * toTarget.x + toTarget.z * toTarget.z;
-	if (lenSq > 0.0001f)
-	{
-		const float invLen = 1.0f / std::sqrt(lenSq);
-		lockedForward_ = { toTarget.x * invLen, 0.0f, toTarget.z * invLen };
-		owner_->SetYaw(std::atan2(lockedForward_.x, lockedForward_.z));
-	}
-	else
-	{
-		lockedForward_ = { std::sin(owner_->GetYaw()), 0.0f, std::cos(owner_->GetYaw()) };
-	}
+	lockedForward_ = owner_->GetDirectionToTargetXZOrForward(startPosition_);
+	owner_->FaceDirectionXZImmediate(lockedForward_); // 突進は開始時の前方へだけ進み、移動中の急な追尾回転を避ける。
 	hasLockedDirection_ = true;
 }
 

--- a/Project/ApplicationLayer/Character/Boss/Attacks/BossHeavyPunchAttack.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Attacks/BossHeavyPunchAttack.cpp
@@ -376,18 +376,8 @@ void BossHeavyPunchAttack::LockAttackDirection()
 	}
 
 	const K4E::Vector3 origin = owner_->GetCenterPosition();
-	K4E::Vector3 toTarget{ owner_->GetTargetPosition().x - origin.x, 0.0f, owner_->GetTargetPosition().z - origin.z };
-	const float lenSq = toTarget.x * toTarget.x + toTarget.z * toTarget.z;
-	if (lenSq > 0.0001f)
-	{
-		const float invLen = 1.0f / std::sqrt(lenSq);
-		lockedForward_ = { toTarget.x * invLen, 0.0f, toTarget.z * invLen };
-		owner_->SetYaw(std::atan2(lockedForward_.x, lockedForward_.z));
-	}
-	else
-	{
-		lockedForward_ = { std::sin(owner_->GetYaw()), 0.0f, std::cos(owner_->GetYaw()) };
-	}
+	lockedForward_ = owner_->GetDirectionToTargetXZOrForward(origin);
+	owner_->FaceDirectionXZImmediate(lockedForward_); // 攻撃開始時だけ共通処理でプレイヤー方向へ向け、判定方向を固定する。
 	hasLockedDirection_ = true;
 }
 

--- a/Project/ApplicationLayer/Character/Boss/Attacks/BossPunchAttack.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Attacks/BossPunchAttack.cpp
@@ -358,18 +358,8 @@ void BossPunchAttack::LockAttackDirection()
 	}
 
 	const K4E::Vector3 origin = owner_->GetCenterPosition();
-	K4E::Vector3 toTarget{ owner_->GetTargetPosition().x - origin.x, 0.0f, owner_->GetTargetPosition().z - origin.z };
-	const float lenSq = toTarget.x * toTarget.x + toTarget.z * toTarget.z;
-	if (lenSq > 0.0001f)
-	{
-		const float invLen = 1.0f / std::sqrt(lenSq);
-		lockedForward_ = { toTarget.x * invLen, 0.0f, toTarget.z * invLen };
-		owner_->SetYaw(std::atan2(lockedForward_.x, lockedForward_.z));
-	}
-	else
-	{
-		lockedForward_ = { std::sin(owner_->GetYaw()), 0.0f, std::cos(owner_->GetYaw()) };
-	}
+	lockedForward_ = owner_->GetDirectionToTargetXZOrForward(origin);
+	owner_->FaceDirectionXZImmediate(lockedForward_); // 攻撃開始時だけ共通処理でプレイヤー方向へ向け、判定方向を固定する。
 	hasLockedDirection_ = true;
 }
 

--- a/Project/ApplicationLayer/Character/Boss/Attacks/GuardianShockwaveAttack.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Attacks/GuardianShockwaveAttack.cpp
@@ -401,22 +401,8 @@ void GuardianShockwaveAttack::LockShockwaveDirection()
 	}
 
 	lockedOrigin_ = owner_->GetCenterPosition();
-	K4E::Vector3 toTarget{
-		owner_->GetTargetPosition().x - lockedOrigin_.x,
-		0.0f,
-		owner_->GetTargetPosition().z - lockedOrigin_.z
-	};
-	const float lenSq = toTarget.x * toTarget.x + toTarget.z * toTarget.z;
-	if (lenSq > 0.0001f)
-	{
-		const float invLen = 1.0f / std::sqrt(lenSq);
-		lockedForward_ = { toTarget.x * invLen, 0.0f, toTarget.z * invLen };
-		owner_->SetYaw(std::atan2(lockedForward_.x, lockedForward_.z));
-	}
-	else
-	{
-		lockedForward_ = { std::sin(owner_->GetYaw()), 0.0f, std::cos(owner_->GetYaw()) };
-	}
+	lockedForward_ = owner_->GetDirectionToTargetXZOrForward(lockedOrigin_);
+	owner_->FaceDirectionXZImmediate(lockedForward_); // 衝撃波は開始時に固定した前方だけで判定・エフェクトを出す。
 	hasLockedDirection_ = true;
 }
 

--- a/Project/ApplicationLayer/Character/Boss/Components/BossAnimationComponent.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Components/BossAnimationComponent.cpp
@@ -51,6 +51,13 @@ void BossAnimationComponent::Finalize()
 /// -------------------------------------------------------------
 void BossAnimationComponent::Update(BossBase& boss, float deltaTime)
 {
+	if (!HasRequiredParts(boss))
+	{
+		return;
+	}
+
+	breathTime_ += deltaTime; // Idle/Walkの周期時間を毎フレーム進め、停止していた呼吸・歩行揺れを復旧する。
+
 	switch (boss.GetState())
 	{
 	case BossState::Idle:
@@ -88,30 +95,7 @@ void BossAnimationComponent::Update(BossBase& boss, float deltaTime)
 /// -------------------------------------------------------------
 void BossAnimationComponent::UpdateIdle(BossBase& boss, float deltaTime)
 {
-	auto& body = boss.GetBody();
-	auto& parts = boss.GetBodyParts();
-	const auto& idx = boss.GetPartIndices();
-
-	const float breath = std::sin(breathTime_ * 2.2f);
-	const float breath01 = (breath * 0.5f) + 0.5f;
-	const float headSway = std::sin(breathTime_ * 1.4f + 0.8f);
-
-	const float targetBodyPitch = idleBreathPitch_ * breath;
-	const float targetHeadPitch = -idleBreathPitch_ * 0.6f * breath01;
-	const float targetHeadYaw = idleHeadSway_ * headSway;
-
-	// 実座標Yは触らない
-	Damp(body.transform.rotate_.x, targetBodyPitch, bodyDampSpeed_, deltaTime);
-	Damp(body.transform.rotate_.z, 0.0f, bodyDampSpeed_, deltaTime);
-
-	Damp(parts[idx.head].transform.rotate_.x, targetHeadPitch, headDampSpeed_, deltaTime);
-	Damp(parts[idx.head].transform.rotate_.y, targetHeadYaw, headDampSpeed_, deltaTime);
-	Damp(parts[idx.head].transform.rotate_.z, 0.0f, headDampSpeed_, deltaTime);
-
-	Damp(parts[idx.leftArm].transform.rotate_.x, -0.05f, limbDampSpeed_, deltaTime);
-	Damp(parts[idx.rightArm].transform.rotate_.x, -0.05f, limbDampSpeed_, deltaTime);
-	Damp(parts[idx.leftLeg].transform.rotate_.x, 0.0f, limbDampSpeed_, deltaTime);
-	Damp(parts[idx.rightLeg].transform.rotate_.x, 0.0f, limbDampSpeed_, deltaTime);
+	UpdateIdleAnimation(boss, deltaTime); // Idle状態は専用関数へ集約し、重複実装で呼吸時間が止まる不具合を防ぐ。
 }
 
 /// -------------------------------------------------------------
@@ -173,13 +157,11 @@ void BossAnimationComponent::UpdateIdleAnimation(BossBase& boss, float deltaTime
 	const float headSway = std::sin(breathTime_ * 1.4f + 0.8f);
 
 	// 目標値
-	const float targetBodyY = idleBreathHeight_ * breath;
 	const float targetBodyPitch = idleBreathPitch_ * breath;
 	const float targetHeadPitch = -idleBreathPitch_ * 0.6f * breath01;
 	const float targetHeadYaw = idleHeadSway_ * headSway;
 
-	Damp(body.transform.translate_.y, targetBodyY, bodyDampSpeed_, deltaTime);
-	Damp(body.transform.rotate_.x, targetBodyPitch, bodyDampSpeed_, deltaTime);
+	Damp(body.transform.rotate_.x, targetBodyPitch, bodyDampSpeed_, deltaTime); // Idle呼吸は回転だけに留め、ワールドY座標をアニメ側で潰さない。
 
 	// ---------------------------------------------------------
 	// Yaw は触らない
@@ -329,6 +311,7 @@ BossAnimationComponent::BossPose BossAnimationComponent::BuildPunchPose() const
 	BossPose pose = BuildDefaultAttackPose();
 
 	BossPunchAttack::Phase punchPhase = BossPunchAttack::Phase::None;
+	float phaseTime = 0.0f;
 	bool hasPunchPhase = false;
 
 	if (owner_)
@@ -338,6 +321,7 @@ BossAnimationComponent::BossPose BossAnimationComponent::BuildPunchPose() const
 			if (auto* punch = dynamic_cast<BossPunchAttack*>(current))
 			{
 				punchPhase = punch->GetPhase();
+				phaseTime = punch->GetPhaseTimer();
 				hasPunchPhase = true;
 			}
 		}
@@ -346,13 +330,13 @@ BossAnimationComponent::BossPose BossAnimationComponent::BuildPunchPose() const
 	// PunchAttackでなければ基本姿勢のまま返す
 	if (!hasPunchPhase) return pose;
 
-	// フェーズごとに目標ポーズを切り替える
+	// フェーズごとの経過時間で補間し、前フェーズのattackAnimTime_残りでポーズが固まる問題を防ぐ。
 	switch (punchPhase)
 	{
 	case BossPunchAttack::Phase::Windup:
 		{
 			// 両手を上に振りかざす
-			const float t = Smoothstep01(attackAnimTime_ / 0.30f);
+			const float t = Smoothstep01(phaseTime / 0.30f);
 
 			pose.bodyPitch = Lerp(0.03f, -0.18f, t);
 			pose.bodyRoll = Lerp(0.0f, 0.0f, t);
@@ -374,7 +358,7 @@ BossAnimationComponent::BossPose BossAnimationComponent::BuildPunchPose() const
 	case BossPunchAttack::Phase::Active:
 		{
 			// 両腕を一気に振り下ろす
-			const float t = Smoothstep01(attackAnimTime_ / 0.12f);
+			const float t = Smoothstep01(phaseTime / 0.12f);
 
 			pose.bodyPitch = Lerp(-0.18f, 0.28f, t);
 			pose.bodyRoll = 0.0f;
@@ -397,7 +381,7 @@ BossAnimationComponent::BossPose BossAnimationComponent::BuildPunchPose() const
 	case BossPunchAttack::Phase::None:
 	default:
 		{
-			const float t = Smoothstep01(attackAnimTime_ / 0.40f);
+			const float t = Smoothstep01(phaseTime / 0.40f);
 
 			pose.bodyPitch = Lerp(0.28f, 0.03f, t);
 			pose.bodyRoll = 0.0f;

--- a/Project/ApplicationLayer/Character/Boss/Core/BossBase.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Core/BossBase.cpp
@@ -409,6 +409,40 @@ float BossBase::GetHPRate() const
 	return statusComponent_ ? statusComponent_->GetHPRate() : 0.0f;
 }
 
+
+/// -------------------------------------------------------------
+/// ターゲット方向の取得 / 即時反映
+/// -------------------------------------------------------------
+K4E::Vector3 BossBase::GetDirectionToTargetXZOrForward(const K4E::Vector3& origin) const
+{
+	K4E::Vector3 toTarget{
+		targetPosition_.x - origin.x,
+		0.0f,
+		targetPosition_.z - origin.z
+	};
+
+	const float lenSq = toTarget.x * toTarget.x + toTarget.z * toTarget.z;
+	if (lenSq > 0.0001f)
+	{
+		const float invLen = 1.0f / std::sqrt(lenSq);
+		return { toTarget.x * invLen, 0.0f, toTarget.z * invLen };
+	}
+
+	return { std::sin(GetYaw()), 0.0f, std::cos(GetYaw()) };
+}
+
+void BossBase::FaceDirectionXZImmediate(const K4E::Vector3& direction)
+{
+	const float lenSq = direction.x * direction.x + direction.z * direction.z;
+	if (lenSq <= 0.0001f)
+	{
+		return;
+	}
+
+	// 攻撃開始時だけ共通処理でYawを確定し、攻撃クラスごとの毎フレーム回転上書きを避ける。
+	SetYaw(std::atan2(direction.x, direction.z));
+}
+
 /// -------------------------------------------------------------
 /// ターゲットまでのXZ距離
 /// -------------------------------------------------------------

--- a/Project/ApplicationLayer/Character/Boss/Core/BossBase.h
+++ b/Project/ApplicationLayer/Character/Boss/Core/BossBase.h
@@ -164,6 +164,16 @@ public: /// ---------- 位置 / 向き ---------- ///
 	void SetYaw(float yaw) { body_.transform.rotate_.y = yaw; }
 
 	/// <summary>
+	/// origin からターゲットへ向かうXZ正規化方向を返す
+	/// </summary>
+	K4E::Vector3 GetDirectionToTargetXZOrForward(const K4E::Vector3& origin) const;
+
+	/// <summary>
+	/// 共通の向き制御としてXZ方向へ即時にYawを合わせる
+	/// </summary>
+	void FaceDirectionXZImmediate(const K4E::Vector3& direction);
+
+	/// <summary>
 	/// 中心座標は BaseCharacter の実装をそのまま使う
 	/// 必要なら派生側で override 可
 	/// </summary>

--- a/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.cpp
@@ -435,8 +435,10 @@ void GuardianBoss::UpdateState(float deltaTime)
 
 			FaceTarget(deltaTime);
 
-			// 攻撃条件成立
-			if (distance <= farAttackRange_)
+			const bool hasStartableAttack = GetAttackComponent() && !GetAttackComponent()->CollectStartableAttacks().empty();
+
+			// 実際に開始可能な攻撃がある時だけAttackへ入り、候補なしAttackで歩行アニメが止まる状態を避ける。
+			if (hasStartableAttack)
 			{
 				BeginAttackState();
 			}
@@ -453,9 +455,10 @@ void GuardianBoss::UpdateState(float deltaTime)
 			FaceTarget(deltaTime);
 
 			const float distance = GetDistanceToTargetXZ();
+			const bool hasStartableAttack = GetAttackComponent() && !GetAttackComponent()->CollectStartableAttacks().empty();
 
-			// 攻撃条件成立
-			if (distance <= farAttackRange_ && attackCooldownTimer_ <= 0.0f)
+			// 移動中も開始可能な攻撃だけをAttackへ渡し、歩行と攻撃選択の責務を分ける。
+			if (attackCooldownTimer_ <= 0.0f && hasStartableAttack)
 			{
 				BeginAttackState();
 			}


### PR DESCRIPTION
### Motivation
- 歩行・待機・パンチ系アニメがShockwave追加以降に止まったり向きが不自然に変わる問題を修正し、攻撃開始時のみ向きを固定して攻撃中の毎フレーム上書きを避けることで既存挙動を復旧する。
- 各コンポーネント（Animation / Attack / BossBase / GuardianBoss）の責務を明確にし、アニメが攻撃ロジックや攻撃選択の影響で停止しないようにする。

### Description
- 毎フレームの呼吸/歩行進行用時間を `BossAnimationComponent::Update` で確実に進めるようにして歩行・Idleアニメを復活させ、Idle処理を `UpdateIdleAnimation` に集約して重複を除去した。 (変更例: `BossAnimationComponent.cpp`)
- 攻撃モーションの補間を攻撃全体タイマー (`attackAnimTime_`) から各攻撃のフェーズタイマーへ切り替え、Punch系のアニメが飛んだり固まる問題を解消した。 (変更例: Punch pose の補間に `GetPhaseTimer()` を使用)
- 向き制御を攻撃クラスに分散させるのをやめ、`BossBase` に `GetDirectionToTargetXZOrForward` と `FaceDirectionXZImmediate` を追加して、Punch/HeavyPunch/GuardianShockwave/ChargeAttack の開始時に共通処理で方向を固定するようにした。これにより攻撃中の毎フレームYaw上書きを防止した。 (変更例: `BossBase.h/.cpp`, 各攻撃の `Lock*Direction` の差し替え)
- Guardian の状態遷移を調整して、距離だけでAttackへ入るのではなく実際に `AttackComponent` に開始可能な攻撃候補がある場合のみAttack状態へ遷移するようにして、候補なしに入ることで生じる歩行アニメ停止を避けた。 (変更例: `GuardianBoss.cpp`)
- 最低限の影響範囲に留め、攻撃の判定パラメータや挙動そのものは維持したままアニメと向き制御を修正した。主な変更ファイル: `BossAnimationComponent.cpp`, `BossBase.h/.cpp`, `BossPunchAttack.cpp`, `BossHeavyPunchAttack.cpp`, `GuardianShockwaveAttack.cpp`, `BossChargeAttack.cpp`, `GuardianBoss.cpp`.

### Testing
- `git diff --check` を実行して差分チェックは問題なし（成功）。
- 変更箇所の検索で期待する置換・参照が存在することを確認するためのパターン検索を実行し (`rg`)、該当箇所の書き換えを検出・確認できた（成功）。
- ソリューションビルドは CI/Windows 環境（`msbuild`）が必要なためこのLinuxコンテナ内では実行できず、`msbuild` が見つからないためビルドは未実行（失敗／環境依存）。
- 自動単体テストは存在しないため未実行。

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a216697241c832d931b5915c7609946)