### PR TITLE
Phase 2: ビューポートツールバーとEditor／Game表示分離

### DIFF
--- a/Project/Engine/Core/Application/GameApplication.cpp
+++ b/Project/Engine/Core/Application/GameApplication.cpp
@@ -15,6 +15,7 @@
 
 #ifdef USE_IMGUI
 #include <ImGuiManager.h>
+#include "Editor/EditorShell.h"
 #include "Editor/EditorWindowManager.h"
 #include "Editor/EditorModeController.h"
 #endif // USE_IMGUI
@@ -211,6 +212,9 @@ namespace Ken4lowEngine
 
 					// WindowメニューのPost Effect Settings表示フラグをPostEffectManager側の×ボタン状態と共有する
 					PostEffectManager::GetInstance()->ImGuiRender(&editorWindowState.showPostEffectSettings);
+
+					// 他のEditorパネルより後に描き、ビューポートツールバーを最前面へ配置する。
+					EditorShell::GetInstance()->DrawViewportOverlay();
 
 					/// ---------- ImGuiフレーム終了 ---------- ///
 					ImGuiManager::GetInstance()->EndFrame();

--- a/Project/Engine/Editor/EditorPanelIds.h
+++ b/Project/Engine/Editor/EditorPanelIds.h
@@ -5,6 +5,7 @@ namespace Ken4lowEngine::EditorPanelIds
 	inline constexpr const char* Toolbar = "Toolbar";
 	inline constexpr const char* PlaceActors = "Place Actors";
 	inline constexpr const char* MainViewport = "Main Viewport";
+	inline constexpr const char* ViewportToolbarOverlay = "ビューポートツールバー###ViewportToolbarOverlay";
 	inline constexpr const char* WorldOutliner = "World Outliner";
 	inline constexpr const char* Details = "Details";
 	inline constexpr const char* ContentBrowser = "Content Browser";

--- a/Project/Engine/Editor/EditorPlayController.cpp
+++ b/Project/Engine/Editor/EditorPlayController.cpp
@@ -11,20 +11,20 @@ namespace Ken4lowEngine
 
 	void EditorPlayController::Play()
 	{
-		// Play開始時はゲーム操作へ即入れるように入力キャプチャも同時に有効化する。
+		// 再生開始時はゲーム操作へ即入れるように入力キャプチャも同時に有効化する。
 		playState_ = EditorPlayState::Play;
 		inputMode_ = EditorInputMode::GameCaptured;
 	}
 
 	void EditorPlayController::Pause()
 	{
-		// Pauseは入力キャプチャ状態を変えず、Play状態だけを一時停止へ遷移させる。
+		// 一時停止は入力キャプチャ状態を変えず、再生状態だけを停止させる。
 		playState_ = EditorPlayState::Pause;
 	}
 
 	void EditorPlayController::Stop()
 	{
-		// Stop時は編集へ戻し、ゲーム入力を解放して各SceneのEsc処理とは独立させる。
+		// 停止時は編集へ戻し、ゲーム入力を解放して各SceneのEsc処理とは独立させる。
 		playState_ = EditorPlayState::Edit;
 		inputMode_ = EditorInputMode::GameReleased;
 	}
@@ -43,13 +43,13 @@ namespace Ken4lowEngine
 
 	void EditorPlayController::CaptureGameInput()
 	{
-		// GameCapturedはゲーム更新を止めずMain Viewport上の操作だけをゲームへ戻す。
+		// ゲーム入力取得中もゲーム更新は止めず、Main Viewport上の操作だけをゲームへ渡す。
 		inputMode_ = EditorInputMode::GameCaptured;
 	}
 
 	void EditorPlayController::ReleaseGameInput()
 	{
-		// GameReleasedはゲーム更新を継続したまま入力だけEditor/ImGuiへ解放する。
+		// 入力解放中はゲーム更新を継続したまま、操作だけをEditorとImGuiへ戻す。
 		inputMode_ = EditorInputMode::GameReleased;
 	}
 
