### PR TITLE
Phase 3: World OutlinerとDetailsをActor階層へ統合

### DIFF
--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
@@ -5,7 +5,7 @@
 #include "AnimationStateController.h"
 
 #include <ActorWorld.h>
-#include <ActorWorldEditorBridge.h>
+#include <Editor/ActorWorldEditorBridge.h>
 #include <LightComponent.h>
 #include <LightManager.h>
 #include <PhysicsWorld.h>

--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
@@ -5,6 +5,7 @@
 #include "AnimationStateController.h"
 
 #include <ActorWorld.h>
+#include <ActorWorldEditorBridge.h>
 #include <LightComponent.h>
 #include <LightManager.h>
 #include <PhysicsWorld.h>
@@ -50,6 +51,14 @@ public: /// ---------- メンバ関数 ---------- ///
 	void Update() override;
 	// Editor停止中もDebugScene専用負荷検証だけは更新する。
 	void UpdateEditor(float deltaTime) override;
+
+	/// <summary>
+	/// ActorWorldが所有するActor / Component階層を統合World Outlinerへ公開する。
+	/// </summary>
+	void CollectEditorObjects(std::vector<K4E::EditorObjectInfo>& outObjects) override
+	{
+		K4E::CollectActorWorldEditorObjects(actorWorld_, outObjects, "DebugScene");
+	}
 
 	// ShadowSystemがCasterを決める前にActorのLightComponentを同期する。
 	void PrepareShadowPass() override

--- a/Project/Engine/Editor/ActorWorldEditorBridge.h
+++ b/Project/Engine/Editor/ActorWorldEditorBridge.h
@@ -9,6 +9,7 @@
 #include <string>
 #include <string_view>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace Ken4lowEngine

