### PR TITLE
Phase 6: Content BrowserからViewportへのアセット配置

### DIFF
--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
@@ -1,4 +1,4 @@
-﻿#pragma once
+#pragma once
 #include "BaseScene.h"
 #include "CollisionManager.h"
 #include "GpuParticleEffectDesc.h"
@@ -58,6 +58,14 @@ public: /// ---------- メンバ関数 ---------- ///
 	void CollectEditorObjects(std::vector<K4E::EditorObjectInfo>& outObjects) override
 	{
 		K4E::CollectActorWorldEditorObjects(actorWorld_, outObjects, "DebugScene");
+	}
+
+	/// <summary>
+	/// Content BrowserからのViewport配置先としてDebugSceneのActorWorldを公開する。
+	/// </summary>
+	K4E::ActorWorld* GetEditorActorWorld() override
+	{
+		return &actorWorld_;
 	}
 
 	// ShadowSystemがCasterを決める前にActorのLightComponentを同期する。

--- a/Project/Engine/Editor/EditorAssetDragDrop.h
+++ b/Project/Engine/Editor/EditorAssetDragDrop.h
@@ -1,0 +1,56 @@
+#pragma once
+
+#include "EditorAssetRegistryV2.h"
+
+#include <array>
+#include <cstdint>
+#include <cstdio>
+#include <filesystem>
+#include <string>
+
+namespace Ken4lowEngine
+{
+	/// <summary>
+	/// ImGuiのContent BrowserとMain Viewportで共有するDrag＆Drop Payload名です。
+	/// </summary>
+	inline constexpr const char* kEditorAssetDragDropPayloadType = "KEN4LOW_EDITOR_ASSET";
+
+	/// <summary>
+	/// ImGui::SetDragDropPayloadで安全にコピーできる固定長のアセット情報です。
+	/// </summary>
+	struct EditorAssetDragDropPayload
+	{
+		uint32_t assetType = static_cast<uint32_t>(EditorAssetType::Other);
+		std::array<char, 512> relativePath{};
+		std::array<char, 160> displayName{};
+	};
+
+	/// <summary>
+	/// 現在Main Viewportへ配置できるアセット種別か判定します。
+	/// </summary>
+	inline bool IsViewportPlaceableAsset(EditorAssetType type)
+	{
+		return type == EditorAssetType::Model || type == EditorAssetType::ActorPrefab;
+	}
+
+	/// <summary>
+	/// Content Browserのアセット情報から固定長Payloadを作成します。
+	/// </summary>
+	inline EditorAssetDragDropPayload MakeEditorAssetDragDropPayload(const EditorAssetData& asset)
+	{
+		EditorAssetDragDropPayload payload{};
+		payload.assetType = static_cast<uint32_t>(asset.type);
+		const std::string relativePath = asset.relativePath.generic_string();
+		std::snprintf(payload.relativePath.data(), payload.relativePath.size(), "%s", relativePath.c_str());
+		std::snprintf(payload.displayName.data(), payload.displayName.size(), "%s", asset.name.c_str());
+		return payload;
+	}
+
+	/// <summary>
+	/// Payloadへ保存された整数値をEditorAssetTypeへ戻します。
+	/// </summary>
+	inline EditorAssetType GetPayloadAssetType(const EditorAssetDragDropPayload& payload)
+	{
+		return static_cast<EditorAssetType>(payload.assetType);
+	}
+} // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorAssetPlacementService.h
+++ b/Project/Engine/Editor/EditorAssetPlacementService.h
@@ -11,11 +11,14 @@
 #include <Matrix4x4.h>
 #include <ModelComponent.h>
 #include <SceneComponent.h>
+#include <SceneManager.h>
 #include <Vector2.h>
 #include <Vector3.h>
 
 #include <algorithm>
+#include <cctype>
 #include <cmath>
+#include <cstdint>
 #include <filesystem>
 #include <string>
 #include <vector>
