### PR TITLE
Fix Content Browser breadcrumb navigation crash

### DIFF
--- a/Project/Engine/Editor/EditorContentBrowserPanel.cpp
+++ b/Project/Engine/Editor/EditorContentBrowserPanel.cpp
@@ -219,23 +219,37 @@ namespace Ken4lowEngine
 
 	void EditorContentBrowserPanel::DrawBreadcrumbs()
 	{
+		std::filesystem::path requestedDirectory;
+		bool navigationRequested = false;
+
 		if (ImGui::Button("コンテンツ"))
 		{
-			NavigateTo({}, true);
+			requestedDirectory.clear();
+			navigationRequested = true;
 		}
 
+		// 描画中にcurrentDirectory_を書き換えるとpathの反復子が無効になるため、コピーを走査する。
+		const std::filesystem::path directorySnapshot = currentDirectory_;
 		std::filesystem::path accumulated;
-		for (const std::filesystem::path& part : currentDirectory_)
+		for (const std::filesystem::path& part : directorySnapshot)
 		{
 			accumulated /= part;
 			ImGui::SameLine();
 			ImGui::TextDisabled(">");
 			ImGui::SameLine();
+
 			const std::string label = part.generic_string() + "##Breadcrumb" + accumulated.generic_string();
 			if (ImGui::Button(label.c_str()))
 			{
-				NavigateTo(accumulated, true);
+				// パンくず描画完了後に移動し、走査中のpathを変更しない。
+				requestedDirectory = accumulated;
+				navigationRequested = true;
 			}
+		}
+
+		if (navigationRequested)
+		{
+			NavigateTo(requestedDirectory, true);
 		}
 	}
 


### PR DESCRIPTION
## 概要
Phase 4のコンテンツブラウザで、`コンテンツ > Shaders > ...` のパンくずをクリックして親フォルダへ戻ると、`std::filesystem::path` の反復中に `currentDirectory_` が書き換えられ、Debug Assertionが発生する問題を修正します。

## 原因
`DrawBreadcrumbs()` が `currentDirectory_` を直接range-forで走査しながら、ボタンクリック時に `NavigateTo()` を即時実行していました。これにより走査中のpath iteratorが無効化され、`cannot dereference string iterator because it is out of range` が発生していました。

## 修正内容
- 描画開始時に `currentDirectory_` のスナップショットを作成
- パンくずクリック時は移動先だけを保存
- range-for終了後に `NavigateTo()` を実行
- 処理意図のコメントを追加

## 確認項目
- `コンテンツ > Shaders > BulletDecal` から `Shaders` をクリックして戻れる
- `コンテンツ` をクリックしてルートへ戻れる
- 戻る／進む／上へボタンが引き続き動作する
- パンくず操作でDebug Assertionが発生しない
