### PR TITLE
Add hit-stun cooldowns for enemies and bosses

### DIFF
--- a/Project/ApplicationLayer/Character/Boss/Components/BossStatusComponent.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Components/BossStatusComponent.cpp
@@ -10,6 +10,7 @@ void BossStatusComponent::Initialize(float maxHP)
 
 	isInvincible_ = false;
 	invincibleTimer_ = 0.0f;
+	hitStunCooldownTimer_ = 0.0f;
 }
 
 /// -------------------------------------------------------------
@@ -26,6 +27,9 @@ void BossStatusComponent::Update(float deltaTime)
 		// 無敵時間が0未満にならないように丸める
 		if (invincibleTimer_ < 0.0f) invincibleTimer_ = 0.0f;
 	}
+
+	// 怯みクールダウン中でもHP処理は通常通り行い、再怯みだけを遅らせる。
+	hitStunCooldownTimer_ = std::max(0.0f, hitStunCooldownTimer_ - deltaTime);
 }
 
 /// -------------------------------------------------------------
@@ -117,4 +121,29 @@ float BossStatusComponent::GetHPRate() const
 
 	// HP割合を計算して返す
 	return hp_ / maxHP_;
+}
+
+/// -------------------------------------------------------------
+///					怯みクールダウン可否
+/// -------------------------------------------------------------
+bool BossStatusComponent::CanStartHitStun() const
+{
+	return hitStunCooldownTimer_ <= 0.0f;
+}
+
+/// -------------------------------------------------------------
+///					怯みクールダウン開始
+/// -------------------------------------------------------------
+void BossStatusComponent::StartHitStunCooldown()
+{
+	hitStunCooldownTimer_ = hitStunCooldownSec_;
+}
+
+/// -------------------------------------------------------------
+///					怯みクールダウン秒数設定
+/// -------------------------------------------------------------
+void BossStatusComponent::SetHitStunCooldownSec(float cooldownSec)
+{
+	hitStunCooldownSec_ = std::max(0.0f, cooldownSec);
+	hitStunCooldownTimer_ = std::min(hitStunCooldownTimer_, hitStunCooldownSec_);
 }

--- a/Project/ApplicationLayer/Character/Boss/Components/BossStatusComponent.h
+++ b/Project/ApplicationLayer/Character/Boss/Components/BossStatusComponent.h
@@ -77,6 +77,15 @@ public: /// ---------- 無敵状態 ---------- ///
 	/// </summary>
 	bool IsInvincible() const { return isInvincible_; }
 
+public: /// ---------- 怯みクールダウン ---------- ///
+
+	// 怯みだけを間引くため、HPダメージとは独立した再発動可否を返す。
+	bool CanStartHitStun() const;
+	void StartHitStunCooldown();
+	void SetHitStunCooldownSec(float cooldownSec);
+	float GetHitStunCooldownSec() const { return hitStunCooldownSec_; }
+	float GetHitStunCooldownTimer() const { return hitStunCooldownTimer_; }
+
 public: /// ---------- 参照 ---------- ///
 
 	// 現在HP
@@ -114,4 +123,8 @@ private: /// ---------- 内部状態 ---------- ///
 
 	// 一定時間の無敵
 	float invincibleTimer_ = 0.0f;
+
+	// 連続ヒット時にボスが怯み状態へ固定されないよう、怯み専用の再発動待ち時間を持つ。
+	float hitStunCooldownSec_ = 1.0f;
+	float hitStunCooldownTimer_ = 0.0f;
 };

--- a/Project/ApplicationLayer/Character/Boss/Core/BossBase.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Core/BossBase.cpp
@@ -19,6 +19,7 @@ namespace
 	constexpr float kDefaultBossStopDistance = 3.0f;
 	constexpr float kDefaultBossAttackRange = 3.0f;
 	constexpr float kDefaultBossAttackCooldown = 1.2f;