@@ -61,7 +61,7 @@ namespace Ken4lowEngine
 
 	void EditorPlayController::SetDebugFreezeEnabled(bool enabled)
 	{
-		// Debug Freezeは入力キャプチャとは別機能としてToolbar表示だけ同期する。
+		// デバッグ停止は入力キャプチャとは別機能としてToolbar表示だけ同期する。
 		debugFreezeEnabled_ = enabled;
 	}
 
@@ -100,12 +100,12 @@ namespace Ken4lowEngine
 		switch (playState_)
 		{
 		case EditorPlayState::Play:
-			return "Play";
+			return "再生中";
 		case EditorPlayState::Pause:
-			return "Pause";
+			return "一時停止";
 		case EditorPlayState::Edit:
 		default:
-			return "Edit";
+			return "編集中";
 		}
 	}
 
@@ -114,12 +114,12 @@ namespace Ken4lowEngine
 		switch (inputMode_)
 		{
 		case EditorInputMode::GameCaptured:
-			return "GameCaptured";
+			return "ゲーム入力取得";
 		case EditorInputMode::GameReleased:
-			return "GameReleased";
+			return "エディターへ解放";
 		case EditorInputMode::Editor:
 		default:
-			return "Editor";
+			return "エディター入力";
 		}
 	}
 
@@ -128,18 +128,18 @@ namespace Ken4lowEngine
 		switch (inputMode_)
 		{
 		case EditorInputMode::GameCaptured:
-			return "Input: Game Captured";
+			return "入力: ゲーム操作";
 		case EditorInputMode::GameReleased:
-			return "Input: Editor Released";
+			return "入力: エディターへ解放";
 		case EditorInputMode::Editor:
 		default:
-			return "Input: Editor";
+			return "入力: エディター操作";
 		}
 	}
 
 	const char* EditorPlayController::GetDebugFreezeStatusText() const
 	{
-		return debugFreezeEnabled_ ? "Debug Freeze: ON" : "Debug Freeze: OFF";
+		return debugFreezeEnabled_ ? "デバッグ停止: 有効" : "デバッグ停止: 無効";
 	}
 
 } // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorShell.h
+++ b/Project/Engine/Editor/EditorShell.h
@@ -3,6 +3,11 @@
 #include "EditorContext.h"
 #include "EditorModeController.h"
 #include "EditorPanelIds.h"
+#include "EditorPlayController.h"
+#include "EditorViewportController.h"
+#include "EditorWindowManager.h"
+
+#include <Wireframe.h>
 
 #include <algorithm>
 #include <array>
@@ -33,9 +38,27 @@ namespace Ken4lowEngine
 #ifdef USE_IMGUI
 			if (!EditorModeController::GetInstance()->IsEditorModeEnabled())
 			{
-				return; // Game Preview中はEditor専用Panelを表示しない。
+				return; // ゲームプレビュー中はEditor専用パネルを表示しない。
 			}
+
+			ApplyViewportVisualPolicy();
 			DrawPlaceActors();
+#endif
+		}
+
+		/// <summary>
+		/// メインビューポートの描画後に、操作モードと表示モードを切り替えるツールバーを重ねます。
+		/// </summary>
+		void DrawViewportOverlay()
+		{
+#ifdef USE_IMGUI
+			if (!EditorModeController::GetInstance()->IsEditorModeEnabled())
+			{
+				return;
+			}
+
+			ApplyViewportVisualPolicy();
+			DrawViewportToolbar();
 #endif
 		}
 
@@ -43,6 +66,7 @@ namespace Ken4lowEngine
 		struct PlaceableEntry
 		{
 			const char* label;
+			const char* searchKeywords;
 			const char* description;
 			EditorPlaceableType type;
 		};
@@ -53,6 +77,15 @@ namespace Ken4lowEngine
 		EditorShell& operator=(const EditorShell&) = delete;
 
 #ifdef USE_IMGUI
