### PR TITLE
Fix GuardianBoss visual yaw offset

### DIFF
--- a/Project/ApplicationLayer/Character/Boss/Core/BossBase.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Core/BossBase.cpp
@@ -4,6 +4,7 @@
 #include <LogString.h>
 #include <ParameterManager.h>
 
+#include <cmath>
 #include <filesystem>
 #include <sstream>
 #include <string>
@@ -195,6 +196,7 @@ void BossBase::Update(float deltaTime)
 
 	// 最後に部位階層更新
 	BaseCharacter::Update(deltaTime);
+	ApplyModelYawOffsetToVisuals();
 }
 
 /// -------------------------------------------------------------
@@ -429,6 +431,37 @@ K4E::Vector3 BossBase::GetDirectionToTargetXZOrForward(const K4E::Vector3& origi
 	}
 
 	return { std::sin(GetYaw()), 0.0f, std::cos(GetYaw()) };
+}
+
+void BossBase::ApplyModelYawOffsetToVisuals()
+{
+	const float modelYawOffset = GetModelYawOffsetRad();
+	if (std::fabs(modelYawOffset) <= 0.0001f)
+	{
+		return;
+	}
+
+	if (body_.object)
+	{
+		K4E::Vector3 visualRotate = body_.transform.rotate_;
+		visualRotate.y += modelYawOffset; // 論理forwardは維持し、メッシュの正面軸だけ表示用Yawで合わせる。
+		body_.object->SetRotate(visualRotate);
+		body_.object->Update();
+	}
+
+	for (auto& part : parts_)
+	{
+		if (!part.object || part.transform.useQuaternionRotation_)
+		{
+			continue;
+		}
+
+		K4E::Vector3 visualRotate = part.transform.worldRotate_;
+		visualRotate.y += modelYawOffset;
+		part.object->SetTranslate(part.transform.worldTranslate_);
+		part.object->SetRotate(visualRotate);
+		part.object->Update();
+	}
 }
 
 void BossBase::FaceDirectionXZImmediate(const K4E::Vector3& direction)

--- a/Project/ApplicationLayer/Character/Boss/Core/BossBase.h
+++ b/Project/ApplicationLayer/Character/Boss/Core/BossBase.h
@@ -164,6 +164,11 @@ public: /// ---------- 位置 / 向き ---------- ///
 	void SetYaw(float yaw) { body_.transform.rotate_.y = yaw; }
 
 	/// <summary>
+	/// 論理Yawとは別にモデル表示だけへ足すY回転補正を返す
+	/// </summary>
+	virtual float GetModelYawOffsetRad() const { return 0.0f; }
+
+	/// <summary>
 	/// origin からターゲットへ向かうXZ正規化方向を返す
 	/// </summary>
 	K4E::Vector3 GetDirectionToTargetXZOrForward(const K4E::Vector3& origin) const;
@@ -172,6 +177,11 @@ public: /// ---------- 位置 / 向き ---------- ///
 	/// 共通の向き制御としてXZ方向へ即時にYawを合わせる
 	/// </summary>
 	void FaceDirectionXZImmediate(const K4E::Vector3& direction);
+
+	/// <summary>
+	/// 攻撃判定用の論理Yawを変えず、Object3Dへ渡す表示Yawだけ補正する
+	/// </summary>
+	void ApplyModelYawOffsetToVisuals();
 
 	/// <summary>
 	/// 中心座標は BaseCharacter の実装をそのまま使う