@@ -120,6 +123,18 @@ namespace Ken4lowEngine
 			// 地面と交差しない視線ではカメラ前方10mを配置位置として使用する。
 			outPosition = rayOrigin + worldDirection * 10.0f;
 			return true;
+		}
+
+		/// <summary>
+		/// SceneManagerが保持する現在SceneへPayloadを配置します。
+		/// </summary>
+		static EditorAssetPlacementResult PlaceAsset(
+			SceneManager* sceneManager,
+			const EditorAssetDragDropPayload& payload,
+			const Vector3& worldPosition)
+		{
+			BaseScene* scene = sceneManager ? sceneManager->GetCurrentScene() : nullptr;
+			return PlaceAsset(scene, payload, worldPosition);
 		}
 
 		/// <summary>

--- a/Project/Engine/Editor/EditorAssetPlacementService.h
+++ b/Project/Engine/Editor/EditorAssetPlacementService.h
@@ -1,0 +1,258 @@
+#pragma once
+
+#include "EditorAssetDragDrop.h"
+#include "EditorContext.h"
+
+#include <Actor.h>
+#include <ActorSpawnOptions.h>
+#include <ActorWorld.h>
+#include <BaseScene.h>
+#include <CameraManager.h>
+#include <Matrix4x4.h>
+#include <ModelComponent.h>
+#include <SceneComponent.h>
+#include <Vector2.h>
+#include <Vector3.h>
+
+#include <algorithm>
+#include <cmath>
+#include <filesystem>
+#include <string>
+#include <vector>
+
+namespace Ken4lowEngine
+{
+	/// <summary>
+	/// Content Browserから配置した通常モデルを、保存時は汎用Actorとして扱うEditor専用Actorです。
+	/// </summary>
+	class EditorPlacedModelActor final : public Actor
+	{
+	public:
+		EditorPlacedModelActor(std::string modelPath, const Vector3& worldPosition)
+		{
+			SceneComponent& root = CreateRootComponent<SceneComponent>();
+			root.SetName("Root Scene Component");
+			root.SetLocalPosition(worldPosition);
+			root.RefreshWorldTransform();
+
+			ModelComponent& model = AddComponent<ModelComponent>();
+			model.SetName("Model Component");
+			model.SetModelPath(modelPath);
+			model.AttachTo(&root);
+		}
+
+		std::string GetClassTypeName() const override
+		{
+			return "Actor"; // LevelやPrefabへ保存した際は既存ActorFactoryで復元できる形式を維持する。
+		}
+	};
+
+	/// <summary>
+	/// Viewportへのアセット配置結果です。
+	/// </summary>
+	struct EditorAssetPlacementResult
+	{
+		Actor* spawnedActor = nullptr;
+		std::string message;
+		bool succeeded = false;
+	};
+
+	/// <summary>
+	/// Content BrowserのPayloadを現在SceneのActorWorldへ配置するEditorサービスです。
+	/// </summary>
+	class EditorAssetPlacementService
+	{
+	public:
+		/// <summary>
+		/// Main Viewport上のスクリーン座標から、Y=0平面またはカメラ前方の配置位置を計算します。
+		/// </summary>
+		static bool CalculateDropPosition(
+			const Vector2& screenMouse,
+			const Vector2& viewportScreenMin,
+			const Vector2& viewportImageSize,
+			Vector3& outPosition)
+		{
+			if (viewportImageSize.x <= 1.0f || viewportImageSize.y <= 1.0f)
+			{
+				return false;
+			}
+
+			const float localX = screenMouse.x - viewportScreenMin.x;
+			const float localY = screenMouse.y - viewportScreenMin.y;
+			if (localX < 0.0f || localY < 0.0f || localX > viewportImageSize.x || localY > viewportImageSize.y)
+			{
+				return false;
+			}
+
+			const float ndcX = (localX / viewportImageSize.x) * 2.0f - 1.0f;
+			const float ndcY = 1.0f - (localY / viewportImageSize.y) * 2.0f;
+			const Matrix4x4 projection = CameraManager::GetInstance()->GetActiveProjectionMatrix();
+			if (std::abs(projection.m[0][0]) <= 0.00001f || std::abs(projection.m[1][1]) <= 0.00001f)
+			{
+				return false;
+			}
+
+			const Vector3 viewDirection{
+				ndcX / projection.m[0][0],
+				ndcY / projection.m[1][1],
+				1.0f
+			};
+			const Matrix4x4 inverseView = Matrix4x4::Inverse(CameraManager::GetInstance()->GetActiveViewMatrix());
+			Vector3 worldDirection{
+				viewDirection.x * inverseView.m[0][0] + viewDirection.y * inverseView.m[1][0] + viewDirection.z * inverseView.m[2][0],
+				viewDirection.x * inverseView.m[0][1] + viewDirection.y * inverseView.m[1][1] + viewDirection.z * inverseView.m[2][1],
+				viewDirection.x * inverseView.m[0][2] + viewDirection.y * inverseView.m[1][2] + viewDirection.z * inverseView.m[2][2]
+			};
+			worldDirection = Vector3::NormalizeSafe(worldDirection, CameraManager::GetInstance()->GetActiveCameraForward());
+
+			const Vector3 rayOrigin = CameraManager::GetInstance()->GetActiveCameraPosition();
+			if (std::abs(worldDirection.y) > 0.0001f)
+			{
+				const float distanceToGround = -rayOrigin.y / worldDirection.y;
+				if (distanceToGround > 0.1f && distanceToGround < 10000.0f)
+				{
+					outPosition = rayOrigin + worldDirection * distanceToGround;
+					outPosition.y = 0.0f;
+					return true;
+				}
+			}
+
+			// 地面と交差しない視線ではカメラ前方10mを配置位置として使用する。
+			outPosition = rayOrigin + worldDirection * 10.0f;
+			return true;
+		}
+
+		/// <summary>
+		/// Payloadを現在Sceneへ配置します。
+		/// </summary>
+		static EditorAssetPlacementResult PlaceAsset(
+			BaseScene* scene,
+			const EditorAssetDragDropPayload& payload,
+			const Vector3& worldPosition)
+		{
+			EditorAssetPlacementResult result{};
+			if (!scene)
+			{
+				result.message = "現在のシーンが存在しないため、アセットを配置できません。";
+				return result;
+			}
+
+			ActorWorld* actorWorld = scene->GetEditorActorWorld();
+			if (!actorWorld)
+			{
+				result.message = "現在のシーンはEditor用ActorWorldを公開していません。";
+				return result;
+			}
+
+			const EditorAssetType assetType = GetPayloadAssetType(payload);
+			const std::filesystem::path relativePath(payload.relativePath.data());
+			if (assetType == EditorAssetType::Model)
+			{
+				const std::string logicalModelPath = ResolveModelLogicalPath(relativePath);
+				if (logicalModelPath.empty())
+				{
+					result.message = "配置できるモデル形式はResources/Models/Sources内のgltf、glb、objです。";
+					return result;
+				}
+
+				EditorPlacedModelActor& actor = actorWorld->SpawnActor<EditorPlacedModelActor>(logicalModelPath, worldPosition);
+				actor.SetName(MakeUniqueActorName(*actorWorld, relativePath.stem().generic_string()));
+				result.spawnedActor = &actor;
+				result.succeeded = true;
+				result.message = "モデルをビューポートへ配置しました: " + logicalModelPath;
+			}
+			else if (assetType == EditorAssetType::ActorPrefab)
+			{
+				ActorSpawnOptions options{};
+				options.applySpawnOffset = false;
+				options.disableAutoRegisterMainCamera = true;
+				const std::string prefabPath = (std::filesystem::path("Resources") / relativePath).generic_string();
+				Actor* actor = actorWorld->SpawnActorFromJson(prefabPath, options);
+				if (!actor)
+				{
+					result.message = "アクタープリファブの読み込みに失敗しました: " + prefabPath;
+					return result;
+				}
+
+				if (SceneComponent* root = actor->GetRootComponent())
+				{
+					root->SetLocalPosition(worldPosition);
+					root->RefreshWorldTransform();
+				}
+				result.spawnedActor = actor;
+				result.succeeded = true;
+				result.message = "アクタープリファブをビューポートへ配置しました: " + prefabPath;
+			}
+			else
+			{
+				result.message = "このアセット種別はビューポート配置に対応していません。";
+			}
+
+			if (result.succeeded && result.spawnedActor)
+			{
+				SelectSpawnedActor(*scene, *result.spawnedActor);
+				EditorContext::GetInstance()->MarkLevelDirty();
+			}
+			return result;
+		}
+
+	private:
+		static std::string ResolveModelLogicalPath(const std::filesystem::path& relativePath)
+		{
+			std::string path = relativePath.generic_string();
+			constexpr const char* sourcesPrefix = "Models/Sources/";
+			if (!path.starts_with(sourcesPrefix))
+			{
+				return {};
+			}
+
+			path.erase(0, std::char_traits<char>::length(sourcesPrefix));
+			std::string extension = std::filesystem::path(path).extension().generic_string();
+			std::transform(extension.begin(), extension.end(), extension.begin(), [](unsigned char character)
+				{
+					return static_cast<char>(std::tolower(character));
+				});
+			if (extension != ".gltf" && extension != ".glb" && extension != ".obj")
+			{
+				return {};
+			}
+			return path;
+		}
+
+		static std::string MakeUniqueActorName(ActorWorld& actorWorld, std::string baseName)
+		{
+			if (baseName.empty())
+			{
+				baseName = "配置アクタ";
+			}
+			if (!actorWorld.FindActorByName(baseName))
+			{
+				return baseName;
+			}
+
+			for (uint32_t index = 2; index < 100000; ++index)
+			{
+				const std::string candidate = baseName + "_" + std::to_string(index);
+				if (!actorWorld.FindActorByName(candidate))
+				{
+					return candidate;
+				}
+			}
+			return baseName + "_Copy";
+		}
+
+		static void SelectSpawnedActor(BaseScene& scene, Actor& actor)
+		{
+			std::vector<EditorObjectInfo> objects;
+			scene.CollectEditorObjects(objects);
+			const auto found = std::find_if(objects.begin(), objects.end(), [&actor](const EditorObjectInfo& object)
+				{
+					return object.objectKind == EditorObjectKind::Actor && object.displayName == actor.GetName();
+				});
+			if (found != objects.end())
+			{
+				EditorContext::GetInstance()->GetSelection().Select(*found);
+			}
+		}
+	};
+} // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorContentBrowserPanel.h
+++ b/Project/Engine/Editor/EditorContentBrowserPanel.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "EditorAssetDragDrop.h"
 #include "EditorAssetRegistryV2.h"
 #include "EditorTexturePreviewCache.h"
 #include "EditorWindowManager.h"