+		static char ToLowerAscii(unsigned char character)
+		{
+			if (character >= 'A' && character <= 'Z')
+			{
+				return static_cast<char>(character - 'A' + 'a');
+			}
+			return static_cast<char>(character);
+		}
+
 		static bool ContainsCaseInsensitive(std::string_view text, std::string_view filter)
 		{
 			if (filter.empty())
@@ -62,9 +95,153 @@ namespace Ken4lowEngine
 
 			std::string loweredText(text);
 			std::string loweredFilter(filter);
-			std::transform(loweredText.begin(), loweredText.end(), loweredText.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
-			std::transform(loweredFilter.begin(), loweredFilter.end(), loweredFilter.begin(), [](unsigned char c) { return static_cast<char>(std::tolower(c)); });
+			std::transform(loweredText.begin(), loweredText.end(), loweredText.begin(), [](unsigned char c) { return ToLowerAscii(c); });
+			std::transform(loweredFilter.begin(), loweredFilter.end(), loweredFilter.begin(), [](unsigned char c) { return ToLowerAscii(c); });
 			return loweredText.find(loweredFilter) != std::string::npos;
+		}
+
+		static bool MatchesPlaceableFilter(const PlaceableEntry& entry, std::string_view filter)
+		{
+			// 日本語名と英語キーワードの両方を検索対象にして、従来の入力にも対応する。
+			return ContainsCaseInsensitive(entry.label, filter) || ContainsCaseInsensitive(entry.searchKeywords, filter);
+		}
+
+		void ApplyViewportVisualPolicy()
+		{
+			const auto* viewportController = EditorViewportController::GetInstance();
+			const bool drawEditorVisuals = EditorModeController::GetInstance()->ShouldDrawDebugVisuals() &&
+				viewportController->IsEditorDisplay() && viewportController->IsAuxiliaryDisplayEnabled();
+			// ゲーム表示ではワイヤー、コライダー、ライト範囲などのEditor補助描画をまとめて除外する。
+			Wireframe::GetInstance()->SetDebugDrawEnabled(drawEditorVisuals);
+		}
+
+		void DrawViewportToolButton(const char* label, EditorViewportTool tool)
+		{
+			auto* viewportController = EditorViewportController::GetInstance();
+			const bool selected = viewportController->GetTool() == tool;
+			if (selected)
+			{
+				ImGui::PushStyleColor(ImGuiCol_Button, ImGui::GetStyleColorVec4(ImGuiCol_ButtonActive));
+			}
+
+			if (ImGui::Button(label, ImVec2(54.0f, 0.0f)))
+			{
+				viewportController->SetTool(tool);
+			}
+
+			if (selected)
+			{
+				ImGui::PopStyleColor();
+			}
+			if (ImGui::IsItemHovered())
+			{
+				ImGui::SetTooltip("現在の操作モード: %s\n変形ギズモへの接続はPhase 8で行います。", label);
+			}
+		}
+
+		void DrawViewportToolbar()
+		{
+			auto* windowManager = EditorWindowManager::GetInstance();
+			const EditorViewportRect& viewportRect = windowManager->GetMainViewportRect();
+			if (!viewportRect.valid)
+			{
+				return;
+			}
+
+			const float viewportWidth = viewportRect.screenMax.x - viewportRect.screenMin.x;
+			if (viewportWidth < 430.0f)
+			{
+				return;
+			}
+
+			ImGui::SetNextWindowPos(ImVec2(viewportRect.screenMin.x + 8.0f, viewportRect.screenMin.y + 8.0f), ImGuiCond_Always);
+			ImGui::SetNextWindowSize(ImVec2(viewportWidth - 16.0f, 42.0f), ImGuiCond_Always);
+			ImGui::SetNextWindowBgAlpha(0.92f);
+
+			const ImGuiWindowFlags flags = ImGuiWindowFlags_NoDecoration |
+				ImGuiWindowFlags_NoDocking |
+				ImGuiWindowFlags_NoSavedSettings |
+				ImGuiWindowFlags_NoMove |
+				ImGuiWindowFlags_NoResize |
+				ImGuiWindowFlags_NoScrollbar |
+				ImGuiWindowFlags_NoScrollWithMouse |
+				ImGuiWindowFlags_NoFocusOnAppearing |
+				ImGuiWindowFlags_NoNav;
+
+			if (ImGui::Begin(EditorPanelIds::ViewportToolbarOverlay, nullptr, flags))
+			{
+				DrawViewportToolButton("選択", EditorViewportTool::Select);
+				ImGui::SameLine();
+				DrawViewportToolButton("移動", EditorViewportTool::Translate);
+				ImGui::SameLine();
+				DrawViewportToolButton("回転", EditorViewportTool::Rotate);
+				ImGui::SameLine();
+				DrawViewportToolButton("拡縮", EditorViewportTool::Scale);
+
+				ImGui::SameLine();
+				ImGui::TextDisabled("|");
+				ImGui::SameLine();
+
+				auto* viewportController = EditorViewportController::GetInstance();
+				ImGui::SetNextItemWidth(130.0f);
+				if (ImGui::BeginCombo("##ビューポート表示", viewportController->GetDisplayModeText()))
+				{
+					const bool editorSelected = viewportController->IsEditorDisplay();
+					if (ImGui::Selectable("エディター表示", editorSelected))
+					{
+						viewportController->SetDisplayMode(EditorViewportDisplayMode::Editor);
+					}
+					const bool gameSelected = viewportController->IsGameDisplay();
+					if (ImGui::Selectable("ゲーム表示", gameSelected))
+					{
+						viewportController->SetDisplayMode(EditorViewportDisplayMode::Game);
+					}
+					ImGui::EndCombo();
+				}
+
+				ImGui::SameLine();
+				bool auxiliaryDisplayEnabled = viewportController->IsAuxiliaryDisplayEnabled();
+				if (viewportController->IsGameDisplay())
+				{
+					ImGui::BeginDisabled();
+				}
+				if (ImGui::Checkbox("補助表示", &auxiliaryDisplayEnabled))
+				{
+					viewportController->SetAuxiliaryDisplayEnabled(auxiliaryDisplayEnabled);
+				}
+				if (viewportController->IsGameDisplay())
+				{
+					ImGui::EndDisabled();
+				}
+				if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+				{
+					ImGui::SetTooltip("グリッド、コライダー、ライト範囲などのEditor補助描画を切り替えます。");
+				}
+
+				ImGui::SameLine();
+				bool performanceVisible = windowManager->IsPerformanceOverlayVisible();
+				if (ImGui::Checkbox("統計", &performanceVisible))
+				{
+					windowManager->SetPerformanceOverlayVisible(performanceVisible);
+				}
+
+				if (viewportWidth >= 760.0f)
+				{
+					auto* playController = EditorPlayController::GetInstance();
+					ImGui::SameLine();
+					ImGui::TextDisabled("状態: %s", playController->GetPlayStateText());
+					if (playController->IsPlaying())
+					{
+						ImGui::SameLine();
+						if (ImGui::Button(playController->IsGameCaptured() ? "入力を解放" : "ゲーム入力を取得"))
+						{
+							playController->ToggleInputCapture();
+							// 再生状態は維持したまま、Main Viewportへ渡す入力だけを切り替える。
+						}
+					}
+				}
+			}
+			ImGui::End();
 		}
 
 		void DrawPlaceableCategory(const char* categoryName, const PlaceableEntry* entries, std::size_t count)
@@ -73,12 +250,9 @@ namespace Ken4lowEngine
 			const std::string_view searchFilter{ placeActorsSearch_.data() };
 
 			bool hasVisibleEntry = false;
-
 			for (std::size_t index = 0; index < count; ++index)
 			{
-				hasVisibleEntry |= ContainsCaseInsensitive(
-					entries[index].label,
-					searchFilter);
+				hasVisibleEntry |= MatchesPlaceableFilter(entries[index], searchFilter);
 			}
 
 			if (!hasVisibleEntry)
@@ -86,9 +260,7 @@ namespace Ken4lowEngine
 				return;
 			}
 
