### PR TITLE
Phase 4: Content Browser V2とAsset Registry基盤

### DIFF
--- a/Project/Engine/Editor/EditorAssetRegistryV2.h
+++ b/Project/Engine/Editor/EditorAssetRegistryV2.h
@@ -1,0 +1,446 @@
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <cctype>
+#include <cstdint>
+#include <ctime>
+#include <filesystem>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace Ken4lowEngine
+{
+	/// <summary>
+	/// コンテンツブラウザで扱うアセット種別です。
+	/// </summary>
+	enum class EditorAssetType
+	{
+		All,
+		Folder,
+		Texture,
+		Model,
+		Animation,
+		Material,
+		ActorPrefab,
+		Level,
+		Shader,
+		Font,
+		Audio,
+		Json,
+		Other,
+	};
+
+	/// <summary>
+	/// Asset Registryが保持するファイル・フォルダの軽量情報です。
+	/// </summary>
+	struct EditorAssetData
+	{
+		uint64_t id = 0;
+		std::string name;
+		std::filesystem::path relativePath;
+		std::filesystem::path parentPath;
+		std::filesystem::path absolutePath;
+		std::string extension;
+		std::string modifiedTime;
+		EditorAssetType type = EditorAssetType::Other;
+		uintmax_t sizeBytes = 0;
+		bool isDirectory = false;
+	};
+
+	/// <summary>
+	/// Resources配下を一度走査し、コンテンツブラウザへ統一的なアセット情報を提供します。
+	/// </summary>
+	class EditorAssetRegistryV2
+	{
+	public:
+		bool Initialize()
+		{
+			projectDirectory_ = ResolveProjectDirectory();
+			contentRoot_ = projectDirectory_ / "Resources";
+			return Refresh();
+		}
+
+		bool Refresh()
+		{
+			assets_.clear();
+			lastError_.clear();
+
+			std::error_code error;
+			if (!std::filesystem::exists(contentRoot_, error) || !std::filesystem::is_directory(contentRoot_, error))
+			{
+				lastError_ = "Resourcesフォルダが見つかりません: " + contentRoot_.generic_string();
+				return false;
+			}
+
+			std::filesystem::recursive_directory_iterator iterator(
+				contentRoot_,
+				std::filesystem::directory_options::skip_permission_denied,
+				error);
+			const std::filesystem::recursive_directory_iterator end;
+
+			for (; iterator != end; iterator.increment(error))
+			{
+				if (error)
+				{
+					lastError_ = "アセット走査中に一部の項目を読み取れませんでした: " + error.message();
+					error.clear();
+					continue;
+				}
+
+				const std::filesystem::directory_entry& entry = *iterator;
+				const bool isDirectory = entry.is_directory(error);
+				if (error)
+				{
+					error.clear();
+					continue;
+				}
+				if (!isDirectory && !entry.is_regular_file(error))
+				{
+					error.clear();
+					continue;
+				}
+
+				EditorAssetData asset{};
+				asset.isDirectory = isDirectory;
+				asset.absolutePath = std::filesystem::absolute(entry.path(), error);
+				if (error)
+				{
+					asset.absolutePath = entry.path();
+					error.clear();
+				}
+				asset.relativePath = NormalizeRelative(std::filesystem::relative(entry.path(), contentRoot_, error));
+				if (error)
+				{
+					error.clear();
+					continue;
+				}
+				asset.parentPath = NormalizeRelative(asset.relativePath.parent_path());
+				asset.name = entry.path().filename().generic_string();
+				asset.extension = isDirectory ? std::string{} : ToLower(entry.path().extension().string());
+				asset.type = DetectAssetType(asset.relativePath, asset.extension, isDirectory);
+				asset.id = MakeAssetId(asset.relativePath.generic_string());
+
+				if (!isDirectory)
+				{
+					asset.sizeBytes = entry.file_size(error);
+					if (error)
+					{
+						asset.sizeBytes = 0;
+						error.clear();
+					}
+				}
+
+				const auto writeTime = entry.last_write_time(error);
+				if (!error)
+				{
+					asset.modifiedTime = FormatFileTime(writeTime);
+				}
+				else
+				{
+					asset.modifiedTime = "不明";
+					error.clear();
+				}
+
+				assets_.push_back(std::move(asset));
+			}
+
+			std::sort(assets_.begin(), assets_.end(), [](const EditorAssetData& lhs, const EditorAssetData& rhs)
+				{
+					if (lhs.parentPath != rhs.parentPath)
+					{
+						return lhs.parentPath.generic_string() < rhs.parentPath.generic_string();
+					}
+					if (lhs.isDirectory != rhs.isDirectory)
+					{
+						return lhs.isDirectory;
+					}
+					return ToLower(lhs.name) < ToLower(rhs.name);
+				});
+			return true;
+		}
+
+		const std::vector<EditorAssetData>& GetAssets() const { return assets_; }
+		const std::filesystem::path& GetProjectDirectory() const { return projectDirectory_; }
+		const std::filesystem::path& GetContentRoot() const { return contentRoot_; }
+		const std::string& GetLastError() const { return lastError_; }
+
+		std::vector<const EditorAssetData*> GetDirectories(const std::filesystem::path& parentPath) const
+		{
+			const std::filesystem::path normalizedParent = NormalizeRelative(parentPath);
+			std::vector<const EditorAssetData*> result;
+			for (const EditorAssetData& asset : assets_)
+			{
+				if (asset.isDirectory && asset.parentPath == normalizedParent)
+				{
+					result.push_back(&asset);
+				}
+			}
+			return result;
+		}
+
+		std::vector<const EditorAssetData*> Query(
+			const std::filesystem::path& directory,
+			std::string_view searchText,
+			EditorAssetType typeFilter) const
+		{
+			const std::filesystem::path normalizedDirectory = NormalizeRelative(directory);
+			const std::string loweredFilter = ToLower(std::string(searchText));
+			const bool recursiveSearch = !loweredFilter.empty();
+			std::vector<const EditorAssetData*> result;
+
+			for (const EditorAssetData& asset : assets_)
+			{
+				const bool insideDirectory = recursiveSearch
+					? IsSameOrDescendant(asset.parentPath, normalizedDirectory)
+					: asset.parentPath == normalizedDirectory;
+				if (!insideDirectory)
+				{
+					continue;
+				}
+
+				if (typeFilter != EditorAssetType::All && !asset.isDirectory && asset.type != typeFilter)
+				{
+					continue;
+				}
+
+				if (recursiveSearch)
+				{
+					const std::string searchable = ToLower(asset.name + " " + asset.relativePath.generic_string() + " " + GetTypeName(asset.type));
+					if (searchable.find(loweredFilter) == std::string::npos)
+					{
+						continue;
+					}
+				}
+
+				result.push_back(&asset);
+			}
+
+			std::sort(result.begin(), result.end(), [](const EditorAssetData* lhs, const EditorAssetData* rhs)
+				{
+					if (lhs->isDirectory != rhs->isDirectory)
+					{
+						return lhs->isDirectory;
+					}
+					return ToLower(lhs->name) < ToLower(rhs->name);
+				});
+			return result;
+		}
+
+		const EditorAssetData* FindById(uint64_t id) const
+		{
+			const auto found = std::find_if(assets_.begin(), assets_.end(), [id](const EditorAssetData& asset)
+				{
+					return asset.id == id;
+				});
+			return found == assets_.end() ? nullptr : &(*found);
+		}
+
+		bool IsValidDirectory(const std::filesystem::path& relativePath) const
+		{
+			const std::filesystem::path normalized = NormalizeRelative(relativePath);
+			if (normalized.empty())
+			{
+				return true;
+			}
+			return std::any_of(assets_.begin(), assets_.end(), [&normalized](const EditorAssetData& asset)
+				{
+					return asset.isDirectory && asset.relativePath == normalized;
+				});
+		}
+
+		std::size_t CountChildren(const std::filesystem::path& relativePath) const
+		{
+			const std::filesystem::path normalized = NormalizeRelative(relativePath);
+			return static_cast<std::size_t>(std::count_if(assets_.begin(), assets_.end(), [&normalized](const EditorAssetData& asset)
+				{
+					return asset.parentPath == normalized;
+				}));
+		}
+
+		static const char* GetTypeName(EditorAssetType type)
+		{
+			switch (type)
+			{
+			case EditorAssetType::All: return "すべて";
+			case EditorAssetType::Folder: return "フォルダ";
+			case EditorAssetType::Texture: return "テクスチャ";
+			case EditorAssetType::Model: return "モデル";
+			case EditorAssetType::Animation: return "アニメーション";
+			case EditorAssetType::Material: return "マテリアル";
+			case EditorAssetType::ActorPrefab: return "アクタープリファブ";
+			case EditorAssetType::Level: return "レベル";
+			case EditorAssetType::Shader: return "シェーダー";
+			case EditorAssetType::Font: return "フォント";
+			case EditorAssetType::Audio: return "オーディオ";
+			case EditorAssetType::Json: return "JSON";
+			case EditorAssetType::Other: return "その他";
+			default: return "不明";
+			}
+		}
+
+		static const char* GetTypeBadge(EditorAssetType type)
+		{
+			switch (type)
+			{
+			case EditorAssetType::Folder: return "DIR";
+			case EditorAssetType::Texture: return "TEX";
+			case EditorAssetType::Model: return "MESH";
+			case EditorAssetType::Animation: return "ANIM";
+			case EditorAssetType::Material: return "MAT";
+			case EditorAssetType::ActorPrefab: return "ACTOR";
+			case EditorAssetType::Level: return "LEVEL";
+			case EditorAssetType::Shader: return "HLSL";
+			case EditorAssetType::Font: return "FONT";
+			case EditorAssetType::Audio: return "AUDIO";
+			case EditorAssetType::Json: return "JSON";
+			default: return "FILE";
+			}
+		}
+
+		static std::filesystem::path NormalizeRelative(const std::filesystem::path& path)
+		{
+			if (path.empty() || path == ".")
+			{
+				return {};
+			}
+			const std::filesystem::path normalized = path.lexically_normal();
+			if (normalized.empty() || normalized == "." || normalized.generic_string().starts_with(".."))
+			{
+				return {};
+			}
+			return normalized;
+		}
+
+	private:
+		static uint64_t MakeAssetId(std::string_view path)
+		{
+			uint64_t hash = 14695981039346656037ull;
+			for (const char character : path)
+			{
+				hash ^= static_cast<unsigned char>(character);
+				hash *= 1099511628211ull;
+			}
+			return hash;
+		}
+
+		static std::string ToLower(std::string value)
+		{
+			std::transform(value.begin(), value.end(), value.begin(), [](unsigned char character)
+				{
+					return static_cast<char>(std::tolower(character));
+				});
+			return value;
+		}
+
+		static bool IsSameOrDescendant(const std::filesystem::path& candidate, const std::filesystem::path& parent)
+		{
+			const std::string candidateText = NormalizeRelative(candidate).generic_string();
+			const std::string parentText = NormalizeRelative(parent).generic_string();
+			if (parentText.empty())
+			{
+				return true;
+			}
+			return candidateText == parentText || candidateText.starts_with(parentText + "/");
+		}
+
+		static EditorAssetType DetectAssetType(
+			const std::filesystem::path& relativePath,
+			const std::string& extension,
+			bool isDirectory)
+		{
+			if (isDirectory)
+			{
+				return EditorAssetType::Folder;
+			}
+
+			const std::string pathText = ToLower(relativePath.generic_string());
+			const std::string fileName = ToLower(relativePath.filename().string());
+			if (extension == ".png" || extension == ".jpg" || extension == ".jpeg" || extension == ".dds" ||
+				extension == ".bmp" || extension == ".tga" || extension == ".hdr")
+			{
+				return EditorAssetType::Texture;
+			}
+			if (extension == ".gltf" || extension == ".glb" || extension == ".fbx" || extension == ".obj" || extension == ".kmesh")
+			{
+				if (pathText.find("animation") != std::string::npos || fileName.find("anim") != std::string::npos)
+				{
+					return EditorAssetType::Animation;
+				}
+				return EditorAssetType::Model;
+			}
+			if (extension == ".hlsl" || extension == ".hlsli" || extension == ".cso")
+			{
+				return EditorAssetType::Shader;
+			}
+			if (extension == ".ttf" || extension == ".otf" || extension == ".font")
+			{
+				return EditorAssetType::Font;
+			}
+			if (extension == ".wav" || extension == ".mp3" || extension == ".ogg" || extension == ".flac")
+			{
+				return EditorAssetType::Audio;
+			}
+			if (extension == ".material" || extension == ".mat" || extension == ".mtl" || pathText.find("material") != std::string::npos)
+			{
+				return EditorAssetType::Material;
+			}
+			if (extension == ".json")
+			{
+				if (pathText.find("actorprefab") != std::string::npos || pathText.find("actor_prefab") != std::string::npos)
+				{
+					return EditorAssetType::ActorPrefab;
+				}
+				if (pathText.find("level") != std::string::npos || pathText.find("stage") != std::string::npos)
+				{
+					return EditorAssetType::Level;
+				}
+				return EditorAssetType::Json;
+			}
+			return EditorAssetType::Other;
+		}
+
+		static std::string FormatFileTime(const std::filesystem::file_time_type& fileTime)
+		{
+			const auto systemTime = std::chrono::time_point_cast<std::chrono::system_clock::duration>(
+				fileTime - std::filesystem::file_time_type::clock::now() + std::chrono::system_clock::now());
+			const std::time_t timeValue = std::chrono::system_clock::to_time_t(systemTime);
+			std::tm localTime{};
+#ifdef _WIN32
+			localtime_s(&localTime, &timeValue);
+#else
+			localtime_r(&timeValue, &localTime);
+#endif
+			std::ostringstream stream;
+			stream << std::put_time(&localTime, "%Y-%m-%d %H:%M:%S");
+			return stream.str();
+		}
+
+		std::filesystem::path ResolveProjectDirectory() const
+		{
+			std::error_code error;
+			std::filesystem::path cursor = std::filesystem::current_path(error);
+			for (int depth = 0; depth < 8 && !cursor.empty(); ++depth)
+			{
+				if (std::filesystem::exists(cursor / "Resources", error))
+				{
+					return cursor;
+				}
+				if (std::filesystem::exists(cursor / "Project" / "Resources", error))
+				{
+					return cursor / "Project";
+				}
+				cursor = cursor.parent_path();
+			}
+			return std::filesystem::current_path(error) / "Project";
+		}
+
+		std::filesystem::path projectDirectory_;
+		std::filesystem::path contentRoot_;
+		std::vector<EditorAssetData> assets_;
+		std::string lastError_;
+	};
+} // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorContentBrowserPanel.cpp
+++ b/Project/Engine/Editor/EditorContentBrowserPanel.cpp
@@ -1,0 +1,512 @@
+#define NOMINMAX
+#include "EditorContentBrowserPanel.h"
+
+#ifdef USE_IMGUI
+#include <imgui.h>
+#endif
+
+namespace Ken4lowEngine
+{
+
+	namespace
+	{
+#ifdef USE_IMGUI
+		template <class Action>
+		void DrawNavigationButton(const char* label, const char* tooltip, bool enabled, Action action)
+		{
+			if (!enabled)
+			{
+				ImGui::BeginDisabled();
+			}
+			if (ImGui::Button(label, ImVec2(30.0f, 0.0f)) && enabled)
+			{
+				action();
+			}
+			if (!enabled)
+			{
+				ImGui::EndDisabled();
+			}
+			if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+			{
+				ImGui::SetTooltip("%s", tooltip);
+			}
+		}
+#endif
+
+	}
+
+	EditorContentBrowserPanel* Ken4lowEngine::EditorContentBrowserPanel::GetInstance()
+	{
+		static EditorContentBrowserPanel instance;
+		return &instance;
+	}
+
+	void EditorContentBrowserPanel::Draw()
+	{
+#ifdef USE_IMGUI
+		InitializeIfNeeded();
+
+		// 旧Content Browserを停止し、同じDock IDへV2だけを登録する。
+		EditorWindowManager::GetInstance()->GetWindowState().showContentBrowser = false;
+
+		if (!ImGui::Begin("コンテンツブラウザ###Content Browser", nullptr, ImGuiWindowFlags_NoCollapse))
+		{
+			ImGui::End();
+			return;
+		}
+
+		DrawToolbar();
+		ImGui::Separator();
+		DrawBrowserBody();
+		ImGui::End();
+#endif
+	}
+
+#ifdef USE_IMGUI
+	void EditorContentBrowserPanel::InitializeIfNeeded()
+	{
+		if (initialized_)
+		{
+			return;
+		}
+
+		registry_.Initialize();
+		history_.push_back({});
+		historyIndex_ = 0;
+		initialized_ = true;
+	}
+
+	void EditorContentBrowserPanel::RefreshRegistry()
+	{
+		registry_.Refresh();
+		if (!registry_.IsValidDirectory(currentDirectory_))
+		{
+			NavigateTo({}, true);
+		}
+		if (selectedAssetId_ != 0 && registry_.FindById(selectedAssetId_) == nullptr)
+		{
+			selectedAssetId_ = 0;
+		}
+	}
+
+	void EditorContentBrowserPanel::NavigateTo(const std::filesystem::path& directory, bool recordHistory)
+	{
+		const std::filesystem::path normalized = EditorAssetRegistryV2::NormalizeRelative(directory);
+		if (!registry_.IsValidDirectory(normalized))
+		{
+			return;
+		}
+
+		if (currentDirectory_ == normalized)
+		{
+			return;
+		}
+
+		currentDirectory_ = normalized;
+		selectedAssetId_ = 0;
+
+		if (recordHistory)
+		{
+			if (historyIndex_ + 1 < history_.size())
+			{
+				history_.erase(history_.begin() + static_cast<std::ptrdiff_t>(historyIndex_ + 1), history_.end());
+			}
+			history_.push_back(currentDirectory_);
+			historyIndex_ = history_.size() - 1;
+		}
+	}
+
+	void EditorContentBrowserPanel::NavigateBack()
+	{
+		if (!CanNavigateBack())
+		{
+			return;
+		}
+		--historyIndex_;
+		currentDirectory_ = history_[historyIndex_];
+		selectedAssetId_ = 0;
+	}
+
+	void EditorContentBrowserPanel::NavigateForward()
+	{
+		if (!CanNavigateForward())
+		{
+			return;
+		}
+		++historyIndex_;
+		currentDirectory_ = history_[historyIndex_];
+		selectedAssetId_ = 0;
+	}
+
+	void EditorContentBrowserPanel::NavigateUp()
+	{
+		if (currentDirectory_.empty())
+		{
+			return;
+		}
+		NavigateTo(currentDirectory_.parent_path(), true);
+	}
+
+	void EditorContentBrowserPanel::DrawToolbar()
+	{
+		ImGui::BeginDisabled();
+		ImGui::Button("+ 追加");
+		ImGui::SameLine();
+		ImGui::Button("インポート");
+		ImGui::EndDisabled();
+
+		ImGui::SameLine();
+		DrawNavigationButton("<", "戻る", CanNavigateBack(), [this]() { NavigateBack(); });
+		ImGui::SameLine();
+		DrawNavigationButton(">", "進む", CanNavigateForward(), [this]() { NavigateForward(); });
+		ImGui::SameLine();
+		DrawNavigationButton("^", "ひとつ上のフォルダ", !currentDirectory_.empty(), [this]() { NavigateUp(); });
+		ImGui::SameLine();
+		if (ImGui::Button("更新"))
+		{
+			RefreshRegistry();
+		}
+
+		ImGui::SameLine();
+		ImGui::SetNextItemWidth(150.0f);
+		if (ImGui::BeginCombo("##AssetTypeFilter", EditorAssetRegistryV2::GetTypeName(typeFilter_)))
+		{
+			constexpr std::array<EditorAssetType, 12> filterTypes = {
+				EditorAssetType::All,
+				EditorAssetType::Texture,
+				EditorAssetType::Model,
+				EditorAssetType::Animation,
+				EditorAssetType::Material,
+				EditorAssetType::ActorPrefab,
+				EditorAssetType::Level,
+				EditorAssetType::Shader,
+				EditorAssetType::Font,
+				EditorAssetType::Audio,
+				EditorAssetType::Json,
+				EditorAssetType::Other,
+			};
+			for (const EditorAssetType type : filterTypes)
+			{
+				const bool selected = typeFilter_ == type;
+				if (ImGui::Selectable(EditorAssetRegistryV2::GetTypeName(type), selected))
+				{
+					typeFilter_ = type;
+					selectedAssetId_ = 0;
+				}
+				if (selected)
+				{
+					ImGui::SetItemDefaultFocus();
+				}
+			}
+			ImGui::EndCombo();
+		}
+
+		ImGui::SameLine();
+		ImGui::SetNextItemWidth(120.0f);
+		ImGui::SliderFloat("##AssetCellSize", &cellWidth_, 88.0f, 176.0f, "表示 %.0f");
+		if (ImGui::IsItemHovered())
+		{
+			ImGui::SetTooltip("アセットの表示サイズを変更します。");
+		}
+
+		ImGui::Spacing();
+		DrawBreadcrumbs();
+		ImGui::SameLine();
+		const float searchWidth = std::clamp(ImGui::GetContentRegionAvail().x, 180.0f, 420.0f);
+		ImGui::SetNextItemWidth(searchWidth);
+		ImGui::InputTextWithHint("##ContentBrowserV2Search", "現在のフォルダ以下を検索...", searchBuffer_.data(), searchBuffer_.size());
+	}
+
+	void EditorContentBrowserPanel::DrawBreadcrumbs()
+	{
+		if (ImGui::Button("コンテンツ"))
+		{
+			NavigateTo({}, true);
+		}
+
+		std::filesystem::path accumulated;
+		for (const std::filesystem::path& part : currentDirectory_)
+		{
+			accumulated /= part;
+			ImGui::SameLine();
+			ImGui::TextDisabled(">");
+			ImGui::SameLine();
+			const std::string label = part.generic_string() + "##Breadcrumb" + accumulated.generic_string();
+			if (ImGui::Button(label.c_str()))
+			{
+				NavigateTo(accumulated, true);
+			}
+		}
+	}
+
+	void EditorContentBrowserPanel::DrawBrowserBody()
+	{
+		const float availableWidth = ImGui::GetContentRegionAvail().x;
+		const bool showDetails = availableWidth >= 980.0f;
+		const float treeWidth = std::clamp(availableWidth * 0.18f, 190.0f, 270.0f);
+		const float detailsWidth = showDetails ? std::clamp(availableWidth * 0.22f, 260.0f, 360.0f) : 0.0f;
+
+		if (ImGui::BeginChild("##ContentSources", ImVec2(treeWidth, 0.0f), true))
+		{
+			ImGui::TextUnformatted("ソース");
+			ImGui::Separator();
+			DrawFolderTree();
+		}
+		ImGui::EndChild();
+
+		ImGui::SameLine();
+		const float centerWidth = showDetails
+			? -(detailsWidth + ImGui::GetStyle().ItemSpacing.x)
+			: 0.0f;
+		if (ImGui::BeginChild("##ContentAssets", ImVec2(centerWidth, 0.0f), true, ImGuiWindowFlags_AlwaysVerticalScrollbar))
+		{
+			DrawAssetGrid();
+		}
+		ImGui::EndChild();
+
+		if (showDetails)
+		{
+			ImGui::SameLine();
+			if (ImGui::BeginChild("##ContentDetails", ImVec2(0.0f, 0.0f), true, ImGuiWindowFlags_AlwaysVerticalScrollbar))
+			{
+				DrawSelectedAssetDetails();
+			}
+			ImGui::EndChild();
+		}
+	}
+
+	void EditorContentBrowserPanel::DrawFolderTree()
+	{
+		ImGuiTreeNodeFlags rootFlags = ImGuiTreeNodeFlags_DefaultOpen |
+			ImGuiTreeNodeFlags_OpenOnArrow |
+			ImGuiTreeNodeFlags_SpanAvailWidth;
+		if (currentDirectory_.empty())
+		{
+			rootFlags |= ImGuiTreeNodeFlags_Selected;
+		}
+		const bool rootOpen = ImGui::TreeNodeEx("コンテンツ##ContentRoot", rootFlags);
+		if (ImGui::IsItemClicked(ImGuiMouseButton_Left))
+		{
+			NavigateTo({}, true);
+		}
+		if (rootOpen)
+		{
+			for (const EditorAssetData* directory : registry_.GetDirectories({}))
+			{
+				DrawFolderNode(*directory);
+			}
+			ImGui::TreePop();
+		}
+	}
+
+	void EditorContentBrowserPanel::DrawFolderNode(const EditorAssetData& directory)
+	{
+		const std::vector<const EditorAssetData*> children = registry_.GetDirectories(directory.relativePath);
+		ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_OpenOnArrow |
+			ImGuiTreeNodeFlags_OpenOnDoubleClick |
+			ImGuiTreeNodeFlags_SpanAvailWidth;
+		if (children.empty())
+		{
+			flags |= ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen;
+		}
+		if (currentDirectory_ == directory.relativePath)
+		{
+			flags |= ImGuiTreeNodeFlags_Selected;
+		}
+
+		ImGui::PushID(reinterpret_cast<void*>(static_cast<uintptr_t>(directory.id)));
+		const std::string label = "[DIR] " + directory.name;
+		const bool open = ImGui::TreeNodeEx(label.c_str(), flags);
+		if (ImGui::IsItemClicked(ImGuiMouseButton_Left))
+		{
+			NavigateTo(directory.relativePath, true);
+		}
+		if (!children.empty() && open)
+		{
+			for (const EditorAssetData* child : children)
+			{
+				DrawFolderNode(*child);
+			}
+			ImGui::TreePop();
+		}
+		ImGui::PopID();
+	}
+
+	void EditorContentBrowserPanel::DrawAssetGrid()
+	{
+		const std::string_view search(searchBuffer_.data());
+		const std::vector<const EditorAssetData*> entries = registry_.Query(currentDirectory_, search, typeFilter_);
+
+		ImGui::Text("%s  (%zu項目)", currentDirectory_.empty() ? "コンテンツ" : currentDirectory_.generic_string().c_str(), entries.size());
+		if (!search.empty())
+		{
+			ImGui::SameLine();
+			ImGui::TextDisabled("サブフォルダを含む検索結果");
+		}
+		ImGui::Separator();
+
+		if (!registry_.GetLastError().empty())
+		{
+			ImGui::TextWrapped("%s", registry_.GetLastError().c_str());
+		}
+		if (entries.empty())
+		{
+			ImGui::TextDisabled("表示できるアセットがありません。");
+			return;
+		}
+
+		const float availableWidth = std::max(1.0f, ImGui::GetContentRegionAvail().x);
+		const float spacing = ImGui::GetStyle().ItemSpacing.x;
+		const int columnCount = std::max(1, static_cast<int>((availableWidth + spacing) / (cellWidth_ + spacing)));
+		const float actualCellWidth = std::floor((availableWidth - spacing * static_cast<float>(columnCount - 1)) / static_cast<float>(columnCount));
+
+		for (std::size_t index = 0; index < entries.size(); ++index)
+		{
+			DrawAssetCard(*entries[index], actualCellWidth, !search.empty());
+			if ((static_cast<int>(index) + 1) % columnCount != 0)
+			{
+				ImGui::SameLine();
+			}
+		}
+	}
+
+	void EditorContentBrowserPanel::DrawAssetCard(const EditorAssetData& asset, float width, bool showRelativePath)
+	{
+		const float previewHeight = std::max(52.0f, width * 0.58f);
+		const float cardHeight = previewHeight + (showRelativePath ? 66.0f : 48.0f);
+		const bool selected = selectedAssetId_ == asset.id;
+
+		ImGui::PushID(reinterpret_cast<void*>(static_cast<uintptr_t>(asset.id)));
+		ImGui::InvisibleButton("##AssetCard", ImVec2(width, cardHeight));
+		if (ImGui::IsItemClicked(ImGuiMouseButton_Left))
+		{
+			selectedAssetId_ = asset.id;
+		}
+		if (asset.isDirectory && ImGui::IsItemHovered() && ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left))
+		{
+			NavigateTo(asset.relativePath, true);
+		}
+
+		if (ImGui::IsItemVisible())
+		{
+			ImDrawList* drawList = ImGui::GetWindowDrawList();
+			const ImVec2 min = ImGui::GetItemRectMin();
+			const ImVec2 max = ImGui::GetItemRectMax();
+			const ImU32 background = ImGui::GetColorU32(selected ? ImVec4(0.20f, 0.33f, 0.52f, 0.95f) : ImVec4(0.09f, 0.10f, 0.12f, 0.95f));
+			const ImU32 border = ImGui::GetColorU32(selected ? ImVec4(0.95f, 0.53f, 0.08f, 1.0f) : ImVec4(0.24f, 0.25f, 0.29f, 1.0f));
+			drawList->AddRectFilled(min, max, background, 4.0f);
+			drawList->AddRect(min, max, border, 4.0f, 0, selected ? 2.0f : 1.0f);
+
+			const char* badge = EditorAssetRegistryV2::GetTypeBadge(asset.type);
+			const ImVec2 badgeSize = ImGui::CalcTextSize(badge);
+			const ImVec2 previewMin(min.x + 7.0f, min.y + 7.0f);
+			const ImVec2 previewMax(max.x - 7.0f, min.y + previewHeight);
+			drawList->AddRectFilled(previewMin, previewMax, ImGui::GetColorU32(ImVec4(0.14f, 0.15f, 0.18f, 1.0f)), 3.0f);
+			drawList->AddText(
+				ImVec2((previewMin.x + previewMax.x - badgeSize.x) * 0.5f, (previewMin.y + previewMax.y - badgeSize.y) * 0.5f),
+				ImGui::GetColorU32(asset.isDirectory ? ImVec4(0.95f, 0.72f, 0.30f, 1.0f) : ImVec4(0.72f, 0.84f, 1.0f, 1.0f)),
+				badge);
+
+			const std::string displayName = TruncateText(asset.name, width - 14.0f);
+			drawList->AddText(ImVec2(min.x + 7.0f, previewMax.y + 7.0f), ImGui::GetColorU32(ImGuiCol_Text), displayName.c_str());
+			if (showRelativePath)
+			{
+				const std::string pathText = TruncateText(asset.parentPath.generic_string(), width - 14.0f);
+				drawList->AddText(ImVec2(min.x + 7.0f, previewMax.y + 27.0f), ImGui::GetColorU32(ImGuiCol_TextDisabled), pathText.c_str());
+			}
+		}
+
+		if (ImGui::IsItemHovered())
+		{
+			ImGui::SetTooltip("%s\n種類: %s\nパス: %s%s",
+				asset.name.c_str(),
+				EditorAssetRegistryV2::GetTypeName(asset.type),
+				asset.relativePath.generic_string().c_str(),
+				asset.isDirectory ? "\nダブルクリックで開く" : "");
+		}
+		ImGui::PopID();
+	}
+
+	void EditorContentBrowserPanel::DrawSelectedAssetDetails()
+	{
+		ImGui::TextUnformatted("選択中のアセット");
+		ImGui::Separator();
+
+		const EditorAssetData* asset = registry_.FindById(selectedAssetId_);
+		if (!asset)
+		{
+			ImGui::TextDisabled("アセットが選択されていません。");
+			return;
+		}
+
+		DrawDetailRow("名前", asset->name);
+		DrawDetailRow("種類", EditorAssetRegistryV2::GetTypeName(asset->type));
+		DrawDetailRow("相対パス", asset->relativePath.generic_string());
+		DrawDetailRow("更新日時", asset->modifiedTime);
+		if (asset->isDirectory)
+		{
+			DrawDetailRow("項目数", std::to_string(registry_.CountChildren(asset->relativePath)));
+			if (ImGui::Button("このフォルダを開く", ImVec2(-1.0f, 0.0f)))
+			{
+				NavigateTo(asset->relativePath, true);
+			}
+		}
+		else
+		{
+			DrawDetailRow("拡張子", asset->extension.empty() ? "なし" : asset->extension);
+			DrawDetailRow("サイズ", FormatBytes(asset->sizeBytes));
+			DrawDetailRow("絶対パス", asset->absolutePath.generic_string());
+		}
+	}
+
+	void EditorContentBrowserPanel::DrawDetailRow(const char* label, const std::string& value)
+	{
+		ImGui::TextDisabled("%s", label);
+		ImGui::TextWrapped("%s", value.empty() ? "なし" : value.c_str());
+		ImGui::Spacing();
+	}
+
+	std::string EditorContentBrowserPanel::FormatBytes(uintmax_t bytes)
+	{
+		std::ostringstream stream;
+		if (bytes >= 1024ull * 1024ull)
+		{
+			stream.setf(std::ios::fixed);
+			stream.precision(2);
+			stream << static_cast<double>(bytes) / (1024.0 * 1024.0) << " MB";
+		}
+		else if (bytes >= 1024ull)
+		{
+			stream.setf(std::ios::fixed);
+			stream.precision(2);
+			stream << static_cast<double>(bytes) / 1024.0 << " KB";
+		}
+		else
+		{
+			stream << bytes << " bytes";
+		}
+		return stream.str();
+	}
+
+	std::string EditorContentBrowserPanel::TruncateText(const std::string& text, float maxWidth)
+	{
+		if (text.empty() || ImGui::CalcTextSize(text.c_str()).x <= maxWidth)
+		{
+			return text;
+		}
+
+		std::string result;
+		for (const char character : text)
+		{
+			const std::string candidate = result + character;
+			if (ImGui::CalcTextSize((candidate + "...").c_str()).x > maxWidth)
+			{
+				break;
+			}
+			result = candidate;
+		}
+		return result + "...";
+	}
+
+#endif
+}

