### PR TITLE
Phase 9: Editor Undo Redo and Command system

### DIFF
--- a/Project/Engine/Editor/ActorWorldEditorBridge.cpp
+++ b/Project/Engine/Editor/ActorWorldEditorBridge.cpp
@@ -1,23 +1,51 @@
 #define NOMINMAX
 #include "ActorWorldEditorBridge.h"
+#include "EditorCommandHistory.h"
 
 #include <SceneComponent.h>
+#include <json.hpp>
 
 #include <algorithm>
 #include <cmath>
 #include <limits>
+#include <memory>
 #include <string>
 #include <unordered_map>
 #include <utility>
 
 namespace Ken4lowEngine
 {
-	bool Ken4lowEngine::BuildInstancedModelInstanceEditorInfo(InstancedModelComponent* component, size_t instanceIndex, uint64_t componentId, std::string_view sceneName, EditorObjectInfo& outInfo)
+	namespace
 	{
-		if (!component || instanceIndex >= component->GetEditableInstanceCount())
+		void ExecuteActiveCommand(const EditorObjectInfo& object, bool active)
 		{
-			return false;
+			bool before = active;
+			if (!object.ReadActive(before) || before == active) return;
+			EditorCommandHistory::GetInstance()->Execute(std::make_unique<EditorValueCommand<bool>>(
+				"有効状態変更", before, active,
+				[object](const bool& value)
+				{
+					object.WriteActive(value);
+					EditorContext::GetInstance()->MarkLevelDirty();
+				}));
 		}
+
+		void ExecuteRenameCommand(const EditorObjectInfo& object, std::string_view name)
+		{
+			if (name.empty() || object.displayName == name) return;
+			EditorCommandHistory::GetInstance()->Execute(std::make_unique<EditorValueCommand<std::string>>(
+				"名前変更", object.displayName, std::string(name),
+				[object](const std::string& value)
+				{
+					object.Rename(value);
+					EditorContext::GetInstance()->MarkLevelDirty();
+				}));
+		}
+	}
+
+	bool BuildInstancedModelInstanceEditorInfo(InstancedModelComponent* component, size_t instanceIndex, uint64_t componentId, std::string_view sceneName, EditorObjectInfo& outInfo)
+	{
+		if (!component || instanceIndex >= component->GetEditableInstanceCount()) return false;
 
 		const std::string instanceKey = std::to_string(componentId) + "/Instance/" + std::to_string(instanceIndex);
 		outInfo = {};
@@ -68,7 +96,33 @@ namespace Ken4lowEngine
 				instanceTransform.scale = transform.scale;
 				component->SetInstanceWorldTransform(instanceIndex, instanceTransform);
 			};
-		outInfo.canDrawObjectId = false; // PickingはComponentの連続ID 1Drawへ集約し、Instanceごとの重複描画を防ぐ。
+		outInfo.canCaptureState = true;
+		outInfo.captureState = [component, instanceIndex]()
+			{
+				InstancedModelComponent::InstanceTransform transform{};
+				if (!component->GetInstanceLocalTransform(instanceIndex, transform)) return std::string{};
+				nlohmann::json state = {
+					{ "Position", { transform.position.x, transform.position.y, transform.position.z } },
+					{ "Rotation", { transform.rotation.x, transform.rotation.y, transform.rotation.z } },
+					{ "Scale", { transform.scale.x, transform.scale.y, transform.scale.z } },
+				};
+				return state.dump();
+			};
+		outInfo.restoreState = [component, instanceIndex](std::string_view stateText)
+			{
+				const nlohmann::json state = nlohmann::json::parse(stateText, nullptr, false);
+				if (state.is_discarded()) return;
+				InstancedModelComponent::InstanceTransform transform{};
+				if (!component->GetInstanceLocalTransform(instanceIndex, transform)) return;
+				const auto position = state.value("Position", std::vector<float>{});
+				const auto rotation = state.value("Rotation", std::vector<float>{});
+				const auto scale = state.value("Scale", std::vector<float>{});
+				if (position.size() == 3) transform.position = { position[0], position[1], position[2] };
+				if (rotation.size() == 3) transform.rotation = { rotation[0], rotation[1], rotation[2] };
+				if (scale.size() == 3) transform.scale = { scale[0], scale[1], scale[2] };
+				component->SetInstanceLocalTransform(instanceIndex, transform); // 個別InstanceのUndoはGPU Buffer更新までComponentへ任せる。
+			};
+		outInfo.canDrawObjectId = false;
 		return true;
 	}
 
@@ -82,8 +136,7 @@ namespace Ken4lowEngine
 			Actor* actor = actorOwner.get();
 			if (!actor || actor->IsPendingDestroy()) continue;
 
-			const std::string actorKey = sceneNameText + "/Actor/" +
-				std::to_string(static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(actor)));
+			const std::string actorKey = sceneNameText + "/Actor/" + std::to_string(static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(actor)));
 			const uint64_t actorId = MakeStableEditorObjectId(actorKey);
 
 			EditorObjectInfo actorInfo{};
@@ -100,6 +153,19 @@ namespace Ken4lowEngine
 			actorInfo.canRename = true;
 			actorInfo.rename = [actor](std::string_view name) { actor->SetName(name); };
 			actorInfo.inspectorHint = "Actor / Component Details";
+			actorInfo.canCaptureState = true;
+			actorInfo.captureState = [actor]()
+				{
+					nlohmann::json state;
+					actor->ToJson(state);
+					state.erase("Components"); // Actor Inspectorの履歴ではComponent構成を作り直さずActor共通値だけ保持する。
+					return state.dump();
+				};
+			actorInfo.restoreState = [actor](std::string_view stateText)
+				{
+					const nlohmann::json state = nlohmann::json::parse(stateText, nullptr, false);
+					if (!state.is_discarded()) actor->FromJson(state);
+				};
 
 			if (SceneComponent* root = actor->GetRootComponent())
 			{
@@ -134,6 +200,10 @@ namespace Ken4lowEngine
 					actorWorld.SetSelectedEditorObject(actor, nullptr);
 					actorWorld.DrawSelectedInspectorContent();
 				};
+
+			EditorObjectInfo actorCommandProxy = actorInfo;
+			actorInfo.writeActive = [actorCommandProxy](bool active) { ExecuteActiveCommand(actorCommandProxy, active); };
+			actorInfo.rename = [actorCommandProxy](std::string_view name) { ExecuteRenameCommand(actorCommandProxy, name); };
 			outObjects.push_back(std::move(actorInfo));
 
 			std::unordered_map<const ActorComponent*, uint64_t> componentIds;
@@ -142,8 +212,7 @@ namespace Ken4lowEngine
 			{
 				ActorComponent* component = componentOwner.get();
 				if (!component) continue;
-				const std::string componentKey = actorKey + "/Component/" +
-					std::to_string(static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(component)));
+				const std::string componentKey = actorKey + "/Component/" + std::to_string(static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(component)));
 				componentIds.emplace(component, MakeStableEditorObjectId(componentKey));
 			}
 
@@ -168,11 +237,20 @@ namespace Ken4lowEngine
 				componentInfo.canRename = true;
 				componentInfo.rename = [component](std::string_view name) { component->SetName(name); };
 				componentInfo.inspectorHint = componentInfo.isRootComponent ? "Root Component" : "Actor Component";
-				componentInfo.canDrawObjectId = actor->IsActive() && component->IsActiveInHierarchy() && component->SupportsEditorObjectId();
-				componentInfo.drawObjectId = [component](uint32_t objectId)
+				componentInfo.canCaptureState = true;
+				componentInfo.captureState = [component]()
 					{
-						component->DrawEditorObjectId(objectId);
+						nlohmann::json state;
+						component->ToJson(state);
+						return state.dump();
 					};
+				componentInfo.restoreState = [component](std::string_view stateText)
+					{
+						const nlohmann::json state = nlohmann::json::parse(stateText, nullptr, false);
+						if (!state.is_discarded()) component->FromJson(state);
+					};
+				componentInfo.canDrawObjectId = actor->IsActive() && component->IsActiveInHierarchy() && component->SupportsEditorObjectId();
+				componentInfo.drawObjectId = [component](uint32_t objectId) { component->DrawEditorObjectId(objectId); };
 
 				if (auto* sceneComponent = dynamic_cast<SceneComponent*>(component))
 				{
@@ -233,6 +311,10 @@ namespace Ken4lowEngine
 						actorWorld.DrawSelectedInspectorContent();
 					};
 
+				EditorObjectInfo componentCommandProxy = componentInfo;
+				componentInfo.writeActive = [componentCommandProxy](bool active) { ExecuteActiveCommand(componentCommandProxy, active); };
+				componentInfo.rename = [componentCommandProxy](std::string_view name) { ExecuteRenameCommand(componentCommandProxy, name); };
+
 				InstancedModelComponent* instancedComponent = dynamic_cast<InstancedModelComponent*>(component);
 				if (instancedComponent && componentInfo.canDrawObjectId)
 				{
@@ -256,10 +338,7 @@ namespace Ken4lowEngine
 					for (size_t instanceIndex = 0; instanceIndex < visibleCount; ++instanceIndex)
 					{
 						EditorObjectInfo instanceInfo{};
-						if (BuildInstancedModelInstanceEditorInfo(instancedComponent, instanceIndex, componentId, sceneNameText, instanceInfo))
-						{
-							outObjects.push_back(std::move(instanceInfo));
-						}
+						if (BuildInstancedModelInstanceEditorInfo(instancedComponent, instanceIndex, componentId, sceneNameText, instanceInfo)) outObjects.push_back(std::move(instanceInfo));
 					}
 
 					const EditorSelection& selection = EditorContext::GetInstance()->GetSelection();
@@ -272,10 +351,7 @@ namespace Ken4lowEngine
 							if (selectedIndex >= visibleCount && selectedIndex < instanceCount)
 							{
 								EditorObjectInfo selectedInfo{};
-								if (BuildInstancedModelInstanceEditorInfo(instancedComponent, selectedIndex, componentId, sceneNameText, selectedInfo))
-								{
-									outObjects.push_back(std::move(selectedInfo)); // 512件超でもViewportで選んだInstanceだけはSelection更新対象へ残す。
-								}
+								if (BuildInstancedModelInstanceEditorInfo(instancedComponent, selectedIndex, componentId, sceneNameText, selectedInfo)) outObjects.push_back(std::move(selectedInfo));
 							}
 						}
 					}
@@ -283,5 +359,4 @@ namespace Ken4lowEngine
 			}
 		}
 	}
-
-}
+} // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorAssetPlacementService.h
+++ b/Project/Engine/Editor/EditorAssetPlacementService.h
@@ -1,9 +1,11 @@
 #pragma once
 
 #include "EditorAssetDragDrop.h"
+#include "EditorCommandHistory.h"
 #include "EditorContext.h"
 
 #include <Actor.h>
+#include <ActorJsonSerializer.h>
 #include <ActorSpawnOptions.h>
 #include <ActorWorld.h>
 #include <BaseScene.h>
@@ -16,18 +18,17 @@
 #include <Vector3.h>
 
 #include <algorithm>
+#include <atomic>
 #include <cctype>
 #include <cmath>
 #include <cstdint>
 #include <filesystem>
+#include <memory>
 #include <string>
 #include <vector>
 
 namespace Ken4lowEngine
 {
-	/// <summary>
-	/// Content Browserから配置した通常モデルを、保存時は汎用Actorとして扱うEditor専用Actorです。
-	/// </summary>
 	class EditorPlacedModelActor final : public Actor
 	{
 	public:
@@ -44,10 +45,7 @@ namespace Ken4lowEngine
 			model.AttachTo(&root);
 		}
 
-		std::string GetClassTypeName() const override
-		{
-			return "Actor"; // LevelやPrefabへ保存した際は既存ActorFactoryで復元できる形式を維持する。
-		}
+		std::string GetClassTypeName() const override { return "Actor"; }
 	};
 
 	struct EditorAssetPlacementResult
@@ -57,9 +55,6 @@ namespace Ken4lowEngine
 		bool succeeded = false;
 	};
 
-	/// <summary>
-	/// Content BrowserのPayloadを現在SceneのActorWorldへ配置するEditorサービスです。
-	/// </summary>
 	class EditorAssetPlacementService
 	{
 	public:
@@ -69,31 +64,17 @@ namespace Ken4lowEngine
 			const Vector2& viewportImageSize,
 			Vector3& outPosition)
 		{
-			if (viewportImageSize.x <= 1.0f || viewportImageSize.y <= 1.0f)
-			{
-				return false;
-			}
-
+			if (viewportImageSize.x <= 1.0f || viewportImageSize.y <= 1.0f) return false;
 			const float localX = screenMouse.x - viewportScreenMin.x;
 			const float localY = screenMouse.y - viewportScreenMin.y;
-			if (localX < 0.0f || localY < 0.0f || localX > viewportImageSize.x || localY > viewportImageSize.y)
-			{
-				return false;
-			}
+			if (localX < 0.0f || localY < 0.0f || localX > viewportImageSize.x || localY > viewportImageSize.y) return false;
 
 			const float ndcX = (localX / viewportImageSize.x) * 2.0f - 1.0f;
 			const float ndcY = 1.0f - (localY / viewportImageSize.y) * 2.0f;
 			const Matrix4x4 projection = CameraManager::GetInstance()->GetActiveProjectionMatrix();
-			if (std::abs(projection.m[0][0]) <= 0.00001f || std::abs(projection.m[1][1]) <= 0.00001f)
-			{
-				return false;
-			}
+			if (std::abs(projection.m[0][0]) <= 0.00001f || std::abs(projection.m[1][1]) <= 0.00001f) return false;
 
-			const Vector3 viewDirection{
-				ndcX / projection.m[0][0],
-				ndcY / projection.m[1][1],
-				1.0f
-			};
+			const Vector3 viewDirection{ ndcX / projection.m[0][0], ndcY / projection.m[1][1], 1.0f };
 			const Matrix4x4 inverseView = Matrix4x4::Inverse(CameraManager::GetInstance()->GetActiveViewMatrix());
 			Vector3 worldDirection{
 				viewDirection.x * inverseView.m[0][0] + viewDirection.y * inverseView.m[1][0] + viewDirection.z * inverseView.m[2][0],
@@ -114,23 +95,16 @@ namespace Ken4lowEngine
 				}
 			}
 
-			outPosition = rayOrigin + worldDirection * 10.0f; // 地面と交差しない視線ではドロップ瞬間のワールド位置へ固定する。
+			outPosition = rayOrigin + worldDirection * 10.0f;
 			return true;
 		}
 
-		static EditorAssetPlacementResult PlaceAsset(
-			SceneManager* sceneManager,
-			const EditorAssetDragDropPayload& payload,
-			const Vector3& worldPosition)
+		static EditorAssetPlacementResult PlaceAsset(SceneManager* sceneManager, const EditorAssetDragDropPayload& payload, const Vector3& worldPosition)
 		{
-			BaseScene* scene = sceneManager ? sceneManager->GetCurrentScene() : nullptr;
-			return PlaceAsset(scene, payload, worldPosition);
+			return PlaceAsset(sceneManager ? sceneManager->GetCurrentScene() : nullptr, payload, worldPosition);
 		}
 
-		static EditorAssetPlacementResult PlaceAsset(
-			BaseScene* scene,
-			const EditorAssetDragDropPayload& payload,
-			const Vector3& worldPosition)
+		static EditorAssetPlacementResult PlaceAsset(BaseScene* scene, const EditorAssetDragDropPayload& payload, const Vector3& worldPosition)
 		{
 			EditorAssetPlacementResult result{};
 			if (!scene)
@@ -156,7 +130,6 @@ namespace Ken4lowEngine
 					result.message = "配置できるモデル形式はResources/Models/Sources内のgltf、glb、objです。";
 					return result;
 				}
-
 				EditorPlacedModelActor& actor = actorWorld->SpawnActor<EditorPlacedModelActor>(logicalModelPath, worldPosition);
 				actor.SetName(MakeUniqueActorName(*actorWorld, relativePath.stem().generic_string()));
 				result.spawnedActor = &actor;
@@ -169,14 +142,12 @@ namespace Ken4lowEngine
 				options.applySpawnOffset = false;
 				options.disableAutoRegisterMainCamera = true;
 				const std::string prefabPath = (std::filesystem::path("Resources") / relativePath).generic_string();
-				Actor* actor = actorWorld->SpawnActorFromJson(prefabPath, options);
-				if (!actor)
+				result.spawnedActor = actorWorld->SpawnActorFromJson(prefabPath, options);
+				if (!result.spawnedActor)
 				{
 					result.message = "アクタープリファブの読み込みに失敗しました: " + prefabPath;
 					return result;
 				}
-
-				result.spawnedActor = actor;
 				result.succeeded = true;
 				result.message = "アクタープリファブをビューポートへ配置しました: " + prefabPath;
 			}
@@ -191,56 +162,60 @@ namespace Ken4lowEngine
 				{
 					root->Detach();
 					root->SetLocalPosition(worldPosition);
-					root->RefreshWorldTransform(); // 配置確定時に親を外し、カメラ追従ではなくWorld座標へ固定する。
+					root->RefreshWorldTransform();
 				}
-
 				SelectSpawnedActor(*scene, *result.spawnedActor);
