### PR TITLE
Phase 1: Add UE-style docking editor shell

### DIFF
--- a/Project/Engine/DebugTools/ImGui/ImGuiManager.cpp
+++ b/Project/Engine/DebugTools/ImGui/ImGuiManager.cpp
@@ -3,6 +3,8 @@
 #include "WinApp.h"
 #include "DirectXCommon.h"
 #include "SRVManager.h"
+#include "../../Editor/EditorPanelIds.h"
+#include "../../Editor/EditorShell.h"
 
 #include <cassert>
 #include <fstream>
@@ -16,7 +18,7 @@ extern IMGUI_IMPL_API LRESULT ImGui_ImplWin32_WndProcHandler(HWND hWnd, UINT msg
 
 namespace
 {
-	constexpr const char* kEditorLayoutIniFilename = "ken4low_editor_layout.ini";
+	constexpr const char* kEditorLayoutIniFilename = "ken4low_editor_layout_v2.ini";
 
 	bool FileExists(const char* path)
 	{
@@ -27,6 +29,76 @@ namespace
 
 		std::ifstream file(path, std::ios::binary);
 		return file.good();
+	}
+
+	void ApplyUnrealInspiredStyle()
+	{
+		ImGui::StyleColorsDark();
+		ImGuiStyle& style = ImGui::GetStyle();
+		style.WindowPadding = ImVec2(8.0f, 8.0f);
+		style.FramePadding = ImVec2(8.0f, 4.0f);
+		style.CellPadding = ImVec2(6.0f, 4.0f);
+		style.ItemSpacing = ImVec2(6.0f, 6.0f);
+		style.ItemInnerSpacing = ImVec2(5.0f, 4.0f);
+		style.IndentSpacing = 18.0f;
+		style.ScrollbarSize = 13.0f;
+		style.GrabMinSize = 10.0f;
+		style.WindowBorderSize = 1.0f;
+		style.ChildBorderSize = 1.0f;
+		style.PopupBorderSize = 1.0f;
+		style.FrameBorderSize = 0.0f;
+		style.WindowRounding = 0.0f;
+		style.ChildRounding = 2.0f;
+		style.FrameRounding = 2.0f;
+		style.PopupRounding = 2.0f;
+		style.ScrollbarRounding = 3.0f;
+		style.GrabRounding = 2.0f;
+		style.TabRounding = 2.0f;
+		style.WindowMenuButtonPosition = ImGuiDir_Right;
+
+		ImVec4* colors = style.Colors;
+		colors[ImGuiCol_Text] = ImVec4(0.88f, 0.89f, 0.91f, 1.00f);
+		colors[ImGuiCol_TextDisabled] = ImVec4(0.46f, 0.48f, 0.52f, 1.00f);
+		colors[ImGuiCol_WindowBg] = ImVec4(0.055f, 0.060f, 0.070f, 1.00f);
+		colors[ImGuiCol_ChildBg] = ImVec4(0.055f, 0.060f, 0.070f, 1.00f);
+		colors[ImGuiCol_PopupBg] = ImVec4(0.070f, 0.075f, 0.085f, 0.98f);
+		colors[ImGuiCol_Border] = ImVec4(0.16f, 0.17f, 0.19f, 1.00f);
+		colors[ImGuiCol_BorderShadow] = ImVec4(0.00f, 0.00f, 0.00f, 0.00f);
+		colors[ImGuiCol_FrameBg] = ImVec4(0.090f, 0.100f, 0.120f, 1.00f);
+		colors[ImGuiCol_FrameBgHovered] = ImVec4(0.140f, 0.160f, 0.190f, 1.00f);
+		colors[ImGuiCol_FrameBgActive] = ImVec4(0.180f, 0.210f, 0.250f, 1.00f);
+		colors[ImGuiCol_TitleBg] = ImVec4(0.040f, 0.045f, 0.055f, 1.00f);
+		colors[ImGuiCol_TitleBgActive] = ImVec4(0.060f, 0.068f, 0.082f, 1.00f);
+		colors[ImGuiCol_TitleBgCollapsed] = ImVec4(0.040f, 0.045f, 0.055f, 1.00f);
+		colors[ImGuiCol_MenuBarBg] = ImVec4(0.045f, 0.050f, 0.060f, 1.00f);
+		colors[ImGuiCol_ScrollbarBg] = ImVec4(0.030f, 0.034f, 0.042f, 1.00f);
+		colors[ImGuiCol_ScrollbarGrab] = ImVec4(0.180f, 0.190f, 0.220f, 1.00f);
+		colors[ImGuiCol_ScrollbarGrabHovered] = ImVec4(0.260f, 0.280f, 0.320f, 1.00f);
+		colors[ImGuiCol_ScrollbarGrabActive] = ImVec4(0.330f, 0.350f, 0.400f, 1.00f);
+		colors[ImGuiCol_CheckMark] = ImVec4(0.95f, 0.53f, 0.08f, 1.00f);
+		colors[ImGuiCol_SliderGrab] = ImVec4(0.78f, 0.39f, 0.06f, 1.00f);
+		colors[ImGuiCol_SliderGrabActive] = ImVec4(1.00f, 0.58f, 0.10f, 1.00f);
+		colors[ImGuiCol_Button] = ImVec4(0.110f, 0.120f, 0.145f, 1.00f);
+		colors[ImGuiCol_ButtonHovered] = ImVec4(0.190f, 0.210f, 0.250f, 1.00f);
+		colors[ImGuiCol_ButtonActive] = ImVec4(0.65f, 0.32f, 0.04f, 1.00f);
+		colors[ImGuiCol_Header] = ImVec4(0.120f, 0.140f, 0.170f, 1.00f);
+		colors[ImGuiCol_HeaderHovered] = ImVec4(0.200f, 0.230f, 0.280f, 1.00f);
+		colors[ImGuiCol_HeaderActive] = ImVec4(0.290f, 0.240f, 0.160f, 1.00f);
+		colors[ImGuiCol_Separator] = ImVec4(0.180f, 0.190f, 0.220f, 1.00f);
+		colors[ImGuiCol_SeparatorHovered] = ImVec4(0.85f, 0.46f, 0.08f, 1.00f);
+		colors[ImGuiCol_SeparatorActive] = ImVec4(1.00f, 0.58f, 0.10f, 1.00f);
+		colors[ImGuiCol_ResizeGrip] = ImVec4(0.30f, 0.31f, 0.34f, 0.35f);
+		colors[ImGuiCol_ResizeGripHovered] = ImVec4(0.85f, 0.46f, 0.08f, 0.75f);
+		colors[ImGuiCol_ResizeGripActive] = ImVec4(1.00f, 0.58f, 0.10f, 0.95f);
+		colors[ImGuiCol_TableHeaderBg] = ImVec4(0.090f, 0.100f, 0.120f, 1.00f);
+		colors[ImGuiCol_TableBorderStrong] = ImVec4(0.180f, 0.190f, 0.220f, 1.00f);
+		colors[ImGuiCol_TableBorderLight] = ImVec4(0.120f, 0.130f, 0.150f, 1.00f);
+		colors[ImGuiCol_TableRowBgAlt] = ImVec4(1.00f, 1.00f, 1.00f, 0.025f);
+		colors[ImGuiCol_TextSelectedBg] = ImVec4(0.78f, 0.39f, 0.06f, 0.45f);
+		colors[ImGuiCol_DragDropTarget] = ImVec4(1.00f, 0.58f, 0.10f, 0.95f);
+		colors[ImGuiCol_NavHighlight] = ImVec4(0.95f, 0.53f, 0.08f, 0.90f);
+		colors[ImGuiCol_ModalWindowDimBg] = ImVec4(0.00f, 0.00f, 0.00f, 0.55f);
+		// 色と余白をEditor全体で一度だけ設定し、各Panelが独自Styleを持たないようにする。
 	}
 }
 #endif // USE_IMGUI
@@ -78,7 +150,7 @@ namespace Ken4lowEngine
 
 		ImGuiIO& io = ImGui::GetIO();				  // ImGuiIOへの参照を取得
 
-		// 手動Dockingレイアウトを次回起動時に復元するため、専用iniへ保存する
+		// Phase 1の新しいUE風配置を旧iniと分離し、初回だけ確実にDefault Layoutを構築する。
 		io.IniFilename = kEditorLayoutIniFilename;
 		shouldApplyDefaultDockLayout_ = !FileExists(io.IniFilename);
 		resetDockLayoutRequested_ = false;
@@ -91,8 +163,9 @@ namespace Ken4lowEngine
 		io.ConfigFlags |= ImGuiConfigFlags_DockingEnable;
 		// 今回は別OSウィンドウ化を避けるため Multi-Viewport は明示的に無効のままにする
 		io.ConfigFlags &= ~ImGuiConfigFlags_ViewportsEnable;
+		io.ConfigWindowsMoveFromTitleBarOnly = true;
 
-		ImGui::StyleColorsDark();					  // ImGuiスタイルの設定
+		ApplyUnrealInspiredStyle();
 		const bool win32Initialized = ImGui_ImplWin32_Init(winApp->GetHwnd()); // Win32バックエンド初期化の失敗を起動時に検出する
 		assert(win32Initialized && "ImGui_ImplWin32_Init failed");
 		if (!win32Initialized)
@@ -190,6 +263,7 @@ namespace Ken4lowEngine
 		ImGui_ImplWin32_NewFrame();
 		ImGui::NewFrame();
 		DrawDockSpace();
+		EditorShell::GetInstance()->Draw(); // 常設ShellパネルはScene固有UIより先に登録してDock先を安定させる。
 #endif // USE_IMGUI
 	}
 