+	constexpr float kDefaultBossHitStunCooldownSec = 1.0f;
 
 	void EnsureBossCommonParameters()
 	{
@@ -49,6 +50,7 @@ namespace
 		parameters->AddItem(kBossCommonGroup, "stopDistance", kDefaultBossStopDistance, 0.0f, 100.0f);
 		parameters->AddItem(kBossCommonGroup, "attackRange", kDefaultBossAttackRange, 0.0f, 100.0f);
 		parameters->AddItem(kBossCommonGroup, "attackCooldownSec", kDefaultBossAttackCooldown, 0.0f, 30.0f);
+		parameters->AddItem(kBossCommonGroup, "BossHitStunCooldownSec", kDefaultBossHitStunCooldownSec, 0.0f, 10.0f);
 		// JSONキーを英数字のまま維持し、ImGui表示だけ日本語化する。
 		parameters->SetDisplayName(kBossCommonGroup, "maxHP", "ボス最大HP");
 		parameters->SetDisplayName(kBossCommonGroup, "moveSpeed", "ボス移動速度");
@@ -56,6 +58,7 @@ namespace
 		parameters->SetDisplayName(kBossCommonGroup, "stopDistance", "ボス停止距離");
 		parameters->SetDisplayName(kBossCommonGroup, "attackRange", "ボス攻撃距離");
 		parameters->SetDisplayName(kBossCommonGroup, "attackCooldownSec", "ボス攻撃クールタイム");
+		parameters->SetDisplayName(kBossCommonGroup, "BossHitStunCooldownSec", "ボス怯みクールタイム");
 	}
 
 	template<typename T>
@@ -104,6 +107,7 @@ void BossBase::Initialize()
 	// ステータス生成
 	statusComponent_ = std::make_unique<BossStatusComponent>();
 	statusComponent_->Initialize(GetBossParameterOrDefault("maxHP", kDefaultBossMaxHP)); // HPはJSON調整値を優先し、失敗時だけ既定値を使う
+	statusComponent_->SetHitStunCooldownSec(GetBossParameterOrDefault("BossHitStunCooldownSec", kDefaultBossHitStunCooldownSec)); // 初期化時からボス怯みクールタイムを反映する。
 
 	// 状態遷移生成
 	stateMachine_ = std::make_unique<BossStateMachine>();
@@ -248,6 +252,7 @@ void BossBase::ApplyParameters()
 	if (statusComponent_)
 	{
 		statusComponent_->SetMaxHP(maxHP); // 最大HPだけを更新し、現在HPはコンポーネント側で範囲内に丸める。
+		statusComponent_->SetHitStunCooldownSec(GetBossParameterOrDefault("BossHitStunCooldownSec", kDefaultBossHitStunCooldownSec)); // ボスの連続怯み防止時間をParameterManagerから反映する。
 	}
 
 	if (movementComponent_)

--- a/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Derived/GuardianBoss/GuardianBoss.cpp
@@ -335,9 +335,10 @@ void GuardianBoss::OnDamaged(float damage)
 		Log(oss.str() + "\n");
 	}
 
-	// 生きていたらひるみへ
-	if (!IsDead())
+	// 怯みクール中はダメージ/ヒット演出を維持しつつ、Staggerへの再遷移だけを抑える。
+	if (!IsDead() && GetStatusComponent() && GetStatusComponent()->CanStartHitStun())
 	{
+		GetStatusComponent()->StartHitStunCooldown();
 		BeginStaggerState();
 	}
 }

--- a/Project/ApplicationLayer/Character/Bullet/Bullet.cpp
+++ b/Project/ApplicationLayer/Character/Bullet/Bullet.cpp
@@ -290,6 +290,7 @@ void Bullet::ApplySplashDamageToType(uint32_t targetType, const K4E::Vector3& ce
 
 				const K4E::Vector3 hitDir = NormalizeSafe(toTarget, NormalizeSafe(moveVelocity_, { 0.0f, 0.0f, 1.0f }));
 				enemy->SpawnHitEffectAt(col->GetCenterPosition());
+				// SplashDamageでも怯み可否は敵側で判定し、範囲内のHPダメージは通常通り通す。
 				enemy->TakeDamage(finalDamage, hitDir, 1.8f);
 			}
 		}