+				RecordPlacementCommand(*scene, *actorWorld, *result.spawnedActor);
 				EditorContext::GetInstance()->MarkLevelDirty();
 			}
 			return result;
 		}
 
 	private:
+		static void RecordPlacementCommand(BaseScene& scene, ActorWorld& actorWorld, Actor& actor)
+		{
+			static std::atomic_uint64_t serial = 0;
+			const std::string snapshotPath = "../Generated/Intermediate/EditorUndo/PlacedActor_" + std::to_string(++serial) + ".json";
+			if (!ActorJsonSerializer::SaveActorToFile(actor, snapshotPath)) return;
+
+			auto actorState = std::make_shared<Actor*>(&actor);
+			EditorCommandHistory::GetInstance()->PushExecuted(std::make_unique<EditorLambdaCommand>(
+				"アセット配置",
+				[&scene, &actorWorld, actorState, snapshotPath]()
+				{
+					*actorState = actorWorld.SpawnActorFromJson(snapshotPath);
+					if (*actorState) SelectSpawnedActor(scene, **actorState);
+					EditorContext::GetInstance()->MarkLevelDirty();
+				},
+				[actorState]()
+				{
+					if (*actorState) (*actorState)->Destroy();
+					*actorState = nullptr;
+					EditorContext::GetInstance()->GetSelection().Clear();
+					EditorContext::GetInstance()->MarkLevelDirty(); // ActorWorldの次回更新で配置Actorを安全に削除する。
+				}));
+		}
+
 		static std::string ResolveModelLogicalPath(const std::filesystem::path& relativePath)
 		{
 			std::string path = relativePath.generic_string();
 			constexpr const char* sourcesPrefix = "Models/Sources/";
-			if (!path.starts_with(sourcesPrefix))
-			{
-				return {};
-			}
-
+			if (!path.starts_with(sourcesPrefix)) return {};
 			path.erase(0, std::char_traits<char>::length(sourcesPrefix));
 			std::string extension = std::filesystem::path(path).extension().generic_string();
-			std::transform(extension.begin(), extension.end(), extension.begin(), [](unsigned char character)
-				{
-					return static_cast<char>(std::tolower(character));
-				});
-			if (extension != ".gltf" && extension != ".glb" && extension != ".obj")
-			{
-				return {};
-			}
+			std::transform(extension.begin(), extension.end(), extension.begin(), [](unsigned char character) { return static_cast<char>(std::tolower(character)); });
+			if (extension != ".gltf" && extension != ".glb" && extension != ".obj") return {};
 			return path;
 		}
 
 		static std::string MakeUniqueActorName(ActorWorld& actorWorld, std::string baseName)
 		{
-			if (baseName.empty())
-			{
-				baseName = "配置アクタ";
-			}
-			if (!actorWorld.FindActorByName(baseName))
-			{
-				return baseName;
-			}
-
+			if (baseName.empty()) baseName = "配置アクタ";
+			if (!actorWorld.FindActorByName(baseName)) return baseName;
 			for (uint32_t index = 2; index < 100000; ++index)
 			{
 				const std::string candidate = baseName + "_" + std::to_string(index);
-				if (!actorWorld.FindActorByName(candidate))
-				{
-					return candidate;
-				}
+				if (!actorWorld.FindActorByName(candidate)) return candidate;
 			}
 			return baseName + "_Copy";
 		}
@@ -253,10 +228,7 @@ namespace Ken4lowEngine
 				{
 					return object.objectKind == EditorObjectKind::Actor && object.displayName == actor.GetName();
 				});
-			if (found != objects.end())
-			{
-				EditorContext::GetInstance()->GetSelection().Select(*found);
-			}
+			if (found != objects.end()) EditorContext::GetInstance()->GetSelection().Select(*found);
 		}
 	};
 } // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorCommandHistory.h
+++ b/Project/Engine/Editor/EditorCommandHistory.h
@@ -154,6 +154,14 @@ namespace Ken4lowEngine
 			cursor_ = 0;
 		}
 
+		void DiscardDependentRedoCommands()
+		{
+			if (!isReplaying_ || cursor_ >= commands_.size()) return;
+			const std::size_t keepCount = cursor_ + 1;
+			commands_.erase(commands_.begin() + static_cast<std::ptrdiff_t>(keepCount), commands_.end());
+			// 構造変更前のComponentを参照する後続Redoだけを捨て、構造Command自身は再実行できるように残す。
+		}
+
 		bool CanUndo() const { return cursor_ > 0 && cursor_ <= commands_.size(); }
 		bool CanRedo() const { return cursor_ < commands_.size(); }
 		bool IsReplaying() const { return isReplaying_; }

--- a/Project/Engine/Editor/EditorCommandHistory.h
+++ b/Project/Engine/Editor/EditorCommandHistory.h
@@ -1,0 +1,206 @@
+#pragma once
+
+#include <algorithm>
+#include <cstddef>
+#include <functional>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <utility>
+#include <vector>
+
+namespace Ken4lowEngine
+{
+	/// <summary>Undo / Redoへ登録できるEditor操作の共通インターフェースです。</summary>
+	class IEditorCommand
+	{
+	public:
+		virtual ~IEditorCommand() = default;
+		virtual void Execute() = 0;
+		virtual void Undo() = 0;
+		virtual const std::string& GetName() const = 0;
+	};
+
+	/// <summary>任意の実行・取り消し処理をCommandとして保持します。</summary>
+	class EditorLambdaCommand final : public IEditorCommand
+	{
+	public:
+		using Action = std::function<void()>;
+
+		EditorLambdaCommand(std::string name, Action execute, Action undo)
+			: name_(std::move(name)), execute_(std::move(execute)), undo_(std::move(undo)) {}
+
+		void Execute() override
+		{
+			if (execute_) execute_(); // Redo時も初回実行と同じ処理を呼び出す。
+		}
+
+		void Undo() override
+		{
+			if (undo_) undo_();
+		}
+
+		const std::string& GetName() const override { return name_; }
+
+	private:
+		std::string name_;
+		Action execute_;
+		Action undo_;
+	};
+
+	/// <summary>値の変更前後と書き戻し関数を保持する汎用Commandです。</summary>
+	template<class TValue>
+	class EditorValueCommand final : public IEditorCommand
+	{
+	public:
+		using Apply = std::function<void(const TValue&)>;
+
+		EditorValueCommand(std::string name, TValue before, TValue after, Apply apply)
+			: name_(std::move(name)), before_(std::move(before)), after_(std::move(after)), apply_(std::move(apply)) {}
+
+		void Execute() override
+		{
+			if (apply_) apply_(after_);
+		}
+
+		void Undo() override
+		{
+			if (apply_) apply_(before_);
+		}
+
+		const std::string& GetName() const override { return name_; }
+
+	private:
+		std::string name_;
+		TValue before_{};
+		TValue after_{};
+		Apply apply_;
+	};
+
+	/// <summary>文字列化したInspector状態を復元するCommandです。</summary>
+	class EditorStateCommand final : public IEditorCommand
+	{
+	public:
+		using Apply = std::function<void(std::string_view)>;
+
+		EditorStateCommand(std::string name, std::string before, std::string after, Apply apply)
+			: name_(std::move(name)), before_(std::move(before)), after_(std::move(after)), apply_(std::move(apply)) {}
+
+		void Execute() override
+		{
+			if (apply_) apply_(after_);
+		}
+
+		void Undo() override
+		{
+			if (apply_) apply_(before_);
+		}
+
+		const std::string& GetName() const override { return name_; }
+
+	private:
+		std::string name_;
+		std::string before_;
+		std::string after_;
+		Apply apply_;
+	};
+
+	/// <summary>Editor全体のCommand履歴とUndo / Redo位置を管理します。</summary>
+	class EditorCommandHistory
+	{
+	public:
+		static EditorCommandHistory* GetInstance()
+		{
+			static EditorCommandHistory instance;
+			return &instance;
+		}
+
+		void Execute(std::unique_ptr<IEditorCommand> command)
+		{
+			if (!command || isReplaying_) return;
+			command->Execute();
+			PushInternal(std::move(command));
+		}
+
+		void PushExecuted(std::unique_ptr<IEditorCommand> command)
+		{
+			if (!command || isReplaying_) return;
+			PushInternal(std::move(command)); // 既に画面へ反映済みのドラッグ操作は再実行せず履歴だけ追加する。
+		}
+
+		bool Undo()
+		{
+			if (!CanUndo()) return false;
+			isReplaying_ = true;
+			--cursor_;
+			commands_[cursor_]->Undo();
+			isReplaying_ = false;
+			return true;
+		}
+
+		bool Redo()
+		{
+			if (!CanRedo()) return false;
+			isReplaying_ = true;
+			commands_[cursor_]->Execute();
+			++cursor_;
+			isReplaying_ = false;
+			return true;
+		}
+
+		void Clear()
+		{
+			commands_.clear();
+			cursor_ = 0;
+		}
+
+		bool CanUndo() const { return cursor_ > 0 && cursor_ <= commands_.size(); }
+		bool CanRedo() const { return cursor_ < commands_.size(); }
+		bool IsReplaying() const { return isReplaying_; }
+		std::size_t GetUndoCount() const { return cursor_; }
+		std::size_t GetRedoCount() const { return commands_.size() - cursor_; }
+
+		const char* GetUndoName() const
+		{
+			return CanUndo() ? commands_[cursor_ - 1]->GetName().c_str() : nullptr;
+		}
+
+		const char* GetRedoName() const
+		{
+			return CanRedo() ? commands_[cursor_]->GetName().c_str() : nullptr;
+		}
+
+		void SetCapacity(std::size_t capacity)
+		{
+			capacity_ = std::max<std::size_t>(1, capacity);
+			TrimToCapacity();
+		}
+
+	private:
+		EditorCommandHistory() = default;
+
+		void PushInternal(std::unique_ptr<IEditorCommand> command)
+		{
+			if (cursor_ < commands_.size())
+			{
+				commands_.erase(commands_.begin() + static_cast<std::ptrdiff_t>(cursor_), commands_.end());
+			}
+			commands_.push_back(std::move(command));
+			cursor_ = commands_.size();
+			TrimToCapacity();
+		}
+
+		void TrimToCapacity()
+		{
+			if (commands_.size() <= capacity_) return;
+			const std::size_t removeCount = commands_.size() - capacity_;
+			commands_.erase(commands_.begin(), commands_.begin() + static_cast<std::ptrdiff_t>(removeCount));
+			cursor_ = cursor_ > removeCount ? cursor_ - removeCount : 0;
+		}
+
+		std::vector<std::unique_ptr<IEditorCommand>> commands_;
+		std::size_t cursor_ = 0;
+		std::size_t capacity_ = 256;
+		bool isReplaying_ = false;
+	};
+} // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorHierarchyPanel.h
+++ b/Project/Engine/Editor/EditorHierarchyPanel.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "EditorCommandHistory.h"
 #include "EditorContext.h"
 #include "EditorPanelIds.h"
 #include "EditorWindowManager.h"
@@ -13,6 +14,8 @@
 #include <cctype>
 #include <cstdint>
 #include <cstdio>
+#include <functional>
+#include <memory>
 #include <string>
 #include <string_view>
 #include <vector>
@@ -23,9 +26,7 @@
 
 namespace Ken4lowEngine
 {
-	/// <summary>
-	/// World OutlinerとDetailsを同じEditorSelectionへ接続し、UE風の階層・検索・Inspector表示を提供します。
-	/// </summary>
+	/// <summary>World OutlinerとDetailsを同じEditorSelectionへ接続します。</summary>
 	class EditorHierarchyPanel
 	{
 	public:
@@ -54,20 +55,12 @@ namespace Ken4lowEngine
 #ifdef USE_IMGUI
 		static char ToLowerAscii(unsigned char character)
 		{
-			if (character >= 'A' && character <= 'Z')
-			{
-				return static_cast<char>(character - 'A' + 'a');
-			}
-			return static_cast<char>(character);
+			return character >= 'A' && character <= 'Z' ? static_cast<char>(character - 'A' + 'a') : static_cast<char>(character);
 		}
 
 		static bool ContainsCaseInsensitive(std::string_view text, std::string_view filter)
 		{
-			if (filter.empty())
-			{
-				return true;
-			}
-
+			if (filter.empty()) return true;
 			std::string loweredText(text);
 			std::string loweredFilter(filter);
 			std::transform(loweredText.begin(), loweredText.end(), loweredText.begin(), [](unsigned char c) { return ToLowerAscii(c); });
@@ -80,21 +73,11 @@ namespace Ken4lowEngine
 			objects_.clear();
 			SceneManager* sceneManager = EditorWindowManager::GetInstance()->GetSceneManager();
 			BaseScene* scene = sceneManager ? sceneManager->GetCurrentScene() : nullptr;
-			if (scene)
-			{
-				scene->CollectEditorObjects(objects_);
-			}
-
+			if (scene) scene->CollectEditorObjects(objects_);
 			std::stable_sort(objects_.begin(), objects_.end(), [](const EditorObjectInfo& lhs, const EditorObjectInfo& rhs)
 				{
-					if (lhs.parentId != rhs.parentId)
-					{
-						return lhs.parentId < rhs.parentId;
-					}
-					if (lhs.sortOrder != rhs.sortOrder)
-					{
-						return lhs.sortOrder < rhs.sortOrder;
-					}
+					if (lhs.parentId != rhs.parentId) return lhs.parentId < rhs.parentId;
+					if (lhs.sortOrder != rhs.sortOrder) return lhs.sortOrder < rhs.sortOrder;
 					return lhs.displayName < rhs.displayName;
 				});
 		}
@@ -102,22 +85,16 @@ namespace Ken4lowEngine
 		void RefreshSelection()
 		{
 			EditorSelection& selection = EditorContext::GetInstance()->GetSelection();
-			if (!selection.HasSelection())
-			{
-				return;
-			}
-
+			if (!selection.HasSelection()) return;
 			const EditorObjectInfo& selected = selection.GetSelected();
 			const auto current = std::find_if(objects_.begin(), objects_.end(), [&selected](const EditorObjectInfo& object)
 				{
 					return object.id == selected.id && object.sceneName == selected.sceneName;
 				});
-			if (current != objects_.end())
-			{
-				selection.RefreshSelected(*current);
-			}
+			if (current != objects_.end()) selection.RefreshSelected(*current);
 			else
 			{
+				CancelInspectorTransaction();
 				selection.Clear();
 			}
 		}
@@ -125,93 +102,56 @@ namespace Ken4lowEngine
 		bool MatchesFilter(const EditorObjectInfo& object) const
 		{
 			const std::string_view filter(outlinerSearch_.data());
-			return ContainsCaseInsensitive(object.displayName, filter) ||
-				ContainsCaseInsensitive(object.typeName, filter) ||
-				ContainsCaseInsensitive(object.sceneName, filter);
+			return ContainsCaseInsensitive(object.displayName, filter) || ContainsCaseInsensitive(object.typeName, filter) || ContainsCaseInsensitive(object.sceneName, filter);
 		}
 
 		bool HasMatchingDescendant(uint64_t objectId) const
 		{
 			for (const EditorObjectInfo& child : objects_)
 			{
-				if (child.parentId != objectId)
-				{
-					continue;
-				}
-				if (MatchesFilter(child) || HasMatchingDescendant(child.id))
-				{
-					return true;
-				}
+				if (child.parentId == objectId && (MatchesFilter(child) || HasMatchingDescendant(child.id))) return true;
 			}
 			return false;
 		}
 
 		bool HasChildren(uint64_t objectId) const
 		{
-			return std::any_of(objects_.begin(), objects_.end(), [objectId](const EditorObjectInfo& object)
-				{
-					return object.parentId == objectId;
-				});
+			return std::any_of(objects_.begin(), objects_.end(), [objectId](const EditorObjectInfo& object) { return object.parentId == objectId; });
 		}
 
 		bool IsSelected(const EditorObjectInfo& object) const
 		{
 			const EditorSelection& selection = EditorContext::GetInstance()->GetSelection();
-			return selection.HasSelection() &&
-				selection.GetSelected().id == object.id &&
-				selection.GetSelected().sceneName == object.sceneName;
+			return selection.HasSelection() && selection.GetSelected().id == object.id && selection.GetSelected().sceneName == object.sceneName;
 		}
 
 		void DrawObjectNode(const EditorObjectInfo& object)
 		{
 			const std::string_view filter(outlinerSearch_.data());
 			const bool filterActive = !filter.empty();
-			if (filterActive && !MatchesFilter(object) && !HasMatchingDescendant(object.id))
-			{
-				return;
-			}
+			if (filterActive && !MatchesFilter(object) && !HasMatchingDescendant(object.id)) return;
 
 			ImGui::PushID(static_cast<int>(object.id & 0x7fffffff));
-
 			bool active = true;
 			if (object.ReadActive(active))
 			{
-				if (ImGui::Checkbox("##OutlinerActive", &active))
-				{
-					object.WriteActive(active);
-				}
-				if (ImGui::IsItemHovered())
-				{
-					ImGui::SetTooltip(active ? "有効" : "無効");
-				}
+				if (ImGui::Checkbox("##OutlinerActive", &active)) object.WriteActive(active);
+				if (ImGui::IsItemHovered()) ImGui::SetTooltip(active ? "有効" : "無効");
 				ImGui::SameLine();
 			}
 
 			const bool hasChildren = HasChildren(object.id);
-			ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_SpanAvailWidth |
-				ImGuiTreeNodeFlags_OpenOnArrow |
-				ImGuiTreeNodeFlags_OpenOnDoubleClick;
-			if (!hasChildren)
-			{
-				flags |= ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen;
-			}
-			if (IsSelected(object))
-			{
-				flags |= ImGuiTreeNodeFlags_Selected;
-			}
-			if (object.objectKind == EditorObjectKind::Actor)
-			{
-				flags |= ImGuiTreeNodeFlags_DefaultOpen;
-			}
-			if (filterActive && hasChildren)
-			{
-				ImGui::SetNextItemOpen(true, ImGuiCond_Always);
-			}
+			ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_SpanAvailWidth | ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick;
+			if (!hasChildren) flags |= ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen;
+			if (IsSelected(object)) flags |= ImGuiTreeNodeFlags_Selected;
+			if (object.objectKind == EditorObjectKind::Actor) flags |= ImGuiTreeNodeFlags_DefaultOpen;
+			if (filterActive && hasChildren) ImGui::SetNextItemOpen(true, ImGuiCond_Always);
 
 			const std::string label = object.icon + "  " + object.displayName + "##OutlinerNode";
 			const bool opened = ImGui::TreeNodeEx(label.c_str(), flags);
 			if (ImGui::IsItemClicked(ImGuiMouseButton_Left))
 			{
+				CommitInspectorTransaction();
 				EditorContext::GetInstance()->GetSelection().Select(object);
 			}
 
@@ -224,29 +164,16 @@ namespace Ken4lowEngine
 					std::snprintf(renameBuffer_.data(), renameBuffer_.size(), "%s", object.displayName.c_str());
 					openRenamePopup_ = true;
 				}
-				if (object.canDuplicate && ImGui::MenuItem("複製"))
-				{
-					object.RequestDuplicate();
-				}
-				if (object.canDelete && ImGui::MenuItem("削除"))
-				{
-					object.RequestDelete();
-				}
+				if (object.canDuplicate && ImGui::MenuItem("複製")) object.RequestDuplicate();
+				if (object.canDelete && ImGui::MenuItem("削除")) object.RequestDelete();
 				ImGui::EndPopup();
 			}
 
 			if (hasChildren && opened)
 			{
-				for (const EditorObjectInfo& child : objects_)
-				{
-					if (child.parentId == object.id)
-					{
-						DrawObjectNode(child);
-					}
-				}
+				for (const EditorObjectInfo& child : objects_) if (child.parentId == object.id) DrawObjectNode(child);
 				ImGui::TreePop();
 			}
-
 			ImGui::PopID();
 		}
 