--- a/Project/Engine/Editor/ActorWorldEditorBridge.h
+++ b/Project/Engine/Editor/ActorWorldEditorBridge.h
@@ -1,0 +1,160 @@
+#pragma once
+
+#include "EditorObjectInfo.h"
+
+#include <ActorWorld.h>
+#include <SceneComponent.h>
+
+#include <cstdint>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <vector>
+
+namespace Ken4lowEngine
+{
+	/// <summary>
+	/// Actor / Componentの実体を直接所有せず、World OutlinerとDetails用の軽量情報へ変換します。
+	/// </summary>
+	inline void CollectActorWorldEditorObjects(
+		ActorWorld& actorWorld,
+		std::vector<EditorObjectInfo>& outObjects,
+		std::string_view sceneName)
+	{
+		const std::string sceneNameText(sceneName);
+		int actorSortOrder = 0;
+
+		for (const auto& actorOwner : actorWorld.GetActors())
+		{
+			Actor* actor = actorOwner.get();
+			if (!actor || actor->IsPendingDestroy())
+			{
+				continue;
+			}
+
+			const std::string actorKey = sceneNameText + "/Actor/" +
+				std::to_string(static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(actor)));
+			const uint64_t actorId = MakeStableEditorObjectId(actorKey);
+
+			EditorObjectInfo actorInfo{};
+			actorInfo.id = actorId;
+			actorInfo.sortOrder = actorSortOrder++;
+			actorInfo.displayName = actor->GetName().empty() ? actor->GetClassTypeName() : actor->GetName();
+			actorInfo.typeName = actor->GetClassTypeName();
+			actorInfo.sceneName = sceneNameText;
+			actorInfo.icon = "[A]";
+			actorInfo.objectKind = EditorObjectKind::Actor;
+			actorInfo.canToggleActive = true;
+			actorInfo.readActive = [actor]() { return actor->IsActive(); };
+			actorInfo.writeActive = [actor](bool active) { actor->SetActive(active); };
+			actorInfo.canRename = true;
+			actorInfo.rename = [actor](std::string_view name) { actor->SetName(name); };
+			actorInfo.inspectorHint = "Actor / Component Details";
+
+			if (SceneComponent* root = actor->GetRootComponent())
+			{
+				actorInfo.canEditTransform = true;
+				actorInfo.inspectorType = EditorInspectorType::Transform;
+				actorInfo.readTransform = [root](EditorTransform& outTransform)
+					{
+						outTransform.position = root->GetLocalPosition();
+						outTransform.rotation = root->GetLocalRotation();
+						outTransform.scale = root->GetLocalScale();
+						return true;
+					};
+				actorInfo.writeTransform = [root](const EditorTransform& transform)
+					{
+						root->SetLocalPosition(transform.position);
+						root->SetLocalRotation(transform.rotation);
+						root->SetLocalScale(transform.scale);
+						root->RefreshWorldTransform();
+					};
+			}
+
+			actorInfo.drawInspector = [&actorWorld, actor]()
+				{
+					actorWorld.SetSelectedEditorObject(actor, nullptr);
+					actorWorld.DrawSelectedInspectorContent();
+				};
+			outObjects.push_back(std::move(actorInfo));
+
+			std::unordered_map<const ActorComponent*, uint64_t> componentIds;
+			int componentSortOrder = 0;
+			for (const auto& componentOwner : actor->GetComponents())
+			{
+				ActorComponent* component = componentOwner.get();
+				if (!component)
+				{
+					continue;
+				}
+				const std::string componentKey = actorKey + "/Component/" +
+					std::to_string(static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(component)));
+				componentIds.emplace(component, MakeStableEditorObjectId(componentKey));
+			}
+
+			for (const auto& componentOwner : actor->GetComponents())
+			{
+				ActorComponent* component = componentOwner.get();
+				if (!component)
+				{
+					continue;
+				}
+
+				EditorObjectInfo componentInfo{};
+				componentInfo.id = componentIds.at(component);
+				componentInfo.parentId = actorId;
+				componentInfo.sortOrder = componentSortOrder++;
+				componentInfo.displayName = component->GetName().empty() ? component->GetClassTypeName() : component->GetName();
+				componentInfo.typeName = component->GetClassTypeName();
+				componentInfo.sceneName = sceneNameText;
+				componentInfo.icon = "[C]";
+				componentInfo.objectKind = EditorObjectKind::Component;
+				componentInfo.isRootComponent = component == actor->GetRootComponent();
+				componentInfo.canToggleActive = true;
+				componentInfo.readActive = [component]() { return component->IsActive(); };
+				componentInfo.writeActive = [component](bool active) { component->SetActive(active); };
+				componentInfo.canRename = true;
+				componentInfo.rename = [component](std::string_view name) { component->SetName(name); };
+				componentInfo.inspectorHint = componentInfo.isRootComponent
+					? "Root Component"
+					: "Actor Component";
+
+				if (auto* sceneComponent = dynamic_cast<SceneComponent*>(component))
+				{
+					if (SceneComponent* parent = sceneComponent->GetParent())
+					{
+						const auto parentId = componentIds.find(parent);
+						if (parentId != componentIds.end())
+						{
+							componentInfo.parentId = parentId->second;
+						}
+					}
+
+					componentInfo.canEditTransform = true;
+					componentInfo.inspectorType = EditorInspectorType::Transform;
+					componentInfo.readTransform = [sceneComponent](EditorTransform& outTransform)
+						{
+							outTransform.position = sceneComponent->GetLocalPosition();
+							outTransform.rotation = sceneComponent->GetLocalRotation();
+							outTransform.scale = sceneComponent->GetLocalScale();
+							return true;
+						};
+					componentInfo.writeTransform = [sceneComponent](const EditorTransform& transform)
+						{
+							sceneComponent->SetLocalPosition(transform.position);
+							sceneComponent->SetLocalRotation(transform.rotation);
+							sceneComponent->SetLocalScale(transform.scale);
+							sceneComponent->RefreshWorldTransform();
+						};
+				}
+
+				componentInfo.drawInspector = [&actorWorld, actor, component]()
+					{
+						actorWorld.SetSelectedEditorObject(actor, component);
+						actorWorld.DrawSelectedInspectorContent();
+					};
+				outObjects.push_back(std::move(componentInfo));
+			}
+		}
+	}
+} // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorHierarchyPanel.h
+++ b/Project/Engine/Editor/EditorHierarchyPanel.h
@@ -1,0 +1,444 @@
+#pragma once
+
+#include "EditorContext.h"
+#include "EditorPanelIds.h"
+#include "EditorWindowManager.h"
+
+#include <BaseScene.h>
+#include <LightManager.h>
+#include <SceneManager.h>
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <cstdint>
+#include <cstdio>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#ifdef USE_IMGUI
+#include <imgui.h>
+#endif
+
+namespace Ken4lowEngine
+{
+	/// <summary>
+	/// World OutlinerとDetailsを同じEditorSelectionへ接続し、UE風の階層・検索・Inspector表示を提供します。
+	/// </summary>
+	class EditorHierarchyPanel
+	{
+	public:
+		static EditorHierarchyPanel* GetInstance()
+		{
+			static EditorHierarchyPanel instance;
+			return &instance;
+		}
+
+		void Draw()
+		{
+#ifdef USE_IMGUI
+			CollectCurrentObjects();
+			RefreshSelection();
+			DrawWorldOutliner();
+			DrawDetails();
+#endif
+		}
+
+	private:
+		EditorHierarchyPanel() = default;
+		~EditorHierarchyPanel() = default;
+		EditorHierarchyPanel(const EditorHierarchyPanel&) = delete;
+		EditorHierarchyPanel& operator=(const EditorHierarchyPanel&) = delete;
+
+#ifdef USE_IMGUI
+		static char ToLowerAscii(unsigned char character)
+		{
+			if (character >= 'A' && character <= 'Z')
+			{
+				return static_cast<char>(character - 'A' + 'a');
+			}
+			return static_cast<char>(character);
+		}
+
+		static bool ContainsCaseInsensitive(std::string_view text, std::string_view filter)
+		{
+			if (filter.empty())
+			{
+				return true;
+			}
+
+			std::string loweredText(text);
+			std::string loweredFilter(filter);
+			std::transform(loweredText.begin(), loweredText.end(), loweredText.begin(), [](unsigned char c) { return ToLowerAscii(c); });
+			std::transform(loweredFilter.begin(), loweredFilter.end(), loweredFilter.begin(), [](unsigned char c) { return ToLowerAscii(c); });
+			return loweredText.find(loweredFilter) != std::string::npos;
+		}
+
+		void CollectCurrentObjects()
+		{
+			objects_.clear();
+			SceneManager* sceneManager = EditorWindowManager::GetInstance()->GetSceneManager();
+			BaseScene* scene = sceneManager ? sceneManager->GetCurrentScene() : nullptr;
+			if (scene)
+			{
+				scene->CollectEditorObjects(objects_);
+			}
+
+			std::stable_sort(objects_.begin(), objects_.end(), [](const EditorObjectInfo& lhs, const EditorObjectInfo& rhs)
+				{
+					if (lhs.parentId != rhs.parentId)
+					{
+						return lhs.parentId < rhs.parentId;
+					}
+					if (lhs.sortOrder != rhs.sortOrder)
+					{
+						return lhs.sortOrder < rhs.sortOrder;
+					}
+					return lhs.displayName < rhs.displayName;
+				});
+		}
+
+		void RefreshSelection()
+		{
+			EditorSelection& selection = EditorContext::GetInstance()->GetSelection();
+			if (!selection.HasSelection())
+			{
+				return;
+			}
+
+			const EditorObjectInfo& selected = selection.GetSelected();
+			const auto current = std::find_if(objects_.begin(), objects_.end(), [&selected](const EditorObjectInfo& object)
+				{
+					return object.id == selected.id && object.sceneName == selected.sceneName;
+				});
+			if (current != objects_.end())
+			{
+				selection.RefreshSelected(*current);
+			}
+			else
+			{
+				selection.Clear();
+			}
+		}
+
+		bool MatchesFilter(const EditorObjectInfo& object) const
+		{
+			const std::string_view filter(outlinerSearch_.data());
+			return ContainsCaseInsensitive(object.displayName, filter) ||
+				ContainsCaseInsensitive(object.typeName, filter) ||
+				ContainsCaseInsensitive(object.sceneName, filter);
+		}
+
+		bool HasMatchingDescendant(uint64_t objectId) const
+		{
+			for (const EditorObjectInfo& child : objects_)
+			{
+				if (child.parentId != objectId)
+				{
+					continue;
+				}
+				if (MatchesFilter(child) || HasMatchingDescendant(child.id))
+				{
+					return true;
+				}
+			}
+			return false;
+		}
+
+		bool HasChildren(uint64_t objectId) const
+		{
+			return std::any_of(objects_.begin(), objects_.end(), [objectId](const EditorObjectInfo& object)
+				{
+					return object.parentId == objectId;
+				});
+		}
+
+		bool IsSelected(const EditorObjectInfo& object) const
+		{
+			const EditorSelection& selection = EditorContext::GetInstance()->GetSelection();
+			return selection.HasSelection() &&
+				selection.GetSelected().id == object.id &&
+				selection.GetSelected().sceneName == object.sceneName;
+		}
+
+		void DrawObjectNode(const EditorObjectInfo& object)
+		{
+			const std::string_view filter(outlinerSearch_.data());
+			const bool filterActive = !filter.empty();
+			if (filterActive && !MatchesFilter(object) && !HasMatchingDescendant(object.id))
+			{
+				return;
+			}
+
+			ImGui::PushID(static_cast<int>(object.id & 0x7fffffff));
+
+			bool active = true;
+			if (object.ReadActive(active))
+			{
+				if (ImGui::Checkbox("##有効", &active))
+				{
+					object.WriteActive(active);
+				}
+				if (ImGui::IsItemHovered())
+				{
+					ImGui::SetTooltip(active ? "有効" : "無効");
+				}
+				ImGui::SameLine();
+			}
+
+			const bool hasChildren = HasChildren(object.id);
+			ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_SpanAvailWidth |
+				ImGuiTreeNodeFlags_OpenOnArrow |
+				ImGuiTreeNodeFlags_OpenOnDoubleClick;
+			if (!hasChildren)
+			{
+				flags |= ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen;
+			}
+			if (IsSelected(object))
+			{
+				flags |= ImGuiTreeNodeFlags_Selected;
+			}
+			if (object.objectKind == EditorObjectKind::Actor)
+			{
+				flags |= ImGuiTreeNodeFlags_DefaultOpen;
+			}
+			if (filterActive && hasChildren)
+			{
+				ImGui::SetNextItemOpen(true, ImGuiCond_Always);
+			}
+
+			const std::string label = object.icon + "  " + object.displayName + "##OutlinerNode";
+			const bool opened = ImGui::TreeNodeEx(label.c_str(), flags);
+			if (ImGui::IsItemClicked(ImGuiMouseButton_Left))
+			{
+				EditorContext::GetInstance()->GetSelection().Select(object);
+			}
+
+			if (ImGui::BeginPopupContextItem("##OutlinerContext"))
+			{
+				ImGui::TextDisabled("%s", object.typeName.c_str());
+				if (object.canRename && ImGui::MenuItem("名前を変更"))
+				{
+					renameTargetId_ = object.id;
+					std::snprintf(renameBuffer_.data(), renameBuffer_.size(), "%s", object.displayName.c_str());
+					openRenamePopup_ = true;
+				}
+				if (object.canDuplicate)
+				{
+					if (ImGui::MenuItem("複製"))
+					{
+						object.RequestDuplicate();
+					}
+				}
+				if (object.canDelete)
+				{
+					if (ImGui::MenuItem("削除"))
+					{
+						object.RequestDelete();
+					}
+				}
+				ImGui::EndPopup();
+			}
+
+			if (hasChildren && opened)
+			{
+				for (const EditorObjectInfo& child : objects_)
+				{
+					if (child.parentId == object.id)
+					{
+						DrawObjectNode(child);
+					}
+				}
+				ImGui::TreePop();
+			}
+
+			ImGui::PopID();
+		}
+
+		void DrawRenamePopup()
+		{
+			if (openRenamePopup_)
+			{
+				ImGui::OpenPopup("名前を変更##OutlinerRename");
+				openRenamePopup_ = false;
+			}
+
+			if (ImGui::BeginPopupModal("名前を変更##OutlinerRename", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+			{
+				ImGui::SetNextItemWidth(320.0f);
+				ImGui::InputText("新しい名前", renameBuffer_.data(), renameBuffer_.size());
+				ImGui::Separator();
+				if (ImGui::Button("変更", ImVec2(120.0f, 0.0f)))
+				{
+					const auto target = std::find_if(objects_.begin(), objects_.end(), [this](const EditorObjectInfo& object)
+						{
+							return object.id == renameTargetId_;
+						});
+					if (target != objects_.end())
+					{
+						target->Rename(renameBuffer_.data());
+						EditorContext::GetInstance()->GetSelection().RefreshSelected(*target);
+					}
+					ImGui::CloseCurrentPopup();
+				}
+				ImGui::SameLine();
+				if (ImGui::Button("キャンセル", ImVec2(120.0f, 0.0f)))
+				{
+					ImGui::CloseCurrentPopup();
+				}
+				ImGui::EndPopup();
+			}
+		}
+
+		void DrawWorldOutliner()
+		{
+			auto& windowState = EditorWindowManager::GetInstance()->GetWindowState();
+			if (!windowState.showWorldOutliner)
+			{
+				return;
+			}
+
+			const ImGuiWindowFlags windowFlags = ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse;
+			if (ImGui::Begin(EditorPanelIds::WorldOutliner, &windowState.showWorldOutliner, windowFlags))
+			{
+				ImGui::SetNextItemWidth(-1.0f);
+				ImGui::InputTextWithHint("##OutlinerSearch", "アクタやコンポーネントを検索...", outlinerSearch_.data(), outlinerSearch_.size());
+				ImGui::TextDisabled("表示中: %zu", objects_.size());
+				ImGui::Separator();
+
+				if (ImGui::BeginChild("##WorldOutlinerBody", ImVec2(0.0f, 0.0f), false))
+				{
+					const char* sceneLabel = objects_.empty() ? "現在のシーン" : objects_.front().sceneName.c_str();
+					if (ImGui::TreeNodeEx(sceneLabel, ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_SpanAvailWidth))
+					{
+						if (objects_.empty())
+						{
+							ImGui::TextDisabled("表示できるEditorオブジェクトがありません。");
+						}
+						for (const EditorObjectInfo& object : objects_)
+						{
+							if (object.parentId == 0)
+							{
+								DrawObjectNode(object);
+							}
+						}
+						ImGui::TreePop();
+					}
+				}
+				ImGui::EndChild();
+				DrawRenamePopup();
+			}
+			ImGui::End();
+		}
+
+		void DrawFallbackTransformInspector(const EditorObjectInfo& selected)
+		{
+			EditorTransform transform{};
+			if (!selected.TryReadTransform(transform))
+			{
+				ImGui::TextDisabled("%s", selected.transformUnavailableReason.c_str());
+				return;
+			}
+
+			bool changed = false;
+			changed |= ImGui::DragFloat3("位置", &transform.position.x, 0.1f);
+			changed |= ImGui::DragFloat3("回転", &transform.rotation.x, 0.01f);
+			changed |= ImGui::DragFloat3("スケール", &transform.scale.x, 0.1f, 0.001f, 1000.0f);
+			if (changed)
+			{
+				selected.WriteTransform(transform);
+				EditorContext::GetInstance()->MarkLevelDirty();
+				// Property変更をDirty状態へ接続し、Phase 10のLevel保存で未保存変更を判定できるようにする。
+			}
+		}
+
+		void DrawDetails()
+		{
+			auto& windowState = EditorWindowManager::GetInstance()->GetWindowState();
+			if (!windowState.showDetails)
+			{
+				return;
+			}
+
+			const ImGuiWindowFlags windowFlags = ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse;
+			if (ImGui::Begin(EditorPanelIds::Details, &windowState.showDetails, windowFlags))
+			{
+				if (ImGui::BeginChild("##DetailsBody", ImVec2(0.0f, 0.0f), false))
+				{
+					EditorSelection& selection = EditorContext::GetInstance()->GetSelection();
+					if (!selection.HasSelection())
+					{
+						ImGui::TextDisabled("オブジェクトが選択されていません。");
+					}
+					else
+					{
+						const EditorObjectInfo& selected = selection.GetSelected();
+						ImGui::Text("%s  %s", selected.icon.c_str(), selected.displayName.c_str());
+						ImGui::TextDisabled("%s", selected.typeName.c_str());
+
+						if (selected.canRename)
+						{
+							std::array<char, 256> nameBuffer{};
+							std::snprintf(nameBuffer.data(), nameBuffer.size(), "%s", selected.displayName.c_str());
+							ImGui::SetNextItemWidth(-1.0f);
+							if (ImGui::InputText("名前", nameBuffer.data(), nameBuffer.size(), ImGuiInputTextFlags_EnterReturnsTrue))
+							{
+								selected.Rename(nameBuffer.data());
+								EditorContext::GetInstance()->MarkLevelDirty();
+							}
+						}
+
+						bool active = true;
+						if (selected.ReadActive(active) && ImGui::Checkbox("有効", &active))
+						{
+							selected.WriteActive(active);
+							EditorContext::GetInstance()->MarkLevelDirty();
+						}
+
+						if (ImGui::CollapsingHeader("基本情報", ImGuiTreeNodeFlags_DefaultOpen))
+						{
+							ImGui::Text("種類: %s", selected.typeName.c_str());
+							ImGui::Text("シーン: %s", selected.sceneName.c_str());
+							ImGui::TextDisabled("Editor ID: %llu", static_cast<unsigned long long>(selected.id));
+							if (!selected.inspectorHint.empty())
+							{
+								ImGui::TextDisabled("%s", selected.inspectorHint.c_str());
+							}
+						}
+
+						ImGui::Separator();
+						if (selected.drawInspector)
+						{
+							selected.drawInspector();
+						}
+						else
+						{
+							switch (selected.inspectorType)
+							{
+							case EditorInspectorType::Transform:
+								DrawFallbackTransformInspector(selected);
+								break;
+							case EditorInspectorType::PunctualLights:
+								LightManager::GetInstance()->DrawPunctualLightsInspector();
+								break;
+							default:
+								ImGui::TextDisabled("このオブジェクトの詳細表示は未実装です。");
+								break;
+							}
+						}
+					}
+				}
+				ImGui::EndChild();
+			}
+			ImGui::End();
+		}
+#endif
+
+		std::vector<EditorObjectInfo> objects_;
+		std::array<char, 128> outlinerSearch_{};
+		std::array<char, 256> renameBuffer_{};
+		uint64_t renameTargetId_ = 0;
+		bool openRenamePopup_ = false;
+	};
+} // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorObjectInfo.h
+++ b/Project/Engine/Editor/EditorObjectInfo.h
@@ -4,6 +4,7 @@
 #include <functional>
 #include <string>
 #include <string_view>
+#include <utility>
 
 #include "Vector3.h"
 
@@ -93,6 +94,17 @@ namespace Ken4lowEngine
 		using WriteActiveFunc = std::function<void(bool)>;
 		using RenameFunc = std::function<void(std::string_view)>;
 		using RequestActionFunc = std::function<void()>;
+
+		EditorObjectInfo() = default;
+
+		EditorObjectInfo(uint64_t objectId, std::string objectDisplayName, std::string objectTypeName, std::string objectSceneName)
+			: id(objectId),
+			displayName(std::move(objectDisplayName)),
+			typeName(std::move(objectTypeName)),
+			sceneName(std::move(objectSceneName))
+		{
+			// 階層用フィールド追加後も既存の4引数初期化を型安全に維持する。
+		}
 
 		uint64_t id = 0;
 		uint64_t parentId = 0;

--- a/Project/Engine/Editor/EditorObjectInfo.h
+++ b/Project/Engine/Editor/EditorObjectInfo.h
@@ -32,6 +32,16 @@ namespace Ken4lowEngine
 		Vector3 scale = { 1.0f, 1.0f, 1.0f };
 	};
 
+	/// <summary>
+	/// World Outliner上でオブジェクトを分類する種類です。
+	/// </summary>
+	enum class EditorObjectKind
+	{
+		Generic,
+		Actor,
+		Component,
+	};
+
 	enum class EditorInspectorType
 	{
 		None,
@@ -71,7 +81,6 @@ namespace Ken4lowEngine
 		}
 	}
 