@@ -14,6 +15,10 @@
 #include <string_view>
 #include <vector>
 
+#ifdef USE_IMGUI
+#include <imgui.h>
+#endif
+
 namespace Ken4lowEngine
 {
 	/// <summary>
@@ -25,6 +30,42 @@ namespace Ken4lowEngine
 		static EditorContentBrowserPanel* GetInstance();
 
 		void Draw();
+
+		/// <summary>
+		/// 選択中のモデルまたはActor PrefabをMain Viewportへ渡すDrag Sourceを更新します。
+		/// </summary>
+		void UpdateAssetDragSource()
+		{
+#ifdef USE_IMGUI
+			const EditorAssetData* asset = registry_.FindById(selectedAssetId_);
+			if (!asset || asset->isDirectory || !IsViewportPlaceableAsset(asset->type))
+			{
+				return;
+			}
+
+			// 同じContent Browserウィンドウへ再度入って、子領域上のドラッグを外部Sourceとして登録する。
+			if (!ImGui::Begin("コンテンツブラウザ###Content Browser", nullptr, ImGuiWindowFlags_NoCollapse))
+			{
+				ImGui::End();
+				return;
+			}
+
+			const bool canStartDrag =
+				ImGui::IsWindowHovered(ImGuiHoveredFlags_ChildWindows | ImGuiHoveredFlags_AllowWhenBlockedByActiveItem) &&
+				ImGui::IsMouseDragging(ImGuiMouseButton_Left, 6.0f);
+
+			if (canStartDrag && ImGui::BeginDragDropSource(ImGuiDragDropFlags_SourceExtern))
+			{
+				const EditorAssetDragDropPayload payload = MakeEditorAssetDragDropPayload(*asset);
+				ImGui::SetDragDropPayload(kEditorAssetDragDropPayloadType, &payload, sizeof(payload));
+				ImGui::TextUnformatted("ビューポートへ配置");
+				ImGui::Text("%s", asset->name.c_str());
+				ImGui::TextDisabled("種類: %s", EditorAssetRegistryV2::GetTypeName(asset->type));
+				ImGui::EndDragDropSource();
+			}
+			ImGui::End();
+#endif
+		}
 
 	private:
 		enum class AssetSortMode

--- a/Project/Engine/Editor/EditorShell.h
+++ b/Project/Engine/Editor/EditorShell.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "EditorAssetPlacementService.h"
 #include "EditorContentBrowserPanel.h"
 #include "EditorContext.h"
 #include "EditorHierarchyPanel.h"
@@ -46,6 +47,7 @@ namespace Ken4lowEngine
 			ApplyViewportVisualPolicy();
 			DrawPlaceActors();
 			EditorContentBrowserPanel::GetInstance()->Draw(); // Resources全体を扱うContent Browser V2をDockSpaceへ登録する。
+			EditorContentBrowserPanel::GetInstance()->UpdateAssetDragSource(); // 選択したモデルやPrefabをViewportへドラッグできるようにする。
 			EditorHierarchyPanel::GetInstance()->Draw(); // World OutlinerとDetailsを同じ選択状態で先に登録する。
 #endif
 		}