@@ -257,7 +184,6 @@ namespace Ken4lowEngine
 				ImGui::OpenPopup("名前を変更##OutlinerRename");
 				openRenamePopup_ = false;
 			}
-
 			if (ImGui::BeginPopupModal("名前を変更##OutlinerRename", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
 			{
 				ImGui::SetNextItemWidth(320.0f);
@@ -265,22 +191,12 @@ namespace Ken4lowEngine
 				ImGui::Separator();
 				if (ImGui::Button("変更", ImVec2(120.0f, 0.0f)))
 				{
-					const auto target = std::find_if(objects_.begin(), objects_.end(), [this](const EditorObjectInfo& object)
-						{
-							return object.id == renameTargetId_;
-						});
-					if (target != objects_.end())
-					{
-						target->Rename(renameBuffer_.data());
-						EditorContext::GetInstance()->GetSelection().RefreshSelected(*target);
-					}
+					const auto target = std::find_if(objects_.begin(), objects_.end(), [this](const EditorObjectInfo& object) { return object.id == renameTargetId_; });
+					if (target != objects_.end()) target->Rename(renameBuffer_.data());
 					ImGui::CloseCurrentPopup();
 				}
 				ImGui::SameLine();
-				if (ImGui::Button("キャンセル", ImVec2(120.0f, 0.0f)))
-				{
-					ImGui::CloseCurrentPopup();
-				}
+				if (ImGui::Button("キャンセル", ImVec2(120.0f, 0.0f))) ImGui::CloseCurrentPopup();
 				ImGui::EndPopup();
 			}
 		}
@@ -288,11 +204,7 @@ namespace Ken4lowEngine
 		void DrawWorldOutliner()
 		{
 			auto& windowState = EditorWindowManager::GetInstance()->GetWindowState();
-			if (!windowState.showWorldOutliner)
-			{
-				return;
-			}
-
+			if (!windowState.showWorldOutliner) return;
 			const ImGuiWindowFlags windowFlags = ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse;
 			if (ImGui::Begin(EditorPanelIds::WorldOutliner, &windowState.showWorldOutliner, windowFlags))
 			{
@@ -300,23 +212,13 @@ namespace Ken4lowEngine
 				ImGui::InputTextWithHint("##OutlinerSearch", "アクタやコンポーネントを検索...", outlinerSearch_.data(), outlinerSearch_.size());
 				ImGui::TextDisabled("表示中: %zu", objects_.size());
 				ImGui::Separator();
-
 				if (ImGui::BeginChild("##WorldOutlinerBody", ImVec2(0.0f, 0.0f), false))
 				{
 					const char* sceneLabel = objects_.empty() ? "現在のシーン" : objects_.front().sceneName.c_str();
 					if (ImGui::TreeNodeEx(sceneLabel, ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_SpanAvailWidth))
 					{
-						if (objects_.empty())
-						{
-							ImGui::TextDisabled("表示できるEditorオブジェクトがありません。");
-						}
-						for (const EditorObjectInfo& object : objects_)
-						{
-							if (object.parentId == 0)
-							{
-								DrawObjectNode(object);
-							}
-						}
+						if (objects_.empty()) ImGui::TextDisabled("表示できるEditorオブジェクトがありません。");
+						for (const EditorObjectInfo& object : objects_) if (object.parentId == 0) DrawObjectNode(object);
 						ImGui::TreePop();
 					}
 				}
@@ -334,7 +236,6 @@ namespace Ken4lowEngine
 				ImGui::TextDisabled("%s", selected.transformUnavailableReason.c_str());
 				return;
 			}
-
 			bool changed = false;
 			changed |= ImGui::DragFloat3("位置", &transform.position.x, 0.1f);
 			changed |= ImGui::DragFloat3("回転", &transform.rotation.x, 0.01f);
@@ -343,18 +244,73 @@ namespace Ken4lowEngine
 			{
 				selected.WriteTransform(transform);
 				EditorContext::GetInstance()->MarkLevelDirty();
-				// Property変更をDirty状態へ接続し、Phase 10のLevel保存で未保存変更を判定できるようにする。
 			}
+		}
+
+		void CommitInspectorTransaction()
+		{
+			if (!inspectorTransactionActive_) return;
+			if (!inspectorBeforeState_.empty() && inspectorBeforeState_ != inspectorAfterState_)
+			{
+				const EditorObjectInfo target = inspectorTarget_;
+				EditorCommandHistory::GetInstance()->PushExecuted(std::make_unique<EditorStateCommand>(
+					"プロパティ変更", inspectorBeforeState_, inspectorAfterState_,
+					[target](std::string_view state)
+					{
+						target.RestoreState(state);
+						EditorContext::GetInstance()->MarkLevelDirty();
+					}));
+			}
+			CancelInspectorTransaction();
+		}
+
+		void CancelInspectorTransaction()
+		{
+			inspectorTransactionActive_ = false;
+			inspectorTarget_ = {};
+			inspectorBeforeState_.clear();
+			inspectorAfterState_.clear();
+		}
+
+		void DrawInspectorWithHistory(const EditorObjectInfo& selected, const std::function<void()>& drawInspector)
+		{
+			if (!selected.canCaptureState)
+			{
+				drawInspector();
+				return;
+			}
+
+			const std::string beforeFrame = selected.CaptureState();
+			drawInspector();
+
+			const EditorSelection& selection = EditorContext::GetInstance()->GetSelection();
+			if (!selection.HasSelection() || selection.GetSelected().id != selected.id || selection.GetSelected().sceneName != selected.sceneName)
+			{
+				CancelInspectorTransaction();
+				return; // 削除や再構築で対象が変わったフレームは古いCallbackを呼ばない。
+			}
+
+			const std::string afterFrame = selected.CaptureState();
+			const bool changed = !beforeFrame.empty() && beforeFrame != afterFrame;
+			if (changed)
+			{
+				if (!inspectorTransactionActive_ || inspectorTarget_.id != selected.id)
+				{
+					CommitInspectorTransaction();
+					inspectorTransactionActive_ = true;
+					inspectorTarget_ = selected;
+					inspectorBeforeState_ = beforeFrame;
+				}
+				inspectorAfterState_ = afterFrame;
+				EditorContext::GetInstance()->MarkLevelDirty();
+			}
+			if (inspectorTransactionActive_ && inspectorTarget_.id == selected.id && !ImGui::IsAnyItemActive()) CommitInspectorTransaction();
 		}
 
 		void DrawDetails()
 		{
 			auto& windowState = EditorWindowManager::GetInstance()->GetWindowState();
-			if (!windowState.showDetails)
-			{
-				return;
-			}
-
+			if (!windowState.showDetails) return;
 			const ImGuiWindowFlags windowFlags = ImGuiWindowFlags_NoScrollbar | ImGuiWindowFlags_NoScrollWithMouse;
 			if (ImGui::Begin(EditorPanelIds::Details, &windowState.showDetails, windowFlags))
 			{
@@ -363,12 +319,13 @@ namespace Ken4lowEngine
 					EditorSelection& selection = EditorContext::GetInstance()->GetSelection();
 					if (!selection.HasSelection())
 					{
+						CommitInspectorTransaction();
 						ImGui::TextDisabled("オブジェクトが選択されていません。");
 					}
 					else
 					{
-						const EditorObjectInfo& selected = selection.GetSelected();
-						ImGui::PushID(static_cast<int>(selected.id & 0x7fffffff)); // 選択オブジェクトごとにDetails全体のID空間を分離する。
+						const EditorObjectInfo selected = selection.GetSelected();
+						ImGui::PushID(static_cast<int>(selected.id & 0x7fffffff));
 						ImGui::Text("%s  %s", selected.icon.c_str(), selected.displayName.c_str());
 						ImGui::TextDisabled("%s", selected.typeName.c_str());
 
@@ -377,53 +334,37 @@ namespace Ken4lowEngine
 							std::array<char, 256> nameBuffer{};
 							std::snprintf(nameBuffer.data(), nameBuffer.size(), "%s", selected.displayName.c_str());
 							ImGui::SetNextItemWidth(-1.0f);
-							if (ImGui::InputText("名前##SelectedObjectName", nameBuffer.data(), nameBuffer.size(), ImGuiInputTextFlags_EnterReturnsTrue))
-							{
-								selected.Rename(nameBuffer.data());
-								EditorContext::GetInstance()->MarkLevelDirty();
-							}
+							if (ImGui::InputText("名前##SelectedObjectName", nameBuffer.data(), nameBuffer.size(), ImGuiInputTextFlags_EnterReturnsTrue)) selected.Rename(nameBuffer.data());
 						}
 
 						bool active = true;
-						if (selected.ReadActive(active) && ImGui::Checkbox("有効##SelectedObjectActive", &active))
-						{
-							selected.WriteActive(active);
-							EditorContext::GetInstance()->MarkLevelDirty();
-						}
+						if (selected.ReadActive(active) && ImGui::Checkbox("有効##SelectedObjectActive", &active)) selected.WriteActive(active);
 
 						if (ImGui::CollapsingHeader("基本情報##SelectedObjectInfo", ImGuiTreeNodeFlags_DefaultOpen))
 						{
 							ImGui::Text("種類: %s", selected.typeName.c_str());
 							ImGui::Text("シーン: %s", selected.sceneName.c_str());
 							ImGui::TextDisabled("Editor ID: %llu", static_cast<unsigned long long>(selected.id));
-							if (!selected.inspectorHint.empty())
-							{
-								ImGui::TextDisabled("%s", selected.inspectorHint.c_str());
-							}
+							if (!selected.inspectorHint.empty()) ImGui::TextDisabled("%s", selected.inspectorHint.c_str());
 						}
 
 						ImGui::Separator();
-						if (selected.drawInspector)
-						{
-							ImGui::PushID("SelectedObjectInspector");
-							selected.drawInspector();
-							ImGui::PopID();
-						}
-						else
-						{
-							switch (selected.inspectorType)
+						DrawInspectorWithHistory(selected, [&selected]()
 							{
-							case EditorInspectorType::Transform:
-								DrawFallbackTransformInspector(selected);
-								break;
-							case EditorInspectorType::PunctualLights:
-								LightManager::GetInstance()->DrawPunctualLightsInspector();
-								break;
-							default:
-								ImGui::TextDisabled("このオブジェクトの詳細表示は未実装です。");
-								break;
-							}
-						}
+								if (selected.drawInspector)
+								{
+									ImGui::PushID("SelectedObjectInspector");
+									selected.drawInspector();
+									ImGui::PopID();
+									return;
+								}
+								switch (selected.inspectorType)
+								{
+								case EditorInspectorType::Transform: EditorHierarchyPanel::GetInstance()->DrawFallbackTransformInspector(selected); break;
+								case EditorInspectorType::PunctualLights: LightManager::GetInstance()->DrawPunctualLightsInspector(); break;
+								default: ImGui::TextDisabled("このオブジェクトの詳細表示は未実装です。"); break;
+								}
+							});
 						ImGui::PopID();
 					}
 				}
@@ -438,5 +379,9 @@ namespace Ken4lowEngine
 		std::array<char, 256> renameBuffer_{};
 		uint64_t renameTargetId_ = 0;
 		bool openRenamePopup_ = false;
+		bool inspectorTransactionActive_ = false;
+		EditorObjectInfo inspectorTarget_{};
+		std::string inspectorBeforeState_;
+		std::string inspectorAfterState_;
 	};
 } // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorModeController.cpp
+++ b/Project/Engine/Editor/EditorModeController.cpp
@@ -1,11 +1,17 @@
 #include "EditorModeController.h"
 
+#include "EditorCommandHistory.h"
+#include "EditorContext.h"
 #include "EditorPlayController.h"
 #include "EditorWindowManager.h"
 #include <Input.h>
 #include <Wireframe.h>
 
 #include <string>
+
+#ifdef USE_IMGUI
+#include <imgui.h>
+#endif
 
 namespace Ken4lowEngine
 {
@@ -18,10 +24,8 @@ namespace Ken4lowEngine
 	void EditorModeController::Initialize()
 	{
 #ifdef _DEBUG
-		// Debug起動直後は従来通りEditor Modeから始める。
 		editorModeEnabled_ = true;
 #else
-		// ReleaseではEditor機能を開かず、常にゲーム画面確認相当にする。
 		editorModeEnabled_ = false;
 #endif
 		ApplyModeSideEffects();
@@ -32,11 +36,32 @@ namespace Ken4lowEngine
 #ifdef _DEBUG
 		if (input != nullptr && input->TriggerRawKey(DIK_F1))
 		{
-			// F1はゲーム操作と競合しにくいDebug専用ショートカットとして扱う。
-			SetEditorModeEnabled(!editorModeEnabled_);
+			SetEditorModeEnabled(!editorModeEnabled_); // F1はEditor / Game Preview切り替え専用にする。
 		}
 
 		EditorPlayController* playController = EditorPlayController::GetInstance();
+		if (input != nullptr && IsEditorModeEnabled() && playController->IsEditing())
+		{
+			bool allowHistoryShortcut = true;
+#ifdef USE_IMGUI
+			allowHistoryShortcut = !ImGui::GetIO().WantTextInput;
+#endif
+			if (allowHistoryShortcut)
+			{
+				const bool control = input->PushRawKey(DIK_LCONTROL) || input->PushRawKey(DIK_RCONTROL);
+				const bool shift = input->PushRawKey(DIK_LSHIFT) || input->PushRawKey(DIK_RSHIFT);
+				EditorCommandHistory* history = EditorCommandHistory::GetInstance();
+				bool changed = false;
+				if (control && input->TriggerRawKey(DIK_Z)) changed = shift ? history->Redo() : history->Undo();
+				else if (control && input->TriggerRawKey(DIK_Y)) changed = history->Redo();
+				if (changed)
+				{
+					EditorContext::GetInstance()->MarkLevelDirty();
+					EditorWindowManager::GetInstance()->AddOutputLog(EditorLogLevel::Info, "[Editor] Undo / Redoを実行しました。");
+				}
+			}
+		}
+
 		if (input != nullptr && IsEditorModeEnabled() && playController->IsPlaying() &&
 			playController->IsGameCaptured() && input->TriggerRawKey(DIK_ESCAPE))
 		{
@@ -47,7 +72,7 @@ namespace Ken4lowEngine
 		{
 			input->SetGameInputEnabled(false);
 			input->SetLockCursor(false);
-			input->SetCursorVisible(true); // UI Mouse SceneでもScene更新前にゲーム入力を止め、Editor操作へ戻す。
+			input->SetCursorVisible(true);
 		}
 #else
 		(void)input;
@@ -67,6 +92,7 @@ namespace Ken4lowEngine
 		}
 
 		editorModeEnabled_ = enabled;
+		if (!editorModeEnabled_) EditorCommandHistory::GetInstance()->Clear(); // Editor対象が無効になる前に古いポインタを持つ履歴を破棄する。
 		ApplyModeSideEffects();
 		NotifyModeChanged();
 	}
@@ -82,14 +108,11 @@ namespace Ken4lowEngine
 
 	void EditorModeController::ApplyModeSideEffects()
 	{
-		// Debug表示の最終入口をモードと同期し、Game Preview中はWireframe/Collider線を破棄する。
 		Wireframe::GetInstance()->SetDebugDrawEnabled(ShouldDrawDebugVisuals());
-
 		if (Input* input = Input::GetInstance())
 		{
 			if (IsGamePreviewMode())
 			{
-				// Preview中はEditor Viewport由来の座標補正と入力抑制を解除し、ゲーム入力を優先する。
 				input->SetGameInputEnabled(true);
 				input->ClearEditorViewportMouseOverride();
 			}
@@ -103,5 +126,4 @@ namespace Ken4lowEngine
 		EditorWindowManager::GetInstance()->AddOutputLog(EditorLogLevel::Info, std::string("[Editor] Switched to ") + modeName + " (F1).");
 #endif
 	}
-
 } // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorObjectInfo.h
+++ b/Project/Engine/Editor/EditorObjectInfo.h
@@ -33,7 +33,7 @@ namespace Ken4lowEngine
 		Generic,
 		Actor,
 		Component,
-		Instance, // GPU Instancing内の1要素を独立したEditor選択対象として扱う。
+		Instance,
 	};
 
 	enum class EditorInspectorType