--- a/Project/Engine/Editor/EditorContentBrowserPanel.h
+++ b/Project/Engine/Editor/EditorContentBrowserPanel.h
@@ -1,0 +1,549 @@
+#pragma once
+
+#include "EditorAssetRegistryV2.h"
+#include "EditorWindowManager.h"
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <cstdint>
+#include <filesystem>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#ifdef USE_IMGUI
+#include <imgui.h>
+#endif
+
+namespace Ken4lowEngine
+{
+	/// <summary>
+	/// UE風のフォルダツリー・パンくず・アセットグリッドを持つコンテンツブラウザです。
+	/// </summary>
+	class EditorContentBrowserPanel
+	{
+	public:
+		static EditorContentBrowserPanel* GetInstance()
+		{
+			static EditorContentBrowserPanel instance;
+			return &instance;
+		}
+
+		void Draw()
+		{
+#ifdef USE_IMGUI
+			InitializeIfNeeded();
+
+			// 旧Content Browserを停止し、同じDock IDへV2だけを登録する。
+			EditorWindowManager::GetInstance()->GetWindowState().showContentBrowser = false;
+
+			if (!ImGui::Begin("コンテンツブラウザ###Content Browser", nullptr, ImGuiWindowFlags_NoCollapse))
+			{
+				ImGui::End();
+				return;
+			}
+
+			DrawToolbar();
+			ImGui::Separator();
+			DrawBrowserBody();
+			ImGui::End();
+#endif
+		}
+
+	private:
+		EditorContentBrowserPanel() = default;
+		~EditorContentBrowserPanel() = default;
+		EditorContentBrowserPanel(const EditorContentBrowserPanel&) = delete;
+		EditorContentBrowserPanel& operator=(const EditorContentBrowserPanel&) = delete;
+
+#ifdef USE_IMGUI
+		void InitializeIfNeeded()
+		{
+			if (initialized_)
+			{
+				return;
+			}
+
+			registry_.Initialize();
+			history_.push_back({});
+			historyIndex_ = 0;
+			initialized_ = true;
+		}
+
+		void RefreshRegistry()
+		{
+			registry_.Refresh();
+			if (!registry_.IsValidDirectory(currentDirectory_))
+			{
+				NavigateTo({}, true);
+			}
+			if (selectedAssetId_ != 0 && registry_.FindById(selectedAssetId_) == nullptr)
+			{
+				selectedAssetId_ = 0;
+			}
+		}
+
+		void NavigateTo(const std::filesystem::path& directory, bool recordHistory)
+		{
+			const std::filesystem::path normalized = EditorAssetRegistryV2::NormalizeRelative(directory);
+			if (!registry_.IsValidDirectory(normalized))
+			{
+				return;
+			}
+
+			if (currentDirectory_ == normalized)
+			{
+				return;
+			}
+
+			currentDirectory_ = normalized;
+			selectedAssetId_ = 0;
+
+			if (recordHistory)
+			{
+				if (historyIndex_ + 1 < history_.size())
+				{
+					history_.erase(history_.begin() + static_cast<std::ptrdiff_t>(historyIndex_ + 1), history_.end());
+				}
+				history_.push_back(currentDirectory_);
+				historyIndex_ = history_.size() - 1;
+			}
+		}
+
+		bool CanNavigateBack() const
+		{
+			return historyIndex_ > 0 && !history_.empty();
+		}
+
+		bool CanNavigateForward() const
+		{
+			return !history_.empty() && historyIndex_ + 1 < history_.size();
+		}
+
+		void NavigateBack()
+		{
+			if (!CanNavigateBack())
+			{
+				return;
+			}
+			--historyIndex_;
+			currentDirectory_ = history_[historyIndex_];
+			selectedAssetId_ = 0;
+		}
+
+		void NavigateForward()
+		{
+			if (!CanNavigateForward())
+			{
+				return;
+			}
+			++historyIndex_;
+			currentDirectory_ = history_[historyIndex_];
+			selectedAssetId_ = 0;
+		}
+
+		void NavigateUp()
+		{
+			if (currentDirectory_.empty())
+			{
+				return;
+			}
+			NavigateTo(currentDirectory_.parent_path(), true);
+		}
+
+		void DrawToolbar()
+		{
+			ImGui::BeginDisabled();
+			ImGui::Button("+ 追加");
+			ImGui::SameLine();
+			ImGui::Button("インポート");
+			ImGui::EndDisabled();
+
+			ImGui::SameLine();
+			DrawNavigationButton("<", "戻る", CanNavigateBack(), [this]() { NavigateBack(); });
+			ImGui::SameLine();
+			DrawNavigationButton(">", "進む", CanNavigateForward(), [this]() { NavigateForward(); });
+			ImGui::SameLine();
+			DrawNavigationButton("^", "ひとつ上のフォルダ", !currentDirectory_.empty(), [this]() { NavigateUp(); });
+			ImGui::SameLine();
+			if (ImGui::Button("更新"))
+			{
+				RefreshRegistry();
+			}
+
+			ImGui::SameLine();
+			ImGui::SetNextItemWidth(150.0f);
+			if (ImGui::BeginCombo("##AssetTypeFilter", EditorAssetRegistryV2::GetTypeName(typeFilter_)))
+			{
+				constexpr std::array<EditorAssetType, 12> filterTypes = {
+					EditorAssetType::All,
+					EditorAssetType::Texture,
+					EditorAssetType::Model,
+					EditorAssetType::Animation,
+					EditorAssetType::Material,
+					EditorAssetType::ActorPrefab,
+					EditorAssetType::Level,
+					EditorAssetType::Shader,
+					EditorAssetType::Font,
+					EditorAssetType::Audio,
+					EditorAssetType::Json,
+					EditorAssetType::Other,
+				};
+				for (const EditorAssetType type : filterTypes)
+				{
+					const bool selected = typeFilter_ == type;
+					if (ImGui::Selectable(EditorAssetRegistryV2::GetTypeName(type), selected))
+					{
+						typeFilter_ = type;
+						selectedAssetId_ = 0;
+					}
+					if (selected)
+					{
+						ImGui::SetItemDefaultFocus();
+					}
+				}
+				ImGui::EndCombo();
+			}
+
+			ImGui::SameLine();
+			ImGui::SetNextItemWidth(120.0f);
+			ImGui::SliderFloat("##AssetCellSize", &cellWidth_, 88.0f, 176.0f, "表示 %.0f");
+			if (ImGui::IsItemHovered())
+			{
+				ImGui::SetTooltip("アセットの表示サイズを変更します。");
+			}
+
+			ImGui::Spacing();
+			DrawBreadcrumbs();
+			ImGui::SameLine();
+			const float searchWidth = std::clamp(ImGui::GetContentRegionAvail().x, 180.0f, 420.0f);
+			ImGui::SetNextItemWidth(searchWidth);
+			ImGui::InputTextWithHint("##ContentBrowserV2Search", "現在のフォルダ以下を検索...", searchBuffer_.data(), searchBuffer_.size());
+		}
+
+		template <class Action>
+		void DrawNavigationButton(const char* label, const char* tooltip, bool enabled, Action action)
+		{
+			if (!enabled)
+			{
+				ImGui::BeginDisabled();
+			}
+			if (ImGui::Button(label, ImVec2(30.0f, 0.0f)) && enabled)
+			{
+				action();
+			}
+			if (!enabled)
+			{
+				ImGui::EndDisabled();
+			}
+			if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+			{
+				ImGui::SetTooltip("%s", tooltip);
+			}
+		}
+
+		void DrawBreadcrumbs()
+		{
+			if (ImGui::Button("コンテンツ"))
+			{
+				NavigateTo({}, true);
+			}
+
+			std::filesystem::path accumulated;
+			for (const std::filesystem::path& part : currentDirectory_)
+			{
+				accumulated /= part;
+				ImGui::SameLine();
+				ImGui::TextDisabled(">");
+				ImGui::SameLine();
+				const std::string label = part.generic_string() + "##Breadcrumb" + accumulated.generic_string();
+				if (ImGui::Button(label.c_str()))
+				{
+					NavigateTo(accumulated, true);
+				}
+			}
+		}
+
+		void DrawBrowserBody()
+		{
+			const float availableWidth = ImGui::GetContentRegionAvail().x;
+			const bool showDetails = availableWidth >= 980.0f;
+			const float treeWidth = std::clamp(availableWidth * 0.18f, 190.0f, 270.0f);
+			const float detailsWidth = showDetails ? std::clamp(availableWidth * 0.22f, 260.0f, 360.0f) : 0.0f;
+
+			if (ImGui::BeginChild("##ContentSources", ImVec2(treeWidth, 0.0f), true))
+			{
+				ImGui::TextUnformatted("ソース");
+				ImGui::Separator();
+				DrawFolderTree();
+			}
+			ImGui::EndChild();
+
+			ImGui::SameLine();
+			const float centerWidth = showDetails
+				? -(detailsWidth + ImGui::GetStyle().ItemSpacing.x)
+				: 0.0f;
+			if (ImGui::BeginChild("##ContentAssets", ImVec2(centerWidth, 0.0f), true, ImGuiWindowFlags_AlwaysVerticalScrollbar))
+			{
+				DrawAssetGrid();
+			}
+			ImGui::EndChild();
+
+			if (showDetails)
+			{
+				ImGui::SameLine();
+				if (ImGui::BeginChild("##ContentDetails", ImVec2(0.0f, 0.0f), true, ImGuiWindowFlags_AlwaysVerticalScrollbar))
+				{
+					DrawSelectedAssetDetails();
+				}
+				ImGui::EndChild();
+			}
+		}
+
+		void DrawFolderTree()
+		{
+			ImGuiTreeNodeFlags rootFlags = ImGuiTreeNodeFlags_DefaultOpen |
+				ImGuiTreeNodeFlags_OpenOnArrow |
+				ImGuiTreeNodeFlags_SpanAvailWidth;
+			if (currentDirectory_.empty())
+			{
+				rootFlags |= ImGuiTreeNodeFlags_Selected;
+			}
+			const bool rootOpen = ImGui::TreeNodeEx("コンテンツ##ContentRoot", rootFlags);
+			if (ImGui::IsItemClicked(ImGuiMouseButton_Left))
+			{
+				NavigateTo({}, true);
+			}
+			if (rootOpen)
+			{
+				for (const EditorAssetData* directory : registry_.GetDirectories({}))
+				{
+					DrawFolderNode(*directory);
+				}
+				ImGui::TreePop();
+			}
+		}
+
+		void DrawFolderNode(const EditorAssetData& directory)
+		{
+			const std::vector<const EditorAssetData*> children = registry_.GetDirectories(directory.relativePath);
+			ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_OpenOnArrow |
+				ImGuiTreeNodeFlags_OpenOnDoubleClick |
+				ImGuiTreeNodeFlags_SpanAvailWidth;
+			if (children.empty())
+			{
+				flags |= ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen;
+			}
+			if (currentDirectory_ == directory.relativePath)
+			{
+				flags |= ImGuiTreeNodeFlags_Selected;
+			}
+
+			ImGui::PushID(reinterpret_cast<void*>(static_cast<uintptr_t>(directory.id)));
+			const std::string label = "[DIR] " + directory.name;
+			const bool open = ImGui::TreeNodeEx(label.c_str(), flags);
+			if (ImGui::IsItemClicked(ImGuiMouseButton_Left))
+			{
+				NavigateTo(directory.relativePath, true);
+			}
+			if (!children.empty() && open)
+			{
+				for (const EditorAssetData* child : children)
+				{
+					DrawFolderNode(*child);
+				}
+				ImGui::TreePop();
+			}
+			ImGui::PopID();
+		}
+
+		void DrawAssetGrid()
+		{
+			const std::string_view search(searchBuffer_.data());
+			const std::vector<const EditorAssetData*> entries = registry_.Query(currentDirectory_, search, typeFilter_);
+
+			ImGui::Text("%s  (%zu項目)", currentDirectory_.empty() ? "コンテンツ" : currentDirectory_.generic_string().c_str(), entries.size());
+			if (!search.empty())
+			{
+				ImGui::SameLine();
+				ImGui::TextDisabled("サブフォルダを含む検索結果");
+			}
+			ImGui::Separator();
+
+			if (!registry_.GetLastError().empty())
+			{
+				ImGui::TextWrapped("%s", registry_.GetLastError().c_str());
+			}
+			if (entries.empty())
+			{
+				ImGui::TextDisabled("表示できるアセットがありません。");
+				return;
+			}
+
+			const float availableWidth = std::max(1.0f, ImGui::GetContentRegionAvail().x);
+			const float spacing = ImGui::GetStyle().ItemSpacing.x;
+			const int columnCount = std::max(1, static_cast<int>((availableWidth + spacing) / (cellWidth_ + spacing)));
+			const float actualCellWidth = std::floor((availableWidth - spacing * static_cast<float>(columnCount - 1)) / static_cast<float>(columnCount));
+
+			for (std::size_t index = 0; index < entries.size(); ++index)
+			{
+				DrawAssetCard(*entries[index], actualCellWidth, !search.empty());
+				if ((static_cast<int>(index) + 1) % columnCount != 0)
+				{
+					ImGui::SameLine();
+				}
+			}
+		}
+
+		void DrawAssetCard(const EditorAssetData& asset, float width, bool showRelativePath)
+		{
+			const float previewHeight = std::max(52.0f, width * 0.58f);
+			const float cardHeight = previewHeight + (showRelativePath ? 66.0f : 48.0f);
+			const bool selected = selectedAssetId_ == asset.id;
+
+			ImGui::PushID(reinterpret_cast<void*>(static_cast<uintptr_t>(asset.id)));
+			ImGui::InvisibleButton("##AssetCard", ImVec2(width, cardHeight));
+			if (ImGui::IsItemClicked(ImGuiMouseButton_Left))
+			{
+				selectedAssetId_ = asset.id;
+			}
+			if (asset.isDirectory && ImGui::IsItemHovered() && ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left))
+			{
+				NavigateTo(asset.relativePath, true);
+			}
+
+			if (ImGui::IsItemVisible())
+			{
+				ImDrawList* drawList = ImGui::GetWindowDrawList();
+				const ImVec2 min = ImGui::GetItemRectMin();
+				const ImVec2 max = ImGui::GetItemRectMax();
+				const ImU32 background = ImGui::GetColorU32(selected ? ImVec4(0.20f, 0.33f, 0.52f, 0.95f) : ImVec4(0.09f, 0.10f, 0.12f, 0.95f));
+				const ImU32 border = ImGui::GetColorU32(selected ? ImVec4(0.95f, 0.53f, 0.08f, 1.0f) : ImVec4(0.24f, 0.25f, 0.29f, 1.0f));
+				drawList->AddRectFilled(min, max, background, 4.0f);
+				drawList->AddRect(min, max, border, 4.0f, 0, selected ? 2.0f : 1.0f);
+
+				const char* badge = EditorAssetRegistryV2::GetTypeBadge(asset.type);
+				const ImVec2 badgeSize = ImGui::CalcTextSize(badge);
+				const ImVec2 previewMin(min.x + 7.0f, min.y + 7.0f);
+				const ImVec2 previewMax(max.x - 7.0f, min.y + previewHeight);
+				drawList->AddRectFilled(previewMin, previewMax, ImGui::GetColorU32(ImVec4(0.14f, 0.15f, 0.18f, 1.0f)), 3.0f);
+				drawList->AddText(
+					ImVec2((previewMin.x + previewMax.x - badgeSize.x) * 0.5f, (previewMin.y + previewMax.y - badgeSize.y) * 0.5f),
+					ImGui::GetColorU32(asset.isDirectory ? ImVec4(0.95f, 0.72f, 0.30f, 1.0f) : ImVec4(0.72f, 0.84f, 1.0f, 1.0f)),
+					badge);
+
+				const std::string displayName = TruncateText(asset.name, width - 14.0f);
+				drawList->AddText(ImVec2(min.x + 7.0f, previewMax.y + 7.0f), ImGui::GetColorU32(ImGuiCol_Text), displayName.c_str());
+				if (showRelativePath)
+				{
+					const std::string pathText = TruncateText(asset.parentPath.generic_string(), width - 14.0f);
+					drawList->AddText(ImVec2(min.x + 7.0f, previewMax.y + 27.0f), ImGui::GetColorU32(ImGuiCol_TextDisabled), pathText.c_str());
+				}
+			}
+
+			if (ImGui::IsItemHovered())
+			{
+				ImGui::SetTooltip("%s\n種類: %s\nパス: %s%s",
+					asset.name.c_str(),
+					EditorAssetRegistryV2::GetTypeName(asset.type),
+					asset.relativePath.generic_string().c_str(),
+					asset.isDirectory ? "\nダブルクリックで開く" : "");
+			}
+			ImGui::PopID();
+		}
+
+		void DrawSelectedAssetDetails()
+		{
+			ImGui::TextUnformatted("選択中のアセット");
+			ImGui::Separator();
+
+			const EditorAssetData* asset = registry_.FindById(selectedAssetId_);
+			if (!asset)
+			{
+				ImGui::TextDisabled("アセットが選択されていません。");
+				return;
+			}
+
+			DrawDetailRow("名前", asset->name);
+			DrawDetailRow("種類", EditorAssetRegistryV2::GetTypeName(asset->type));
+			DrawDetailRow("相対パス", asset->relativePath.generic_string());
+			DrawDetailRow("更新日時", asset->modifiedTime);
+			if (asset->isDirectory)
+			{
+				DrawDetailRow("項目数", std::to_string(registry_.CountChildren(asset->relativePath)));
+				if (ImGui::Button("このフォルダを開く", ImVec2(-1.0f, 0.0f)))
+				{
+					NavigateTo(asset->relativePath, true);
+				}
+			}
+			else
+			{
+				DrawDetailRow("拡張子", asset->extension.empty() ? "なし" : asset->extension);
+				DrawDetailRow("サイズ", FormatBytes(asset->sizeBytes));
+				DrawDetailRow("絶対パス", asset->absolutePath.generic_string());
+			}
+		}
+
+		static void DrawDetailRow(const char* label, const std::string& value)
+		{
+			ImGui::TextDisabled("%s", label);
+			ImGui::TextWrapped("%s", value.empty() ? "なし" : value.c_str());
+			ImGui::Spacing();
+		}
+
+		static std::string FormatBytes(uintmax_t bytes)
+		{
+			std::ostringstream stream;
+			if (bytes >= 1024ull * 1024ull)
+			{
+				stream.setf(std::ios::fixed);
+				stream.precision(2);
+				stream << static_cast<double>(bytes) / (1024.0 * 1024.0) << " MB";
+			}
+			else if (bytes >= 1024ull)
+			{
+				stream.setf(std::ios::fixed);
+				stream.precision(2);
+				stream << static_cast<double>(bytes) / 1024.0 << " KB";
+			}
+			else
+			{
+				stream << bytes << " bytes";
+			}
+			return stream.str();
+		}
+
+		static std::string TruncateText(const std::string& text, float maxWidth)
+		{
+			if (text.empty() || ImGui::CalcTextSize(text.c_str()).x <= maxWidth)
+			{
+				return text;
+			}
+
+			std::string result;
+			for (const char character : text)
+			{
+				const std::string candidate = result + character;
+				if (ImGui::CalcTextSize((candidate + "...").c_str()).x > maxWidth)
+				{
+					break;
+				}
+				result = candidate;
+			}
+			return result + "...";
+		}
+#endif
+
+		EditorAssetRegistryV2 registry_{};
+		std::filesystem::path currentDirectory_{};
+		std::vector<std::filesystem::path> history_{};
+		std::size_t historyIndex_ = 0;
+		uint64_t selectedAssetId_ = 0;
+		EditorAssetType typeFilter_ = EditorAssetType::All;
+		std::array<char, 160> searchBuffer_{};
+		float cellWidth_ = 128.0f;
+		bool initialized_ = false;
+	};
+} // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorContentBrowserPanel.h
+++ b/Project/Engine/Editor/EditorContentBrowserPanel.h
@@ -13,9 +13,7 @@
 #include <string_view>
 #include <vector>
 