@@ -202,7 +276,7 @@ namespace Ken4lowEngine
 	{
 #ifdef USE_IMGUI
 		const ImGuiViewport* viewport = ImGui::GetMainViewport();
-		// 既存描画の見た目を変えないよう中央ノードは透過したDockSpaceを毎フレーム用意する
+		// 中央ノードへMain Viewportを置きつつ、Editor全体を一つのDockSpaceとして管理する。
 		const ImGuiID dockspaceId = ImGui::DockSpaceOverViewport(0, viewport, ImGuiDockNodeFlags_PassthruCentralNode);
 
 		if (shouldApplyDefaultDockLayout_ || resetDockLayoutRequested_)
@@ -224,25 +298,46 @@ namespace Ken4lowEngine
 			return;
 		}
 
-		ImGuiID rootNode = dockspaceId;
+		ImGuiID centerNode = dockspaceId;
+		ImGuiID toolbarNode = 0;
+		ImGuiID leftNode = 0;
 		ImGuiID rightNode = 0;
 		ImGuiID bottomNode = 0;
-		ImGui::DockBuilderRemoveNodeChildNodes(rootNode);
-		ImGui::DockBuilderSetNodeSize(rootNode, viewport->Size);
-		ImGui::DockBuilderSplitNode(rootNode, ImGuiDir_Right, 0.28f, &rightNode, &rootNode);
-		ImGui::DockBuilderSplitNode(rootNode, ImGuiDir_Down, 0.28f, &bottomNode, &rootNode);
+		ImGuiID outlinerNode = 0;
+		ImGuiID detailsNode = 0;
 