@@ -85,6 +85,8 @@ namespace Ken4lowEngine
 		using WriteActiveFunc = std::function<void(bool)>;
 		using RenameFunc = std::function<void(std::string_view)>;
 		using RequestActionFunc = std::function<void()>;
+		using CaptureStateFunc = std::function<std::string()>;
+		using RestoreStateFunc = std::function<void(std::string_view)>;
 
 		EditorObjectInfo() = default;
 		EditorObjectInfo(uint64_t objectId, std::string objectDisplayName, std::string objectTypeName, std::string objectSceneName)
@@ -119,6 +121,10 @@ namespace Ken4lowEngine
 		RequestActionFunc requestDuplicate;
 		bool canDelete = false;
 		RequestActionFunc requestDelete;
+
+		bool canCaptureState = false;
+		CaptureStateFunc captureState;
+		RestoreStateFunc restoreState;
 
 		bool canDrawObjectId = false;
 		DrawObjectIdFunc drawObjectId;
@@ -177,6 +183,16 @@ namespace Ken4lowEngine
 		void RequestDelete() const
 		{
 			if (canDelete && requestDelete) requestDelete();
+		}
+
+		std::string CaptureState() const
+		{
+			return canCaptureState && captureState ? captureState() : std::string{};
+		}
+
+		void RestoreState(std::string_view state) const
+		{
+			if (canCaptureState && restoreState) restoreState(state); // Inspector Commandは同じ対象へ文字列化した状態を戻す。
 		}
 
 		void DrawObjectId(uint32_t objectId) const

--- a/Project/Engine/Editor/EditorPlayController.cpp
+++ b/Project/Engine/Editor/EditorPlayController.cpp
@@ -1,8 +1,8 @@
 #include "EditorPlayController.h"
+#include "EditorCommandHistory.h"
 
 namespace Ken4lowEngine
 {
-
 	EditorPlayController* EditorPlayController::GetInstance()
 	{
 		static EditorPlayController instance;
@@ -11,7 +11,10 @@ namespace Ken4lowEngine
 
 	void EditorPlayController::Play()
 	{
-		// 再生開始時はゲーム操作へ即入れるように入力キャプチャも同時に有効化する。
+		if (playState_ == EditorPlayState::Edit)
+		{
+			EditorCommandHistory::GetInstance()->Clear(); // Runtime更新でEditor対象が変化する前に履歴を破棄する。
+		}
 		playState_ = EditorPlayState::Play;
 		inputMode_ = EditorInputMode::GameCaptured;
 	}
@@ -19,93 +22,44 @@ namespace Ken4lowEngine
 	void EditorPlayController::Pause()
 	{
 		playState_ = EditorPlayState::Pause;
-		inputMode_ = EditorInputMode::GameReleased; // 一時停止後すぐにPause/Stopを操作できるようカーソルをEditorへ返す。
+		inputMode_ = EditorInputMode::GameReleased;
 	}
 
 	void EditorPlayController::Stop()
 	{
-		// 停止時は編集へ戻し、ゲーム入力を解放して各SceneのEsc処理とは独立させる。
 		playState_ = EditorPlayState::Edit;
 		inputMode_ = EditorInputMode::GameReleased;
 	}
 
 	void EditorPlayController::ToggleInputCapture()
 	{
-		// F8はEscと独立したゲーム入力キャプチャ専用トグルにする。
 		if (IsGameCaptured())
 		{
 			ReleaseGameInput();
 			return;
 		}
-
 		CaptureGameInput();
 	}
 
-	void EditorPlayController::CaptureGameInput()
-	{
-		// ゲーム入力取得中もゲーム更新は止めず、Main Viewport上の操作だけをゲームへ渡す。
-		inputMode_ = EditorInputMode::GameCaptured;
-	}
-
-	void EditorPlayController::ReleaseGameInput()
-	{
-		// 入力解放中はゲーム更新を継続したまま、操作だけをEditorとImGuiへ戻す。
-		inputMode_ = EditorInputMode::GameReleased;
-	}
-
-	void EditorPlayController::ForceReleaseToEditor()
-	{
-		// Shift+F8は現在状態に関係なくEditor操作へ復帰できる非常口にする。
-		ReleaseGameInput();
-	}
-
-	void EditorPlayController::SetDebugFreezeEnabled(bool enabled)
-	{
-		// デバッグ停止は入力キャプチャとは別機能としてToolbar表示だけ同期する。
-		debugFreezeEnabled_ = enabled;
-	}
-
-	bool EditorPlayController::IsEditing() const
-	{
-		return playState_ == EditorPlayState::Edit;
-	}
-
-	bool EditorPlayController::IsPlaying() const
-	{
-		return playState_ == EditorPlayState::Play;
-	}
-
-	bool EditorPlayController::IsPaused() const
-	{
-		return playState_ == EditorPlayState::Pause;
-	}
-
-	bool EditorPlayController::IsGameCaptured() const
-	{
-		return inputMode_ == EditorInputMode::GameCaptured;
-	}
-
-	bool EditorPlayController::IsGameReleased() const
-	{
-		return inputMode_ == EditorInputMode::GameReleased;
-	}
-
-	bool EditorPlayController::IsEditorInputMode() const
-	{
-		return inputMode_ == EditorInputMode::Editor;
-	}
+	void EditorPlayController::CaptureGameInput() { inputMode_ = EditorInputMode::GameCaptured; }
+	void EditorPlayController::ReleaseGameInput() { inputMode_ = EditorInputMode::GameReleased; }
+	void EditorPlayController::ForceReleaseToEditor() { ReleaseGameInput(); }
+	void EditorPlayController::SetDebugFreezeEnabled(bool enabled) { debugFreezeEnabled_ = enabled; }
+	bool EditorPlayController::IsEditing() const { return playState_ == EditorPlayState::Edit; }
+	bool EditorPlayController::IsPlaying() const { return playState_ == EditorPlayState::Play; }
+	bool EditorPlayController::IsPaused() const { return playState_ == EditorPlayState::Pause; }
+	bool EditorPlayController::IsGameCaptured() const { return inputMode_ == EditorInputMode::GameCaptured; }
+	bool EditorPlayController::IsGameReleased() const { return inputMode_ == EditorInputMode::GameReleased; }
+	bool EditorPlayController::IsEditorInputMode() const { return inputMode_ == EditorInputMode::Editor; }
 
 	const char* EditorPlayController::GetPlayStateText() const
 	{
 		switch (playState_)
 		{
-		case EditorPlayState::Play:
-			return "再生中";
-		case EditorPlayState::Pause:
-			return "一時停止";
+		case EditorPlayState::Play: return "再生中";
+		case EditorPlayState::Pause: return "一時停止";
 		case EditorPlayState::Edit:
-		default:
-			return "編集中";
+		default: return "編集中";
 		}
 	}
 
@@ -113,13 +67,10 @@ namespace Ken4lowEngine
 	{
 		switch (inputMode_)
 		{
-		case EditorInputMode::GameCaptured:
-			return "ゲーム入力取得";
-		case EditorInputMode::GameReleased:
-			return "エディターへ解放";
+		case EditorInputMode::GameCaptured: return "ゲーム入力取得";
+		case EditorInputMode::GameReleased: return "エディターへ解放";
 		case EditorInputMode::Editor:
-		default:
-			return "エディター入力";
+		default: return "エディター入力";
 		}
 	}
 
@@ -127,13 +78,10 @@ namespace Ken4lowEngine
 	{
 		switch (inputMode_)
 		{
-		case EditorInputMode::GameCaptured:
-			return "入力: ゲーム操作";
-		case EditorInputMode::GameReleased:
-			return "入力: エディターへ解放";
+		case EditorInputMode::GameCaptured: return "入力: ゲーム操作";
+		case EditorInputMode::GameReleased: return "入力: エディターへ解放";
 		case EditorInputMode::Editor:
-		default:
-			return "入力: エディター操作";
+		default: return "入力: エディター操作";
 		}
 	}
 
@@ -141,5 +89,4 @@ namespace Ken4lowEngine
 	{
 		return debugFreezeEnabled_ ? "デバッグ停止: 有効" : "デバッグ停止: 無効";
 	}
-
 } // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorTransformGizmo.cpp
+++ b/Project/Engine/Editor/EditorTransformGizmo.cpp
@@ -2,6 +2,7 @@
 #include "EditorTransformGizmo.h"
 
 #ifdef USE_IMGUI
+#include "EditorCommandHistory.h"
 #include "EditorContext.h"
 #include "EditorModeController.h"
 #include "EditorPlayController.h"
@@ -17,6 +18,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <memory>
 #include <numbers>
 
 namespace Ken4lowEngine
@@ -41,13 +43,21 @@ namespace Ken4lowEngine
 			return value < 0.0f ? -0.001f : 0.001f;
 		}
 
+		bool IsSameVector(const Vector3& lhs, const Vector3& rhs)
+		{
+			constexpr float epsilon = 0.00001f;
+			return std::abs(lhs.x - rhs.x) <= epsilon && std::abs(lhs.y - rhs.y) <= epsilon && std::abs(lhs.z - rhs.z) <= epsilon;
+		}
+
+		bool IsSameTransform(const EditorTransform& lhs, const EditorTransform& rhs)
+		{
+			return IsSameVector(lhs.position, rhs.position) && IsSameVector(lhs.rotation, rhs.rotation) && IsSameVector(lhs.scale, rhs.scale);
+		}
+
 		void UpdateToolShortcuts(EditorViewportController& controller)
 		{
 			const ImGuiIO& io = ImGui::GetIO();
-			if (io.WantTextInput || ImGui::IsAnyItemActive() || io.MouseDown[ImGuiMouseButton_Right] || io.MouseDown[ImGuiMouseButton_Middle])
-			{
-				return;
-			}
+			if (io.WantTextInput || ImGui::IsAnyItemActive() || io.MouseDown[ImGuiMouseButton_Right] || io.MouseDown[ImGuiMouseButton_Middle]) return;
 			if (ImGui::IsKeyPressed(ImGuiKey_Q, false)) controller.SetTool(EditorViewportTool::Select);
 			if (ImGui::IsKeyPressed(ImGuiKey_W, false)) controller.SetTool(EditorViewportTool::Translate);
 			if (ImGui::IsKeyPressed(ImGuiKey_E, false)) controller.SetTool(EditorViewportTool::Rotate);
@@ -59,23 +69,15 @@ namespace Ken4lowEngine
 			EditorTransform worldTransform{};
 			CameraManager* cameraManager = CameraManager::GetInstance();
 			DebugCamera* debugCamera = cameraManager->GetDebugCamera();
-			if (!cameraManager->IsUsingDebugCamera() || !debugCamera || !selected.TryReadWorldTransform(worldTransform))
-			{
-				return;
-			}
-			const Vector3 forward = cameraManager->GetActiveCameraForward();
-			debugCamera->SetTranslate(worldTransform.position - forward * 8.0f);
+			if (!cameraManager->IsUsingDebugCamera() || !debugCamera || !selected.TryReadWorldTransform(worldTransform)) return;
+			debugCamera->SetTranslate(worldTransform.position - cameraManager->GetActiveCameraForward() * 8.0f);
 			debugCamera->RefreshViewProjection();
 		}
 
 		void ReleaseViewportImageItemForGizmo(ImGuiWindow* viewportWindow)
 		{
 			ImGuiContext& context = *ImGui::GetCurrentContext();
-			if (context.HoveredWindow != viewportWindow || !ImGui::IsMouseClicked(ImGuiMouseButton_Left))
-			{
-				return;
-			}
-
+			if (context.HoveredWindow != viewportWindow || !ImGui::IsMouseClicked(ImGuiMouseButton_Left)) return;
 			context.HoveredId = 0;
 			context.HoveredIdPreviousFrame = 0;
 			ImGui::ClearActiveID(); // MainViewportのInvisibleButtonだけを解除してImGuizmoへ左クリックを渡す。
@@ -88,23 +90,65 @@ namespace Ken4lowEngine
 		return &instance;
 	}
 
+	void EditorTransformGizmo::BeginTransformCommand(const EditorObjectInfo& target, const EditorTransform& before)
+	{
+		transformCommandActive_ = true;
+		transformCommandTarget_ = target;
+		transformCommandBefore_ = before; // ドラッグ開始時の値を1回だけ保存して連続フレームを1履歴へまとめる。
+	}
+
+	void EditorTransformGizmo::EndTransformCommand()
+	{
+		if (!transformCommandActive_) return;
+
+		EditorTransform after{};
+		if (transformCommandTarget_.TryReadWorldTransform(after) && !IsSameTransform(transformCommandBefore_, after))
+		{
+			const EditorObjectInfo target = transformCommandTarget_;
+			EditorCommandHistory::GetInstance()->PushExecuted(std::make_unique<EditorValueCommand<EditorTransform>>(
+				"Transform変更",
+				transformCommandBefore_,
+				after,
+				[target](const EditorTransform& value)
+				{
+					target.WriteWorldTransform(value);
+					EditorContext::GetInstance()->MarkLevelDirty();
+				}));
+		}
+		transformCommandActive_ = false;
+		transformCommandTarget_ = {};
+	}
+
 	void EditorTransformGizmo::Draw()
 	{
-		if (!EditorModeController::GetInstance()->IsEditorModeEnabled() || EditorPlayController::GetInstance()->IsPlaying()) return;
+		if (!EditorModeController::GetInstance()->IsEditorModeEnabled() || EditorPlayController::GetInstance()->IsPlaying())
+		{
+			EndTransformCommand();
+			return;
+		}
 
 		EditorViewportController& viewportController = *EditorViewportController::GetInstance();
-		if (!viewportController.IsEditorDisplay()) return;
+		if (!viewportController.IsEditorDisplay())
+		{
+			EndTransformCommand();
+			return;
+		}
 		UpdateToolShortcuts(viewportController);
 
 		EditorSelection& selection = EditorContext::GetInstance()->GetSelection();
-		if (!selection.HasSelection()) return;
+		if (!selection.HasSelection())
+		{
+			EndTransformCommand();
+			return;
+		}
 
 		const EditorObjectInfo& selected = selection.GetSelected();
-		if (ImGui::IsKeyPressed(ImGuiKey_F, false) && !ImGui::GetIO().WantTextInput && !ImGui::IsAnyItemActive())
+		if (ImGui::IsKeyPressed(ImGuiKey_F, false) && !ImGui::GetIO().WantTextInput && !ImGui::IsAnyItemActive()) FocusDebugCamera(selected);
+		if (viewportController.GetTool() == EditorViewportTool::Select || !selected.canEditTransform)
 		{
-			FocusDebugCamera(selected);
+			EndTransformCommand();
+			return;
 		}
-		if (viewportController.GetTool() == EditorViewportTool::Select || !selected.canEditTransform) return;
 
 		const EditorViewportRect& viewportRect = EditorWindowManager::GetInstance()->GetMainViewportRect();
 		if (!viewportRect.valid || viewportRect.imageSize.x <= 1.0f || viewportRect.imageSize.y <= 1.0f) return;
@@ -135,7 +179,6 @@ namespace Ken4lowEngine
 		ImGuizmo::SetDrawlist(viewportWindow->DrawList);
 		ImGuizmo::SetAlternativeWindow(viewportWindow);
 		ImGuizmo::SetRect(viewportRect.screenMin.x, viewportRect.screenMin.y, viewportRect.imageSize.x, viewportRect.imageSize.y);
-
 		ReleaseViewportImageItemForGizmo(viewportWindow);
 
 		const EditorViewportTool activeTool = viewportController.GetTool();
@@ -154,10 +197,7 @@ namespace Ken4lowEngine
 				snap[1] = std::max(0.001f, translationSnap.y);
 				snap[2] = std::max(0.001f, translationSnap.z);
 			}