@@ -297,6 +298,7 @@ void Bullet::ApplySplashDamageToType(uint32_t targetType, const K4E::Vector3& ce
 		{
 			if (auto* boss = col->GetOwner<BossBase>(); boss && boss->IsAlive())
 			{
+				// SplashDamageでも怯み可否はボス側で判定し、範囲内のHPダメージは通常通り通す。
 				boss->OnBulletDamaged(static_cast<float>(finalDamage));
 			}
 		}

--- a/Project/ApplicationLayer/Character/Enemy/Core/Enemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/Enemy.cpp
@@ -729,8 +729,10 @@ void Enemy::OnBulletHit(K4E::Collider* bulletCollider)
 	EnemyBase::OnBulletHit(bulletCollider);
 	suppressNextDamageStimulus_ = false;
 
-	if (!IsDead())
+	// 怯みクール中の追撃はHP/演出だけ通し、行動停止の再発動は抑制する。
+	if (!IsDead() && CanStartHitStun())
 	{
+		StartHitStunCooldown();
 		hitReactionTimer_ = reaction_.hitReactionTime * traits_.reactionDelayScale;
 		hitChainTimer_ = reaction_.hitChainWindow;
 		++consecutiveHitCount_;

--- a/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.cpp
@@ -6,8 +6,12 @@
 #include <vector>
 #include "EnemyParticleEffectSystem.h"
 #include <Bullet.h>
+#include <LogString.h>
+#include <ParameterManager.h>
 
 #include "CollisionTypeIdDef.h"
+
+#include <filesystem>
 
 #ifdef USE_IMGUI
 #include "imgui.h"
@@ -31,6 +35,47 @@ Vector3 EnemyBase::s_lastDebugAttackCenter_ = { 0.0f, 0.0f, 0.0f };
 
 namespace
 {
+
+	constexpr const char* kEnemyCommonGroup = "EnemyCommon";
+	constexpr float kDefaultEnemyHitStunCooldownSec = 0.5f;
+
+	void EnsureEnemyCommonParameters()
+	{
+		static bool isInitialized = false;
+		if (isInitialized)
+		{
+			return;
+		}
+		isInitialized = true;
+
+		auto* parameters = ParameterManager::GetInstance();
+		parameters->CreateGroup(kEnemyCommonGroup);
+		if (std::filesystem::exists("Resources/ParameterManager/EnemyCommon.json"))
+		{
+			parameters->LoadFile(kEnemyCommonGroup);
+		}
+		else
+		{
+			Log("[EnemyBase] EnemyCommon.json not found. Use built-in default enemy parameters.\n");
+		}
+
+		parameters->AddItem(kEnemyCommonGroup, "EnemyHitStunCooldownSec", kDefaultEnemyHitStunCooldownSec, 0.0f, 10.0f);
+		parameters->SetDisplayName(kEnemyCommonGroup, "EnemyHitStunCooldownSec", "敵怯みクールタイム");
+	}
+
+	template<typename T>
+	T GetEnemyParameterOrDefault(const std::string& key, const T& defaultValue)
+	{
+		try
+		{
+			return ParameterManager::GetInstance()->GetValue<T>(kEnemyCommonGroup, key);
+		}
+		catch (const std::exception& e)
+		{
+			Log("[EnemyBase] Failed to read EnemyCommon." + key + ": " + e.what() + ". Use default.\n");
+			return defaultValue;
+		}
+	}
 	static float Clamp01(float v)
 	{
 		if (v < 0.0f) return 0.0f;
@@ -176,11 +221,20 @@ void EnemyBase::MoveVisualFar(const Vector3& pos)
 	}
 }
 
+EnemyBase::~EnemyBase()
+{
+	ParameterManager::GetInstance()->UnregisterParameterApplier(kEnemyCommonGroup, this);
+}
+
 /// -------------------------------------------------------------
 /// 初期化
 /// -------------------------------------------------------------
 void EnemyBase::Initialize()
 {
+	EnsureEnemyCommonParameters();
+	ApplyParameters();
+	ParameterManager::GetInstance()->RegisterParameterApplier(kEnemyCommonGroup, this, [this]() { ApplyParameters(); }); // 保存/反映後に通常敵の怯みクールタイムを再適用する。
+
 	SetTypeID(static_cast<uint32_t>(CollisionTypeIdDef::kEnemy));
 	SetOwner(this);
 
@@ -190,6 +244,7 @@ void EnemyBase::Initialize()
 	InitializeHumanoidVisual();
 	SetColor(baseColor_);
 	hitFlashTimer_ = 0.0f;
+	hitStunCooldownTimer_ = 0.0f;
 
 	SetCenterPosition({ 0.0f, 0.0f, 0.0f });
 
@@ -341,6 +396,9 @@ void EnemyBase::Update(float deltaTime)
 	// フレーム落ち時の移動暴走を防ぐため、敵更新用deltaTimeを制限する。
 	deltaTime = std::clamp(deltaTime, 0.0f, kMaxUpdateDeltaTime);
 
+	// 怯みクールダウン中でもダメージやヒット演出は通し、再怯みだけを遅延させる。
+	hitStunCooldownTimer_ = std::max(0.0f, hitStunCooldownTimer_ - deltaTime);
+
 	// 死亡演出
 	if (isDead_)
 	{
@@ -429,6 +487,26 @@ void EnemyBase::Update(float deltaTime)
 
 	SetCenterPosition(newPos);
 	UpdateHitFlash(deltaTime);
+}
+
+/// -------------------------------------------------------------
+/// ParameterManager値の反映
+/// -------------------------------------------------------------
+void EnemyBase::ApplyParameters()
+{
+	EnsureEnemyCommonParameters();
+	hitStunCooldownSec_ = std::max(0.0f, GetEnemyParameterOrDefault("EnemyHitStunCooldownSec", kDefaultEnemyHitStunCooldownSec));
+	hitStunCooldownTimer_ = std::min(hitStunCooldownTimer_, hitStunCooldownSec_);
+}
+
+bool EnemyBase::CanStartHitStun() const
+{
+	return hitStunCooldownTimer_ <= 0.0f;
+}
+
+void EnemyBase::StartHitStunCooldown()
+{
+	hitStunCooldownTimer_ = hitStunCooldownSec_;
 }
 
 /// -------------------------------------------------------------

--- a/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.h
+++ b/Project/ApplicationLayer/Character/Enemy/Core/EnemyBase.h
@@ -45,7 +45,7 @@ public:
 
 public:
 	EnemyBase() = default;
-	virtual ~EnemyBase() = default;
+	virtual ~EnemyBase();
 
 	virtual void Initialize();
 	virtual void Update(float deltaTime);
@@ -53,6 +53,7 @@ public:
 	virtual void DrawImGui();
 	virtual void UpdateShadowMatrix(const K4E::Matrix4x4& lightViewProjection);
 	virtual void DrawShadow();
+	virtual void ApplyParameters();
 
 public:
 	// HP
@@ -118,6 +119,10 @@ public:
 	void SetHitFlashFrequency(float hz) { hitFlashFrequencyHz_ = hz; }
 	void SetHitFlashColor(const K4E::Vector4& c) { hitFlashColor_ = c; }
 	void StartHitFlash();
+
+	// 怯みだけを間引くため、ダメージ処理とは独立してクールダウン可否を判定する。
+	bool CanStartHitStun() const;
+	void StartHitStunCooldown();
 
 	// Collider events
 	void OnCollisionEnter(K4E::Collider* other) override;
@@ -237,6 +242,10 @@ protected:
 	float hitFlashDuration_ = 0.12f;
 	float hitFlashFrequencyHz_ = 18.0f;
 	bool hitFlashEnabled_ = true;
+
+	// 連続ヒットで怯みが上書きされ続けないよう、怯み専用の再発動待ち時間を持つ。
+	float hitStunCooldownSec_ = 0.5f;
+	float hitStunCooldownTimer_ = 0.0f;
 
 	// stage AABB
 	const std::vector<K4E::AABB>* worldAABBs_ = nullptr;

--- a/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MeleeEnemy.cpp
@@ -857,8 +857,9 @@ void MeleeEnemy::TakeDamage(int amount, const Vector3& hitDir, float hitPower)
 
 void MeleeEnemy::StartHitReaction(const Vector3& hitDirection)
 {
-	// 被ダメージ時にのけぞり状態を開始する。
-	if (!hitReactionSettings_.enabled || IsDead()) { return; }
+	// 怯みクール中はダメージ/ヒット演出を維持しつつ、のけぞり再開だけを抑える。
+	if (!hitReactionSettings_.enabled || IsDead() || !CanStartHitStun()) { return; }
+	StartHitStunCooldown();
 	Vector3 dir = NormalizeXZ(hitDirection * -1.0f);
 	if (LengthXZ(dir) <= kEpsilon)
 	{

--- a/Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.cpp
+++ b/Project/ApplicationLayer/Character/Enemy/Core/MidRangeEnemy.cpp
@@ -829,12 +829,18 @@ void MidRangeEnemy::UpdateVisualAnimation(float deltaTime)
 
 void MidRangeEnemy::StartHitReaction(const Vector3& hitDirection)
 {
-    // 追加: 被ダメージリアクション開始。
+    // 怯みクール中はダメージ/ヒット演出を維持しつつ、被ダメージリアクションだけを抑える。
     if (!hitReaction_.enabled)
     {
         hitReactionState_.lastReason = "Disabled";
         return;
     }
+    if (!CanStartHitStun())
+    {
+        hitReactionState_.lastReason = "Cooldown";
+        return;
+    }
+    StartHitStunCooldown();
     hitReactionState_.active = true;
     hitReactionState_.timer = hitReaction_.duration;
     hitReactionState_.knockbackDirection = NormalizeXZ(hitDirection);

--- a/Project/ApplicationLayer/Character/Player/Component/PlayerMeleeComponent.cpp
+++ b/Project/ApplicationLayer/Character/Player/Component/PlayerMeleeComponent.cpp
@@ -250,6 +250,7 @@ void PlayerMeleeComponent::EvaluateHit(const K4E::Vector3& playerPos)
 				<< ", hpBefore=" << boss->GetHP() << "/" << boss->GetMaxHP();
 			LogPlayerAttack(oss.str());
 		}
+		// プレイヤー近接の連続ヒットでも、怯み可否はボス側クールダウンに任せてダメージは通す。
 		boss->OnDamaged(bossDamage);
 		if (onHit_) onHit_();
 	}

--- a/Project/Resources/ParameterManager/BossCommon.json
+++ b/Project/Resources/ParameterManager/BossCommon.json
@@ -5,6 +5,7 @@
         "turnSpeed": 4.0,
         "stopDistance": 3.0,
         "attackRange": 3.0,
-        "attackCooldownSec": 1.2
+        "attackCooldownSec": 1.2,
+        "BossHitStunCooldownSec": 1.0
     }
 }

--- a/Project/Resources/ParameterManager/EnemyCommon.json
+++ b/Project/Resources/ParameterManager/EnemyCommon.json
@@ -1,0 +1,5 @@
+{
+    "EnemyCommon": {
+        "EnemyHitStunCooldownSec": 0.5
+    }
+}


### PR DESCRIPTION
### Motivation
- Prevent repeated stun/hit-reaction stacking from multi-hit, splash or rapid attacks while keeping HP, hit effects and SFX working as before.  
- Make stun suppression tunable at runtime via `ParameterManager` and allow different cooldowns for normal enemies and bosses.  
- Ensure only the stun/reaction activation is suppressed; damage application, hit effects and death logic remain unchanged.

### Description
- Added per-entity hit-stun cooldown support: `EnemyBase` now has `hitStunCooldownSec_` / `hitStunCooldownTimer_` plus `CanStartHitStun()` / `StartHitStunCooldown()` and `ApplyParameters()` to read `EnemyCommon.EnemyHitStunCooldownSec` from `ParameterManager`. (files: `EnemyBase.h`, `EnemyBase.cpp`).
- Added boss-side cooldown in `BossStatusComponent` with `hitStunCooldownSec_` / `hitStunCooldownTimer_`, `CanStartHitStun()`, `StartHitStunCooldown()` and `SetHitStunCooldownSec()` and made `BossBase` propagate `BossCommon.BossHitStunCooldownSec` into the component. (files: `BossStatusComponent.*`, `BossBase.cpp`).
- Guarded existing stun/reaction entry points so damage and effects still occur but reaction/stagger activation is suppressed while cooldown is active: `Enemy::OnBulletHit`, `MeleeEnemy::StartHitReaction`, `MidRangeEnemy::StartHitReaction`, and `GuardianBoss::OnDamaged` now use the cooldown check and start the cooldown when a reaction is triggered. (files: `Enemy.cpp`, `MeleeEnemy.cpp`, `MidRangeEnemy.cpp`, `GuardianBoss.cpp`).
- Kept splash and player-melee flows applying HP and visual feedback unchanged while adding comments clarifying that stun decision is delegated to the target's new cooldown logic (files: `Bullet.cpp`, `PlayerMeleeComponent.cpp`).
- Added ParameterManager entries and defaults: `EnemyCommon.EnemyHitStunCooldownSec = 0.5` (表示名 "敵怯みクールタイム") and `BossCommon.BossHitStunCooldownSec = 1.0` (表示名 "ボス怯みクールタイム"). (files: `BossCommon.json`, `EnemyCommon.json`, changes in `BossBase.cpp` and `EnemyBase.cpp` to register/read parameters).

### Testing
- Validated parameter JSON files with `python3 -m json.tool` for both `BossCommon.json` and `EnemyCommon.json`, which succeeded.  
- Ran a syntax-only check `clang++ -std=c++20 -fsyntax-only` on `BossStatusComponent.cpp` (included headers available in the sandbox), which succeeded.  
- Ran repository checks (`diff --check`) and code-style/quick scan; no issues reported.  
- Full Visual Studio/msbuild Debug and Release builds were not executed in this Linux container because `msbuild` is not available, and one broader syntax check that required DirectX headers failed due to missing platform SDK headers; runtime/IDE build verification should be performed on the target Windows build environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2173326ba4832d8a0101c4a29ca0af)