-#ifdef USE_IMGUI
-#include <imgui.h>
-#endif
+
 
 namespace Ken4lowEngine
 {
@@ -25,32 +23,9 @@ namespace Ken4lowEngine
 	class EditorContentBrowserPanel
 	{
 	public:
-		static EditorContentBrowserPanel* GetInstance()
-		{
-			static EditorContentBrowserPanel instance;
-			return &instance;
-		}
+		static EditorContentBrowserPanel* GetInstance();
 
-		void Draw()
-		{
-#ifdef USE_IMGUI
-			InitializeIfNeeded();
-
-			// 旧Content Browserを停止し、同じDock IDへV2だけを登録する。
-			EditorWindowManager::GetInstance()->GetWindowState().showContentBrowser = false;
-
-			if (!ImGui::Begin("コンテンツブラウザ###Content Browser", nullptr, ImGuiWindowFlags_NoCollapse))
-			{
-				ImGui::End();
-				return;
-			}
-
-			DrawToolbar();
-			ImGui::Separator();
-			DrawBrowserBody();
-			ImGui::End();
-#endif
-		}
+		void Draw();
 
 	private:
 		EditorContentBrowserPanel() = default;
@@ -59,58 +34,9 @@ namespace Ken4lowEngine
 		EditorContentBrowserPanel& operator=(const EditorContentBrowserPanel&) = delete;
 
 #ifdef USE_IMGUI
-		void InitializeIfNeeded()
-		{
-			if (initialized_)
-			{
-				return;
-			}
-
-			registry_.Initialize();
-			history_.push_back({});
-			historyIndex_ = 0;
-			initialized_ = true;
-		}
-
-		void RefreshRegistry()
-		{
-			registry_.Refresh();
-			if (!registry_.IsValidDirectory(currentDirectory_))
-			{
-				NavigateTo({}, true);
-			}
-			if (selectedAssetId_ != 0 && registry_.FindById(selectedAssetId_) == nullptr)
-			{
-				selectedAssetId_ = 0;
-			}
-		}
-
-		void NavigateTo(const std::filesystem::path& directory, bool recordHistory)
-		{
-			const std::filesystem::path normalized = EditorAssetRegistryV2::NormalizeRelative(directory);
-			if (!registry_.IsValidDirectory(normalized))
-			{
-				return;
-			}
-
-			if (currentDirectory_ == normalized)
-			{
-				return;
-			}
-
-			currentDirectory_ = normalized;
-			selectedAssetId_ = 0;
-
-			if (recordHistory)
-			{
-				if (historyIndex_ + 1 < history_.size())
-				{
-					history_.erase(history_.begin() + static_cast<std::ptrdiff_t>(historyIndex_ + 1), history_.end());
-				}
-				history_.push_back(currentDirectory_);
-				historyIndex_ = history_.size() - 1;
-			}
-		}
+		void InitializeIfNeeded();
+		void RefreshRegistry();
+		void NavigateTo(const std::filesystem::path& directory, bool recordHistory);
 
 		bool CanNavigateBack() const
 		{
@@ -122,420 +48,33 @@ namespace Ken4lowEngine
 			return !history_.empty() && historyIndex_ + 1 < history_.size();
 		}
 
-		void NavigateBack()
-		{
-			if (!CanNavigateBack())
-			{
-				return;
-			}
-			--historyIndex_;
-			currentDirectory_ = history_[historyIndex_];
-			selectedAssetId_ = 0;
-		}
+		void NavigateBack();
+		void NavigateForward();
+		void NavigateUp();
 
-		void NavigateForward()
-		{
-			if (!CanNavigateForward())
-			{
-				return;
-			}
-			++historyIndex_;
-			currentDirectory_ = history_[historyIndex_];
-			selectedAssetId_ = 0;
-		}
+		void DrawToolbar();
 
-		void NavigateUp()
-		{
-			if (currentDirectory_.empty())
-			{
-				return;
-			}
-			NavigateTo(currentDirectory_.parent_path(), true);
-		}
+		void DrawBreadcrumbs();
 
-		void DrawToolbar()
-		{
-			ImGui::BeginDisabled();
-			ImGui::Button("+ 追加");
-			ImGui::SameLine();
-			ImGui::Button("インポート");
-			ImGui::EndDisabled();
+		void DrawBrowserBody();
 
-			ImGui::SameLine();
-			DrawNavigationButton("<", "戻る", CanNavigateBack(), [this]() { NavigateBack(); });
-			ImGui::SameLine();
-			DrawNavigationButton(">", "進む", CanNavigateForward(), [this]() { NavigateForward(); });
-			ImGui::SameLine();
-			DrawNavigationButton("^", "ひとつ上のフォルダ", !currentDirectory_.empty(), [this]() { NavigateUp(); });
-			ImGui::SameLine();
-			if (ImGui::Button("更新"))
-			{
-				RefreshRegistry();
-			}
+		void DrawFolderTree();
 
-			ImGui::SameLine();
-			ImGui::SetNextItemWidth(150.0f);
-			if (ImGui::BeginCombo("##AssetTypeFilter", EditorAssetRegistryV2::GetTypeName(typeFilter_)))
-			{
-				constexpr std::array<EditorAssetType, 12> filterTypes = {
-					EditorAssetType::All,
-					EditorAssetType::Texture,
-					EditorAssetType::Model,
-					EditorAssetType::Animation,
-					EditorAssetType::Material,
-					EditorAssetType::ActorPrefab,
-					EditorAssetType::Level,
-					EditorAssetType::Shader,
-					EditorAssetType::Font,
-					EditorAssetType::Audio,
-					EditorAssetType::Json,
-					EditorAssetType::Other,
-				};
-				for (const EditorAssetType type : filterTypes)
-				{
-					const bool selected = typeFilter_ == type;
-					if (ImGui::Selectable(EditorAssetRegistryV2::GetTypeName(type), selected))
-					{
-						typeFilter_ = type;
-						selectedAssetId_ = 0;
-					}
-					if (selected)
-					{
-						ImGui::SetItemDefaultFocus();
-					}
-				}
-				ImGui::EndCombo();
-			}
+		void DrawFolderNode(const EditorAssetData& directory);
 
-			ImGui::SameLine();
-			ImGui::SetNextItemWidth(120.0f);
-			ImGui::SliderFloat("##AssetCellSize", &cellWidth_, 88.0f, 176.0f, "表示 %.0f");
-			if (ImGui::IsItemHovered())
-			{
-				ImGui::SetTooltip("アセットの表示サイズを変更します。");
-			}
+		void DrawAssetGrid();
 
-			ImGui::Spacing();
-			DrawBreadcrumbs();
-			ImGui::SameLine();
-			const float searchWidth = std::clamp(ImGui::GetContentRegionAvail().x, 180.0f, 420.0f);
-			ImGui::SetNextItemWidth(searchWidth);
-			ImGui::InputTextWithHint("##ContentBrowserV2Search", "現在のフォルダ以下を検索...", searchBuffer_.data(), searchBuffer_.size());
-		}
+		void DrawAssetCard(const EditorAssetData& asset, float width, bool showRelativePath);
 
-		template <class Action>
-		void DrawNavigationButton(const char* label, const char* tooltip, bool enabled, Action action)
-		{
-			if (!enabled)
-			{
-				ImGui::BeginDisabled();
-			}
-			if (ImGui::Button(label, ImVec2(30.0f, 0.0f)) && enabled)
-			{
-				action();
-			}
-			if (!enabled)
-			{
-				ImGui::EndDisabled();
-			}
-			if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
-			{
-				ImGui::SetTooltip("%s", tooltip);
-			}
-		}
+		void DrawSelectedAssetDetails();
 
-		void DrawBreadcrumbs()
-		{
-			if (ImGui::Button("コンテンツ"))
-			{
-				NavigateTo({}, true);
-			}
+		static void DrawDetailRow(const char* label, const std::string& value);
 
-			std::filesystem::path accumulated;
-			for (const std::filesystem::path& part : currentDirectory_)
-			{
-				accumulated /= part;
-				ImGui::SameLine();
-				ImGui::TextDisabled(">");
-				ImGui::SameLine();
-				const std::string label = part.generic_string() + "##Breadcrumb" + accumulated.generic_string();
-				if (ImGui::Button(label.c_str()))
-				{
-					NavigateTo(accumulated, true);
-				}
-			}
-		}
+		static std::string FormatBytes(uintmax_t bytes);
 
-		void DrawBrowserBody()
-		{
-			const float availableWidth = ImGui::GetContentRegionAvail().x;
-			const bool showDetails = availableWidth >= 980.0f;
-			const float treeWidth = std::clamp(availableWidth * 0.18f, 190.0f, 270.0f);
-			const float detailsWidth = showDetails ? std::clamp(availableWidth * 0.22f, 260.0f, 360.0f) : 0.0f;
-
-			if (ImGui::BeginChild("##ContentSources", ImVec2(treeWidth, 0.0f), true))
-			{
-				ImGui::TextUnformatted("ソース");
-				ImGui::Separator();
-				DrawFolderTree();
-			}
-			ImGui::EndChild();
-
-			ImGui::SameLine();
-			const float centerWidth = showDetails
-				? -(detailsWidth + ImGui::GetStyle().ItemSpacing.x)
-				: 0.0f;
-			if (ImGui::BeginChild("##ContentAssets", ImVec2(centerWidth, 0.0f), true, ImGuiWindowFlags_AlwaysVerticalScrollbar))
-			{
-				DrawAssetGrid();
-			}
-			ImGui::EndChild();
-
-			if (showDetails)
-			{
-				ImGui::SameLine();
-				if (ImGui::BeginChild("##ContentDetails", ImVec2(0.0f, 0.0f), true, ImGuiWindowFlags_AlwaysVerticalScrollbar))
-				{
-					DrawSelectedAssetDetails();
-				}
-				ImGui::EndChild();
-			}
-		}
-
-		void DrawFolderTree()
-		{
-			ImGuiTreeNodeFlags rootFlags = ImGuiTreeNodeFlags_DefaultOpen |
-				ImGuiTreeNodeFlags_OpenOnArrow |
-				ImGuiTreeNodeFlags_SpanAvailWidth;
-			if (currentDirectory_.empty())
-			{
-				rootFlags |= ImGuiTreeNodeFlags_Selected;
-			}
-			const bool rootOpen = ImGui::TreeNodeEx("コンテンツ##ContentRoot", rootFlags);
-			if (ImGui::IsItemClicked(ImGuiMouseButton_Left))
-			{
-				NavigateTo({}, true);
-			}
-			if (rootOpen)
-			{
-				for (const EditorAssetData* directory : registry_.GetDirectories({}))
-				{
-					DrawFolderNode(*directory);
-				}
-				ImGui::TreePop();
-			}
-		}
-
-		void DrawFolderNode(const EditorAssetData& directory)
-		{
-			const std::vector<const EditorAssetData*> children = registry_.GetDirectories(directory.relativePath);
-			ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_OpenOnArrow |
-				ImGuiTreeNodeFlags_OpenOnDoubleClick |
-				ImGuiTreeNodeFlags_SpanAvailWidth;
-			if (children.empty())
-			{
-				flags |= ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen;
-			}
-			if (currentDirectory_ == directory.relativePath)
-			{
-				flags |= ImGuiTreeNodeFlags_Selected;
-			}
-
-			ImGui::PushID(reinterpret_cast<void*>(static_cast<uintptr_t>(directory.id)));
-			const std::string label = "[DIR] " + directory.name;
-			const bool open = ImGui::TreeNodeEx(label.c_str(), flags);
-			if (ImGui::IsItemClicked(ImGuiMouseButton_Left))
-			{
-				NavigateTo(directory.relativePath, true);
-			}
-			if (!children.empty() && open)
-			{
-				for (const EditorAssetData* child : children)
-				{
-					DrawFolderNode(*child);
-				}
-				ImGui::TreePop();
-			}
-			ImGui::PopID();
-		}
-
-		void DrawAssetGrid()
-		{
-			const std::string_view search(searchBuffer_.data());
-			const std::vector<const EditorAssetData*> entries = registry_.Query(currentDirectory_, search, typeFilter_);
-
-			ImGui::Text("%s  (%zu項目)", currentDirectory_.empty() ? "コンテンツ" : currentDirectory_.generic_string().c_str(), entries.size());
-			if (!search.empty())
-			{
-				ImGui::SameLine();
-				ImGui::TextDisabled("サブフォルダを含む検索結果");
-			}
-			ImGui::Separator();
-
-			if (!registry_.GetLastError().empty())
-			{
-				ImGui::TextWrapped("%s", registry_.GetLastError().c_str());
-			}
-			if (entries.empty())
-			{
-				ImGui::TextDisabled("表示できるアセットがありません。");
-				return;
-			}
-
-			const float availableWidth = std::max(1.0f, ImGui::GetContentRegionAvail().x);
-			const float spacing = ImGui::GetStyle().ItemSpacing.x;
-			const int columnCount = std::max(1, static_cast<int>((availableWidth + spacing) / (cellWidth_ + spacing)));
-			const float actualCellWidth = std::floor((availableWidth - spacing * static_cast<float>(columnCount - 1)) / static_cast<float>(columnCount));
-
-			for (std::size_t index = 0; index < entries.size(); ++index)
-			{
-				DrawAssetCard(*entries[index], actualCellWidth, !search.empty());
-				if ((static_cast<int>(index) + 1) % columnCount != 0)
-				{
-					ImGui::SameLine();
-				}
-			}
-		}
-
-		void DrawAssetCard(const EditorAssetData& asset, float width, bool showRelativePath)
-		{
-			const float previewHeight = std::max(52.0f, width * 0.58f);
-			const float cardHeight = previewHeight + (showRelativePath ? 66.0f : 48.0f);
-			const bool selected = selectedAssetId_ == asset.id;
-
-			ImGui::PushID(reinterpret_cast<void*>(static_cast<uintptr_t>(asset.id)));
-			ImGui::InvisibleButton("##AssetCard", ImVec2(width, cardHeight));
-			if (ImGui::IsItemClicked(ImGuiMouseButton_Left))
-			{
-				selectedAssetId_ = asset.id;
-			}
-			if (asset.isDirectory && ImGui::IsItemHovered() && ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left))
-			{
-				NavigateTo(asset.relativePath, true);
-			}
-
-			if (ImGui::IsItemVisible())
-			{
-				ImDrawList* drawList = ImGui::GetWindowDrawList();
-				const ImVec2 min = ImGui::GetItemRectMin();
-				const ImVec2 max = ImGui::GetItemRectMax();
-				const ImU32 background = ImGui::GetColorU32(selected ? ImVec4(0.20f, 0.33f, 0.52f, 0.95f) : ImVec4(0.09f, 0.10f, 0.12f, 0.95f));
-				const ImU32 border = ImGui::GetColorU32(selected ? ImVec4(0.95f, 0.53f, 0.08f, 1.0f) : ImVec4(0.24f, 0.25f, 0.29f, 1.0f));
-				drawList->AddRectFilled(min, max, background, 4.0f);
-				drawList->AddRect(min, max, border, 4.0f, 0, selected ? 2.0f : 1.0f);
-
-				const char* badge = EditorAssetRegistryV2::GetTypeBadge(asset.type);
-				const ImVec2 badgeSize = ImGui::CalcTextSize(badge);
-				const ImVec2 previewMin(min.x + 7.0f, min.y + 7.0f);
-				const ImVec2 previewMax(max.x - 7.0f, min.y + previewHeight);
-				drawList->AddRectFilled(previewMin, previewMax, ImGui::GetColorU32(ImVec4(0.14f, 0.15f, 0.18f, 1.0f)), 3.0f);
-				drawList->AddText(
-					ImVec2((previewMin.x + previewMax.x - badgeSize.x) * 0.5f, (previewMin.y + previewMax.y - badgeSize.y) * 0.5f),
-					ImGui::GetColorU32(asset.isDirectory ? ImVec4(0.95f, 0.72f, 0.30f, 1.0f) : ImVec4(0.72f, 0.84f, 1.0f, 1.0f)),
-					badge);
-
-				const std::string displayName = TruncateText(asset.name, width - 14.0f);
-				drawList->AddText(ImVec2(min.x + 7.0f, previewMax.y + 7.0f), ImGui::GetColorU32(ImGuiCol_Text), displayName.c_str());
-				if (showRelativePath)
-				{
-					const std::string pathText = TruncateText(asset.parentPath.generic_string(), width - 14.0f);
-					drawList->AddText(ImVec2(min.x + 7.0f, previewMax.y + 27.0f), ImGui::GetColorU32(ImGuiCol_TextDisabled), pathText.c_str());
-				}
-			}
-
-			if (ImGui::IsItemHovered())
-			{
-				ImGui::SetTooltip("%s\n種類: %s\nパス: %s%s",
-					asset.name.c_str(),
-					EditorAssetRegistryV2::GetTypeName(asset.type),
-					asset.relativePath.generic_string().c_str(),
-					asset.isDirectory ? "\nダブルクリックで開く" : "");
-			}
-			ImGui::PopID();
-		}
-
-		void DrawSelectedAssetDetails()
-		{
-			ImGui::TextUnformatted("選択中のアセット");
-			ImGui::Separator();
-
-			const EditorAssetData* asset = registry_.FindById(selectedAssetId_);
-			if (!asset)
-			{
-				ImGui::TextDisabled("アセットが選択されていません。");
-				return;
-			}
-
-			DrawDetailRow("名前", asset->name);
-			DrawDetailRow("種類", EditorAssetRegistryV2::GetTypeName(asset->type));
-			DrawDetailRow("相対パス", asset->relativePath.generic_string());
-			DrawDetailRow("更新日時", asset->modifiedTime);
-			if (asset->isDirectory)
-			{
-				DrawDetailRow("項目数", std::to_string(registry_.CountChildren(asset->relativePath)));
-				if (ImGui::Button("このフォルダを開く", ImVec2(-1.0f, 0.0f)))
-				{
-					NavigateTo(asset->relativePath, true);
-				}
-			}
-			else
-			{
-				DrawDetailRow("拡張子", asset->extension.empty() ? "なし" : asset->extension);
-				DrawDetailRow("サイズ", FormatBytes(asset->sizeBytes));
-				DrawDetailRow("絶対パス", asset->absolutePath.generic_string());
-			}
-		}
-
-		static void DrawDetailRow(const char* label, const std::string& value)
-		{
-			ImGui::TextDisabled("%s", label);
-			ImGui::TextWrapped("%s", value.empty() ? "なし" : value.c_str());
-			ImGui::Spacing();
-		}
-
-		static std::string FormatBytes(uintmax_t bytes)
-		{
-			std::ostringstream stream;
-			if (bytes >= 1024ull * 1024ull)
-			{
-				stream.setf(std::ios::fixed);
-				stream.precision(2);
-				stream << static_cast<double>(bytes) / (1024.0 * 1024.0) << " MB";
-			}
-			else if (bytes >= 1024ull)
-			{
-				stream.setf(std::ios::fixed);
-				stream.precision(2);
-				stream << static_cast<double>(bytes) / 1024.0 << " KB";
-			}
-			else
-			{
-				stream << bytes << " bytes";
-			}
-			return stream.str();
-		}
-
-		static std::string TruncateText(const std::string& text, float maxWidth)
-		{
-			if (text.empty() || ImGui::CalcTextSize(text.c_str()).x <= maxWidth)
-			{
-				return text;
-			}
-
-			std::string result;
-			for (const char character : text)
-			{
-				const std::string candidate = result + character;
-				if (ImGui::CalcTextSize((candidate + "...").c_str()).x > maxWidth)
-				{
-					break;
-				}
-				result = candidate;
-			}
-			return result + "...";
-		}
+		static std::string TruncateText(const std::string& text, float maxWidth);
 #endif
-
+	private:
 		EditorAssetRegistryV2 registry_{};
 		std::filesystem::path currentDirectory_{};
 		std::vector<std::filesystem::path> history_{};

--- a/Project/Engine/Editor/EditorShell.h
+++ b/Project/Engine/Editor/EditorShell.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "EditorContentBrowserPanel.h"
 #include "EditorContext.h"
 #include "EditorHierarchyPanel.h"
 #include "EditorModeController.h"
@@ -44,6 +45,7 @@ namespace Ken4lowEngine
 
 			ApplyViewportVisualPolicy();
 			DrawPlaceActors();
+			EditorContentBrowserPanel::GetInstance()->Draw(); // Resources全体を扱うContent Browser V2をDockSpaceへ登録する。
 			EditorHierarchyPanel::GetInstance()->Draw(); // World OutlinerとDetailsを同じ選択状態で先に登録する。
 #endif
 		}