-			else if (activeTool == EditorViewportTool::Rotate)
-			{
-				snap[0] = std::max(0.1f, viewportController.GetRotationSnapDegrees());
-			}
+			else if (activeTool == EditorViewportTool::Rotate) snap[0] = std::max(0.1f, viewportController.GetRotationSnapDegrees());
 			else
 			{
 				snap[0] = std::max(0.001f, viewportController.GetScaleSnap());
@@ -170,33 +210,29 @@ namespace Ken4lowEngine
 		const bool changed = ImGuizmo::Manipulate(
 			&view.m[0][0], &projection.m[0][0], operation, mode,
 			&transformMatrix.m[0][0], nullptr, snapValues);
-		if (!changed) return;
+		const bool usingGizmo = ImGuizmo::IsUsing();
+		if (usingGizmo && !transformCommandActive_) BeginTransformCommand(selected, worldTransform);
 
-		float translation[3] = {};
-		float rotationDegrees[3] = {};
-		float scale[3] = {};
-		ImGuizmo::DecomposeMatrixToComponents(&transformMatrix.m[0][0], translation, rotationDegrees, scale);
+		if (changed)
+		{
+			float translation[3] = {};
+			float rotationDegrees[3] = {};
+			float scale[3] = {};
+			ImGuizmo::DecomposeMatrixToComponents(&transformMatrix.m[0][0], translation, rotationDegrees, scale);
 
-		constexpr float toRadians = std::numbers::pi_v<float> / 180.0f;
-		EditorTransform editedWorldTransform{};
-		editedWorldTransform.position = { translation[0], translation[1], translation[2] };
-		editedWorldTransform.rotation = {
-			rotationDegrees[0] * toRadians,
-			rotationDegrees[1] * toRadians,
-			rotationDegrees[2] * toRadians,
-		};
-		editedWorldTransform.scale = {
-			KeepScaleInvertible(scale[0]), KeepScaleInvertible(scale[1]), KeepScaleInvertible(scale[2]),
-		};
+			constexpr float toRadians = std::numbers::pi_v<float> / 180.0f;
+			EditorTransform editedWorldTransform{};
+			editedWorldTransform.position = { translation[0], translation[1], translation[2] };
+			editedWorldTransform.rotation = { rotationDegrees[0] * toRadians, rotationDegrees[1] * toRadians, rotationDegrees[2] * toRadians };
+			editedWorldTransform.scale = { KeepScaleInvertible(scale[0]), KeepScaleInvertible(scale[1]), KeepScaleInvertible(scale[2]) };
+			selected.WriteWorldTransform(editedWorldTransform);
+			EditorContext::GetInstance()->MarkLevelDirty();
+		}
 
-		selected.WriteWorldTransform(editedWorldTransform);
-		EditorContext::GetInstance()->MarkLevelDirty();
+		if (transformCommandActive_ && !usingGizmo) EndTransformCommand();
 	}
 
-	bool EditorTransformGizmo::IsUsing() const
-	{
-		return ImGuizmo::IsUsing();
-	}
+	bool EditorTransformGizmo::IsUsing() const { return ImGuizmo::IsUsing(); }
 
 	bool EditorTransformGizmo::IsOver() const
 	{

--- a/Project/Engine/Editor/EditorTransformGizmo.h
+++ b/Project/Engine/Editor/EditorTransformGizmo.h
@@ -1,23 +1,17 @@
 #pragma once
 
 #ifdef USE_IMGUI
+#include "EditorObjectInfo.h"
+
 namespace Ken4lowEngine
 {
-	/// <summary>
-	/// Main Viewport上で選択Objectの移動・回転・拡縮を操作します。
-	/// </summary>
+	/// <summary>Main Viewport上で選択Objectの移動・回転・拡縮を操作します。</summary>
 	class EditorTransformGizmo
 	{
 	public:
 		static EditorTransformGizmo* GetInstance();
-
-		/// <summary>Viewport Toolbar描画後にショートカットとImGuizmoを更新します。</summary>
 		void Draw();
-
-		/// <summary>現在Gizmo本体をドラッグしているか返します。</summary>
 		bool IsUsing() const;
-
-		/// <summary>マウスがGizmoの軸・平面・回転リング上にあるか返します。</summary>
 		bool IsOver() const;
 
 	private:
@@ -25,6 +19,13 @@ namespace Ken4lowEngine
 		~EditorTransformGizmo() = default;
 		EditorTransformGizmo(const EditorTransformGizmo&) = delete;
 		EditorTransformGizmo& operator=(const EditorTransformGizmo&) = delete;
+
+		void BeginTransformCommand(const EditorObjectInfo& target, const EditorTransform& before);
+		void EndTransformCommand();
+
+		bool transformCommandActive_ = false;
+		EditorObjectInfo transformCommandTarget_{};
+		EditorTransform transformCommandBefore_{};
 	};
 } // namespace Ken4lowEngine
 #endif // USE_IMGUI

--- a/Project/Engine/Scene/Actor/Core/ActorWorld_ComponentEdit.cpp
+++ b/Project/Engine/Scene/Actor/Core/ActorWorld_ComponentEdit.cpp
@@ -114,6 +114,7 @@ namespace Ken4lowEngine
 		ActorComponent* deleteTarget = selectedComponent_;
 		selectedComponent_ = nullptr;
 		selectedActor_ = owner;
+		EditorContext::GetInstance()->GetSelection().Clear(); // 削除直後のDetailsが破棄済みComponentを再参照しないようにする。
 		const bool removed = owner->RemoveComponent(deleteTarget);
 		if (wasPhysicsRegistered) RegisterPhysicsComponents(*owner);
 		if (!removed)

--- a/Project/Engine/Scene/Actor/Core/ActorWorld_ComponentEdit.cpp
+++ b/Project/Engine/Scene/Actor/Core/ActorWorld_ComponentEdit.cpp
@@ -59,10 +59,7 @@ namespace Ken4lowEngine
 		lastActorJsonSaveMessage_ = "Added Component : " + newComponent->GetName();
 
 		const std::string afterState = ActorJsonSerializer::SerializeActor(*targetActor).dump();
-		EditorCommandHistory::GetInstance()->Clear(); // Component再構築で無効になる古いComponentポインタを履歴へ残さない。
-		EditorCommandHistory::GetInstance()->PushExecuted(std::make_unique<EditorStateCommand>(
-			"コンポーネント追加", beforeState, afterState,
-			[this, targetActor](std::string_view stateText)
+		auto applyState = [this, targetActor](const std::string& stateText)
 			{
 				const nlohmann::json state = nlohmann::json::parse(stateText, nullptr, false);
 				if (state.is_discarded()) return;
@@ -73,6 +70,16 @@ namespace Ken4lowEngine
 				selectedComponent_ = nullptr;
 				EditorContext::GetInstance()->GetSelection().Clear();
 				EditorContext::GetInstance()->MarkLevelDirty();
+			};
+
+		EditorCommandHistory::GetInstance()->Clear();
+		EditorCommandHistory::GetInstance()->PushExecuted(std::make_unique<EditorLambdaCommand>(
+			"コンポーネント追加",
+			[applyState, afterState]() { applyState(afterState); },
+			[applyState, beforeState]()
+			{
+				applyState(beforeState);
+				EditorCommandHistory::GetInstance()->DiscardDependentRedoCommands(); // 再生成前のComponentを参照する後続Redoを除去する。
 			}));
 		EditorContext::GetInstance()->MarkLevelDirty();
 	}
@@ -125,10 +132,7 @@ namespace Ken4lowEngine
 		}
 
 		const std::string afterState = ActorJsonSerializer::SerializeActor(*owner).dump();
-		EditorCommandHistory::GetInstance()->Clear();
-		EditorCommandHistory::GetInstance()->PushExecuted(std::make_unique<EditorStateCommand>(
-			"コンポーネント削除", beforeState, afterState,
-			[this, owner](std::string_view stateText)
+		auto applyState = [this, owner](const std::string& stateText)
 			{
 				const nlohmann::json state = nlohmann::json::parse(stateText, nullptr, false);
 				if (state.is_discarded()) return;
@@ -139,6 +143,16 @@ namespace Ken4lowEngine
 				selectedComponent_ = nullptr;
 				EditorContext::GetInstance()->GetSelection().Clear();
 				EditorContext::GetInstance()->MarkLevelDirty();
+			};
+
+		EditorCommandHistory::GetInstance()->Clear();
+		EditorCommandHistory::GetInstance()->PushExecuted(std::make_unique<EditorLambdaCommand>(
+			"コンポーネント削除",
+			[applyState, afterState]() { applyState(afterState); },
+			[applyState, beforeState]()
+			{
+				applyState(beforeState);
+				EditorCommandHistory::GetInstance()->DiscardDependentRedoCommands();
 			}));
 		lastActorJsonSaveMessage_ = "Deleted Component : " + deletedComponentName;
 		EditorContext::GetInstance()->MarkLevelDirty();
@@ -209,10 +223,7 @@ namespace Ken4lowEngine
 		lastActorJsonSaveMessage_ = "Duplicated Component : " + duplicatedComponent->GetName();
 
 		const std::string afterState = ActorJsonSerializer::SerializeActor(*owner).dump();
-		EditorCommandHistory::GetInstance()->Clear();
-		EditorCommandHistory::GetInstance()->PushExecuted(std::make_unique<EditorStateCommand>(
-			"コンポーネント複製", beforeState, afterState,
-			[this, owner](std::string_view stateText)
+		auto applyState = [this, owner](const std::string& stateText)
 			{
 				const nlohmann::json state = nlohmann::json::parse(stateText, nullptr, false);
 				if (state.is_discarded()) return;
@@ -223,6 +234,16 @@ namespace Ken4lowEngine
 				selectedComponent_ = nullptr;
 				EditorContext::GetInstance()->GetSelection().Clear();
 				EditorContext::GetInstance()->MarkLevelDirty();
+			};
+
+		EditorCommandHistory::GetInstance()->Clear();
+		EditorCommandHistory::GetInstance()->PushExecuted(std::make_unique<EditorLambdaCommand>(
+			"コンポーネント複製",
+			[applyState, afterState]() { applyState(afterState); },
+			[applyState, beforeState]()
+			{
+				applyState(beforeState);
+				EditorCommandHistory::GetInstance()->DiscardDependentRedoCommands();
 			}));
 		EditorContext::GetInstance()->MarkLevelDirty();
 	}

--- a/Project/Engine/Scene/Actor/Core/ActorWorld_ComponentEdit.cpp
+++ b/Project/Engine/Scene/Actor/Core/ActorWorld_ComponentEdit.cpp
@@ -1,8 +1,13 @@
 #include "ActorWorld.h"
 
+#include "ActorJsonSerializer.h"
 #include "ComponentFactory.h"
+#include "EditorCommandHistory.h"
+#include "EditorContext.h"
 #include "SceneComponent.h"
 
+#include <json.hpp>
+#include <memory>
 #include <string>
 
 namespace Ken4lowEngine
@@ -10,12 +15,7 @@ namespace Ken4lowEngine
 	void ActorWorld::AddComponentToSelectedActor(std::string_view componentClassName)
 	{
 		Actor* targetActor = selectedActor_;
-
-		if (!targetActor && selectedComponent_)
-		{
-			targetActor = selectedComponent_->GetOwner(); // Component選択中なら所有Actorへ追加する
-		}
-
+		if (!targetActor && selectedComponent_) targetActor = selectedComponent_->GetOwner();
 		if (!targetActor)
 		{
 			lastActorJsonSaveMessage_ = "Add Component failed : no selected Actor";
@@ -23,147 +23,67 @@ namespace Ken4lowEngine
 		}
 
 		const std::string className{ componentClassName };
-
 		if (!ComponentFactory::IsAllowMultiple(className) && targetActor->HasComponentClass(className))
 		{
-			lastActorJsonSaveMessage_ = "Add Component failed : already exists" + className;
-			return; // alloMutiple = false のComponentはUI以外の経路からも重複追加させない
-		}
-
-		// 既にPhysicsWorldへ登録済みなら、一度解除してからComponentを追加する
-		const bool wasPhysicsRegistered = targetActor->IsPhysicsRegistered();
-		if (wasPhysicsRegistered)
-		{
-			UnregisterPhysicsComponents(*targetActor);
-		}
-
-		ActorComponent* newComponent = nullptr;
-
-		// RootComponentが無いActorにSceneComponent系を追加する場合はRootとして生成する
-		if (!targetActor->GetRootComponent())
-		{
-			newComponent = ComponentFactory::CreateRootSceneComponent(targetActor, componentClassName);
-		}
-
-		if (!newComponent)
-		{
-			newComponent = ComponentFactory::CreateComponent(targetActor, componentClassName);
-		}
-
-		if (!newComponent)
-		{
-			if (wasPhysicsRegistered)
-			{
-				RegisterPhysicsComponents(*targetActor); // 追加失敗時は元のPhysics登録状態へ戻す
-			}
-
-			lastActorJsonSaveMessage_ = "Add Component failed : " + std::string(componentClassName);
+			lastActorJsonSaveMessage_ = "Add Component failed : already exists " + className;
 			return;
 		}
 
-		// Component名が重複しないようにする
-		newComponent->SetName(MakeUniqueComponentName(*targetActor, std::string(componentClassName)));
+		const std::string beforeState = ActorJsonSerializer::SerializeActor(*targetActor).dump();
+		const bool wasPhysicsRegistered = targetActor->IsPhysicsRegistered();
+		if (wasPhysicsRegistered) UnregisterPhysicsComponents(*targetActor);
 
-		// SceneComponent系なら、Rootがある場合はRoot配下へAttachする
+		ActorComponent* newComponent = nullptr;
+		if (!targetActor->GetRootComponent()) newComponent = ComponentFactory::CreateRootSceneComponent(targetActor, componentClassName);
+		if (!newComponent) newComponent = ComponentFactory::CreateComponent(targetActor, componentClassName);
+		if (!newComponent)
+		{
+			if (wasPhysicsRegistered) RegisterPhysicsComponents(*targetActor);
+			lastActorJsonSaveMessage_ = "Add Component failed : " + className;
+			return;
+		}
+
+		newComponent->SetName(MakeUniqueComponentName(*targetActor, className));
 		if (SceneComponent* newSceneComponent = dynamic_cast<SceneComponent*>(newComponent))
 		{
 			SceneComponent* rootComponent = targetActor->GetRootComponent();
-
-			if (rootComponent && rootComponent != newSceneComponent)
-			{
-				newSceneComponent->AttachTo(rootComponent); // 追加したSceneComponentはRoot配下に置く
-			}
-
+			if (rootComponent && rootComponent != newSceneComponent) newSceneComponent->AttachTo(rootComponent);
 			newSceneComponent->RefreshWorldTransform();
 		}
-
-		if (isInitialized_)
-		{
-			newComponent->Initialize(); // 追加したComponentだけ初期化する
-		}
-
-		if (wasPhysicsRegistered)
-		{
-			RegisterPhysicsComponents(*targetActor); // Collider/Rigidbody追加に対応するためPhysics登録を作り直す
-		}
+		if (isInitialized_) newComponent->Initialize();
+		if (wasPhysicsRegistered) RegisterPhysicsComponents(*targetActor);
 
 		selectedActor_ = nullptr;
 		selectedComponent_ = newComponent;
 		requestFocusActorDetails_ = true;
-
 		lastActorJsonSaveMessage_ = "Added Component : " + newComponent->GetName();
+
+		const std::string afterState = ActorJsonSerializer::SerializeActor(*targetActor).dump();
+		EditorCommandHistory::GetInstance()->PushExecuted(std::make_unique<EditorStateCommand>(
+			"コンポーネント追加", beforeState, afterState,
+			[this, targetActor](std::string_view stateText)
+			{
+				const nlohmann::json state = nlohmann::json::parse(stateText, nullptr, false);
+				if (state.is_discarded()) return;
+				UnregisterPhysicsComponents(*targetActor);
+				ActorJsonSerializer::LoadActorFromJson(*targetActor, state);
+				RegisterPhysicsComponents(*targetActor);
+				selectedActor_ = targetActor;
+				selectedComponent_ = nullptr;
+				EditorContext::GetInstance()->GetSelection().Clear();
+				EditorContext::GetInstance()->MarkLevelDirty(); // Component再構築後は古いComponent選択を残さない。
+			}));
+		EditorContext::GetInstance()->MarkLevelDirty();
 	}
 
 	void ActorWorld::ProcessPendingComponentDelete()
 	{
-		if (!hasPendingDeleteComponent_ || !pendingDeleteComponent_)
-		{
-			return; // Component削除予約が無い場合は何もしない。
-		}
-
+		if (!hasPendingDeleteComponent_ || !pendingDeleteComponent_) return;
 		ActorComponent* deleteComponent = pendingDeleteComponent_;
-
-		hasPendingDeleteComponent_ = false; // 再処理防止。
+		hasPendingDeleteComponent_ = false;
 		pendingDeleteComponent_ = nullptr;
-
-		Actor* owner = deleteComponent->GetOwner();
-		if (!owner)
-		{
-			lastActorJsonSaveMessage_ = "Delete Component failed : no owner";
-			return;
-		}
-
-		// ActorWorldが所有しているActorか確認する。
-		bool ownerExists = false;
-		for (const auto& actor : actors_)
-		{
-			if (actor.get() == owner)
-			{
-				ownerExists = true;
-				break;
-			}
-		}
-
-		if (!ownerExists)
-		{
-			lastActorJsonSaveMessage_ = "Delete Component failed : owner not found";
-			return;
-		}
-
-		if (deleteComponent == owner->GetRootComponent())
-		{
-			lastActorJsonSaveMessage_ = "Delete Component failed : RootComponent cannot be deleted";
-			return;
-		}
-
-		const std::string deletedComponentName = deleteComponent->GetName();
-
-		const bool wasPhysicsRegistered = owner->IsPhysicsRegistered();
-		if (wasPhysicsRegistered)
-		{
-			UnregisterPhysicsComponents(*owner); // Collider/Rigidbodyを消す可能性があるので一度解除する。
-		}
-
-		if (selectedComponent_ == deleteComponent)
-		{
-			selectedComponent_ = nullptr; // 削除対象を選択していた場合は選択解除する。
-			selectedActor_ = owner;       // 削除後は所有Actorを選択状態に戻す。
-		}
-
-		const bool removed = owner->RemoveComponent(deleteComponent);
-
-		if (wasPhysicsRegistered)
-		{
-			RegisterPhysicsComponents(*owner); // 残ったCollider/Rigidbodyを再登録する。
-		}
-
-		if (!removed)
-		{
-			lastActorJsonSaveMessage_ = "Delete Component failed : " + deletedComponentName;
-			return;
-		}
-
-		lastActorJsonSaveMessage_ = "Deleted Component : " + deletedComponentName;
+		selectedComponent_ = deleteComponent;
+		DeleteSelectedComponent();
 	}
 
 	void ActorWorld::DeleteSelectedComponent()
@@ -180,17 +100,45 @@ namespace Ken4lowEngine
 			lastActorJsonSaveMessage_ = "Delete Component failed : no owner";
 			return;
 		}
-
 		if (selectedComponent_ == owner->GetRootComponent())
 		{
 			lastActorJsonSaveMessage_ = "Delete Component failed : RootComponent cannot be deleted";
 			return;
 		}
 
-		pendingDeleteComponent_ = selectedComponent_;
-		hasPendingDeleteComponent_ = true;
+		const std::string beforeState = ActorJsonSerializer::SerializeActor(*owner).dump();
+		const std::string deletedComponentName = selectedComponent_->GetName();
+		const bool wasPhysicsRegistered = owner->IsPhysicsRegistered();
+		if (wasPhysicsRegistered) UnregisterPhysicsComponents(*owner);
 
-		lastActorJsonSaveMessage_ = "Delete Component requested : " + selectedComponent_->GetName();
+		ActorComponent* deleteTarget = selectedComponent_;
+		selectedComponent_ = nullptr;
+		selectedActor_ = owner;
+		const bool removed = owner->RemoveComponent(deleteTarget);
+		if (wasPhysicsRegistered) RegisterPhysicsComponents(*owner);
+		if (!removed)
+		{
+			lastActorJsonSaveMessage_ = "Delete Component failed : " + deletedComponentName;
+			return;
+		}
+
+		const std::string afterState = ActorJsonSerializer::SerializeActor(*owner).dump();
+		EditorCommandHistory::GetInstance()->PushExecuted(std::make_unique<EditorStateCommand>(
+			"コンポーネント削除", beforeState, afterState,
+			[this, owner](std::string_view stateText)
+			{
+				const nlohmann::json state = nlohmann::json::parse(stateText, nullptr, false);
+				if (state.is_discarded()) return;
+				UnregisterPhysicsComponents(*owner);
+				ActorJsonSerializer::LoadActorFromJson(*owner, state);
+				RegisterPhysicsComponents(*owner);
+				selectedActor_ = owner;
+				selectedComponent_ = nullptr;
+				EditorContext::GetInstance()->GetSelection().Clear();
+				EditorContext::GetInstance()->MarkLevelDirty();
+			}));
+		lastActorJsonSaveMessage_ = "Deleted Component : " + deletedComponentName;
+		EditorContext::GetInstance()->MarkLevelDirty();
 	}
 
 	void ActorWorld::DuplicateSelectedComponent()
@@ -207,97 +155,71 @@ namespace Ken4lowEngine
 			lastActorJsonSaveMessage_ = "Duplicate Component failed : no owner Actor";
 			return;
 		}
-
 		if (selectedComponent_ == owner->GetRootComponent())
 		{
 			lastActorJsonSaveMessage_ = "Duplicate Component failed : RootComponent cannot be duplicated";
 			return;
 		}
 
-		const bool wasPhysicsRegistered = owner->IsPhysicsRegistered();
-		if (wasPhysicsRegistered)
-		{
-			UnregisterPhysicsComponents(*owner); // Physics登録済みのときだけ一度解除する
-		}
-
 		nlohmann::json sourceJson;
-		selectedComponent_->ToJson(sourceJson); // Serialize / Deserializeを使ってComponent設定を安全に複製する
-
+		selectedComponent_->ToJson(sourceJson);
 		if (!sourceJson.contains("Class") || !sourceJson["Class"].is_string())
 		{
-			if (wasPhysicsRegistered)
-			{
-				RegisterPhysicsComponents(*owner);
-			}
-
 			lastActorJsonSaveMessage_ = "Duplicate Component failed : invalid Component class";
 			return;
 		}
-
 		const std::string className = sourceJson["Class"].get<std::string>();
-
 		if (!ComponentFactory::IsAllowMultiple(className) && owner->HasComponentClass(className))
 		{
-			if (wasPhysicsRegistered)
-			{
-				RegisterPhysicsComponents(*owner);
-			}
-
 			lastActorJsonSaveMessage_ = "Duplicate Component failed : already exists " + className;
-			return; // Camera / Rigidbodyなど１つだけのComponentは複製させない
+			return;
 		}
+
+		const std::string beforeState = ActorJsonSerializer::SerializeActor(*owner).dump();
+		const bool wasPhysicsRegistered = owner->IsPhysicsRegistered();
+		if (wasPhysicsRegistered) UnregisterPhysicsComponents(*owner);
 
 		ActorComponent* duplicatedComponent = ComponentFactory::CreateComponent(owner, className);
 		if (!duplicatedComponent)
 		{
-			if (wasPhysicsRegistered)
-			{
-				RegisterPhysicsComponents(*owner); // 追加失敗時は元のPhysics登録状態へ戻す
-			}
-
+			if (wasPhysicsRegistered) RegisterPhysicsComponents(*owner);
 			lastActorJsonSaveMessage_ = "Duplicate Component failed : " + className;
 			return;
 		}
 
 		duplicatedComponent->FromJson(sourceJson);
-
-		const std::string baseName = selectedComponent_->GetName().empty()
-			? className
-			: selectedComponent_->GetName();
-
+		const std::string baseName = selectedComponent_->GetName().empty() ? className : selectedComponent_->GetName();
 		duplicatedComponent->SetName(MakeUniqueComponentName(*owner, baseName + "_Copy"));
-
 		if (SceneComponent* duplicatedScene = dynamic_cast<SceneComponent*>(duplicatedComponent))
 		{
 			SceneComponent* sourceScene = dynamic_cast<SceneComponent*>(selectedComponent_);
-
-			if (sourceScene && sourceScene->GetParent())
-			{
-				duplicatedScene->AttachTo(sourceScene->GetParent());
-			}
-			else if (owner->GetRootComponent() && owner->GetRootComponent() != duplicatedScene)
-			{
-				duplicatedScene->AttachTo(owner->GetRootComponent());
-			}
-
+			if (sourceScene && sourceScene->GetParent()) duplicatedScene->AttachTo(sourceScene->GetParent());
+			else if (owner->GetRootComponent() && owner->GetRootComponent() != duplicatedScene) duplicatedScene->AttachTo(owner->GetRootComponent());
 			duplicatedScene->RefreshWorldTransform();
 		}
-
-		if (isInitialized_)
-		{
-			duplicatedComponent->Initialize();
-		}
-
-		if (wasPhysicsRegistered)
-		{
-			RegisterPhysicsComponents(*owner); // 複製後のCollider/Rigidbodyを再登録する
-		}
+		if (isInitialized_) duplicatedComponent->Initialize();
+		if (wasPhysicsRegistered) RegisterPhysicsComponents(*owner);
 
 		selectedActor_ = nullptr;
 		selectedComponent_ = duplicatedComponent;
 		requestFocusActorDetails_ = true;
-
 		lastActorJsonSaveMessage_ = "Duplicated Component : " + duplicatedComponent->GetName();
-	}
 