-			if (!ImGui::CollapsingHeader(
-				categoryName,
-				ImGuiTreeNodeFlags_DefaultOpen))
+			if (!ImGui::CollapsingHeader(categoryName, ImGuiTreeNodeFlags_DefaultOpen))
 			{
 				return;
 			}
@@ -96,28 +268,21 @@ namespace Ken4lowEngine
 			for (std::size_t index = 0; index < count; ++index)
 			{
 				const PlaceableEntry& entry = entries[index];
-
-				if (!ContainsCaseInsensitive(entry.label, searchFilter))
+				if (!MatchesPlaceableFilter(entry, searchFilter))
 				{
 					continue;
 				}
 
-				ImGui::PushID(static_cast<int>(index));
-
+				ImGui::PushID(entry.searchKeywords);
 				if (ImGui::Button(entry.label, ImVec2(-1.0f, 34.0f)))
 				{
-					EditorContext::GetInstance()->QueuePlacement(
-						entry.type,
-						entry.label);
-
+					EditorContext::GetInstance()->QueuePlacement(entry.type, entry.label);
 					// Phase 1では配置要求だけを保存し、実際の生成は後続Phaseで接続する。
 				}
-
 				if (ImGui::IsItemHovered())
 				{
 					ImGui::SetTooltip("%s", entry.description);
 				}
-
 				ImGui::PopID();
 			}
 		}