--- a/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.cpp
@@ -23,6 +23,7 @@ using namespace Ken4lowEngine;
 namespace
 {
 	constexpr const char* kGuardianBossGroup = "GuardianBoss";
+	constexpr float kDegToRad = 3.14159265358979323846f / 180.0f;
 
 	void EnsureGuardianBossParameters()
 	{
@@ -84,6 +85,7 @@ namespace
 		parameters->AddItem(kGuardianBossGroup, "heavyPunchReuseDelay", 1.0f, 0.0f, 30.0f);
 		parameters->AddItem(kGuardianBossGroup, "animationWalkSpeed", 6.0f, 0.0f, 30.0f);
 		parameters->AddItem(kGuardianBossGroup, "animationWalkAmplitude", 0.55f, 0.0f, 5.0f);
+		parameters->AddItem(kGuardianBossGroup, "GuardianModelYawOffsetDeg", 180.0f, -360.0f, 360.0f);
 		parameters->AddItem(kGuardianBossGroup, "skinPath", std::string("Characters/zombie.dds"));
 		// 内部キーとは別にImGui専用の日本語ラベルを登録する。
 		parameters->SetDisplayName(kGuardianBossGroup, "moveSpeed", "ガーディアン移動速度");
@@ -123,6 +125,7 @@ namespace
 		parameters->SetDisplayName(kGuardianBossGroup, "heavyPunchReuseDelay", "強攻撃再使用間隔");
 		parameters->SetDisplayName(kGuardianBossGroup, "animationWalkSpeed", "歩行アニメ速度");
 		parameters->SetDisplayName(kGuardianBossGroup, "animationWalkAmplitude", "歩行アニメ振幅");
+		parameters->SetDisplayName(kGuardianBossGroup, "GuardianModelYawOffsetDeg", "ガーディアンモデル向き補正");
 		parameters->SetDisplayName(kGuardianBossGroup, "skinPath", "スキンパス");
 	}
 
@@ -196,6 +199,7 @@ void GuardianBoss::ApplyParameters()
 	heavyPunchReuseDelay_ = GetGuardianParameterOrDefault("heavyPunchReuseDelay", heavyPunchReuseDelay_);
 	animationWalkSpeed_ = GetGuardianParameterOrDefault("animationWalkSpeed", animationWalkSpeed_);
 	animationWalkAmplitude_ = GetGuardianParameterOrDefault("animationWalkAmplitude", animationWalkAmplitude_);
+	guardianModelYawOffsetDeg_ = GetGuardianParameterOrDefault("GuardianModelYawOffsetDeg", guardianModelYawOffsetDeg_);
 	if (GetAnimationComponent())
 	{
 		GetAnimationComponent()->SetWalkSpeed(animationWalkSpeed_);
@@ -211,6 +215,11 @@ std::string GuardianBoss::GetGuardianSkinPath() const
 {
 	EnsureGuardianBossParameters();
 	return GetGuardianParameterOrDefault("skinPath", std::string("Characters/zombie.dds")); // スキンもJSONから参照し、失敗時は既定テクスチャへ戻す
+}
+
+float GuardianBoss::GetModelYawOffsetRad() const
+{
+	return guardianModelYawOffsetDeg_ * kDegToRad;
 }
 
 /// -------------------------------------------------------------
@@ -259,6 +268,7 @@ void GuardianBoss::SetupBoss()
 	heavyPunchReuseDelay_ = GetGuardianParameterOrDefault("heavyPunchReuseDelay", heavyPunchReuseDelay_); // HeavyPunch再使用間隔をJSON調整値から復元する
 	animationWalkSpeed_ = GetGuardianParameterOrDefault("animationWalkSpeed", animationWalkSpeed_); // 歩行アニメ速度をJSON調整値から復元する
 	animationWalkAmplitude_ = GetGuardianParameterOrDefault("animationWalkAmplitude", animationWalkAmplitude_); // 歩行アニメ振幅をJSON調整値から復元する
+	guardianModelYawOffsetDeg_ = GetGuardianParameterOrDefault("GuardianModelYawOffsetDeg", guardianModelYawOffsetDeg_); // 攻撃forwardは変えず、Guardianメッシュの見た目正面だけ補正する。
 
 	// フェーズ初期化
 	SetPhase(BossPhase::Phase1);

--- a/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.h
+++ b/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.h
@@ -40,6 +40,7 @@ protected: /// ---------- BossBase override ---------- ///
 	void UpdateAttack(float deltaTime) override;
 	void CheckDeath() override;
 	void OnTargetPlayerDamaged(float damage) override;
+	float GetModelYawOffsetRad() const override;
 
 	void SetupAttacks() override;
 	void SetupPhaseData() override;
@@ -144,6 +145,7 @@ protected: /// ---------- Guardian固有パラメータ ---------- ///
 	float staggerDuration_ = 0.30f;   // ひるみ時間
 	float animationWalkSpeed_ = 6.0f;   // 歩行アニメ速度
 	float animationWalkAmplitude_ = 0.55f; // 歩行アニメ振幅
+	float guardianModelYawOffsetDeg_ = 180.0f; // Guardianモデルの見た目正面を論理forwardへ合わせるY補正
 
 	float stateTimer_ = 0.0f;         // 状態滞在時間
 	float attackCooldownTimer_ = 0.0f;// クールダウン残り

--- a/Project/Resources/ParameterManager/GuardianBoss.json
+++ b/Project/Resources/ParameterManager/GuardianBoss.json
@@ -28,6 +28,7 @@
         "ParticleSpawnCount": 48,
         "ParticleSpawnRadius": 0.5,
         "ParticleLifetime": 1.0,
-        "ParticleInitialSpeed": 1.0
+        "ParticleInitialSpeed": 1.0,
+        "GuardianModelYawOffsetDeg": 180.0
     }
 }


### PR DESCRIPTION
### Motivation
- The Guardian model's visual forward axis was opposite the engine forward, causing the mesh to face the wrong way while logical forward and attack hit directions remained correct.
- The goal was to separate logical forward used for attack/colliders from the model display forward and apply a visual-only Yaw correction for Guardian without changing attack logic.

### Description
- Added a virtual `GetModelYawOffsetRad()` hook to `BossBase` and an `ApplyModelYawOffsetToVisuals()` helper that applies a model-only Y (Yaw) offset to `Object3D` rotations while leaving logical `GetYaw()`/attack forward unchanged.
- Call `ApplyModelYawOffsetToVisuals()` from `BossBase::Update()` after `BaseCharacter::Update()` so display rotations are adjusted after hierarchy/world transforms are computed.
- Implemented a Guardian-specific override that reads a new `GuardianModelYawOffsetDeg` parameter (default `180.0f`) and converts it to radians for `GetModelYawOffsetRad()`.
- Registered `GuardianModelYawOffsetDeg` in `ParameterManager` with display name `ガーディアンモデル向き補正`, added it to `GuardianBoss.json`, and load it during `ApplyParameters()` / `SetupBoss()`; included an explanatory inline comment when applying the offset in `ApplyModelYawOffsetToVisuals()`.

### Testing
- Ran `python3 -m json.tool Project/Resources/ParameterManager/GuardianBoss.json` which succeeded and validated the modified JSON file.
- Ran repository search commands (`rg`) to confirm attack code still uses logical forward (`GetYaw()` / `GetDirectionToTargetXZOrForward()` / `FaceDirectionXZImmediate()`), which succeeded and shows no changes to attack hit direction logic.
- Attempted to build with `msbuild` for Debug and Release, but `msbuild` is not available in this container so full binary builds were not run.
- Changes were committed as `Fix GuardianBoss visual yaw offset` and are ready for CI/build verification on the target platform.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a216a47cfb8832d9edffcac0486bbe3)