-}
+		const std::string afterState = ActorJsonSerializer::SerializeActor(*owner).dump();
+		EditorCommandHistory::GetInstance()->PushExecuted(std::make_unique<EditorStateCommand>(
+			"コンポーネント複製", beforeState, afterState,
+			[this, owner](std::string_view stateText)
+			{
+				const nlohmann::json state = nlohmann::json::parse(stateText, nullptr, false);
+				if (state.is_discarded()) return;
+				UnregisterPhysicsComponents(*owner);
+				ActorJsonSerializer::LoadActorFromJson(*owner, state);
+				RegisterPhysicsComponents(*owner);
+				selectedActor_ = owner;
+				selectedComponent_ = nullptr;
+				EditorContext::GetInstance()->GetSelection().Clear();
+				EditorContext::GetInstance()->MarkLevelDirty();
+			}));
+		EditorContext::GetInstance()->MarkLevelDirty();
+	}
+} // namespace Ken4lowEngine

--- a/Project/Engine/Scene/Actor/Core/ActorWorld_ComponentEdit.cpp
+++ b/Project/Engine/Scene/Actor/Core/ActorWorld_ComponentEdit.cpp
@@ -59,6 +59,7 @@ namespace Ken4lowEngine
 		lastActorJsonSaveMessage_ = "Added Component : " + newComponent->GetName();
 
 		const std::string afterState = ActorJsonSerializer::SerializeActor(*targetActor).dump();
+		EditorCommandHistory::GetInstance()->Clear(); // Component再構築で無効になる古いComponentポインタを履歴へ残さない。
 		EditorCommandHistory::GetInstance()->PushExecuted(std::make_unique<EditorStateCommand>(
 			"コンポーネント追加", beforeState, afterState,
 			[this, targetActor](std::string_view stateText)
@@ -71,7 +72,7 @@ namespace Ken4lowEngine
 				selectedActor_ = targetActor;
 				selectedComponent_ = nullptr;
 				EditorContext::GetInstance()->GetSelection().Clear();
-				EditorContext::GetInstance()->MarkLevelDirty(); // Component再構築後は古いComponent選択を残さない。
+				EditorContext::GetInstance()->MarkLevelDirty();
 			}));
 		EditorContext::GetInstance()->MarkLevelDirty();
 	}
@@ -114,7 +115,7 @@ namespace Ken4lowEngine
 		ActorComponent* deleteTarget = selectedComponent_;
 		selectedComponent_ = nullptr;
 		selectedActor_ = owner;
-		EditorContext::GetInstance()->GetSelection().Clear(); // 削除直後のDetailsが破棄済みComponentを再参照しないようにする。
+		EditorContext::GetInstance()->GetSelection().Clear();
 		const bool removed = owner->RemoveComponent(deleteTarget);
 		if (wasPhysicsRegistered) RegisterPhysicsComponents(*owner);
 		if (!removed)
@@ -124,6 +125,7 @@ namespace Ken4lowEngine
 		}
 
 		const std::string afterState = ActorJsonSerializer::SerializeActor(*owner).dump();