@@ -125,41 +290,41 @@ namespace Ken4lowEngine
 		void DrawPlaceActors()
 		{
 			constexpr std::array<PlaceableEntry, 4> basicEntries = {
-				PlaceableEntry{ "Empty Actor", "Create an Actor with only a root SceneComponent.", EditorPlaceableType::EmptyActor },
-				PlaceableEntry{ "Cube", "Create a cube ModelComponent Actor.", EditorPlaceableType::Cube },
-				PlaceableEntry{ "Sphere", "Create a sphere ModelComponent Actor.", EditorPlaceableType::Sphere },
-				PlaceableEntry{ "Plane", "Create a plane ModelComponent Actor.", EditorPlaceableType::Plane },
+				PlaceableEntry{ "空のアクタ", "Empty Actor", "ルートSceneComponentだけを持つアクタを作成します。", EditorPlaceableType::EmptyActor },
+				PlaceableEntry{ "キューブ", "Cube", "キューブモデルを持つアクタを作成します。", EditorPlaceableType::Cube },
+				PlaceableEntry{ "スフィア", "Sphere", "球体モデルを持つアクタを作成します。", EditorPlaceableType::Sphere },
+				PlaceableEntry{ "平面", "Plane", "平面モデルを持つアクタを作成します。", EditorPlaceableType::Plane },
 			};
 			constexpr std::array<PlaceableEntry, 3> lightEntries = {
-				PlaceableEntry{ "Directional Light", "Create a directional LightComponent Actor.", EditorPlaceableType::DirectionalLight },
-				PlaceableEntry{ "Point Light", "Create a point LightComponent Actor.", EditorPlaceableType::PointLight },
-				PlaceableEntry{ "Spot Light", "Create a spot LightComponent Actor.", EditorPlaceableType::SpotLight },
+				PlaceableEntry{ "ディレクショナルライト", "Directional Light", "平行光源のLightComponentを持つアクタを作成します。", EditorPlaceableType::DirectionalLight },
+				PlaceableEntry{ "ポイントライト", "Point Light", "点光源のLightComponentを持つアクタを作成します。", EditorPlaceableType::PointLight },
+				PlaceableEntry{ "スポットライト", "Spot Light", "スポット光源のLightComponentを持つアクタを作成します。", EditorPlaceableType::SpotLight },
 			};
 			constexpr std::array<PlaceableEntry, 2> volumeEntries = {
-				PlaceableEntry{ "Trigger Box", "Create an overlap-only box trigger Actor.", EditorPlaceableType::TriggerBox },
-				PlaceableEntry{ "Trigger Sphere", "Create an overlap-only sphere trigger Actor.", EditorPlaceableType::TriggerSphere },
+				PlaceableEntry{ "トリガーボックス", "Trigger Box", "Overlap専用のBox Triggerアクタを作成します。", EditorPlaceableType::TriggerBox },
+				PlaceableEntry{ "トリガースフィア", "Trigger Sphere", "Overlap専用のSphere Triggerアクタを作成します。", EditorPlaceableType::TriggerSphere },
 			};
 
 			const ImGuiWindowFlags flags = ImGuiWindowFlags_NoCollapse;
 			if (ImGui::Begin(EditorPanelIds::PlaceActors, nullptr, flags))
 			{
-				ImGui::TextUnformatted("Place Actors");
-				ImGui::TextDisabled("Select an item now; viewport placement is connected in Phase 6.");
+				ImGui::TextUnformatted("アクタを配置");
+				ImGui::TextDisabled("配置する種類を選択してください。実際の配置は後続Phaseで接続します。");
 				ImGui::Separator();
 				ImGui::SetNextItemWidth(-1.0f);
-				ImGui::InputTextWithHint("##PlaceActorsSearch", "Search classes...", placeActorsSearch_.data(), placeActorsSearch_.size());
+				ImGui::InputTextWithHint("##PlaceActorsSearch", "クラスを検索...", placeActorsSearch_.data(), placeActorsSearch_.size());
 				ImGui::Spacing();
 
-				DrawPlaceableCategory("Basic", basicEntries.data(), basicEntries.size());
-				DrawPlaceableCategory("Lights", lightEntries.data(), lightEntries.size());
-				DrawPlaceableCategory("Volumes", volumeEntries.data(), volumeEntries.size());
+				DrawPlaceableCategory("基本", basicEntries.data(), basicEntries.size());
+				DrawPlaceableCategory("ライト", lightEntries.data(), lightEntries.size());
+				DrawPlaceableCategory("ボリューム", volumeEntries.data(), volumeEntries.size());
 
 				const EditorPlacementRequest& request = EditorContext::GetInstance()->GetPlacementRequest();
 				if (request.pending)
 				{
 					ImGui::Separator();
-					ImGui::Text("Selected: %s", request.displayName.c_str());
-					if (ImGui::Button("Cancel Placement", ImVec2(-1.0f, 0.0f)))
+					ImGui::Text("選択中: %s", request.displayName.c_str());
+					if (ImGui::Button("配置をキャンセル", ImVec2(-1.0f, 0.0f)))
 					{
 						EditorContext::GetInstance()->ClearPlacementRequest();
 					}

--- a/Project/Engine/Editor/EditorViewportController.h
+++ b/Project/Engine/Editor/EditorViewportController.h
@@ -1,0 +1,82 @@
+#pragma once
+
+#include <cstdint>
+
+namespace Ken4lowEngine
+{
+	/// <summary>
+	/// メインビューポートに表示する内容を、編集確認用とゲーム確認用で切り替えます。
+	/// </summary>
+	enum class EditorViewportDisplayMode : uint8_t
+	{
+		Editor = 0,
+		Game,
+	};
+
+	/// <summary>
+	/// ビューポート上部ツールバーで選択する操作モードです。
+	/// 実際のギズモ操作はPhase 8で接続します。
+	/// </summary>
+	enum class EditorViewportTool : uint8_t
+	{
+		Select = 0,
+		Translate,
+		Rotate,
+		Scale,
+	};
+
+	/// <summary>
+	/// ビューポートツールバーの表示状態と、Editor/Game表示の切り替え状態を管理します。
+	/// </summary>
+	class EditorViewportController
+	{
+	public:
+		static EditorViewportController* GetInstance()
+		{
+			static EditorViewportController instance;
+			return &instance;
+		}
+
+		void SetDisplayMode(EditorViewportDisplayMode mode) { displayMode_ = mode; }
+		EditorViewportDisplayMode GetDisplayMode() const { return displayMode_; }
+		bool IsEditorDisplay() const { return displayMode_ == EditorViewportDisplayMode::Editor; }
+		bool IsGameDisplay() const { return displayMode_ == EditorViewportDisplayMode::Game; }
+
+		void SetTool(EditorViewportTool tool) { activeTool_ = tool; }
+		EditorViewportTool GetTool() const { return activeTool_; }
+
+		void SetAuxiliaryDisplayEnabled(bool enabled) { auxiliaryDisplayEnabled_ = enabled; }
+		bool IsAuxiliaryDisplayEnabled() const { return auxiliaryDisplayEnabled_; }
+
+		const char* GetDisplayModeText() const
+		{
+			return IsGameDisplay() ? "ゲーム表示" : "エディター表示";
+		}
+
+		const char* GetToolText() const
+		{
+			switch (activeTool_)
+			{
+			case EditorViewportTool::Translate:
+				return "移動";
+			case EditorViewportTool::Rotate:
+				return "回転";
+			case EditorViewportTool::Scale:
+				return "拡縮";
+			case EditorViewportTool::Select:
+			default:
+				return "選択";
+			}
+		}
+
+	private:
+		EditorViewportController() = default;
+		~EditorViewportController() = default;
+		EditorViewportController(const EditorViewportController&) = delete;
+		EditorViewportController& operator=(const EditorViewportController&) = delete;
+
+		EditorViewportDisplayMode displayMode_ = EditorViewportDisplayMode::Editor;
+		EditorViewportTool activeTool_ = EditorViewportTool::Select;
+		bool auxiliaryDisplayEnabled_ = true;
+	};
+} // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorWindowManager.h
+++ b/Project/Engine/Editor/EditorWindowManager.h
@@ -123,6 +123,12 @@ namespace Ken4lowEngine
 		EditorWindowState& GetWindowState() { return windowState_; }
 		const EditorWindowState& GetWindowState() const { return windowState_; }
 
+		/// <summary>
+		/// メインビューポート左上のパフォーマンス表示を切り替えます。
+		/// </summary>
+		void SetPerformanceOverlayVisible(bool visible) { showPerformanceOverlay_ = visible; }
+		bool IsPerformanceOverlayVisible() const { return showPerformanceOverlay_; }
+
 	private:
 		EditorWindowManager() = default;
 		~EditorWindowManager() = default;


### PR DESCRIPTION
## 概要
UE風Editor計画のPhase 2として、メインビューポート内の操作ツールバーとEditor／Game表示の切り替えを追加します。

## 実装内容
- メインビューポート上部へ日本語のオーバーレイツールバーを追加
  - 選択
  - 移動
  - 回転
  - 拡縮
- 表示モードを追加
  - エディター表示
  - ゲーム表示
- ゲーム表示では、ワイヤー、コライダー、ライト範囲などのEditor補助描画を除外
- 補助表示のON／OFFを追加
- パフォーマンス統計のON／OFFを追加
- 再生中のゲーム入力取得／解放をビューポートから操作可能化
- 操作モードを`EditorViewportController`へ集約
- Place Actorsの表示を日本語化
  - 日本語名と従来の英語名の両方で検索可能
- 再生状態と入力状態の表示を日本語化

## 補足
- 移動／回転／拡縮ボタンは操作モードを保持するところまでです。
- 実際のXYZ Gizmo操作は計画どおりPhase 8で接続します。
- Editor表示とGame表示は同じGameRenderTargetを使用しつつ、Editor補助描画だけを明確に分離します。

## 確認項目
- ビューポート上部にツールバーが表示される
- エディター表示では補助線が表示される
- ゲーム表示では補助線が消える
- 補助表示チェックでワイヤー表示を切り替えられる
- 統計チェックでFPS表示を切り替えられる
- 再生中にゲーム入力取得／解放を切り替えられる
- Place Actorsを日本語・英語の両方で検索できる