@@ -63,6 +65,7 @@ namespace Ken4lowEngine
 
 			ApplyViewportVisualPolicy();
 			DrawViewportToolbar();
+			DrawViewportAssetDropTarget();
 #endif
 		}
 
@@ -243,6 +246,114 @@ namespace Ken4lowEngine
 							// 再生状態は維持したまま、Main Viewportへ渡す入力だけを切り替える。
 						}
 					}
+				}
+			}
+			ImGui::End();
+		}
+
+		/// <summary>
+		/// Content Browserからドラッグ中のアセットをMain Viewportで受け取り、配置位置へ生成します。
+		/// </summary>
+		void DrawViewportAssetDropTarget()
+		{
+			const ImGuiPayload* activePayload = ImGui::GetDragDropPayload();
+			if (!activePayload || !activePayload->IsDataType(kEditorAssetDragDropPayloadType))
+			{
+				return;
+			}
+
+			auto* windowManager = EditorWindowManager::GetInstance();
+			const EditorViewportRect& viewportRect = windowManager->GetMainViewportRect();
+			const float viewportWidth = viewportRect.screenMax.x - viewportRect.screenMin.x;
+			const float viewportHeight = viewportRect.screenMax.y - viewportRect.screenMin.y;
+			if (!viewportRect.valid || viewportWidth <= 1.0f || viewportHeight <= 1.0f)
+			{
+				return;
+			}
+
+			ImGui::SetNextWindowPos(ImVec2(viewportRect.screenMin.x, viewportRect.screenMin.y), ImGuiCond_Always);
+			ImGui::SetNextWindowSize(ImVec2(viewportWidth, viewportHeight), ImGuiCond_Always);
+			ImGui::SetNextWindowBgAlpha(0.0f);
+			const ImGuiWindowFlags flags = ImGuiWindowFlags_NoDecoration |
+				ImGuiWindowFlags_NoDocking |
+				ImGuiWindowFlags_NoSavedSettings |
+				ImGuiWindowFlags_NoMove |
+				ImGuiWindowFlags_NoResize |
+				ImGuiWindowFlags_NoScrollbar |
+				ImGuiWindowFlags_NoScrollWithMouse |
+				ImGuiWindowFlags_NoFocusOnAppearing |
+				ImGuiWindowFlags_NoNav |
+				ImGuiWindowFlags_NoBackground;
+
+			if (ImGui::Begin("##MainViewportAssetDropTarget", nullptr, flags))
+			{
+				ImGui::InvisibleButton("##ViewportAssetDropArea", ImVec2(viewportWidth, viewportHeight));
+				if (ImGui::BeginDragDropTarget())
+				{
+					const ImGuiPayload* payload = ImGui::AcceptDragDropPayload(
+						kEditorAssetDragDropPayloadType,
+						ImGuiDragDropFlags_AcceptBeforeDelivery | ImGuiDragDropFlags_AcceptNoDrawDefaultRect);
+					if (payload && payload->DataSize == sizeof(EditorAssetDragDropPayload))
+					{
+						const bool canPlace = !EditorPlayController::GetInstance()->IsPlaying();
+						const ImU32 borderColor = ImGui::GetColorU32(
+							canPlace ? ImVec4(0.95f, 0.62f, 0.12f, 1.0f) : ImVec4(0.95f, 0.24f, 0.20f, 1.0f));
+						ImDrawList* drawList = ImGui::GetWindowDrawList();
+						drawList->AddRect(
+							ImGui::GetItemRectMin(),
+							ImGui::GetItemRectMax(),
+							borderColor,
+							2.0f,
+							0,
+							4.0f);
+
+						const char* guideText = canPlace
+							? "ここにドロップしてアセットを配置"
+							: "再生中はアセットを配置できません";
+						const ImVec2 textSize = ImGui::CalcTextSize(guideText);
+						const ImVec2 itemMin = ImGui::GetItemRectMin();
+						const ImVec2 itemMax = ImGui::GetItemRectMax();
+						drawList->AddText(
+							ImVec2(
+								(itemMin.x + itemMax.x - textSize.x) * 0.5f,
+								(itemMin.y + itemMax.y - textSize.y) * 0.5f),
+							borderColor,
+							guideText);
+
+						if (payload->IsDelivery())
+						{
+							if (!canPlace)
+							{
+								windowManager->AddOutputLog(EditorLogLevel::Warning, "再生中はビューポートへアセットを配置できません。");
+							}
+							else
+							{
+								const ImVec2 mouse = ImGui::GetMousePos();
+								Vector3 worldPosition{};
+								const bool positionResolved = EditorAssetPlacementService::CalculateDropPosition(
+									{ mouse.x, mouse.y },
+									viewportRect.screenMin,
+									viewportRect.imageSize,
+									worldPosition);
+								if (!positionResolved)
+								{
+									windowManager->AddOutputLog(EditorLogLevel::Error, "ドロップ位置をワールド座標へ変換できませんでした。");
+								}
+								else
+								{
+									const auto* assetPayload = static_cast<const EditorAssetDragDropPayload*>(payload->Data);
+									const EditorAssetPlacementResult result = EditorAssetPlacementService::PlaceAsset(
+										windowManager->GetSceneManager(),
+										*assetPayload,
+										worldPosition);
+									windowManager->AddOutputLog(
+										result.succeeded ? EditorLogLevel::Info : EditorLogLevel::Error,
+										result.message);
+								}
+							}
+						}
+					}
+					ImGui::EndDragDropTarget();
 				}
 			}
 			ImGui::End();

--- a/Project/Engine/Scene/Actor/Factory/ActorFactory.cpp
+++ b/Project/Engine/Scene/Actor/Factory/ActorFactory.cpp
@@ -29,6 +29,12 @@ namespace Ken4lowEngine
 
 	std::unique_ptr<Actor> Ken4lowEngine::ActorFactory::CreateActor(std::string_view className)
 	{
+		if (className == "Actor")
+		{
+			// EditorがModelComponent構成から生成した汎用Actorは、個別登録なしでJSONから復元する。
+			return std::make_unique<Actor>();
+		}
+
 		const auto& registry = GetActorFactoryRegister();
 
 		const auto it = registry.find(std::string(className));
@@ -42,8 +48,13 @@ namespace Ken4lowEngine
 
 	bool ActorFactory::IsRegistered(std::string_view className)
 	{
+		if (className == "Actor")
+		{
+			return true; // 汎用ActorはFactory組み込み型として常に生成可能にする。
+		}
+
 		const auto& registry = GetActorFactoryRegister();
 		return registry.contains(std::string(className)); // 登録済みかどうかを返す
 	}
 
-}
+} // namespace Ken4lowEngine