+		EditorCommandHistory::GetInstance()->Clear();
 		EditorCommandHistory::GetInstance()->PushExecuted(std::make_unique<EditorStateCommand>(
 			"コンポーネント削除", beforeState, afterState,
 			[this, owner](std::string_view stateText)
@@ -207,6 +209,7 @@ namespace Ken4lowEngine
 		lastActorJsonSaveMessage_ = "Duplicated Component : " + duplicatedComponent->GetName();
 
 		const std::string afterState = ActorJsonSerializer::SerializeActor(*owner).dump();
+		EditorCommandHistory::GetInstance()->Clear();
 		EditorCommandHistory::GetInstance()->PushExecuted(std::make_unique<EditorStateCommand>(
 			"コンポーネント複製", beforeState, afterState,
 			[this, owner](std::string_view stateText)

--- a/Project/Engine/Scene/Actor/Core/ActorWorld_ComponentEdit.cpp
+++ b/Project/Engine/Scene/Actor/Core/ActorWorld_ComponentEdit.cpp
@@ -2,9 +2,9 @@
 
 #include "ActorJsonSerializer.h"
 #include "ComponentFactory.h"
-#include "EditorCommandHistory.h"
-#include "EditorContext.h"
 #include "SceneComponent.h"
+#include <Editor/EditorCommandHistory.h>
+#include <Editor/EditorContext.h>
 
 #include <json.hpp>
 #include <memory>

--- a/Project/Engine/Scene/Actor/Core/ActorWorld_ImGui.cpp
+++ b/Project/Engine/Scene/Actor/Core/ActorWorld_ImGui.cpp
@@ -2,8 +2,8 @@
 
 #include "ActorJsonSerializer.h"
 #include "ComponentFactory.h"
-#include "EditorCommandHistory.h"
-#include "EditorContext.h"
+#include <Editor/EditorCommandHistory.h>
+#include <Editor/EditorContext.h>
 
 #include <atomic>
 #include <cstdint>

--- a/Project/Engine/Scene/Actor/Core/ActorWorld_ImGui.cpp
+++ b/Project/Engine/Scene/Actor/Core/ActorWorld_ImGui.cpp
@@ -2,7 +2,12 @@
 
 #include "ActorJsonSerializer.h"
 #include "ComponentFactory.h"
+#include "EditorCommandHistory.h"
+#include "EditorContext.h"
 
+#include <atomic>
+#include <filesystem>
+#include <memory>
 #include <string>
 
 #ifdef USE_IMGUI
@@ -11,6 +16,17 @@
 
 namespace Ken4lowEngine
 {
+	namespace
+	{
+		std::string MakeEditorUndoActorPath(const char* prefix, const Actor* actor)
+		{
+			static std::atomic_uint64_t serial = 0;
+			const auto value = ++serial;
+			return "../Generated/Intermediate/EditorUndo/" + std::string(prefix) + "_" +
+				std::to_string(reinterpret_cast<uintptr_t>(actor)) + "_" + std::to_string(value) + ".json";
+		}
+	}
+
 	void ActorWorld::DrawImGui()
 	{
 #ifdef USE_IMGUI
@@ -21,34 +37,23 @@ namespace Ken4lowEngine
 				ImGui::Text("アクタ数: %zu", actors_.size());
 				DrawActorPrefabSpawnImGui();
 				ImGui::Separator();
-
 				for (size_t actorIndex = 0; actorIndex < actors_.size(); ++actorIndex)
 				{
 					Actor* actor = actors_[actorIndex].get();
-					if (!actor)
-					{
-						continue;
-					}
-
+					if (!actor) continue;
 					Actor* beforeSelectedActor = selectedActor_;
 					ActorComponent* beforeSelectedComponent = selectedComponent_;
 					ImGui::PushID(static_cast<int>(actorIndex));
 					actor->DrawHierarchyImGui(selectedActor_, selectedComponent_);
 					ImGui::PopID();
-
-					if (beforeSelectedActor != selectedActor_ || beforeSelectedComponent != selectedComponent_)
-					{
-						requestFocusActorDetails_ = true;
-					}
+					if (beforeSelectedActor != selectedActor_ || beforeSelectedComponent != selectedComponent_) requestFocusActorDetails_ = true;
 				}
 			}
 			ImGui::End();
 			DrawDetailsImGui();
 		}
-
-		// 統合Detailsで編集したライト設定も同じフレームの描画へ反映する。
 		SyncLightComponentsToLightManager();
-#endif // USE_IMGUI
+#endif
 	}
 
 	void ActorWorld::DrawDetailsImGui()
@@ -59,44 +64,31 @@ namespace Ken4lowEngine
 			ImGui::SetNextWindowFocus();
 			requestFocusActorDetails_ = false;
 		}
-
-		if (ImGui::Begin("Actor Details"))
-		{
-			DrawSelectedInspectorContent();
-		}
+		if (ImGui::Begin("Actor Details")) DrawSelectedInspectorContent();
 		ImGui::End();
-#endif // USE_IMGUI
+#endif
 	}
 
 	void ActorWorld::DrawSelectedInspectorContent()
 	{
 #ifdef USE_IMGUI
 		Actor* saveTargetActor = selectedActor_;
-		if (!saveTargetActor && selectedComponent_)
-		{
-			saveTargetActor = selectedComponent_->GetOwner();
-		}
+		if (!saveTargetActor && selectedComponent_) saveTargetActor = selectedComponent_->GetOwner();
 
 		if (saveTargetActor)
 		{
 			if (ImGui::Button("選択アクタをJSON保存"))
 			{
-				const std::string actorName = saveTargetActor->GetName().empty()
-					? saveTargetActor->GetClassTypeName()
-					: saveTargetActor->GetName();
+				const std::string actorName = saveTargetActor->GetName().empty() ? saveTargetActor->GetClassTypeName() : saveTargetActor->GetName();
 				const std::string filePath = "Resources/ActorPrefabs/" + actorName + ".json";
 				const bool succeeded = ActorJsonSerializer::SaveActorToFile(*saveTargetActor, filePath);
-				lastActorJsonSaveMessage_ = succeeded
-					? "保存しました: " + filePath
-					: "保存に失敗しました: " + filePath;
+				lastActorJsonSaveMessage_ = succeeded ? "保存しました: " + filePath : "保存に失敗しました: " + filePath;
 			}
 
 			ImGui::SameLine();
 			if (ImGui::Button("JSONから再読込"))
 			{
-				const std::string actorName = saveTargetActor->GetName().empty()
-					? saveTargetActor->GetClassTypeName()
-					: saveTargetActor->GetName();
+				const std::string actorName = saveTargetActor->GetName().empty() ? saveTargetActor->GetClassTypeName() : saveTargetActor->GetName();
 				const std::string filePath = "Resources/ActorPrefabs/" + actorName + ".json";
 				selectedComponent_ = nullptr;
 				pendingReloadActor_ = saveTargetActor;
@@ -106,45 +98,87 @@ namespace Ken4lowEngine
 			}
 
 			ImGui::SameLine();
-			if (ImGui::Button("アクタを削除"))
+			if (ImGui::Button("アクタを複製"))
 			{
-				ImGui::OpenPopup("アクタを削除しますか？");
+				const std::string snapshotPath = MakeEditorUndoActorPath("DuplicateActor", saveTargetActor);
+				if (ActorJsonSerializer::SaveActorToFile(*saveTargetActor, snapshotPath))
+				{
+					auto duplicatedActor = std::make_shared<Actor*>(nullptr);
+					EditorCommandHistory::GetInstance()->Execute(std::make_unique<EditorLambdaCommand>(
+						"アクタ複製",
+						[this, duplicatedActor, snapshotPath]()
+						{
+							*duplicatedActor = SpawnActorFromJson(snapshotPath);
+							if (*duplicatedActor)
+							{
+								selectedActor_ = *duplicatedActor;
+								selectedComponent_ = nullptr;
+								EditorContext::GetInstance()->GetSelection().Clear();
+								EditorContext::GetInstance()->MarkLevelDirty();
+							}
+						},
+						[this, duplicatedActor]()
+						{
+							if (!*duplicatedActor) return;
+							(*duplicatedActor)->Destroy();
+							*duplicatedActor = nullptr;
+							selectedActor_ = nullptr;
+							selectedComponent_ = nullptr;
+							EditorContext::GetInstance()->GetSelection().Clear();
+							EditorContext::GetInstance()->MarkLevelDirty(); // ActorWorld::UpdateでDestroy予約を安全に確定する。
+						}));
+				}
 			}
+
+			ImGui::SameLine();
+			if (ImGui::Button("アクタを削除")) ImGui::OpenPopup("アクタを削除しますか？");
 
 			if (ImGui::BeginPopupModal("アクタを削除しますか？", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
 			{
 				ImGui::Text("%s を削除します。", saveTargetActor->GetName().c_str());
-				ImGui::TextDisabled("この操作はPhase 9でUndo / Redoへ接続します。");
+				ImGui::TextDisabled("Ctrl+Zで削除前の状態へ戻せます。");
 				ImGui::Separator();
 				if (ImGui::Button("削除", ImVec2(120.0f, 0.0f)))
 				{
-					pendingDeleteActor_ = saveTargetActor;
-					hasPendingDeleteActor_ = true;
-					selectedActor_ = nullptr;
-					selectedComponent_ = nullptr;
-					lastActorJsonSaveMessage_ = "削除を予約しました: " + saveTargetActor->GetName();
+					const std::string snapshotPath = MakeEditorUndoActorPath("DeleteActor", saveTargetActor);
+					if (ActorJsonSerializer::SaveActorToFile(*saveTargetActor, snapshotPath))
+					{
+						auto actorState = std::make_shared<Actor*>(saveTargetActor);
+						EditorCommandHistory::GetInstance()->Execute(std::make_unique<EditorLambdaCommand>(
+							"アクタ削除",
+							[this, actorState]()
+							{
+								if (!*actorState) return;
+								(*actorState)->Destroy();
+								*actorState = nullptr;
+								selectedActor_ = nullptr;
+								selectedComponent_ = nullptr;
+								EditorContext::GetInstance()->GetSelection().Clear();
+								EditorContext::GetInstance()->MarkLevelDirty();
+							},
+							[this, actorState, snapshotPath]()
+							{
+								*actorState = SpawnActorFromJson(snapshotPath);
+								selectedActor_ = *actorState;
+								selectedComponent_ = nullptr;
+								EditorContext::GetInstance()->GetSelection().Clear();
+								EditorContext::GetInstance()->MarkLevelDirty();
+							}));
+					}
 					ImGui::CloseCurrentPopup();
 				}
 				ImGui::SameLine();
-				if (ImGui::Button("キャンセル", ImVec2(120.0f, 0.0f)))
-				{
-					ImGui::CloseCurrentPopup();
-				}
+				if (ImGui::Button("キャンセル", ImVec2(120.0f, 0.0f))) ImGui::CloseCurrentPopup();
 				ImGui::EndPopup();
 			}
 
-			if (!lastActorJsonSaveMessage_.empty())
-			{
-				ImGui::TextWrapped("%s", lastActorJsonSaveMessage_.c_str());
-			}
+			if (!lastActorJsonSaveMessage_.empty()) ImGui::TextWrapped("%s", lastActorJsonSaveMessage_.c_str());
 			ImGui::Separator();
 		}
 
 		if (selectedComponent_)
 		{
-			const std::string componentName = selectedComponent_->GetName().empty()
-				? "名前なしコンポーネント"
-				: selectedComponent_->GetName();
+			const std::string componentName = selectedComponent_->GetName().empty() ? "名前なしコンポーネント" : selectedComponent_->GetName();
 			ImGui::Text("選択中のコンポーネント: %s", componentName.c_str());
 
 			Actor* owner = selectedComponent_->GetOwner();
@@ -155,15 +189,9 @@ namespace Ken4lowEngine
 			}
 			else
 			{
-				if (ImGui::Button("コンポーネントを複製"))
-				{
-					DuplicateSelectedComponent();
-				}
+				if (ImGui::Button("コンポーネントを複製")) DuplicateSelectedComponent();
 				ImGui::SameLine();
-				if (ImGui::Button("コンポーネントを削除"))
-				{
-					ImGui::OpenPopup("コンポーネントを削除しますか？");
-				}
+				if (ImGui::Button("コンポーネントを削除")) ImGui::OpenPopup("コンポーネントを削除しますか？");
 			}
 
 			if (ImGui::BeginPopupModal("コンポーネントを削除しますか？", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
@@ -176,21 +204,19 @@ namespace Ken4lowEngine
 					ImGui::CloseCurrentPopup();
 				}
 				ImGui::SameLine();
-				if (ImGui::Button("キャンセル", ImVec2(120.0f, 0.0f)))
-				{
-					ImGui::CloseCurrentPopup();
-				}
+				if (ImGui::Button("キャンセル", ImVec2(120.0f, 0.0f))) ImGui::CloseCurrentPopup();
 				ImGui::EndPopup();
 			}
 
-			ImGui::Separator();
-			selectedComponent_->DrawInspectorImGui();
+			if (selectedComponent_)
+			{
+				ImGui::Separator();
+				selectedComponent_->DrawInspectorImGui(); // 即時削除後は無効になったComponentへアクセスしない。
+			}
 		}
 		else if (selectedActor_)
 		{
-			const std::string actorName = selectedActor_->GetName().empty()
-				? "名前なしアクタ"
-				: selectedActor_->GetName();
+			const std::string actorName = selectedActor_->GetName().empty() ? "名前なしアクタ" : selectedActor_->GetName();
 			ImGui::Text("選択中のアクタ: %s", actorName.c_str());
 			ImGui::Separator();
 			selectedActor_->DrawInspectorImGui();
@@ -201,17 +227,14 @@ namespace Ken4lowEngine
 		}
 
 		DrawAddComponentImGui();
-#endif // USE_IMGUI
+#endif
 	}
 
 	void ActorWorld::DrawAddComponentImGui()
 	{
 #ifdef USE_IMGUI
 		Actor* targetActor = selectedActor_;
-		if (!targetActor && selectedComponent_)
-		{
-			targetActor = selectedComponent_->GetOwner();
-		}
+		if (!targetActor && selectedComponent_) targetActor = selectedComponent_->GetOwner();
 
 		ImGui::SeparatorText("コンポーネント追加");
 		if (!targetActor)
@@ -227,12 +250,7 @@ namespace Ken4lowEngine
 			return;
 		}
 
-		if (selectedAddComponentTypeIndex_ < 0 ||
-			selectedAddComponentTypeIndex_ >= static_cast<int>(componentTypes.size()))
-		{
-			selectedAddComponentTypeIndex_ = 0;
-		}
-
+		if (selectedAddComponentTypeIndex_ < 0 || selectedAddComponentTypeIndex_ >= static_cast<int>(componentTypes.size())) selectedAddComponentTypeIndex_ = 0;
 		const ComponentFactory::ComponentTypeInfo& selectedType = componentTypes[selectedAddComponentTypeIndex_];
 		if (ImGui::BeginCombo("種類", selectedType.displayName.c_str()))
 		{
@@ -245,32 +263,15 @@ namespace Ken4lowEngine
 					currentCategory = typeInfo.category;
 					ImGui::TextDisabled("%s", currentCategory.c_str());
 				}
-
 				const bool alreadyExists = targetActor->HasComponentClass(typeInfo.className);
 				const bool disabled = !typeInfo.allowMultiple && alreadyExists;
-				if (disabled)
-				{
-					ImGui::BeginDisabled();
-				}
-
+				if (disabled) ImGui::BeginDisabled();
 				const bool isSelected = selectedAddComponentTypeIndex_ == index;
 				const std::string selectableLabel = typeInfo.displayName + "##" + typeInfo.className;
-				if (ImGui::Selectable(selectableLabel.c_str(), isSelected))
-				{
-					selectedAddComponentTypeIndex_ = index;
-				}
-				if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
-				{
-					ImGui::SetTooltip("%s", typeInfo.description.c_str());
-				}
-				if (isSelected)
-				{
-					ImGui::SetItemDefaultFocus();
-				}
-				if (disabled)
-				{
-					ImGui::EndDisabled();
-				}
+				if (ImGui::Selectable(selectableLabel.c_str(), isSelected)) selectedAddComponentTypeIndex_ = index;
+				if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled)) ImGui::SetTooltip("%s", typeInfo.description.c_str());
+				if (isSelected) ImGui::SetItemDefaultFocus();
+				if (disabled) ImGui::EndDisabled();
 			}
 			ImGui::EndCombo();
 		}
@@ -284,14 +285,8 @@ namespace Ken4lowEngine
 			ImGui::TextDisabled("このコンポーネントは1つだけ追加できます。");
 			ImGui::BeginDisabled();
 		}
-		if (ImGui::Button("追加##AddComponent"))
-		{
-			AddComponentToSelectedActor(selectedType.className);
-		}
-		if (!canAdd)
-		{
-			ImGui::EndDisabled();
-		}
-#endif // USE_IMGUI
+		if (ImGui::Button("追加##AddComponent")) AddComponentToSelectedActor(selectedType.className);
+		if (!canAdd) ImGui::EndDisabled();
+#endif
 	}
 } // namespace Ken4lowEngine

--- a/Project/Engine/Scene/Actor/Core/ActorWorld_ImGui.cpp
+++ b/Project/Engine/Scene/Actor/Core/ActorWorld_ImGui.cpp
@@ -6,6 +6,7 @@
 #include "EditorContext.h"
 
 #include <atomic>
+#include <cstdint>
 #include <filesystem>
 #include <memory>
 #include <string>
@@ -104,6 +105,7 @@ namespace Ken4lowEngine
 				if (ActorJsonSerializer::SaveActorToFile(*saveTargetActor, snapshotPath))
 				{
 					auto duplicatedActor = std::make_shared<Actor*>(nullptr);
+					EditorCommandHistory::GetInstance()->Clear(); // Actor寿命を変更する前に古いActor参照を持つCommandを破棄する。
 					EditorCommandHistory::GetInstance()->Execute(std::make_unique<EditorLambdaCommand>(
 						"アクタ複製",
 						[this, duplicatedActor, snapshotPath]()
@@ -125,7 +127,7 @@ namespace Ken4lowEngine
 							selectedActor_ = nullptr;
 							selectedComponent_ = nullptr;
 							EditorContext::GetInstance()->GetSelection().Clear();
-							EditorContext::GetInstance()->MarkLevelDirty(); // ActorWorld::UpdateでDestroy予約を安全に確定する。
+							EditorContext::GetInstance()->MarkLevelDirty();
 						}));
 				}
 			}