-
 	/// <summary>
 	/// World OutlinerとDetailsへ安全に渡すための軽量なエディタ表示用オブジェクト情報です。
 	/// </summary>
@@ -80,11 +89,21 @@ namespace Ken4lowEngine
 		using ReadTransformFunc = std::function<bool(EditorTransform&)>;
 		using WriteTransformFunc = std::function<void(const EditorTransform&)>;
 		using DrawInspectorFunc = std::function<void()>;
+		using ReadActiveFunc = std::function<bool()>;
+		using WriteActiveFunc = std::function<void(bool)>;
+		using RenameFunc = std::function<void(std::string_view)>;
+		using RequestActionFunc = std::function<void()>;
 
 		uint64_t id = 0;
+		uint64_t parentId = 0;
+		int sortOrder = 0;
 		std::string displayName;
 		std::string typeName;
 		std::string sceneName;
+		std::string icon = "[O]";
+		EditorObjectKind objectKind = EditorObjectKind::Generic;
+		bool isRootComponent = false;
+
 		bool canEditTransform = false;
 		std::string transformUnavailableReason = "Transform editing is not available for this object.";
 		EditorInspectorType inspectorType = EditorInspectorType::None;
@@ -92,6 +111,16 @@ namespace Ken4lowEngine
 		ReadTransformFunc readTransform;
 		DrawInspectorFunc drawInspector;
 		WriteTransformFunc writeTransform;