--- a/Project/Engine/Scene/Management/BaseScene.h
+++ b/Project/Engine/Scene/Management/BaseScene.h
@@ -7,6 +7,7 @@
 namespace Ken4lowEngine
 {
 	/// ---------- 前方宣言 ---------- ///
+	class ActorWorld;
 	class SceneManager;
 
 
@@ -59,6 +60,12 @@ namespace Ken4lowEngine
 		// World Outliner用の安全な表示情報をScene側から収集する入口です。
 		virtual void CollectEditorObjects(std::vector<Ken4lowEngine::EditorObjectInfo>& /*outObjects*/) {}
 
+		/// <summary>
+		/// ViewportへのEditor配置を受け入れるActorWorldを返します。
+		/// Actor編集に対応していないSceneはnullptrのままにします。
+		/// </summary>
+		virtual ActorWorld* GetEditorActorWorld() { return nullptr; }
+
 		// シーンマネージャーをセット
 		virtual void SetSceneManager(SceneManager* sceneManager) { sceneManager_ = sceneManager; }
 
@@ -87,4 +94,4 @@ namespace Ken4lowEngine
 
 	};
 
-}
+} // namespace Ken4lowEngine


### PR DESCRIPTION
## 概要
UE風Editor計画のPhase 6として、Content Browserで選択したモデル／Actor PrefabをMain Viewportへドラッグ＆ドロップして配置できるようにします。