@@ -144,6 +146,7 @@ namespace Ken4lowEngine
 					if (ActorJsonSerializer::SaveActorToFile(*saveTargetActor, snapshotPath))
 					{
 						auto actorState = std::make_shared<Actor*>(saveTargetActor);
+						EditorCommandHistory::GetInstance()->Clear();
 						EditorCommandHistory::GetInstance()->Execute(std::make_unique<EditorLambdaCommand>(
 							"アクタ削除",
 							[this, actorState]()
@@ -180,7 +183,6 @@ namespace Ken4lowEngine
 		{
 			const std::string componentName = selectedComponent_->GetName().empty() ? "名前なしコンポーネント" : selectedComponent_->GetName();
 			ImGui::Text("選択中のコンポーネント: %s", componentName.c_str());
-
 			Actor* owner = selectedComponent_->GetOwner();
 			const bool isRootComponent = owner && selectedComponent_ == owner->GetRootComponent();
 			if (isRootComponent)
@@ -211,7 +213,7 @@ namespace Ken4lowEngine
 			if (selectedComponent_)
 			{
 				ImGui::Separator();
-				selectedComponent_->DrawInspectorImGui(); // 即時削除後は無効になったComponentへアクセスしない。
+				selectedComponent_->DrawInspectorImGui();
 			}
 		}
 		else if (selectedActor_)
@@ -235,7 +237,6 @@ namespace Ken4lowEngine
 #ifdef USE_IMGUI
 		Actor* targetActor = selectedActor_;
 		if (!targetActor && selectedComponent_) targetActor = selectedComponent_->GetOwner();
-
 		ImGui::SeparatorText("コンポーネント追加");
 		if (!targetActor)
 		{

--- a/Project/Engine/Scene/Actor/Serialization/ActorJsonSerializer.cpp
+++ b/Project/Engine/Scene/Actor/Serialization/ActorJsonSerializer.cpp
@@ -10,70 +10,56 @@
 #include <string>
 #include <unordered_map>
 #include <vector>
-#include <json.hpp>
 
 namespace Ken4lowEngine
 {
+	namespace
+	{
+		bool ValidateActorJson(const nlohmann::json& actorJson)
+		{
+			if (!actorJson.is_object() || !actorJson.contains("Components") || !actorJson["Components"].is_array()) return false;
+			for (const auto& componentJson : actorJson["Components"])
+			{
+				if (!componentJson.is_object() || !componentJson.contains("Class") || !componentJson["Class"].is_string()) return false;
+			}
+			return true;
+		}
+	}
+
+	nlohmann::json ActorJsonSerializer::SerializeActor(const Actor& actor)
+	{
+		nlohmann::json actorJson;
+		actor.ToJson(actorJson); // Command履歴はファイルを経由せずActor構成を保持する。
+		return actorJson;
+	}
+
 	bool ActorJsonSerializer::SaveActorToFile(const Actor& actor, std::string_view filePath)
 	{
 		const std::filesystem::path path(filePath);
-
-		if (path.has_parent_path())
-		{
-			std::filesystem::create_directories(path.parent_path()); // 親ディレクトリが存在しない場合は作成する
-		}
+		if (path.has_parent_path()) std::filesystem::create_directories(path.parent_path());
 
 		std::ofstream file(path);
-		if (!file.is_open())
-		{
-			return false; // ファイルが開けなかった場合は失敗を返す
-		}
-
-		nlohmann::json actorJson;
-		actor.ToJson(actorJson); // Actorの情報をJSONへ保存する
-
-		file << actorJson.dump(4); // JSONデータをフォーマットしてファイルに書き込む
+		if (!file.is_open()) return false;
+		file << SerializeActor(actor).dump(4);
 		return true;
 	}
 
 	bool ActorJsonSerializer::LoadActorFromFile(Actor& actor, std::string_view filePath)
 	{
-		const std::filesystem::path path{ std::string(filePath) }; // string_viewを安全にpathへ変換する。
-
-		std::ifstream file{ path }; // Most Vexing Parseを避けるため、波括弧でifstreamを生成する。
-		if (!file.is_open())
-		{
-			return false; // ファイルを開けなかった場合は読み込み失敗。
-		}
+		std::ifstream file{ std::filesystem::path{ std::string(filePath) } };
+		if (!file.is_open()) return false;
 
 		nlohmann::json actorJson;
-		file >> actorJson; // JSONファイルを読み込む。
+		file >> actorJson;
+		return LoadActorFromJson(actor, actorJson);
+	}
 
-		if (!actorJson.is_object())
-		{
-			return false; // Actor用JSONではない場合は読み込まない。
-		}
+	bool ActorJsonSerializer::LoadActorFromJson(Actor& actor, const nlohmann::json& actorJson)
+	{
+		if (!ValidateActorJson(actorJson)) return false;
 
-		if (!actorJson.contains("Components") || !actorJson["Components"].is_array())
-		{
-			return false; // Component配列が無い場合はActor構成として扱わない。
-		}
-
-		for (const auto& componentJson : actorJson["Components"])
-		{
-			if (!componentJson.is_object())
-			{
-				return false; // 不正なComponent要素がある場合は、Actorを壊す前に読み込みを中止する。
-			}
-
-			if (!componentJson.contains("Class") || !componentJson["Class"].is_string())
-			{
-				return false; // Classが無いComponentは復元できないため、Actorを壊す前に読み込みを中止する。
-			}
-		}
-
-		actor.ClearComponents(); // 既存Componentを破棄して、JSON構成で作り直す。
-		actor.FromJson(actorJson); // Actor名などの共通情報を復元する。
+		actor.ClearComponents();
+		actor.FromJson(actorJson);
 
 		std::unordered_map<std::string, SceneComponent*> sceneComponentsByName;
 		std::vector<std::pair<SceneComponent*, std::string>> pendingAttachments;
@@ -81,120 +67,62 @@ namespace Ken4lowEngine
 		for (const auto& componentJson : actorJson["Components"])
 		{
 			const std::string className = componentJson["Class"].get<std::string>();
-
-			std::string componentType = "ActorComponent";
-			if (componentJson.contains("Type") && componentJson["Type"].is_string())
-			{
-				componentType = componentJson["Type"].get<std::string>(); // SceneComponentかActorComponentかを取得する。
-			}
-
-			std::string parentName;
-			if (componentJson.contains("Parent") && componentJson["Parent"].is_string())
-			{
-				parentName = componentJson["Parent"].get<std::string>(); // 後でAttachToするため親名を保持する。
-			}
+			const std::string componentType = componentJson.value("Type", std::string("ActorComponent"));
+			const std::string parentName = componentJson.value("Parent", std::string{});
 
 			ActorComponent* createdComponent = nullptr;
-
 			if (componentType == "SceneComponent" && parentName.empty())
 			{
-				createdComponent = ComponentFactory::CreateRootSceneComponent(&actor, className); // 親が無いSceneComponentはRootとして生成する。
+				createdComponent = ComponentFactory::CreateRootSceneComponent(&actor, className);
 			}
 			else
 			{
-				createdComponent = ComponentFactory::CreateComponent(&actor, className); // 通常Componentとして生成する。
+				createdComponent = ComponentFactory::CreateComponent(&actor, className);
 			}
+			if (!createdComponent) continue;
 
-			if (!createdComponent)
-			{
-				continue; // 未対応Classなら無視する。
-			}
-
-			createdComponent->FromJson(componentJson); // Component固有情報を復元する。
-
+			createdComponent->FromJson(componentJson);
 			if (SceneComponent* sceneComponent = dynamic_cast<SceneComponent*>(createdComponent))
 			{
-				sceneComponentsByName[sceneComponent->GetName()] = sceneComponent; // 親子接続用に名前で登録する。
-
-				if (!parentName.empty())
-				{
-					pendingAttachments.emplace_back(sceneComponent, parentName); // 全Component生成後に親子接続する。
-				}
-				else if (!actor.GetRootComponent())
-				{
-					actor.SetRootComponent(sceneComponent); // Rootが未設定なら親無しSceneComponentをRootにする。
-				}
+				sceneComponentsByName[sceneComponent->GetName()] = sceneComponent;
+				if (!parentName.empty()) pendingAttachments.emplace_back(sceneComponent, parentName);
+				else if (!actor.GetRootComponent()) actor.SetRootComponent(sceneComponent);
 			}
 		}
 
 		for (const auto& [child, parentName] : pendingAttachments)
 		{
-			if (!child)
-			{
-				continue; // 子が無効なら接続しない。
-			}
-
 			const auto parentIt = sceneComponentsByName.find(parentName);
-			if (parentIt == sceneComponentsByName.end())
-			{
-				continue; // 親名に一致するSceneComponentが無い場合は接続しない。
-			}
-
-			child->AttachTo(parentIt->second); // JSONに保存されていた親子関係を復元する。
+			if (child && parentIt != sceneComponentsByName.end()) child->AttachTo(parentIt->second);
 		}
 
-		actor.InitializeComponents(); // 派生ActorのInitializeを呼ばず、復元したComponentだけを初期化する
+		actor.InitializeComponents();
 		return true;
 	}
 
 	std::unique_ptr<Actor> ActorJsonSerializer::CreateActorFromJson(std::string_view filePath, const ActorSpawnOptions& options)
 	{
-		const std::filesystem::path path{ std::string(filePath) }; // string_viewを安全にpathへ変換する
-
-		std::ifstream file{ path }; // Most Vexing Parseを避けるため、波括弧でifstreamを生成する
-		if (!file.is_open())
-		{
-			return nullptr; // ファイルを開けなかった場合はnullptrを返す
-		}
+		std::ifstream file{ std::filesystem::path{ std::string(filePath) } };
+		if (!file.is_open()) return nullptr;
 
 		nlohmann::json actorJson;
-		file >> actorJson; // JSONファイルを読み込む
+		file >> actorJson;
+		return CreateActorFromJson(actorJson, options);
+	}
 
-		if (!actorJson.is_object())
-		{
-			return nullptr; // Actor用JSONではない場合はnullptrを返す
-		}
+	std::unique_ptr<Actor> ActorJsonSerializer::CreateActorFromJson(const nlohmann::json& actorJson, const ActorSpawnOptions& options)
+	{
+		if (!ValidateActorJson(actorJson) || !actorJson.contains("Class") || !actorJson["Class"].is_string()) return nullptr;
 
-		if (!actorJson.contains("Class") || !actorJson["Class"].is_string())
-		{
-			return nullptr; // Classが無いActorは生成できないため、nullptrを返す
-		}
-
-		const std::string actorClass = actorJson["Class"].get<std::string>();
-
-		std::unique_ptr<Actor> actor = ActorFactory::CreateActor(actorClass); // ActorFactoryで指定ClassのActorを生成する
-		if (!actor)
-		{
-			return nullptr; // 未対応Classならnullptrを返す
-		}
-
-		if (!LoadActorFromFile(*actor, filePath))
-		{
-			return nullptr; // JSON読み込みに失敗した場合はnullptrを返す
-		}
+		std::unique_ptr<Actor> actor = ActorFactory::CreateActor(actorJson["Class"].get<std::string>());
+		if (!actor || !LoadActorFromJson(*actor, actorJson)) return nullptr;
 
 		if (options.applySpawnOffset && actor->GetRootComponent())
 		{
-			if (SceneComponent* root = actor->GetRootComponent())
-			{
-				Vector3 position = Vector3::Add(root->GetLocalPosition(), options.spawnOffset);
-				root->SetLocalPosition(position); // SpawnOffsetをRootComponentのローカル位置に適用する
-				root->RefreshWorldTransform(); // SpawnOffsetを適用した後にWorldTransformを更新する
-			}
+			SceneComponent* root = actor->GetRootComponent();
+			root->SetLocalPosition(Vector3::Add(root->GetLocalPosition(), options.spawnOffset));
+			root->RefreshWorldTransform(); // Actor生成CommandのRedoでも同じSpawnOffsetを再現する。
 		}
-
-
 		return actor;
 	}
-
-}
+} // namespace Ken4lowEngine

--- a/Project/Engine/Scene/Actor/Serialization/ActorJsonSerializer.h
+++ b/Project/Engine/Scene/Actor/Serialization/ActorJsonSerializer.h
@@ -2,36 +2,24 @@
 
 #include "ActorSpawnOptions.h"
 
+#include <json.hpp>
 #include <memory>
 #include <string_view>
 
 namespace Ken4lowEngine
 {
-	/// ---------- 前方宣言 ---------- ///
-
-	// ActorJsonSerializerがActorを参照するための前方宣言
 	class Actor;
 
-	/// -------------------------------------------------------------
-	///		Actor・ActorComponentのJSONシリアライズを行うクラス
-	/// -------------------------------------------------------------
+	/// <summary>Actor・ActorComponentのJSONシリアライズを行うクラスです。</summary>
 	class ActorJsonSerializer
 	{
-	public: /// ---------- 静的メンバ関数 ---------- ///
-
-		/// <summary>
-		/// Actor構成をJSONファイルへ保存する。
-		/// </summary>
+	public:
 		static bool SaveActorToFile(const Actor& actor, std::string_view filePath);
-
-		/// <summary>
-		/// JSONファイルからActorへComponent構成を読み込む
-		/// </summary>
 		static bool LoadActorFromFile(Actor& actor, std::string_view filePath);
-
-		/// <summary>
-		/// JSONファイルからActorを生成してComponent構成を読み込む
-		/// </summary>
 		static std::unique_ptr<Actor> CreateActorFromJson(std::string_view filePath, const ActorSpawnOptions& options = {});
+
+		static nlohmann::json SerializeActor(const Actor& actor);
+		static bool LoadActorFromJson(Actor& actor, const nlohmann::json& actorJson);
+		static std::unique_ptr<Actor> CreateActorFromJson(const nlohmann::json& actorJson, const ActorSpawnOptions& options = {});
 	};
-}
+} // namespace Ken4lowEngine

--- a/Project/Engine/Scene/Management/SceneManager.cpp
+++ b/Project/Engine/Scene/Management/SceneManager.cpp
@@ -7,12 +7,14 @@
 #include <GameTimer.h>
 
 #ifdef USE_IMGUI
+#include <Editor/EditorCommandHistory.h>
+#include <Editor/EditorContext.h>
 #include <Editor/EditorModeController.h>
 #include <Editor/EditorPlayController.h>
-#endif // USE_IMGUI
+#endif
 
-#include <cassert>
 #include <algorithm>
+#include <cassert>
 #include <vector>
 
 namespace K4E = ::Ken4lowEngine;
@@ -37,42 +39,30 @@ namespace Ken4lowEngine
 	void SceneManager::UpdateEditorPlaySession()
 	{
 #ifdef USE_IMGUI
-		if (!scene_ || K4E::EditorModeController::GetInstance()->IsGamePreviewMode())
-		{
-			return;
-		}
-
+		if (!scene_ || K4E::EditorModeController::GetInstance()->IsGamePreviewMode()) return;
 		K4E::EditorPlayController* playController = K4E::EditorPlayController::GetInstance();
 		if (playController->IsPlaying() && !editorPlaySessionActive_)
 		{
 			scene_->BeginEditorPlay();
-			editorPlaySessionActive_ = true; // Pauseからの再開ではSnapshotを取り直さない。
+			editorPlaySessionActive_ = true;
 		}
 		else if (playController->IsEditing() && editorPlaySessionActive_)
 		{
 			scene_->EndEditorPlay();
 			editorPlaySessionActive_ = false;
 		}
-#endif // USE_IMGUI
+#endif
 	}
 
 	void SceneManager::RefreshEditorVisualState(float deltaTime)
 	{
 #ifdef USE_IMGUI
 		ActorWorld* actorWorld = scene_ ? scene_->GetEditorActorWorld() : nullptr;
-		if (!actorWorld)
-		{
-			return;
-		}
-
+		if (!actorWorld) return;
 		for (const auto& actorOwner : actorWorld->GetActors())
 		{
 			Actor* actor = actorOwner.get();
-			if (!actor || !actor->IsActive() || actor->IsPendingDestroy())
-			{
-				continue;
-			}
-
+			if (!actor || !actor->IsActive() || actor->IsPendingDestroy()) continue;
 			std::vector<ActorComponent*> components;
 			for (const auto& componentOwner : actor->GetComponents())
 			{
@@ -83,21 +73,17 @@ namespace Ken4lowEngine
 				{
 					return lhs->GetUpdateOrder() < rhs->GetUpdateOrder();
 				});
-			for (ActorComponent* component : components)
-			{
-				component->UpdateEditor(deltaTime); // Edit/Pause中はTransformと描画バッファだけを更新する。
-			}
+			for (ActorComponent* component : components) component->UpdateEditor(deltaTime);
 		}
 #else
 		(void)deltaTime;
-#endif // USE_IMGUI
+#endif
 	}
 
 	void SceneManager::Update()
 	{
 		float dtRaw = K4E::GameTimer::GetInstance()->GetDeltaTime();
 		float dtFade = std::min(dtRaw, 1.0f / 30.0f);
-
 		if (sceneTransition_) sceneTransition_->Update(dtFade);
 
 		if (isTransitioning_)
@@ -115,7 +101,6 @@ namespace Ken4lowEngine
 						}
 						scene_->UpdateUnload();
 					}
-
 					const bool readyToSwap = (!scene_) || scene_->IsReadyToSwapOut();
 					if (readyToSwap)
 					{
@@ -169,17 +154,13 @@ namespace Ken4lowEngine
 		}
 
 		UpdateEditorPlaySession();
-
 		if (scene_ && (!isTransitioning_ || sceneSwapped_))
 		{
 			bool shouldUpdateGame = true;
 #ifdef USE_IMGUI
 			shouldUpdateGame = K4E::EditorModeController::GetInstance()->IsGamePreviewMode() || K4E::EditorPlayController::GetInstance()->IsPlaying();
-#endif // USE_IMGUI
-			if (shouldUpdateGame)
-			{
-				scene_->Update();
-			}
+#endif
+			if (shouldUpdateGame) scene_->Update();
 			else
 			{
 				scene_->UpdateEditor(dtRaw);
@@ -220,6 +201,9 @@ namespace Ken4lowEngine
 			scene_->Finalize();
 		}
 		if (sceneTransition_) sceneTransition_->Finalize();
+#ifdef USE_IMGUI
+		K4E::EditorCommandHistory::GetInstance()->Clear();
+#endif
 	}
 
 	void SceneManager::ChangeScene(const std::string& sceneName)
@@ -231,14 +215,12 @@ namespace Ken4lowEngine
 			hasQueuedChange_ = true;
 			return;
 		}
-
 		nextScene_ = sceneFactory_->CreateScene(sceneName);
 		if (!sceneTransition_)
 		{
 			ApplyNextScene();
 			return;
 		}
-
 		sceneTransition_->StartCover();
 		isTransitioning_ = true;
 		sceneSwapped_ = false;
@@ -251,6 +233,10 @@ namespace Ken4lowEngine
 	void SceneManager::ApplyNextScene()
 	{
 		if (!nextScene_) return;
+#ifdef USE_IMGUI
+		K4E::EditorCommandHistory::GetInstance()->Clear();
+		K4E::EditorContext::GetInstance()->ResetTransientState(); // Scene固有ポインタを持つSelectionとCommandを同時に破棄する。
+#endif
 		if (scene_)
 		{
 			if (editorPlaySessionActive_)
@@ -260,7 +246,6 @@ namespace Ken4lowEngine
 			}
 			scene_->Finalize();
 		}
-
 		scene_ = std::move(nextScene_);
 		if (scene_)
 		{


### PR DESCRIPTION
## 概要
UE風Editor計画のPhase 9として、編集操作をCommand化しUndo / Redoへ接続しました。

## 実装内容
- `IEditorCommand` / `EditorCommandHistory`を追加
- 最大256件のUndo / Redo履歴を管理
- 新しい操作を行った際にRedo履歴を破棄
- `Ctrl+Z`でUndo
- `Ctrl+Y`または`Ctrl+Shift+Z`でRedo
- ImGuiの文字入力中とPlay中はショートカットを無効化
- Gizmoの連続ドラッグを1件のTransform Commandとして記録
- Detailsの連続Property編集を1件へまとめる
- Actor / Component / Instanceの名前、有効状態、Transform、シリアライズ済みPropertyをCommand化
- Componentの追加、複製、削除をActor構成SnapshotでUndo / Redo
- Actorの複製、削除を一時SnapshotでUndo / Redo
- Content BrowserからViewportへ配置したActorをUndo / Redo
- Actor構成をファイルなしで保持できるメモリ内JSONシリアライズを追加
- Component再構築で無効になる古いRedo Commandを安全に除去
- Play開始、Editor Mode終了、Scene切り替え、終了処理で古い履歴を破棄
- Undo / Redo実行時にLevel Dirty状態とOutput Logを更新

## 操作
- Undo: `Ctrl+Z`
- Redo: `Ctrl+Y` または `Ctrl+Shift+Z`

## 確認項目
1. Gizmoで移動・回転・拡縮した後、1回のUndoでドラッグ開始位置へ戻る
2. Detailsの数値をドラッグした後、1回のUndoで変更前へ戻る
3. 名前と有効状態をUndo / Redoできる
4. Componentの追加・複製・削除をUndo / Redoできる
5. Actorの複製・削除をUndo / Redoできる
6. Viewportへ配置したActorをUndo / Redoできる
7. Play開始後に古いEditor履歴が残らない
8. Scene切り替え後に古いActor / Componentポインタを参照しない

## 検証
- GitHub Actions: Debug Build 成功
- GitHub Actions: Release Build 成功
- コンパイラ診断: Debug / Releaseともに0 Errors