+
+		bool canToggleActive = false;
+		ReadActiveFunc readActive;
+		WriteActiveFunc writeActive;
+		bool canRename = false;
+		RenameFunc rename;
+		bool canDuplicate = false;
+		RequestActionFunc requestDuplicate;
+		bool canDelete = false;
+		RequestActionFunc requestDelete;
 
 		// Detailsは毎フレーム再収集された入口だけを使い、古いraw pointerへ直接触れないようにする。
 		bool TryReadTransform(EditorTransform& outTransform) const
@@ -105,6 +134,48 @@ namespace Ken4lowEngine
 			if (canEditTransform && writeTransform)
 			{
 				writeTransform(transform);
+			}
+		}
+
+		bool ReadActive(bool& outActive) const
+		{
+			if (!canToggleActive || !readActive)
+			{
+				return false;
+			}
+			outActive = readActive();
+			return true;
+		}
+
+		void WriteActive(bool active) const
+		{
+			if (canToggleActive && writeActive)
+			{
+				writeActive(active);
+			}
+		}
+
+		void Rename(std::string_view name) const
+		{
+			if (canRename && rename && !name.empty())
+			{
+				rename(name);
+			}
+		}
+
+		void RequestDuplicate() const
+		{
+			if (canDuplicate && requestDuplicate)
+			{
+				requestDuplicate();
+			}
+		}
+
+		void RequestDelete() const
+		{
+			if (canDelete && requestDelete)
+			{
+				requestDelete();
 			}
 		}
 	};