-		// Main Viewportを中央Dockに固定名で配置し、Debug系は右/下タブ候補として初期配置する。
-		ImGui::DockBuilderDockWindow("Main Viewport", rootNode);
-		ImGui::DockBuilderDockWindow("Details", rightNode);
-		ImGui::DockBuilderDockWindow("Post Effect Settings", rightNode);
-		ImGui::DockBuilderDockWindow("Light Editor", rightNode);
-		ImGui::DockBuilderDockWindow("Player Debug", rightNode);
-		ImGui::DockBuilderDockWindow("Weapon Debug", rightNode);
-		ImGui::DockBuilderDockWindow("Enemy Debug", rightNode);
-		ImGui::DockBuilderDockWindow("Game Debug", bottomNode);
-		ImGui::DockBuilderDockWindow("Collision Debug", bottomNode);
-		ImGui::DockBuilderDockWindow("Culling Debug", bottomNode);
+		ImGui::DockBuilderRemoveNodeChildNodes(dockspaceId);
+		ImGui::DockBuilderSetNodeSize(dockspaceId, viewport->WorkSize);
+		ImGui::DockBuilderSplitNode(centerNode, ImGuiDir_Up, 0.075f, &toolbarNode, &centerNode);
+		ImGui::DockBuilderSplitNode(centerNode, ImGuiDir_Left, 0.18f, &leftNode, &centerNode);
+		ImGui::DockBuilderSplitNode(centerNode, ImGuiDir_Right, 0.26f, &rightNode, &centerNode);
+		ImGui::DockBuilderSplitNode(centerNode, ImGuiDir_Down, 0.31f, &bottomNode, &centerNode);
+		ImGui::DockBuilderSplitNode(rightNode, ImGuiDir_Down, 0.58f, &detailsNode, &outlinerNode);
+
+		// UEの基本配置に合わせ、中央Viewport・左配置・右階層/詳細・下Asset/Logへ分ける。
+		ImGui::DockBuilderDockWindow(EditorPanelIds::Toolbar, toolbarNode);
+		ImGui::DockBuilderDockWindow(EditorPanelIds::PlaceActors, leftNode);
+		ImGui::DockBuilderDockWindow(EditorPanelIds::MainViewport, centerNode);
+		ImGui::DockBuilderDockWindow(EditorPanelIds::Scene, centerNode);
+		ImGui::DockBuilderDockWindow(EditorPanelIds::WorldOutliner, outlinerNode);
+		ImGui::DockBuilderDockWindow(EditorPanelIds::Details, detailsNode);
+		ImGui::DockBuilderDockWindow(EditorPanelIds::ContentBrowser, bottomNode);
+		ImGui::DockBuilderDockWindow(EditorPanelIds::OutputLog, bottomNode);
+
+		ImGui::DockBuilderDockWindow(EditorPanelIds::PostEffectSettings, detailsNode);
+		ImGui::DockBuilderDockWindow(EditorPanelIds::LightEditor, detailsNode);
+		ImGui::DockBuilderDockWindow(EditorPanelIds::Parameters, detailsNode);
+		ImGui::DockBuilderDockWindow(EditorPanelIds::Display, detailsNode);
+		ImGui::DockBuilderDockWindow(EditorPanelIds::JsonAssetManager, detailsNode);
+
+		ImGui::DockBuilderDockWindow("Player Debug", bottomNode);
+		ImGui::DockBuilderDockWindow("Weapon Debug", bottomNode);
+		ImGui::DockBuilderDockWindow("Enemy Debug", bottomNode);
+		ImGui::DockBuilderDockWindow(EditorPanelIds::GameDebug, bottomNode);
+		ImGui::DockBuilderDockWindow(EditorPanelIds::CollisionDebug, bottomNode);
+		ImGui::DockBuilderDockWindow(EditorPanelIds::CullingDebug, bottomNode);
+		ImGui::DockBuilderDockWindow(EditorPanelIds::PhysicsWorldDebug, bottomNode);
+		ImGui::DockBuilderDockWindow(EditorPanelIds::GpuParticleEditor, bottomNode);
 		ImGui::DockBuilderFinish(dockspaceId);
 	}
 #endif // USE_IMGUI