--- a/Project/Ken4lowEngine.vcxproj
+++ b/Project/Ken4lowEngine.vcxproj
@@ -120,6 +120,7 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
   <ItemGroup>
     <ClCompile Include="ApplicationLayer\Character\CharacterWorld\BulletEnemySoABridge.cpp" />
     <ClCompile Include="ApplicationLayer\Scene\DebugScene\DebugActorRegistration.cpp" />
+    <ClCompile Include="Engine\Editor\EditorContentBrowserPanel.cpp" />
     <ClCompile Include="Engine\Physics\Collision\Specialized\BulletEnemyCollisionSoA.cpp" />
     <ClCompile Include="Engine\Scene\Actor\Core\ActorWorld_ComponentEdit.cpp" />
     <ClCompile Include="Engine\Scene\Actor\Core\ActorWorld_Draw.cpp" />
@@ -839,9 +840,14 @@ copy "$(WindowsSdkDir)bin\$(TargetPlatformVersion)\x64\dxil.dll" "$(TargetDir)dx
     <ClInclude Include="ApplicationLayer\Scene\DebugScene\BulletEnemySoABenchmarkPanel.h" />
     <ClInclude Include="ApplicationLayer\Scene\DebugScene\DebugActorRegistration.h" />
     <ClInclude Include="ApplicationLayer\UISystem\UiSpriteFactory.h" />
