### PR TITLE
Fix camera-dependent and local-light shadow artifacts

### DIFF
--- a/Project/Engine/Graphics/Lighting/ShadowSystem.cpp
+++ b/Project/Engine/Graphics/Lighting/ShadowSystem.cpp
@@ -18,6 +18,8 @@ namespace Ken4lowEngine
 
 	namespace
 	{
+		constexpr uint32_t kDirectionalShadowTechnique = 1;
+		constexpr uint32_t kSpotLinearShadowTechnique = 2;
 		constexpr uint32_t kPointShadowTechnique = 3;
 		constexpr uint32_t kCsmShadowTechnique = 4;
 
@@ -80,6 +82,8 @@ namespace Ken4lowEngine
 		}
 
 		const uint32_t gpuLightIndex = ResolveGpuLightIndex(lightManager, lightIndex);
+		gpuData_->shadowCasterLightIndex = gpuLightIndex; // 通常描画側は選択中ライトだけへShadowを適用する。
+
 		if (casterType == LightManager::ShadowCasterType::Point)
 		{
 			ExecutePointPass(lightManager, light, gpuLightIndex, drawShadowObjects);
@@ -94,6 +98,19 @@ namespace Ken4lowEngine
 		}
 		else
 		{
+			if (casterType == LightManager::ShadowCasterType::Spot)
+			{
+				const float farZ = std::max(ClampPositive(light.distance, 1.0f), 1.0f);
+				const float nearZ = std::clamp(lightManager.spotShadowNearZ_, 0.01f, farZ * 0.5f);
+				gpuData_->shadowTechnique = kSpotLinearShadowTechnique;
+				gpuData_->pointLightPositionAndFar = { light.position.x, light.position.y, light.position.z, farZ };
+				gpuData_->cameraPositionAndPointNear.w = nearZ;
+			}
+			else if (casterType == LightManager::ShadowCasterType::Directional)
+			{
+				gpuData_->shadowTechnique = kDirectionalShadowTechnique;
+			}
+
 			ExecuteLegacyPass(lightManager, drawShadowObjects);
 			csmRenderTarget_->End(dxCommon_->GetCommandManager()->GetCommandList());
 			pointRenderTarget_->End(dxCommon_->GetCommandManager()->GetCommandList());
@@ -112,6 +129,7 @@ namespace Ken4lowEngine
 	void ShadowSystem::ExecuteLegacyPass(LightManager& lightManager, const std::function<void()>& drawShadowObjects)
 	{
 		activePassLightViewProjection_ = lightManager.BuildShadowLightViewProjection(CameraManager::GetInstance()->GetActiveCameraPosition());
+		gpuData_->cascadeLightViewProjection[0] = activePassLightViewProjection_; // Receiverは各Objectの更新状態ではなくFrame共通行列を参照する。
 		dxCommon_->BeginShadowMapPass();
 		if (drawShadowObjects) { drawShadowObjects(); }
 		dxCommon_->EndShadowMapPass();
@@ -166,13 +184,17 @@ namespace Ken4lowEngine
 		}
 
 		const Vector3 cameraPosition = cameraManager->GetActiveCameraPosition();
-		const Vector3 forward = cameraManager->GetActiveCameraForward();
+		const Vector3 forward = Vector3::NormalizeSafe(cameraManager->GetActiveCameraForward(), { 0.0f, 0.0f, 1.0f });
 		const Vector3 worldUp = std::fabs(Vector3::Dot(forward, { 0.0f, 1.0f, 0.0f })) > 0.98f ? Vector3{ 1.0f, 0.0f, 0.0f } : Vector3{ 0.0f, 1.0f, 0.0f };
 		const Vector3 right = Vector3::NormalizeSafe(Vector3::Cross(worldUp, forward), { 1.0f, 0.0f, 0.0f });
 		const Vector3 up = Vector3::NormalizeSafe(Vector3::Cross(forward, right), { 0.0f, 1.0f, 0.0f });
 		const float tanHalfFov = std::tan(cameraManager->GetActiveFovY() * 0.5f);
 		const float aspect = std::max(cameraManager->GetActiveAspectRatio(), 0.01f);
 		const Vector3 lightDirection = Vector3::NormalizeSafe(light.direction, { 0.3f, -1.0f, 0.2f });
+
+		gpuData_->shadowTechnique = kCsmShadowTechnique;
+		gpuData_->shadowCasterLightIndex = gpuLightIndex;
+		gpuData_->pointLightPositionAndFar = { forward.x, forward.y, forward.z, shadowFar }; // CSM時はxyzをCamera ForwardとしてCascade選択へ使う。
 
 		float sliceNear = cameraNear;
 		for (uint32_t cascade = 0; cascade < kCascadeCount; ++cascade)
@@ -212,8 +234,6 @@ namespace Ken4lowEngine
 		csmRenderTarget_->End(dxCommon_->GetCommandManager()->GetCommandList());
 		gpuData_->cascadeSplits = { splits[0], splits[1], splits[2], splits[3] };
 		gpuData_->cascadeCount = kCascadeCount;
-		gpuData_->shadowTechnique = kCsmShadowTechnique;
-		gpuData_->shadowCasterLightIndex = gpuLightIndex;
 	}
 
 	uint32_t ShadowSystem::ResolveGpuLightIndex(const LightManager& lightManager, int32_t legacyLightIndex) const

