### PR TITLE
Fix Direct3D live-object report shutdown order

### DIFF
--- a/Project/WinMain.cpp
+++ b/Project/WinMain.cpp
@@ -7,8 +7,8 @@ using namespace Ken4lowEngine;
 int WINAPI WinMain(HINSTANCE, HINSTANCE, LPSTR, int)
 {
 #ifdef _DEBUG
-	// 解放し忘れがないか確認するリークチェッカー
-	D3DResourceLeakChecker resourceLeakCheck;
+	// シングルトン群の破棄後に最終報告するため、リークチェッカーを先に生成したstaticへ変更する。
+	static D3DResourceLeakChecker resourceLeakCheck;
 #endif // _DEBUG
 
 	// Frameworkの派生クラスであるGameEngineを使用


### PR DESCRIPTION
## 原因
Phase 5で追加したContent Browserのテクスチャサムネイルは、`EditorContentBrowserPanel`の関数ローカルstaticシングルトンが保持しています。

一方、`WinMain`の`D3DResourceLeakChecker`は自動変数だったため、関数ローカルstaticシングルトンが破棄される前にデストラクタが実行されていました。その結果、終了処理後もまだサムネイル用`ID3D12Resource`が生存しているタイミングで`ReportLiveObjects()`が呼ばれ、`LIVE_DEVICE`警告とDebug LayerのBreakが発生していました。

## 修正
- `D3DResourceLeakChecker`を関数ローカルstaticへ変更
- 他のstaticシングルトンより先に生成し、プロセス終了時はそれらの破棄後に最終レポートを実行
- 処理意図を示す日本語コメントを追加

## 確認項目
- Content Browserで複数の画像サムネイルを表示する
- アプリを通常終了する
- `LIVE_DEVICE`警告でVisual Studioが停止しない
- 本当に解放されていないD3D12オブジェクトがある場合は、従来どおり最終レポートへ出力される