+    <ClInclude Include="Engine\Editor\ActorWorldEditorBridge.h" />
+    <ClInclude Include="Engine\Editor\EditorAssetRegistryV2.h" />
+    <ClInclude Include="Engine\Editor\EditorContentBrowserPanel.h" />
     <ClInclude Include="Engine\Editor\EditorContext.h" />
+    <ClInclude Include="Engine\Editor\EditorHierarchyPanel.h" />
     <ClInclude Include="Engine\Editor\EditorPanelIds.h" />
     <ClInclude Include="Engine\Editor\EditorShell.h" />
+    <ClInclude Include="Engine\Editor\EditorViewportController.h" />
     <ClInclude Include="Engine\Math\MathUtil.h" />
     <ClInclude Include="Engine\Physics\Collision\Specialized\BulletEnemyCollisionSoA.h" />
     <ClInclude Include="Engine\Scene\Actor\Factory\ActorFactory.h" />

--- a/Project/Ken4lowEngine.vcxproj.filters
+++ b/Project/Ken4lowEngine.vcxproj.filters
@@ -1282,6 +1282,7 @@
     <ClCompile Include="Engine\Scene\Management\SceneManager.cpp">
       <Filter>Engine\Scene\Management</Filter>
     </ClCompile>
+    <ClCompile Include="Engine\Editor\EditorContentBrowserPanel.cpp" />
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="ApplicationLayer\UISystem\Crosshair\Crosshair.h">
@@ -2626,6 +2627,21 @@
       <Filter>Engine\Editor</Filter>
     </ClInclude>
     <ClInclude Include="Engine\Editor\EditorContext.h">