--- a/Project/Engine/Editor/EditorPanelIds.h
+++ b/Project/Engine/Editor/EditorPanelIds.h
@@ -6,8 +6,8 @@ namespace Ken4lowEngine::EditorPanelIds
 	inline constexpr const char* PlaceActors = "Place Actors";
 	inline constexpr const char* MainViewport = "Main Viewport";
 	inline constexpr const char* ViewportToolbarOverlay = "ビューポートツールバー###ViewportToolbarOverlay";
-	inline constexpr const char* WorldOutliner = "World Outliner";
-	inline constexpr const char* Details = "Details";
+	inline constexpr const char* WorldOutliner = "アウトライナー###World Outliner";
+	inline constexpr const char* Details = "詳細###Details";
 	inline constexpr const char* ContentBrowser = "Content Browser";
 	inline constexpr const char* OutputLog = "Output Log";
 	inline constexpr const char* Scene = "Scene";

--- a/Project/Engine/Editor/EditorShell.h
+++ b/Project/Engine/Editor/EditorShell.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "EditorContext.h"
+#include "EditorHierarchyPanel.h"
 #include "EditorModeController.h"
 #include "EditorPanelIds.h"
 #include "EditorPlayController.h"
@@ -43,6 +44,7 @@ namespace Ken4lowEngine
 
 			ApplyViewportVisualPolicy();
 			DrawPlaceActors();
+			EditorHierarchyPanel::GetInstance()->Draw(); // World OutlinerとDetailsを同じ選択状態で先に登録する。
 #endif
 		}
 

--- a/Project/Engine/Editor/EditorWindowManager.h
+++ b/Project/Engine/Editor/EditorWindowManager.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include "Vector2.h"
 #include "EditorContext.h"
 #include "EditorAssetBrowser.h"
@@ -10,7 +10,6 @@
 namespace Ken4lowEngine
 {
 	class SceneManager;
-
 
 	/// <summary>
 	/// UE5風エディタUIの各ウィンドウ表示状態を保持します。
@@ -88,6 +87,7 @@ namespace Ken4lowEngine
 
 		// SceneManagerの所有権はGameApplicationに残し、Editorは参照だけを保持する。
 		void SetSceneManager(SceneManager* sceneManager) { sceneManager_ = sceneManager; }
+		SceneManager* GetSceneManager() const { return sceneManager_; }
 
 		void Draw();
 		void DrawMenuBar();

--- a/Project/Engine/Scene/Actor/Core/ActorWorld.h
+++ b/Project/Engine/Scene/Actor/Core/ActorWorld.h
@@ -79,7 +79,8 @@ namespace Ken4lowEngine
 		void DrawShadow();
 
 		/// <summary>
-		/// ActorWorldが所有する全ActorのEditor表示を行う
+		/// ActorWorldが所有する全ActorのEditor表示を行う。
+		/// Phase 3以降はWorld Outliner / Detailsへ統合し、既定では旧ウィンドウを表示しない。
 		/// </summary>
 		void DrawImGui();
 
@@ -87,6 +88,26 @@ namespace Ken4lowEngine
 		/// 選択中ActorまたはComponentのDetailsウィンドウを描画する。
 		/// </summary>
 		void DrawDetailsImGui();
+
+		/// <summary>
+		/// 統合Detailsパネル内へ選択中ActorまたはComponentの編集UIだけを描画する。
+		/// </summary>
+		void DrawSelectedInspectorContent();
+
+		/// <summary>
+		/// World Outlinerから選択されたActor / ComponentをActorWorld側へ同期する。
+		/// </summary>
+		void SetSelectedEditorObject(Actor* actor, ActorComponent* component)
+		{
+			selectedActor_ = actor;
+			selectedComponent_ = component;
+		}
+
+		/// <summary>
+		/// 旧Actor World / Actor Detailsウィンドウを互換表示するか設定する。
+		/// </summary>
+		void SetLegacyEditorWindowsEnabled(bool enabled) { legacyEditorWindowsEnabled_ = enabled; }
+		bool IsLegacyEditorWindowsEnabled() const { return legacyEditorWindowsEnabled_; }
 
 		/// <summary>
 		/// ActorWorldが所有する全Actorの終了処理を行う
@@ -293,6 +314,9 @@ namespace Ken4lowEngine
 		// Actor Detailsウィンドウへフォーカスを移す要求
 		bool requestFocusActorDetails_ = false;
 
+		// 旧Actor World / Actor Detailsウィンドウを表示する互換フラグ
+		bool legacyEditorWindowsEnabled_ = false;
+
 		// ActorWorldが所有するPhysicsWorldへの参照
 		PhysicsWorld* physicsWorld_ = nullptr;
 
@@ -316,4 +340,4 @@ namespace Ken4lowEngine
 		// 選択中ActorをPrefabとして保存する際のデフォルトパス
 		std::string actorPrefabSavePath_ = "Resources/ActorPrefabs/NewActorPrefab.json";
 	};
-}
+} // namespace Ken4lowEngine