## 実装内容
- Content Browserの選択アセットをImGui Drag＆Drop Payloadへ変換
- Main Viewport全体へEditor専用Drop Targetを追加
- ドラッグ中に配置可能範囲と日本語ガイドを表示
- Viewport上のマウス位置をカメラRayへ変換
- Y=0平面との交点へ配置
- 地面と交差しない場合はカメラ前方10mへ配置
- `Resources/Models/Sources`配下のgltf／glb／objを汎用Actor＋ModelComponentとして生成
- Actor Prefab JSONをドロップ位置へ生成
- 生成Actorをアウトライナー／詳細で自動選択
- 配置後にLevel Dirty状態を更新
- 再生中は配置を拒否してOutput Logへ警告
- DebugSceneからEditor用ActorWorldを安全に公開

## 対応アセット
- モデル
- アクタープリファブ

Material／Textureのドロップ割り当ては、ID Pickingで対象Componentを特定できるPhase 7以降に接続します。

## 確認項目
1. Content Browserでモデルを選び、そのままMain Viewportへドラッグできる
2. Viewportへ入ると配置ガイド枠が表示される
3. ドロップ位置付近へモデルが生成される
4. Actor Prefabも同様に生成される
5. 生成Actorがアウトライナーと詳細で選択状態になる
6. 同名モデルを複数配置しても名前が重複しない
7. 再生中は配置されず、Output Logへ警告される
8. 未対応アセットではドラッグ配置が開始されない