+      <Filter>Engine\Editor</Filter>
+    </ClInclude>
+    <ClInclude Include="Engine\Editor\ActorWorldEditorBridge.h">
+      <Filter>Engine\Editor</Filter>
+    </ClInclude>
+    <ClInclude Include="Engine\Editor\EditorAssetRegistryV2.h">
+      <Filter>Engine\Editor</Filter>
+    </ClInclude>
+    <ClInclude Include="Engine\Editor\EditorContentBrowserPanel.h">
+      <Filter>Engine\Editor</Filter>
+    </ClInclude>
+    <ClInclude Include="Engine\Editor\EditorHierarchyPanel.h">
+      <Filter>Engine\Editor</Filter>
+    </ClInclude>
+    <ClInclude Include="Engine\Editor\EditorViewportController.h">
       <Filter>Engine\Editor</Filter>
     </ClInclude>
   </ItemGroup>

--- a/Project/ken4low_editor_layout_v2.ini
+++ b/Project/ken4low_editor_layout_v2.ini
@@ -1,30 +1,30 @@
 [Window][Toolbar]
 Pos=0,26
-Size=1920,53
+Size=1920,62
 Collapsed=0
 DockId=0x00000001,0
 
 [Window][Place Actors]
-Pos=0,81
-Size=230,928
+Pos=0,90
+Size=230,919
 Collapsed=0
 DockId=0x00000003,0
 
 [Window][Main Viewport]