--- a/Project/Engine/Scene/Actor/Core/ActorWorld_ImGui.cpp
+++ b/Project/Engine/Scene/Actor/Core/ActorWorld_ImGui.cpp
@@ -14,39 +14,40 @@ namespace Ken4lowEngine
 	void ActorWorld::DrawImGui()
 	{
 #ifdef USE_IMGUI
-		if (ImGui::Begin("Actor World"))
+		if (legacyEditorWindowsEnabled_)
 		{
-			ImGui::Text("Actor Count: %zu", actors_.size());
-
-			DrawActorPrefabSpawnImGui(); // Actor PrefabsのSpawnボタンを描画する
-
-			ImGui::Separator();
-
-			for (size_t actorIndex = 0; actorIndex < actors_.size(); ++actorIndex)
+			if (ImGui::Begin("Actor World"))
 			{
-				Actor* actor = actors_[actorIndex].get();
-				if (!actor)
+				ImGui::Text("アクタ数: %zu", actors_.size());
+				DrawActorPrefabSpawnImGui();
+				ImGui::Separator();
+
+				for (size_t actorIndex = 0; actorIndex < actors_.size(); ++actorIndex)
 				{
-					continue; // Actorがnullptrなら表示しない
-				}
+					Actor* actor = actors_[actorIndex].get();
+					if (!actor)
+					{
+						continue;
+					}
 
-				Actor* beforeSelectedActor = selectedActor_;
-				ActorComponent* beforeSelectedComponent = selectedComponent_;
+					Actor* beforeSelectedActor = selectedActor_;
+					ActorComponent* beforeSelectedComponent = selectedComponent_;
+					ImGui::PushID(static_cast<int>(actorIndex));
+					actor->DrawHierarchyImGui(selectedActor_, selectedComponent_);
+					ImGui::PopID();
 
-				ImGui::PushID(static_cast<int>(actorIndex));
-				actor->DrawHierarchyImGui(selectedActor_, selectedComponent_); // Actor World上にActor/Component階層を表示する
-				ImGui::PopID();
-
-				if (beforeSelectedActor != selectedActor_ || beforeSelectedComponent != selectedComponent_)
-				{
-					requestFocusActorDetails_ = true; // 選択中ActorまたはComponentが変化した場合にDetailsウィンドウを更新する
+					if (beforeSelectedActor != selectedActor_ || beforeSelectedComponent != selectedComponent_)
+					{
+						requestFocusActorDetails_ = true;
+					}
 				}
 			}
+			ImGui::End();
+			DrawDetailsImGui();
 		}
-		ImGui::End();
 
-		DrawDetailsImGui(); // 選択中ActorまたはComponentのDetailsウィンドウを描画する
-		SyncLightComponentsToLightManager(); // ImGuiで編集したライト設定を次の描画へ反映する
+		// 統合Detailsで編集したライト設定も同じフレームの描画へ反映する。
+		SyncLightComponentsToLightManager();
 #endif // USE_IMGUI
 	}
 
@@ -55,153 +56,151 @@ namespace Ken4lowEngine
 #ifdef USE_IMGUI
 		if (requestFocusActorDetails_)
 		{
-			ImGui::SetNextWindowFocus(); // 選択が変わったらActor Detailsを前面へ出す
+			ImGui::SetNextWindowFocus();
 			requestFocusActorDetails_ = false;
 		}
 
 		if (ImGui::Begin("Actor Details"))
 		{
-			Actor* saveTargetActor = selectedActor_;
+			DrawSelectedInspectorContent();
+		}
+		ImGui::End();
+#endif // USE_IMGUI
+	}
 