--- a/Project/Engine/Editor/EditorContext.h
+++ b/Project/Engine/Editor/EditorContext.h
@@ -5,6 +5,7 @@
 #include <cstdint>
 #include <string>
 #include <string_view>
+#include <utility>
 
 namespace Ken4lowEngine
 {

--- a/Project/Engine/Editor/EditorContext.h
+++ b/Project/Engine/Editor/EditorContext.h
@@ -1,0 +1,102 @@
+#pragma once
+
+#include "EditorSelection.h"
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+
+namespace Ken4lowEngine
+{
+	/// <summary>
+	/// Place ActorsからViewport配置へ渡す生成対象の種類です。
+	/// </summary>
+	enum class EditorPlaceableType : uint8_t
+	{
+		None = 0,
+		EmptyActor,
+		Cube,
+		Sphere,
+		Plane,
+		DirectionalLight,
+		PointLight,
+		SpotLight,
+		TriggerBox,
+		TriggerSphere,
+	};
+
+	/// <summary>
+	/// Place Actorsで選択された配置要求を保持します。
+	/// </summary>
+	struct EditorPlacementRequest
+	{
+		EditorPlaceableType type = EditorPlaceableType::None;
+		std::string displayName;
+		uint64_t serial = 0;
+		bool pending = false;
+	};
+
+	/// <summary>
+	/// Editor全体で共有する選択状態、Level状態、配置要求を一元管理します。
+	/// </summary>
+	class EditorContext
+	{
+	public:
+		static EditorContext* GetInstance()
+		{
+			static EditorContext instance;
+			return &instance;
+		}
+
+		EditorSelection& GetSelection() { return selection_; }
+		const EditorSelection& GetSelection() const { return selection_; }
+
+		void SetActiveLevelName(std::string levelName)
+		{
+			activeLevelName_ = std::move(levelName);
+		}
+
+		const std::string& GetActiveLevelName() const { return activeLevelName_; }
+
+		void MarkLevelDirty(bool dirty = true) { levelDirty_ = dirty; }
+		bool IsLevelDirty() const { return levelDirty_; }
+
+		void QueuePlacement(EditorPlaceableType type, std::string_view displayName)
+		{
+			placementRequest_.type = type;
+			placementRequest_.displayName.assign(displayName.begin(), displayName.end());
+			placementRequest_.serial = ++placementSerial_;
+			placementRequest_.pending = type != EditorPlaceableType::None;
+			// Phase 6ではこの要求をViewportのRaycast位置へ生成するCommandへ接続する。
+		}
+
+		const EditorPlacementRequest& GetPlacementRequest() const { return placementRequest_; }
+		bool HasPendingPlacement() const { return placementRequest_.pending; }
+
+		void ClearPlacementRequest()
+		{
+			placementRequest_.type = EditorPlaceableType::None;
+			placementRequest_.displayName.clear();
+			placementRequest_.pending = false;
+		}
+
+		void ResetTransientState()
+		{
+			selection_.Clear();
+			ClearPlacementRequest();
+			// Scene切り替え時は寿命の短いEditor状態だけを破棄し、Level名とDirty状態は呼び出し側で決める。
+		}
+
+	private:
+		EditorContext() = default;
+		~EditorContext() = default;
+		EditorContext(const EditorContext&) = delete;
+		EditorContext& operator=(const EditorContext&) = delete;
+
+		EditorSelection selection_{};
+		std::string activeLevelName_ = "Untitled";
+		bool levelDirty_ = false;
+		uint64_t placementSerial_ = 0;
+		EditorPlacementRequest placementRequest_{};
+	};
+} // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorPanelIds.h
+++ b/Project/Engine/Editor/EditorPanelIds.h
@@ -1,0 +1,25 @@
+#pragma once
+
+namespace Ken4lowEngine::EditorPanelIds
+{
+	inline constexpr const char* Toolbar = "Toolbar";
+	inline constexpr const char* PlaceActors = "Place Actors";
+	inline constexpr const char* MainViewport = "Main Viewport";
+	inline constexpr const char* WorldOutliner = "World Outliner";
+	inline constexpr const char* Details = "Details";
+	inline constexpr const char* ContentBrowser = "Content Browser";
+	inline constexpr const char* OutputLog = "Output Log";
+	inline constexpr const char* Scene = "Scene";
+
+	inline constexpr const char* Parameters = "Parameters";
+	inline constexpr const char* Display = "Display";
+	inline constexpr const char* PostEffectSettings = "Post Effect Settings";
+	inline constexpr const char* LightEditor = "Light Editor";
+	inline constexpr const char* JsonAssetManager = "Json Asset Manager";
+
+	inline constexpr const char* GameDebug = "Game Debug";
+	inline constexpr const char* CollisionDebug = "Collision Debug";
+	inline constexpr const char* CullingDebug = "Culling Debug";
+	inline constexpr const char* PhysicsWorldDebug = "PhysicsWorld Debug";
+	inline constexpr const char* GpuParticleEditor = "GPU Particle Editor";
+} // namespace Ken4lowEngine::EditorPanelIds

--- a/Project/Engine/Editor/EditorShell.h
+++ b/Project/Engine/Editor/EditorShell.h
@@ -1,0 +1,153 @@
+#pragma once
+
+#include "EditorContext.h"
+#include "EditorPanelIds.h"
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <string>
+#include <string_view>
+
+#ifdef USE_IMGUI
+#include <imgui.h>
+#endif
+
+namespace Ken4lowEngine
+{
+	/// <summary>
+	/// DockSpaceへ常設するEditor Shell固有パネルを描画します。
+	/// </summary>
+	class EditorShell
+	{
+	public:
+		static EditorShell* GetInstance()
+		{
+			static EditorShell instance;
+			return &instance;
+		}
+
+		void Draw()
+		{
+#ifdef USE_IMGUI
+			DrawPlaceActors();
+#endif
+		}
+
+	private:
+		struct PlaceableEntry
+		{
+			const char* label;
+			const char* description;
+			EditorPlaceableType type;
+		};
+
+		EditorShell() = default;
+		~EditorShell() = default;
+		EditorShell(const EditorShell&) = delete;
+		EditorShell& operator=(const EditorShell&) = delete;
+
+#ifdef USE_IMGUI
+		static bool ContainsCaseInsensitive(std::string_view text, std::string_view filter)
+		{
+			if (filter.empty())
+			{
+				return true;
+			}
+
+			std::string loweredText(text);
+			std::string loweredFilter(filter);
+			std::transform(loweredText.begin(), loweredText.end(), loweredText.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+			std::transform(loweredFilter.begin(), loweredFilter.end(), loweredFilter.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+			return loweredText.find(loweredFilter) != std::string::npos;
+		}
+
+		void DrawPlaceableCategory(const char* categoryName, const PlaceableEntry* entries, std::size_t count)
+		{
+			bool hasVisibleEntry = false;
+			for (std::size_t index = 0; index < count; ++index)
+			{
+				hasVisibleEntry |= ContainsCaseInsensitive(entries[index].label, placeActorsSearch_);
+			}
+			if (!hasVisibleEntry)
+			{
+				return;
+			}
+
+			if (!ImGui::CollapsingHeader(categoryName, ImGuiTreeNodeFlags_DefaultOpen))
+			{
+				return;
+			}
+
+			for (std::size_t index = 0; index < count; ++index)
+			{
+				const PlaceableEntry& entry = entries[index];
+				if (!ContainsCaseInsensitive(entry.label, placeActorsSearch_))
+				{
+					continue;
+				}
+
+				ImGui::PushID(static_cast<int>(index));
+				if (ImGui::Button(entry.label, ImVec2(-1.0f, 34.0f)))
+				{
+					EditorContext::GetInstance()->QueuePlacement(entry.type, entry.label);
+					// Phase 1では配置対象を選び、実際のViewport生成はPhase 6のDrag＆Dropへ接続する。
+				}
+				if (ImGui::IsItemHovered())
+				{
+					ImGui::SetTooltip("%s", entry.description);
+				}
+				ImGui::PopID();
+			}
+		}
+
+		void DrawPlaceActors()
+		{
+			constexpr std::array<PlaceableEntry, 4> basicEntries = {
+				PlaceableEntry{ "Empty Actor", "Create an Actor with only a root SceneComponent.", EditorPlaceableType::EmptyActor },
+				PlaceableEntry{ "Cube", "Create a cube ModelComponent Actor.", EditorPlaceableType::Cube },
+				PlaceableEntry{ "Sphere", "Create a sphere ModelComponent Actor.", EditorPlaceableType::Sphere },
+				PlaceableEntry{ "Plane", "Create a plane ModelComponent Actor.", EditorPlaceableType::Plane },
+			};
+			constexpr std::array<PlaceableEntry, 3> lightEntries = {
+				PlaceableEntry{ "Directional Light", "Create a directional LightComponent Actor.", EditorPlaceableType::DirectionalLight },
+				PlaceableEntry{ "Point Light", "Create a point LightComponent Actor.", EditorPlaceableType::PointLight },
+				PlaceableEntry{ "Spot Light", "Create a spot LightComponent Actor.", EditorPlaceableType::SpotLight },
+			};
+			constexpr std::array<PlaceableEntry, 2> volumeEntries = {
+				PlaceableEntry{ "Trigger Box", "Create an overlap-only box trigger Actor.", EditorPlaceableType::TriggerBox },
+				PlaceableEntry{ "Trigger Sphere", "Create an overlap-only sphere trigger Actor.", EditorPlaceableType::TriggerSphere },
+			};
+
+			const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
+			if (ImGui::Begin(EditorPanelIds::PlaceActors, nullptr, flags))
+			{
+				ImGui::TextUnformatted("Place Actors");
+				ImGui::TextDisabled("Select an item now; viewport placement is connected in Phase 6.");
+				ImGui::Separator();
+				ImGui::SetNextItemWidth(-1.0f);
+				ImGui::InputTextWithHint("##PlaceActorsSearch", "Search classes...", placeActorsSearch_.data(), placeActorsSearch_.size());
+				ImGui::Spacing();
+
+				DrawPlaceableCategory("Basic", basicEntries.data(), basicEntries.size());
+				DrawPlaceableCategory("Lights", lightEntries.data(), lightEntries.size());
+				DrawPlaceableCategory("Volumes", volumeEntries.data(), volumeEntries.size());
+
+				const EditorPlacementRequest& request = EditorContext::GetInstance()->GetPlacementRequest();
+				if (request.pending)
+				{
+					ImGui::Separator();
+					ImGui::Text("Selected: %s", request.displayName.c_str());
+					if (ImGui::Button("Cancel Placement", ImVec2(-1.0f, 0.0f)))
+					{
+						EditorContext::GetInstance()->ClearPlacementRequest();
+					}
+				}
+			}
+			ImGui::End();
+		}
+#endif
+
+		std::array<char, 96> placeActorsSearch_{};
+	};
+} // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorShell.h
+++ b/Project/Engine/Editor/EditorShell.h
@@ -69,10 +69,13 @@ namespace Ken4lowEngine
 
 		void DrawPlaceableCategory(const char* categoryName, const PlaceableEntry* entries, std::size_t count)
 		{
+			// ImGuiの固定長入力バッファを終端文字列としてstring_viewへ明示変換する。
+			const std::string_view searchFilter(placeActorsSearch_.data());
+
 			bool hasVisibleEntry = false;
 			for (std::size_t index = 0; index < count; ++index)
 			{
-				hasVisibleEntry |= ContainsCaseInsensitive(entries[index].label, placeActorsSearch_);
+				hasVisibleEntry |= ContainsCaseInsensitive(entries[index].label, searchFilter);
 			}
 			if (!hasVisibleEntry)
 			{
@@ -87,7 +90,7 @@ namespace Ken4lowEngine
 			for (std::size_t index = 0; index < count; ++index)
 			{
 				const PlaceableEntry& entry = entries[index];
-				if (!ContainsCaseInsensitive(entry.label, placeActorsSearch_))
+				if (!ContainsCaseInsensitive(entry.label, searchFilter))
 				{
 					continue;
 				}

--- a/Project/Engine/Editor/EditorShell.h
+++ b/Project/Engine/Editor/EditorShell.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "EditorContext.h"
+#include "EditorModeController.h"
 #include "EditorPanelIds.h"
 
 #include <algorithm>
@@ -30,6 +31,10 @@ namespace Ken4lowEngine
 		void Draw()
 		{
 #ifdef USE_IMGUI
+			if (!EditorModeController::GetInstance()->IsEditorModeEnabled())
+			{
+				return; // Game Preview中はEditor専用Panelを表示しない。
+			}
 			DrawPlaceActors();
 #endif
 		}

--- a/Project/Engine/Editor/EditorWindowManager.h
+++ b/Project/Engine/Editor/EditorWindowManager.h
@@ -1,6 +1,6 @@
 ﻿#pragma once
 #include "Vector2.h"
-#include "EditorSelection.h"
+#include "EditorContext.h"
 #include "EditorAssetBrowser.h"
 #include "EditorAssetBuildService.h"
 #include "EditorOutputLog.h"
@@ -139,7 +139,7 @@ namespace Ken4lowEngine
 		Vector2 mainViewportScreenPosition_ = { 0.0f, 0.0f }; // マウス座標をMain Viewport基準へ変換するための左上座標
 		Vector2 mainViewportSize_ = { 0.0f, 0.0f }; // Main Viewport内でGameRenderTargetを表示しているサイズ
 		EditorInputDebugInfo inputDebugInfo_{}; // Toolbarへゲーム入力ゲートの状態を可視化する
-		EditorSelection selection_{}; // World OutlinerとDetailsで共有する軽量な選択状態
+		EditorSelection& selection_ = EditorContext::GetInstance()->GetSelection(); // 全Editor Panelが同じ選択状態を参照する。
 		EditorOutputLog outputLog_{}; // Content BrowserとBuild結果を表示するエディタ用ログバッファ
 		EditorAssetBrowser assetBrowser_{}; // Resources配下の実ファイル列挙を担当するContent Browserモデル
 		EditorTexturePreviewCache texturePreviewCache_{}; // Content Browserの選択画像だけをSRV化してプレビューするキャッシュ


### PR DESCRIPTION
## 概要
UE風Editor計画のPhase 1として、既存のImGui画面をDocking対応Editor Shellへ整理します。

## 実装内容
- 中央Main Viewport、左Place Actors、右World Outliner/Details、下Content Browser/Output Logの初期Dock配置
- Toolbarを上部専用Dockへ配置
- UEを参考にした暗色Editorテーマ、余白、境界、操作色を共通化
- 新しいレイアウトを`ken4low_editor_layout_v2.ini`へ保存し、旧配置から自動移行
- Place Actorsパネルを追加
  - Basic / Lights / Volumesカテゴリ
  - クラス検索
  - Phase 6へ渡す配置要求の予約
- `EditorContext`を追加
  - OutlinerとDetailsの選択状態を一元化
  - Level名、Dirty状態、配置要求の共通入口を用意
- Panel名を`EditorPanelIds`へ集約し、DockBuilderとの文字列不一致を防止

## Phase 1の完了条件
- 初回起動時にUE風の基本配置が構築される
- 各既存パネルをDock/Undockできる
- 終了時のレイアウトが次回起動時に復元される
- Window > Layout > Rebuild Default Layoutで初期配置へ戻せる
- OutlinerとDetailsが同じEditorContext上の選択を参照する
- Place Actorsで生成対象を検索・選択できる

## 今後の接続
- Phase 2: Viewport ToolbarとGame/Editor表示分離
- Phase 6: Place Actorsの配置要求をViewport Raycast / Drag & Drop生成へ接続

## 検証
- GitHub ActionsでDebug / Releaseビルドを実行
- Windows実機では初期Dock配置、保存復元、Place Actors検索を確認予定