-Pos=232,81
-Size=1289,720
+Pos=232,90
+Size=1289,493
 Collapsed=0
 DockId=0x00000007,0
 
 [Window][Scene]
-Pos=232,81
-Size=1289,720
+Pos=232,90
+Size=1289,493
 Collapsed=0
 DockId=0x00000007,1
 
 [Window][World Outliner]
-Pos=1523,81
-Size=397,388
+Pos=1523,90
+Size=397,379
 Collapsed=0
 DockId=0x00000009,0
 
@@ -35,14 +35,14 @@ Collapsed=0
 DockId=0x0000000A,0
 
 [Window][Content Browser]
-Pos=232,803
-Size=1289,206
+Pos=232,585
+Size=1289,424
 Collapsed=0
 DockId=0x00000008,0
 
 [Window][Output Log]
-Pos=232,803
-Size=1289,206
+Pos=232,585
+Size=1289,424
 Collapsed=0
 DockId=0x00000008,1
 
@@ -101,14 +101,14 @@ Collapsed=0
 DockId=0x00000008
 
 [Window][PhysicsWorld Debug]
-Pos=232,803
-Size=1289,206
+Pos=232,585
+Size=1289,424
 Collapsed=0
 DockId=0x00000008,2
 
 [Window][GPU Particle Editor]