-			if (!saveTargetActor && selectedComponent_)
+	void ActorWorld::DrawSelectedInspectorContent()
+	{
+#ifdef USE_IMGUI
+		Actor* saveTargetActor = selectedActor_;
+		if (!saveTargetActor && selectedComponent_)
+		{
+			saveTargetActor = selectedComponent_->GetOwner();
+		}
+
+		if (saveTargetActor)
+		{
+			if (ImGui::Button("選択アクタをJSON保存"))
 			{
-				saveTargetActor = selectedComponent_->GetOwner(); // Componentが選択中なら所有Actorを取得する
+				const std::string actorName = saveTargetActor->GetName().empty()
+					? saveTargetActor->GetClassTypeName()
+					: saveTargetActor->GetName();
+				const std::string filePath = "Resources/ActorPrefabs/" + actorName + ".json";
+				const bool succeeded = ActorJsonSerializer::SaveActorToFile(*saveTargetActor, filePath);
+				lastActorJsonSaveMessage_ = succeeded
+					? "保存しました: " + filePath
+					: "保存に失敗しました: " + filePath;
 			}
 
-			if (saveTargetActor)
+			ImGui::SameLine();
+			if (ImGui::Button("JSONから再読込"))
 			{
-				if (ImGui::Button("Save Selected Actor JSON"))
+				const std::string actorName = saveTargetActor->GetName().empty()
+					? saveTargetActor->GetClassTypeName()
+					: saveTargetActor->GetName();
+				const std::string filePath = "Resources/ActorPrefabs/" + actorName + ".json";
+				selectedComponent_ = nullptr;
+				pendingReloadActor_ = saveTargetActor;
+				pendingReloadFilePath_ = filePath;
+				hasPendingReloadActor_ = true;
+				lastActorJsonSaveMessage_ = "再読込を予約しました: " + filePath;
+			}
+
+			ImGui::SameLine();
+			if (ImGui::Button("アクタを削除"))
+			{
+				ImGui::OpenPopup("アクタを削除しますか？");
+			}
+
+			if (ImGui::BeginPopupModal("アクタを削除しますか？", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+			{
+				ImGui::Text("%s を削除します。", saveTargetActor->GetName().c_str());
+				ImGui::TextDisabled("この操作はPhase 9でUndo / Redoへ接続します。");
+				ImGui::Separator();
+				if (ImGui::Button("削除", ImVec2(120.0f, 0.0f)))
 				{
-					const std::string actorName = saveTargetActor->GetName().empty()
-						? saveTargetActor->GetClassTypeName()
-						: saveTargetActor->GetName();
-
-					const std::string filePath = "Resources/ActorPrefabs/" + actorName + ".json";
-
-					const bool succeeded = ActorJsonSerializer::SaveActorToFile(*saveTargetActor, filePath);
-
-					lastActorJsonSaveMessage_ = succeeded
-						? "Saved : " + filePath
-						: "Save failed : " + filePath;
-				}
-
-				ImGui::SameLine();
-
-				if (ImGui::Button("Load Selected Actor JSON"))
-				{
-					const std::string actorName = saveTargetActor->GetName().empty()
-						? saveTargetActor->GetClassTypeName()
-						: saveTargetActor->GetName();
-
-					const std::string filePath = "Resources/ActorPrefabs/" + actorName + ".json";
-
-					selectedComponent_ = nullptr; // Componentは作り直されるので選択解除する
-
-					pendingReloadActor_ = saveTargetActor; // JSON読込予約を次フレームの安全なタイミングで処理する
-					pendingReloadFilePath_ = filePath;
-					hasPendingReloadActor_ = true;
-
-					lastActorJsonSaveMessage_ = "Reload requested : " + filePath;
-				}
-
-				ImGui::SameLine();
-
-				if (ImGui::Button("Delete Selected Actor"))
-				{
-					pendingDeleteActor_ = saveTargetActor; // Destroy予約を次フレームの安全なタイミングで処理する
+					pendingDeleteActor_ = saveTargetActor;
 					hasPendingDeleteActor_ = true;
-
-					selectedActor_ = nullptr; // Actorは削除されるので選択解除する
-					selectedComponent_ = nullptr; // Componentは削除されるので選択解除する
-
-					lastActorJsonSaveMessage_ = "Delete requested : " + saveTargetActor->GetName();
+					selectedActor_ = nullptr;
+					selectedComponent_ = nullptr;
+					lastActorJsonSaveMessage_ = "削除を予約しました: " + saveTargetActor->GetName();
+					ImGui::CloseCurrentPopup();
 				}
-
-				if (!lastActorJsonSaveMessage_.empty())
+				ImGui::SameLine();
+				if (ImGui::Button("キャンセル", ImVec2(120.0f, 0.0f)))
 				{
-					ImGui::Text("%s", lastActorJsonSaveMessage_.c_str());
+					ImGui::CloseCurrentPopup();
 				}
-
-				ImGui::Separator();
+				ImGui::EndPopup();
 			}
 
-			if (selectedComponent_)
+			if (!lastActorJsonSaveMessage_.empty())
 			{
-				const std::string componentName = selectedComponent_->GetName().empty()
-					? "Unnamed Component"
-					: selectedComponent_->GetName();
-
-				ImGui::Text("Selected Component: %s", componentName.c_str());
-
-				Actor* owner = selectedComponent_->GetOwner();
-				const bool isRootComponent = owner && selectedComponent_ == owner->GetRootComponent();
-
-				if (isRootComponent)
-				{
-					ImGui::TextDisabled("RootComponent cannot be deleted or duplicated.");
-				}
-				else
-				{
-					if (ImGui::Button("Duplicate Selected Component"))
-					{
-						DuplicateSelectedComponent();
-					}
-
-					ImGui::SameLine();
-
-					if (ImGui::Button("Delete Selected Component"))
-					{
-						ImGui::OpenPopup("Delete Component?");
-					}
-				}
-
-				if (ImGui::BeginPopupModal("Delete Component?", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
-				{
-					ImGui::Text("Delete this Component?");
-					ImGui::Text("%s", componentName.c_str());
-
-					ImGui::Separator();
-
-					if (ImGui::Button("Delete", ImVec2(120.0f, 0.0f)))
-					{
-						DeleteSelectedComponent(); // Draw中には消さず、次フレームUpdateで削除する。
-						ImGui::CloseCurrentPopup();
-					}
-
-					ImGui::SameLine();
-
-					if (ImGui::Button("Cancel", ImVec2(120.0f, 0.0f)))
-					{
-						ImGui::CloseCurrentPopup();
-					}
-
-					ImGui::EndPopup();
-				}
-
-				ImGui::Separator();
-
-				selectedComponent_->DrawInspectorImGui();
+				ImGui::TextWrapped("%s", lastActorJsonSaveMessage_.c_str());
 			}
-			else if (selectedActor_)
+			ImGui::Separator();
+		}
+
+		if (selectedComponent_)
+		{
+			const std::string componentName = selectedComponent_->GetName().empty()
+				? "名前なしコンポーネント"
+				: selectedComponent_->GetName();
+			ImGui::Text("選択中のコンポーネント: %s", componentName.c_str());
+
+			Actor* owner = selectedComponent_->GetOwner();
+			const bool isRootComponent = owner && selectedComponent_ == owner->GetRootComponent();
+			if (isRootComponent)
 			{
-				const std::string actorName = selectedActor_->GetName().empty()
-					? "Unnamed Actor"
-					: selectedActor_->GetName();
-
-				ImGui::Text("Selected Actor: %s", actorName.c_str());
-				ImGui::Separator();
-
-				selectedActor_->DrawInspectorImGui(); // 選択中Actorの詳細を描画する。
+				ImGui::TextDisabled("ルートコンポーネントは複製・削除できません。");
 			}
 			else
 			{
-				ImGui::Text("No selection.");
+				if (ImGui::Button("コンポーネントを複製"))
+				{
+					DuplicateSelectedComponent();
+				}
+				ImGui::SameLine();
+				if (ImGui::Button("コンポーネントを削除"))
+				{
+					ImGui::OpenPopup("コンポーネントを削除しますか？");
+				}
 			}
 
-			DrawAddComponentImGui(); // 選択中ActorにComponentを追加するUIを描画する
+			if (ImGui::BeginPopupModal("コンポーネントを削除しますか？", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+			{
+				ImGui::Text("%s を削除します。", componentName.c_str());
+				ImGui::Separator();
+				if (ImGui::Button("削除", ImVec2(120.0f, 0.0f)))
+				{
+					DeleteSelectedComponent();
+					ImGui::CloseCurrentPopup();
+				}
+				ImGui::SameLine();
+				if (ImGui::Button("キャンセル", ImVec2(120.0f, 0.0f)))
+				{
+					ImGui::CloseCurrentPopup();
+				}
+				ImGui::EndPopup();
+			}
+
+			ImGui::Separator();
+			selectedComponent_->DrawInspectorImGui();
+		}
+		else if (selectedActor_)
+		{
+			const std::string actorName = selectedActor_->GetName().empty()
+				? "名前なしアクタ"
+				: selectedActor_->GetName();
+			ImGui::Text("選択中のアクタ: %s", actorName.c_str());
+			ImGui::Separator();
+			selectedActor_->DrawInspectorImGui();
+		}
+		else
+		{
+			ImGui::TextDisabled("アクタまたはコンポーネントが選択されていません。");
 		}
 
-		ImGui::End();
+		DrawAddComponentImGui();
 #endif // USE_IMGUI
 	}
 
@@ -209,44 +208,38 @@ namespace Ken4lowEngine
 	{
 #ifdef USE_IMGUI
 		Actor* targetActor = selectedActor_;
-
 		if (!targetActor && selectedComponent_)
 		{
-			targetActor = selectedComponent_->GetOwner(); // Component選択中なら所有Actorを対象にする。
+			targetActor = selectedComponent_->GetOwner();
 		}
 
 		ImGui::SeparatorText("コンポーネント追加");
-
 		if (!targetActor)
 		{
-			ImGui::TextDisabled("Actorが選択されていません。");
+			ImGui::TextDisabled("アクタが選択されていません。");
 			return;
 		}
 
 		const auto& componentTypes = ComponentFactory::GetRegisteredComponentTypes();
-
 		if (componentTypes.empty())
 		{
-			ImGui::TextDisabled("登録済みのComponentがありません。");
+			ImGui::TextDisabled("登録済みのコンポーネントがありません。");
 			return;
 		}
 
 		if (selectedAddComponentTypeIndex_ < 0 ||
-		selectedAddComponentTypeIndex_ >= static_cast<int>(componentTypes.size()))
+			selectedAddComponentTypeIndex_ >= static_cast<int>(componentTypes.size()))
 		{
 			selectedAddComponentTypeIndex_ = 0;
 		}
 
 		const ComponentFactory::ComponentTypeInfo& selectedType = componentTypes[selectedAddComponentTypeIndex_];
-
 		if (ImGui::BeginCombo("種類", selectedType.displayName.c_str()))
 		{
 			std::string currentCategory;
-
 			for (int index = 0; index < static_cast<int>(componentTypes.size()); ++index)
 			{
 				const ComponentFactory::ComponentTypeInfo& typeInfo = componentTypes[index];
-
 				if (currentCategory != typeInfo.category)
 				{
 					currentCategory = typeInfo.category;
@@ -255,7 +248,6 @@ namespace Ken4lowEngine
 
 				const bool alreadyExists = targetActor->HasComponentClass(typeInfo.className);
 				const bool disabled = !typeInfo.allowMultiple && alreadyExists;
-
 				if (disabled)
 				{
 					ImGui::BeginDisabled();
@@ -263,56 +255,43 @@ namespace Ken4lowEngine
 
 				const bool isSelected = selectedAddComponentTypeIndex_ == index;
 				const std::string selectableLabel = typeInfo.displayName + "##" + typeInfo.className;
-
 				if (ImGui::Selectable(selectableLabel.c_str(), isSelected))
 				{
 					selectedAddComponentTypeIndex_ = index;
 				}
-
 				if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
 				{
 					ImGui::SetTooltip("%s", typeInfo.description.c_str());
 				}
-
 				if (isSelected)
 				{
 					ImGui::SetItemDefaultFocus();
 				}
-
 				if (disabled)
 				{
 					ImGui::EndDisabled();
 				}
 			}
-
 			ImGui::EndCombo();
 		}
 
 		const bool alreadyExists = targetActor->HasComponentClass(selectedType.className);
 		const bool canAdd = selectedType.allowMultiple || !alreadyExists;
-
 		ImGui::Text("カテゴリ: %s", selectedType.category.c_str());
 		ImGui::TextWrapped("%s", selectedType.description.c_str());
-
 		if (!canAdd)
 		{
-			ImGui::TextDisabled("このComponentは1つだけ追加できます。");
-		}
-
-		if (!canAdd)
-		{
+			ImGui::TextDisabled("このコンポーネントは1つだけ追加できます。");
 			ImGui::BeginDisabled();
 		}
-
 		if (ImGui::Button("追加##AddComponent"))
 		{
 			AddComponentToSelectedActor(selectedType.className);
 		}
-
 		if (!canAdd)
 		{
 			ImGui::EndDisabled();
 		}
 #endif // USE_IMGUI
 	}
-}
+} // namespace Ken4lowEngine

--- a/Project/ken4low_editor_layout_v2.ini
+++ b/Project/ken4low_editor_layout_v2.ini
@@ -118,18 +118,18 @@ Size=1920,983
 Collapsed=0
 
 [Window][Debug##Default]
-Pos=60,60
-Size=400,400
+Pos=12,715
+Size=335,32
 Collapsed=0
 
 [Window][FadeManager]
-Pos=60,60
+Pos=9,677
 Size=422,688
-Collapsed=0
+Collapsed=1
 
 [Window][AnimationModel Test]
-Pos=60,60
-Size=335,688
+Pos=7,759
+Size=335,32
 Collapsed=0
 DockId=0x0000000B,0
 
@@ -144,7 +144,7 @@ Size=273,104
 Collapsed=0
 
 [Docking][Data]
-DockNode          ID=0x0000000B Pos=60,60 Size=335,688 Selected=0x1037DE37
+DockNode          ID=0x0000000B Pos=7,759 Size=335,32 Selected=0x273AB186
 DockSpace         ID=0x08BD597D Window=0x1BBC0F80 Pos=0,26 Size=1920,983 Split=Y
   DockNode        ID=0x00000001 Parent=0x08BD597D SizeRef=1280,53 Selected=0x0C01D6D5
   DockNode        ID=0x00000002 Parent=0x08BD597D SizeRef=1280,665 Split=X


### PR DESCRIPTION
## 概要
UE風Editor計画のPhase 3として、World OutlinerとDetailsをActor / Component階層へ統合します。

Phase 2のビューポートツールバー変更を含む現在のEditor状態を土台にしています。

## 実装内容
- DebugSceneのActorWorldをWorld Outlinerへ接続
- Actor → Component → 子SceneComponentの階層表示
- Outliner検索
  - Actor名
  - Component名
  - 型名
  - Scene名
- Actor / Componentの有効状態切り替え
- Actor / Component選択をEditorContextへ集約
- 右クリックから名前変更
- Detailsを日本語中心のInspectorへ整理
  - 名前
  - 有効状態
  - 基本情報
  - Transform
  - Actor固有Inspector
  - Component固有Inspector
  - Component追加
  - JSON保存 / 再読込
  - Actor / Component削除確認
- 旧`Actor World`と`Actor Details`は既定で非表示にし、統合パネルへ移行
- Property変更時にLevel Dirty状態を更新する入口を追加

## UI方針
- UE日本語版を参考に、ユーザーが直接操作する表示はできる限り日本語化
- 内部クラス名やアセット識別に必要な英語名は補助情報として維持

## 確認項目
- World OutlinerにDebugSceneのActorが表示される
- Actorを展開するとComponent階層が表示される
- SceneComponentの親子関係が階層へ反映される
- OutlinerとDetailsの選択が同期する
- Actor / Componentの有効状態を切り替えられる
- 名前変更がOutlinerへ反映される
- Transformや各Component固有値をDetailsで編集できる
- 旧Actor World / Actor Detailsの浮動ウィンドウが表示されない