--- a/Project/Engine/Graphics/Lighting/ShadowSystem.h
+++ b/Project/Engine/Graphics/Lighting/ShadowSystem.h
@@ -16,15 +16,15 @@ namespace Ken4lowEngine
 	class ShadowMapArrayRenderTarget;
 
 	/// <summary>
-	/// 既存b4 ShadowParameterを変更せず、Point Cube ShadowとCSMだけをb6へ追加するGPU契約です。
+	/// 既存b4 ShadowParameterを変更せず、選択ライトのFrame共通行列とPoint Cube / CSM情報をb6へ追加するGPU契約です。
 	/// </summary>
 	struct ExtendedShadowParameterGPU
 	{
-		std::array<Matrix4x4, 4> cascadeLightViewProjection{};
+		std::array<Matrix4x4, 4> cascadeLightViewProjection{}; // [0]はLegacy Directional/SpotでもFrame共通行列として使用する。
 		Vector4 cascadeSplits{};
-		Vector4 pointLightPositionAndFar{};
+		Vector4 pointLightPositionAndFar{}; // Local Light時はPosition/Far、CSM時はCamera Forward/MaxDistance。
 		Vector4 cameraPositionAndPointNear{};
-		uint32_t shadowTechnique = 0; // 0:Legacy/Off 3:PointCube 4:CSM
+		uint32_t shadowTechnique = 0; // 0:Off 1:Directional 2:SpotLinear 3:PointCube 4:CSM
 		uint32_t cascadeCount = 0;
 		uint32_t shadowCasterLightIndex = UINT32_MAX; // GPU転送後のPunctualLight index
 		uint32_t padding0 = 0;
@@ -48,7 +48,7 @@ namespace Ken4lowEngine
 		void Finalize();
 		void Resize(uint32_t shadowMapSize);
 
-		/// <summary>選択中ライトに応じ、Legacy/Spotを1回、Pointを6回、CSMを4回描画します。</summary>
+		/// <summary>選択中ライトに応じ、Directional/Spotを1回、Pointを6回、CSMを4回描画します。</summary>
 		void Execute(LightManager& lightManager, const std::function<void()>& drawShadowObjects);
 
 		/// <summary>b6、t10、t11を現在のRootSignatureへバインドします。</summary>

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3DCommon.cpp
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3DCommon.cpp
@@ -1,3 +1,4 @@
+#define NOMINMAX
 #include "Object3DCommon.h"
 #include "DirectXCommon.h"
 #include "CameraManager.h"

--- a/Project/Engine/Graphics/Renderer/Object3D/Object3DCommon.cpp
+++ b/Project/Engine/Graphics/Renderer/Object3D/Object3DCommon.cpp
@@ -139,7 +139,7 @@ namespace Ken4lowEngine
 		LightManager::PunctualLightGPU light{};
 		LightManager::ShadowCasterType casterType = LightManager::ShadowCasterType::None;
 		if (!LightManager::GetInstance()->TryGetActiveShadowCasterLightInfo(lightIndex, light, casterType) ||
-			casterType != LightManager::ShadowCasterType::Point)
+			(casterType != LightManager::ShadowCasterType::Point && casterType != LightManager::ShadowCasterType::Spot))
 		{
 			pointShadowPassData_->lightPositionAndFar = { 0.0f, 0.0f, 0.0f, 1.0f };
 			return;
@@ -152,33 +152,35 @@ namespace Ken4lowEngine
 	void Object3DCommon::SetShadowMapRenderSetting()
 	{
 		auto* commandList = dxCommon_->GetCommandManager()->GetCommandList();
-		const bool isPointShadow = LightManager::GetInstance()->GetActiveShadowCasterType() == LightManager::ShadowCasterType::Point;
-		const PipelineBundle& pipeline = isPointShadow
+		const LightManager::ShadowCasterType casterType = LightManager::GetInstance()->GetActiveShadowCasterType();
+		const bool isLocalLinearShadow = casterType == LightManager::ShadowCasterType::Point || casterType == LightManager::ShadowCasterType::Spot;
+		const PipelineBundle& pipeline = isLocalLinearShadow
 			? shadowCasterPipelineSet_.GetObjectPoint()
 			: shadowCasterPipelineSet_.GetObjectDepth();
 
 		commandList->SetGraphicsRootSignature(pipeline.rootSignature.Get());
 		commandList->SetPipelineState(pipeline.pipelineState.Get());
 		commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-		if (isPointShadow && pointShadowPassResource_)
+		if (isLocalLinearShadow && pointShadowPassResource_)
 		{
 			UpdatePointShadowPassData();
-			commandList->SetGraphicsRootConstantBufferView(1, pointShadowPassResource_->GetGPUVirtualAddress()); // 6面で共通のLight位置とFar距離をPSへ渡す。
+			commandList->SetGraphicsRootConstantBufferView(1, pointShadowPassResource_->GetGPUVirtualAddress()); // SpotとPointは同じ線形距離Depth契約を使う。
 		}
 	}
 
 	void Object3DCommon::SetInstancedShadowMapRenderSetting()
 	{
 		auto* commandList = dxCommon_->GetCommandManager()->GetCommandList();
-		const bool isPointShadow = LightManager::GetInstance()->GetActiveShadowCasterType() == LightManager::ShadowCasterType::Point;
-		const PipelineBundle& pipeline = isPointShadow
+		const LightManager::ShadowCasterType casterType = LightManager::GetInstance()->GetActiveShadowCasterType();
+		const bool isLocalLinearShadow = casterType == LightManager::ShadowCasterType::Point || casterType == LightManager::ShadowCasterType::Spot;
+		const PipelineBundle& pipeline = isLocalLinearShadow
 			? shadowCasterPipelineSet_.GetInstancedPoint()
 			: shadowCasterPipelineSet_.GetInstancedDepth();
 
 		commandList->SetGraphicsRootSignature(pipeline.rootSignature.Get());
 		commandList->SetPipelineState(pipeline.pipelineState.Get());
 		commandList->IASetPrimitiveTopology(D3D_PRIMITIVE_TOPOLOGY_TRIANGLELIST);
-		if (isPointShadow && pointShadowPassResource_)
+		if (isLocalLinearShadow && pointShadowPassResource_)
 		{
 			UpdatePointShadowPassData();
 			commandList->SetGraphicsRootConstantBufferView(2, pointShadowPassResource_->GetGPUVirtualAddress()); // Instancing用Rootのt0を避けてb1をIndex 2へ束縛する。

--- a/Project/Resources/Shaders/Object3D/LightingCommon.hlsli
+++ b/Project/Resources/Shaders/Object3D/LightingCommon.hlsli
@@ -121,6 +121,7 @@ LightingTerms EvaluateDirectionalLight(
     ShadowParameter shadowParam,
     float shininess,
     LightingSettings lightingSettings,
+    uint lightIndex,
     Texture2D<float> shadowMap,
     ExtendedShadowParameter extendedShadowParam,
     Texture2DArray<float> csmShadowMaps,
@@ -132,9 +133,18 @@ LightingTerms EvaluateDirectionalLight(
     float NdotL = CalculateDiffuseFactor(normal, lightDir, lightingSettings);
     float3 lightColor = light.color.rgb * light.intensity;
 
-    float shadow = (shadowParam.shadowMode == 4)
-        ? CalculateCsmShadow(worldPosition, normal, lightDir, extendedShadowParam, csmShadowMaps, shadowSampler)
-        : CalculateShadow(worldPosition, normal, lightDir, shadowParam, shadowMap, shadowSampler);
+    float shadow = 1.0f;
+    if (lightIndex == extendedShadowParam.shadowCasterLightIndex)
+    {
+        if (extendedShadowParam.shadowTechnique == SHADOW_TECHNIQUE_CSM)
+        {
+            shadow = CalculateCsmShadow(worldPosition, normal, lightDir, extendedShadowParam, csmShadowMaps, shadowSampler);
+        }
+        else if (extendedShadowParam.shadowTechnique == SHADOW_TECHNIQUE_DIRECTIONAL)
+        {
+            shadow = CalculateDirectionalShadow(worldPosition, normal, lightDir, extendedShadowParam, shadowMap, shadowSampler);
+        }
+    }
 
     terms.diffuse = lightColor * NdotL * shadow;
     terms.specular = lightColor * ComputeSpecular(normal, lightDir, viewDir, shininess, lightingSettings) * shadow;
@@ -167,7 +177,7 @@ LightingTerms EvaluatePointLight(
     float NdotL = CalculateDiffuseFactor(normal, lightDir, lightingSettings);
     float3 lightColor = light.color.rgb * (light.intensity * atten);
 
-    const float shadow = (extendedShadowParam.shadowTechnique == 3 && lightIndex == extendedShadowParam.shadowCasterLightIndex)
+    const float shadow = (extendedShadowParam.shadowTechnique == SHADOW_TECHNIQUE_POINT_CUBE && lightIndex == extendedShadowParam.shadowCasterLightIndex)
         ? CalculatePointCubeShadow(worldPosition, normal, lightDir, extendedShadowParam, pointShadowMap, shadowSampler)
         : 1.0f;
     terms.diffuse = lightColor * NdotL * shadow;
@@ -183,7 +193,9 @@ LightingTerms EvaluateSpotLight(
     ShadowParameter shadowParam,
     float shininess,
     LightingSettings lightingSettings,
+    uint lightIndex,
     Texture2D<float> shadowMap,
+    ExtendedShadowParameter extendedShadowParam,
     SamplerComparisonState shadowSampler)
 {
     LightingTerms terms = MakeEmptyLightingTerms();
@@ -203,7 +215,9 @@ LightingTerms EvaluateSpotLight(
     float NdotL = CalculateDiffuseFactor(normal, lightDir, lightingSettings);
     float3 lightColor = light.color.rgb * (light.intensity * atten * spot);
 
-    float shadow = (shadowParam.shadowMode == 2) ? CalculateShadow(worldPosition, normal, lightDir, shadowParam, shadowMap, shadowSampler) : 1.0f;
+    const float shadow = (extendedShadowParam.shadowTechnique == SHADOW_TECHNIQUE_SPOT_LINEAR && lightIndex == extendedShadowParam.shadowCasterLightIndex)
+        ? CalculateSpotLinearShadow(worldPosition, normal, lightDir, extendedShadowParam, shadowMap, shadowSampler)
+        : 1.0f;
     terms.diffuse = lightColor * NdotL * shadow;
     terms.specular = lightColor * ComputeSpecular(normal, lightDir, viewDir, shininess, lightingSettings) * NdotL * shadow;
     return terms;
@@ -270,6 +284,7 @@ float3 AccumulateLighting(
                 shadowParam,
                 shininess,
                 lightingSettings,
+                i,
                 shadowMap,
                 extendedShadowParam,
                 csmShadowMaps,
@@ -278,7 +293,7 @@ float3 AccumulateLighting(
         }
         else if (light.lightType == LIGHT_TYPE_POINT)
         {
-			// 選択中Point Lightだけが6面Cube Shadowを使用し、他のPoint Lightは従来の減衰照明を維持する。
+            // 選択中Point Lightだけが6面Cube Shadowを使用し、他のPoint Lightは従来の減衰照明を維持する。
             terms = EvaluatePointLight(
                 light,
                 worldPosition,
@@ -302,7 +317,9 @@ float3 AccumulateLighting(
                 shadowParam,
                 shininess,
                 lightingSettings,
+                i,
                 shadowMap,
+                extendedShadowParam,
                 shadowSampler);
             activeLightCount++;
         }

--- a/Project/Resources/Shaders/Object3D/PbrDirectLighting.hlsli
+++ b/Project/Resources/Shaders/Object3D/PbrDirectLighting.hlsli
@@ -167,9 +167,17 @@ float3 DirectLightingPBR(
         if (light.lightType == LIGHT_TYPE_DIRECTIONAL)
         {
             lightDir = normalize(-light.direction);
-            shadow = (shadowParam.shadowMode == 4)
-                ? CalculateCsmShadow(worldPosition, surface.normal, lightDir, extendedShadowParam, csmShadowMaps, shadowSampler)
-                : CalculateShadow(worldPosition, surface.normal, lightDir, shadowParam, shadowMap, shadowSampler);
+            if (i == extendedShadowParam.shadowCasterLightIndex)
+            {
+                if (extendedShadowParam.shadowTechnique == SHADOW_TECHNIQUE_CSM)
+                {
+                    shadow = CalculateCsmShadow(worldPosition, surface.normal, lightDir, extendedShadowParam, csmShadowMaps, shadowSampler);
+                }
+                else if (extendedShadowParam.shadowTechnique == SHADOW_TECHNIQUE_DIRECTIONAL)
+                {
+                    shadow = CalculateDirectionalShadow(worldPosition, surface.normal, lightDir, extendedShadowParam, shadowMap, shadowSampler);
+                }
+            }
         }
         else if (light.lightType == LIGHT_TYPE_POINT)
         {
@@ -178,7 +186,7 @@ float3 DirectLightingPBR(
             lightDir = toL / max(d, kMinLightLength);
             float range = max(light.radius, kMinRange);
             attenuation = pow(saturate(1.0f - d / range), max(light.decay, kMinRange)) * step(d, range);
-            if (extendedShadowParam.shadowTechnique == 3 && i == extendedShadowParam.shadowCasterLightIndex)
+            if (extendedShadowParam.shadowTechnique == SHADOW_TECHNIQUE_POINT_CUBE && i == extendedShadowParam.shadowCasterLightIndex)
             {
                 shadow = CalculatePointCubeShadow(worldPosition, surface.normal, lightDir, extendedShadowParam, pointShadowMap, shadowSampler);
             }
@@ -194,7 +202,10 @@ float3 DirectLightingPBR(
             float3 dir = normalize(light.direction);
             float ct = dot(-dir, lightDir);
             attenuation *= smoothstep(light.cosAngle, light.cosFalloffStart, ct) * step(light.cosAngle, ct);
-            shadow = (shadowParam.shadowMode == 2) ? CalculateShadow(worldPosition, surface.normal, lightDir, shadowParam, shadowMap, shadowSampler) : 1.0f;
+            if (extendedShadowParam.shadowTechnique == SHADOW_TECHNIQUE_SPOT_LINEAR && i == extendedShadowParam.shadowCasterLightIndex)
+            {
+                shadow = CalculateSpotLinearShadow(worldPosition, surface.normal, lightDir, extendedShadowParam, shadowMap, shadowSampler);
+            }
         }
         else
         {

--- a/Project/Resources/Shaders/Object3D/ShadowCommon.hlsli
+++ b/Project/Resources/Shaders/Object3D/ShadowCommon.hlsli
@@ -2,8 +2,14 @@
 #define SHADOW_COMMON_HLSLI
 
 static const float kEpsilon = 1e-5f;
-static const float kDefaultShadowStrength = 0.60f; // 真っ黒にしない
-static const int kPCFRadius = 1; // 3x3 PCF
+static const float kDefaultShadowStrength = 0.60f;
+static const int kPCFRadius = 1;
+
+static const uint SHADOW_TECHNIQUE_OFF = 0;
+static const uint SHADOW_TECHNIQUE_DIRECTIONAL = 1;
+static const uint SHADOW_TECHNIQUE_SPOT_LINEAR = 2;
+static const uint SHADOW_TECHNIQUE_POINT_CUBE = 3;
+static const uint SHADOW_TECHNIQUE_CSM = 4;
 
 struct ShadowParameter
 {
@@ -11,19 +17,18 @@ struct ShadowParameter
     float shadowBias;
     float normalBias;
     float shadowStrength;
-    uint shadowMode; // 0:Off 1:Directional 2:Spot 3:PointCube 4:CSM
-    uint shadowDebugMode; // 0:None 1:ShadowMap 2:ShadowFactor
+    uint shadowMode;
+    uint shadowDebugMode;
     float padding;
 };
 
-// 既存ShadowParameter(b4)のレイアウトは変更せず、Phase 5の拡張値だけをb6へ分離する。
 struct ExtendedShadowParameter
 {
     float4x4 cascadeLightViewProjection[4];
     float4 cascadeSplits;
     float4 pointLightPositionAndFar;
     float4 cameraPositionAndPointNear;
-    uint shadowTechnique; // 0:Legacy/Off 3:PointCube 4:CSM
+    uint shadowTechnique; // 0:Off 1:Directional 2:SpotLinear 3:PointCube 4:CSM
     uint cascadeCount;
     uint shadowCasterLightIndex;
     uint padding0;
@@ -33,6 +38,68 @@ struct ExtendedShadowParameter
     float padding1;
 };
 
+float ResolveShadowVisibility(float visibility, float strength)
+{
+    return lerp(1.0f - saturate(strength), 1.0f, visibility);
+}
+
+float SampleShadowMapPCF(
+    Texture2D<float> shadowMap,
+    SamplerComparisonState shadowSampler,
+    float2 uv,
+    float compareDepth)
+{
+    uint shadowWidth, shadowHeight;
+    shadowMap.GetDimensions(shadowWidth, shadowHeight);
+    const float2 texelSize = 1.0f / max(float2(shadowWidth, shadowHeight), float2(1.0f, 1.0f));
+
+    float visibility = 0.0f;
+    [unroll]
+    for (int y = -kPCFRadius; y <= kPCFRadius; ++y)
+    {
+        [unroll]
+        for (int x = -kPCFRadius; x <= kPCFRadius; ++x)
+        {
+            visibility += shadowMap.SampleCmpLevelZero(
+                shadowSampler,
+                uv + float2(x, y) * texelSize,
+                compareDepth);
+        }
+    }
+    return visibility / 9.0f;
+}
+
+float CalculateProjectedShadowPCF(
+    float3 worldPosition,
+    float3 normal,
+    float3 lightDir,
+    float4x4 lightViewProjection,
+    float shadowBias,
+    float normalBias,
+    float shadowStrength,
+    Texture2D<float> shadowMap,
+    SamplerComparisonState shadowSampler)
+{
+    const float NoL = saturate(dot(normal, lightDir));
+    const float3 biasedWorldPosition = worldPosition + normal * normalBias * (1.0f - NoL);
+    const float4 shadowPosition = mul(float4(biasedWorldPosition, 1.0f), lightViewProjection);
+
+    if (shadowPosition.w <= kEpsilon)
+    {
+        return 1.0f;
+    }
+
+    const float3 projected = shadowPosition.xyz / shadowPosition.w;
+    const float2 uv = float2(projected.x * 0.5f + 0.5f, -projected.y * 0.5f + 0.5f);
+    if (any(uv < 0.0f) || any(uv > 1.0f) || projected.z < 0.0f || projected.z > 1.0f)
+    {
+        return 1.0f;
+    }
+
+    const float visibility = SampleShadowMapPCF(shadowMap, shadowSampler, uv, projected.z - shadowBias);
+    return ResolveShadowVisibility(visibility, shadowStrength);
+}
+
 float CalculateShadowPCF(
     float3 worldPosition,
     float3 normal,
@@ -41,61 +108,18 @@ float CalculateShadowPCF(
     Texture2D<float> shadowMap,
     SamplerComparisonState shadowSampler)
 {
-    float NoL = saturate(dot(normal, lightDir));
-
-    // 法線バイアス
-    float offsetAmount = shadowParam.normalBias * (1.0f - NoL);
-    float3 biasedWorldPosition = worldPosition + normal * offsetAmount;
-
-    float4 shadowPosition = mul(float4(biasedWorldPosition, 1.0f), shadowParam.lightViewProjection);
-
-    if (abs(shadowPosition.w) < kEpsilon)
-    {
-        return 1.0f;
-    }
-
-    float3 proj = shadowPosition.xyz / shadowPosition.w;
-
-    float2 uv;
-    uv.x = proj.x * 0.5f + 0.5f;
-    uv.y = -proj.y * 0.5f + 0.5f;
-
-    if (uv.x < 0.0f || uv.x > 1.0f ||
-        uv.y < 0.0f || uv.y > 1.0f ||
-        proj.z < 0.0f || proj.z > 1.0f)
-    {
-        return 1.0f;
-    }
-
-    float compareDepth = proj.z - shadowParam.shadowBias;
-
-    uint shadowWidth, shadowHeight;
-    shadowMap.GetDimensions(shadowWidth, shadowHeight);
-
-    float2 texelSize = 1.0f / float2((float) shadowWidth, (float) shadowHeight);
-
-    float visibility = 0.0f;
-    float sampleCount = 0.0f;
-
-    [unroll]
-    for (int y = -kPCFRadius; y <= kPCFRadius; ++y)
-    {
-        [unroll]
-        for (int x = -kPCFRadius; x <= kPCFRadius; ++x)
-        {
-            float2 offset = float2((float) x, (float) y) * texelSize;
-            visibility += shadowMap.SampleCmpLevelZero(shadowSampler, uv + offset, compareDepth);
-            sampleCount += 1.0f;
-        }
-    }
-
-    visibility /= sampleCount;
-
-    // ShadowStrengthでDirectLightにのみ掛かる可視度を調整する。
-    return lerp(1.0f - saturate(shadowParam.shadowStrength), 1.0f, visibility);
+    return CalculateProjectedShadowPCF(
+        worldPosition,
+        normal,
+        lightDir,
+        shadowParam.lightViewProjection,
+        shadowParam.shadowBias,
+        shadowParam.normalBias,
+        shadowParam.shadowStrength,
+        shadowMap,
+        shadowSampler);
 }
 
-// 既存名を残したいならこれでラップ
 float CalculateShadow(
     float3 worldPosition,
     float3 normal,
@@ -104,22 +128,92 @@ float CalculateShadow(
     Texture2D<float> shadowMap,
     SamplerComparisonState shadowSampler)
 {
-    return CalculateShadowPCF(
+    return CalculateShadowPCF(worldPosition, normal, lightDir, shadowParam, shadowMap, shadowSampler);
+}
+
+float CalculateDirectionalShadow(
+    float3 worldPosition,
+    float3 normal,
+    float3 lightDir,
+    ExtendedShadowParameter shadowParam,
+    Texture2D<float> shadowMap,
+    SamplerComparisonState shadowSampler)
+{
+    if (shadowParam.shadowTechnique != SHADOW_TECHNIQUE_DIRECTIONAL)
+    {
+        return 1.0f;
+    }
+
+    return CalculateProjectedShadowPCF(
         worldPosition,
         normal,
         lightDir,
-        shadowParam,
+        shadowParam.cascadeLightViewProjection[0],
+        shadowParam.shadowBias,
+        shadowParam.normalBias,
+        shadowParam.shadowStrength,
         shadowMap,
         shadowSampler);
 }
 
-uint SelectShadowCascade(float cameraDistance, ExtendedShadowParameter shadowParam)
+float CalculateSpotLinearShadow(
+    float3 worldPosition,
+    float3 normal,
+    float3 lightDir,
+    ExtendedShadowParameter shadowParam,
+    Texture2D<float> shadowMap,
+    SamplerComparisonState shadowSampler)
+{
+    if (shadowParam.shadowTechnique != SHADOW_TECHNIQUE_SPOT_LINEAR)
+    {
+        return 1.0f;
+    }
+
+    const float3 lightPosition = shadowParam.pointLightPositionAndFar.xyz;
+    const float farZ = max(shadowParam.pointLightPositionAndFar.w, 0.02f);
+    const float nearZ = clamp(shadowParam.cameraPositionAndPointNear.w, 0.01f, farZ * 0.5f);
+    const float NoL = saturate(dot(normal, lightDir));
+    const float3 biasedPosition = worldPosition + normal * shadowParam.normalBias * (1.0f - NoL);
+    const float4 shadowPosition = mul(float4(biasedPosition, 1.0f), shadowParam.cascadeLightViewProjection[0]);
+
+    if (shadowPosition.w <= kEpsilon)
+    {
+        return 1.0f;
+    }
+
+    const float3 projected = shadowPosition.xyz / shadowPosition.w;
+    const float2 uv = float2(projected.x * 0.5f + 0.5f, -projected.y * 0.5f + 0.5f);
+    const float distanceToLight = length(biasedPosition - lightPosition);
+    if (any(uv < 0.0f) || any(uv > 1.0f) || distanceToLight <= nearZ || distanceToLight >= farZ)
+    {
+        return 1.0f;
+    }
+
+    const float minimumWorldBias = 0.01f / farZ;
+    const float compareDepth = saturate(distanceToLight / farZ) - max(shadowParam.shadowBias, minimumWorldBias);
+    const float visibility = SampleShadowMapPCF(shadowMap, shadowSampler, uv, compareDepth);
+    return ResolveShadowVisibility(visibility, shadowParam.shadowStrength);
+}
+
+uint SelectShadowCascade(float cameraDepth, ExtendedShadowParameter shadowParam)
 {
     uint cascadeIndex = 0;
-    cascadeIndex += cameraDistance > shadowParam.cascadeSplits.x;
-    cascadeIndex += cameraDistance > shadowParam.cascadeSplits.y;
-    cascadeIndex += cameraDistance > shadowParam.cascadeSplits.z;
+    cascadeIndex += cameraDepth > shadowParam.cascadeSplits.x;
+    cascadeIndex += cameraDepth > shadowParam.cascadeSplits.y;
+    cascadeIndex += cameraDepth > shadowParam.cascadeSplits.z;
     return min(cascadeIndex, max(shadowParam.cascadeCount, 1u) - 1u);
+}
+
+float CalculateCsmCameraDepth(float3 worldPosition, ExtendedShadowParameter shadowParam)
+{
+    const float3 cameraForward = shadowParam.pointLightPositionAndFar.xyz;
+    const float forwardLengthSq = dot(cameraForward, cameraForward);
+    if (forwardLengthSq <= kEpsilon)
+    {
+        return length(worldPosition - shadowParam.cameraPositionAndPointNear.xyz);
+    }
+
+    return max(dot(worldPosition - shadowParam.cameraPositionAndPointNear.xyz, normalize(cameraForward)), 0.0f);
 }
 
 float CalculateCsmShadow(
@@ -130,17 +224,18 @@ float CalculateCsmShadow(
     Texture2DArray<float> csmShadowMaps,
     SamplerComparisonState shadowSampler)
 {
-    if (shadowParam.shadowTechnique != 4 || shadowParam.cascadeCount == 0)
+    if (shadowParam.shadowTechnique != SHADOW_TECHNIQUE_CSM || shadowParam.cascadeCount == 0)
     {
         return 1.0f;
     }
 
-    const float cameraDistance = length(worldPosition - shadowParam.cameraPositionAndPointNear.xyz);
-    const uint cascadeIndex = SelectShadowCascade(cameraDistance, shadowParam);
+    const float cameraDepth = CalculateCsmCameraDepth(worldPosition, shadowParam);
+    const uint cascadeIndex = SelectShadowCascade(cameraDepth, shadowParam);
     const float NoL = saturate(dot(normal, lightDir));
     const float3 biasedPosition = worldPosition + normal * shadowParam.normalBias * (1.0f - NoL);
     const float4 shadowPosition = mul(float4(biasedPosition, 1.0f), shadowParam.cascadeLightViewProjection[cascadeIndex]);
-    if (abs(shadowPosition.w) < kEpsilon) { return 1.0f; }
+    if (shadowPosition.w <= kEpsilon) { return 1.0f; }
+
     const float3 projected = shadowPosition.xyz / shadowPosition.w;
     const float2 uv = float2(projected.x * 0.5f + 0.5f, -projected.y * 0.5f + 0.5f);
     if (any(uv < 0.0f) || any(uv > 1.0f) || projected.z < 0.0f || projected.z > 1.0f) { return 1.0f; }
@@ -161,8 +256,8 @@ float CalculateCsmShadow(
                 projected.z - shadowParam.shadowBias);
         }
     }
-    visibility /= 9.0f;
-    return lerp(1.0f - saturate(shadowParam.shadowStrength), 1.0f, visibility);
+
+    return ResolveShadowVisibility(visibility / 9.0f, shadowParam.shadowStrength);
 }
 
 float CalculatePointCubeShadow(
@@ -173,7 +268,7 @@ float CalculatePointCubeShadow(
     TextureCube<float> pointShadowMap,
     SamplerComparisonState shadowSampler)
 {
-    if (shadowParam.shadowTechnique != 3) { return 1.0f; }
+    if (shadowParam.shadowTechnique != SHADOW_TECHNIQUE_POINT_CUBE) { return 1.0f; }
 
     const float3 lightPosition = shadowParam.pointLightPositionAndFar.xyz;
     const float farZ = max(shadowParam.pointLightPositionAndFar.w, 0.02f);
@@ -184,7 +279,8 @@ float CalculatePointCubeShadow(
     const float distanceToLight = length(fromLight);
     if (distanceToLight <= nearZ || distanceToLight >= farZ) { return 1.0f; }
 
-    const float compareDepth = saturate(distanceToLight / farZ) - shadowParam.shadowBias;
+    const float minimumWorldBias = 0.01f / farZ;
+    const float compareDepth = saturate(distanceToLight / farZ) - max(shadowParam.shadowBias, minimumWorldBias);
     const float3 sampleDirection = normalize(fromLight);
 
     uint shadowWidth, shadowHeight, mipLevels;
@@ -203,7 +299,7 @@ float CalculatePointCubeShadow(
     visibility += pointShadowMap.SampleCmpLevelZero(shadowSampler, normalize(sampleDirection - bitangent * texelAngle), compareDepth);
     visibility /= 5.0f; // Cube Face境界を跨いでも同じ距離基準の5tap PCFとして評価する。
 
-    return lerp(1.0f - saturate(shadowParam.shadowStrength), 1.0f, visibility);
+    return ResolveShadowVisibility(visibility, shadowParam.shadowStrength);
 }
 
 #endif


### PR DESCRIPTION
## 概要
カメラ位置・角度によってShadowの形や適用先が変化する問題と、Spot / Point Lightで不自然な影が発生する問題を修正します。

このPRは、閉じたPR #644 のShadow Caster実装最終コミットを土台にしています。

## 修正内容
- Shadow受信側がObjectごとの古いb4行列へ依存しないよう、フレーム共通のLight View Projectionをb6へ保持
- 1枚のShadow Mapを同じ種類の全ライトへ適用せず、選択中のShadow Caster Lightだけへ適用
- Spot Shadowを射影深度からライト距離ベースの線形深度へ変更
- Point Cube Shadowの線形距離比較へ最小ワールド空間Biasを追加
- CSMのCascade選択をカメラからの直線距離ではなく、Camera Forward方向のView Depthへ変更
- Legacy / PBRの両ライティング経路で同じShadow Caster選択規則を使用
- Directional / Spot / Point / CSMのTechnique契約をb6へ明示

## 主な確認項目
- カメラを左右・上下へ移動／回転しても、物体と影の対応関係が崩れないこと
- Spot LightのRangeを大きくしても、射影深度精度による巨大な偽影が出ないこと
- Point LightでCube Face境界状の十字・扇形の影が出ないこと
- 複数ライトが存在しても、Shadow Mapが選択中Caster以外へ適用されないこと
- Legacy MaterialとPBR Materialで同じ位置に影が出ること
- Animated / Skeletal / Instanced ModelのShadow Casterが維持されること

## 検証状況
- GitHub上で差分とGPU契約の整合性を確認
- Windows / DirectX12実機ビルドおよび描画確認は未実施