-Pos=232,803
-Size=1289,206
+Pos=232,585
+Size=1289,424
 Collapsed=0
 DockId=0x00000008,3
 
@@ -118,20 +118,19 @@ Size=1920,983
 Collapsed=0
 
 [Window][Debug##Default]
-Pos=12,715
-Size=335,32
+Pos=3,680
+Size=226,43
 Collapsed=0
 
 [Window][FadeManager]
-Pos=9,677
+Pos=10,679
 Size=422,688
 Collapsed=1
 
 [Window][AnimationModel Test]
-Pos=7,759
-Size=335,32
+Pos=23,701
+Size=149,122
 Collapsed=0
-DockId=0x0000000B,0
 
 [Window][Actor World]
 Pos=62,98
@@ -144,16 +143,15 @@ Size=273,104
 Collapsed=0
 
 [Docking][Data]
-DockNode          ID=0x0000000B Pos=7,759 Size=335,32 Selected=0x273AB186
 DockSpace         ID=0x08BD597D Window=0x1BBC0F80 Pos=0,26 Size=1920,983 Split=Y
-  DockNode        ID=0x00000001 Parent=0x08BD597D SizeRef=1280,53 Selected=0x0C01D6D5
-  DockNode        ID=0x00000002 Parent=0x08BD597D SizeRef=1280,665 Split=X
+  DockNode        ID=0x00000001 Parent=0x08BD597D SizeRef=1280,62 Selected=0x0C01D6D5
+  DockNode        ID=0x00000002 Parent=0x08BD597D SizeRef=1280,919 Split=X
     DockNode      ID=0x00000003 Parent=0x00000002 SizeRef=230,665 Selected=0xDDC1CAE2
     DockNode      ID=0x00000004 Parent=0x00000002 SizeRef=1048,665 Split=X
       DockNode    ID=0x00000005 Parent=0x00000004 SizeRef=1289,665 Split=Y
-        DockNode  ID=0x00000007 Parent=0x00000005 SizeRef=774,457 CentralNode=1 Selected=0x6E0FC501
-        DockNode  ID=0x00000008 Parent=0x00000005 SizeRef=774,206 Selected=0x78F77AC4
+        DockNode  ID=0x00000007 Parent=0x00000005 SizeRef=774,493 CentralNode=1 Selected=0x6E0FC501
+        DockNode  ID=0x00000008 Parent=0x00000005 SizeRef=774,424 Selected=0x3DF3100E
       DockNode    ID=0x00000006 Parent=0x00000004 SizeRef=397,665 Split=Y
-        DockNode  ID=0x00000009 Parent=0x00000006 SizeRef=272,278 Selected=0x49BD536E
-        DockNode  ID=0x0000000A Parent=0x00000006 SizeRef=272,385 Selected=0x5DB496A6
+        DockNode  ID=0x00000009 Parent=0x00000006 SizeRef=272,379 Selected=0x49BD536E
+        DockNode  ID=0x0000000A Parent=0x00000006 SizeRef=272,538 Selected=0x5DB496A6
 


### PR DESCRIPTION
## 概要
UE風Editor計画のPhase 4として、既存のカテゴリ別Content BrowserをResources全体を扱うContent Browser V2へ置き換えます。

## 実装内容
- `EditorAssetRegistryV2`を追加
  - `Project/Resources`を再帰走査
  - フォルダとアセットを統一管理
  - 安定ID、相対パス、絶対パス、サイズ、更新日時を保持
- アセット種別を自動分類
  - テクスチャ
  - モデル
  - アニメーション
  - マテリアル
  - アクタープリファブ
  - レベル
  - シェーダー
  - フォント
  - オーディオ
  - JSON
- UE風Content Browser V2
  - 左側フォルダツリー
  - パンくずリスト
  - 戻る／進む／上へ
  - フォルダのダブルクリック移動
  - 現在フォルダ以下の再帰検索
  - アセット種別フィルター
  - 表示サイズ変更
  - アセットグリッド
  - 選択アセット詳細
- 旧Content Browserは描画を停止し、既存Dock IDをV2が引き継ぐ
- ユーザー向け表示を日本語中心に統一

## Phase 5へ残す内容
- 実画像アイコンと高度なサムネイル
- 右クリックメニュー
- Explorerで開く
- 名前変更／複製／削除
- 検索条件保存と追加フィルター

## 確認項目
- 下部に「コンテンツブラウザ」が表示される
- Resourcesのフォルダ階層が左側へ表示される
- フォルダツリーとダブルクリックで移動できる
- 戻る／進む／上へが動作する
- パンくずから任意の親フォルダへ戻れる
- 検索がサブフォルダを含めて動作する
- 種別フィルターで表示対象を絞り込める
- 選択したアセットのパス・種類・サイズ・更新日時が表示される
