### PR TITLE
Phase 10: World Outliner V2 hierarchy tools

### DIFF
--- a/Project/Engine/Editor/ActorWorldEditorBridge.cpp
+++ b/Project/Engine/Editor/ActorWorldEditorBridge.cpp
@@ -1,22 +1,166 @@
 #define NOMINMAX
 #include "ActorWorldEditorBridge.h"
+
+#include "ActorJsonSerializer.h"
+#include "EditorActorStateRegistry.h"
 #include "EditorCommandHistory.h"
 
+#include <CameraManager.h>
+#include <DebugCamera.h>
 #include <SceneComponent.h>
 #include <json.hpp>
 
 #include <algorithm>
+#include <atomic>
 #include <cmath>
+#include <filesystem>
 #include <limits>
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
+#include <vector>
 
 namespace Ken4lowEngine
 {
 	namespace
 	{
+		uint64_t MakeActorEditorId(std::string_view sceneName, const Actor* actor)
+		{
+			const std::string actorKey = std::string(sceneName) + "/Actor/" +
+				std::to_string(static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(actor)));
+			return MakeStableEditorObjectId(actorKey);
+		}
+
+		uint64_t MakeFolderEditorId(std::string_view sceneName, std::string_view folderPath)
+		{
+			return MakeStableEditorObjectId(std::string(sceneName) + "/Folder/" + std::string(folderPath));
+		}
+
+		std::string NormalizeFolderPath(std::string_view path)
+		{
+			std::string normalized(path);
+			std::replace(normalized.begin(), normalized.end(), '\\', '/');
+			while (!normalized.empty() && normalized.front() == '/') normalized.erase(normalized.begin());
+			while (!normalized.empty() && normalized.back() == '/') normalized.pop_back();
+
+			std::string compact;
+			compact.reserve(normalized.size());
+			for (const char character : normalized)
+			{
+				if (character == '/' && !compact.empty() && compact.back() == '/') continue;
+				compact.push_back(character);
+			}
+			return compact;
+		}
+
+		std::string GetFolderName(std::string_view folderPath)
+		{
+			const size_t separator = folderPath.find_last_of('/');
+			return separator == std::string_view::npos
+				? std::string(folderPath)
+				: std::string(folderPath.substr(separator + 1));
+		}
+
+		std::string GetParentFolderPath(std::string_view folderPath)
+		{
+			const size_t separator = folderPath.find_last_of('/');
+			return separator == std::string_view::npos ? std::string{} : std::string(folderPath.substr(0, separator));
+		}
+
+		void CollectFolderPrefixes(std::string_view folderPath, std::unordered_set<std::string>& outFolders)
+		{
+			const std::string normalized = NormalizeFolderPath(folderPath);
+			if (normalized.empty()) return;
+
+			size_t cursor = 0;
+			while (cursor < normalized.size())
+			{
+				const size_t separator = normalized.find('/', cursor);
+				outFolders.insert(normalized.substr(0, separator));
+				if (separator == std::string::npos) break;
+				cursor = separator + 1;
+			}
+		}
+
+		Actor* GetParentActor(const Actor* actor)
+		{
+			if (!actor || !actor->GetRootComponent()) return nullptr;
+			SceneComponent* parentComponent = actor->GetRootComponent()->GetParent();
+			Actor* parentActor = parentComponent ? parentComponent->GetOwner() : nullptr;
+			return parentActor != actor ? parentActor : nullptr;
+		}
+
+		Actor* FindActorByEditorId(ActorWorld& actorWorld, std::string_view sceneName, uint64_t objectId)
+		{
+			for (const auto& actorOwner : actorWorld.GetActors())
+			{
+				Actor* actor = actorOwner.get();
+				if (actor && !actor->IsPendingDestroy() && MakeActorEditorId(sceneName, actor) == objectId) return actor;
+			}
+			return nullptr;
+		}
+
+		bool WouldCreateActorCycle(Actor* actor, Actor* proposedParent)
+		{
+			for (Actor* current = proposedParent; current; current = GetParentActor(current))
+			{
+				if (current == actor) return true;
+			}
+			return false;
+		}
+
+		EditorTransform ReadSceneComponentWorldTransform(const SceneComponent& component)
+		{
+			EditorTransform transform{};
+			transform.position = component.GetWorldPosition();
+			transform.rotation = component.GetWorldRotation();
+			transform.scale = component.GetWorldScale();
+			return transform;
+		}
+
+		void WriteSceneComponentWorldTransform(SceneComponent& component, const EditorTransform& worldTransform)
+		{
+			EditorTransform localTransform = worldTransform;
+			if (const SceneComponent* parent = component.GetParent())
+			{
+				const Vector3& parentPosition = parent->GetWorldPosition();
+				const Vector3& parentRotation = parent->GetWorldRotation();
+				const Vector3& parentScale = parent->GetWorldScale();
+				localTransform.position = worldTransform.position - parentPosition;
+				localTransform.rotation = worldTransform.rotation - parentRotation;
+				localTransform.scale = {
+					std::abs(parentScale.x) > 0.0001f ? worldTransform.scale.x / parentScale.x : worldTransform.scale.x,
+					std::abs(parentScale.y) > 0.0001f ? worldTransform.scale.y / parentScale.y : worldTransform.scale.y,
+					std::abs(parentScale.z) > 0.0001f ? worldTransform.scale.z / parentScale.z : worldTransform.scale.z,
+				};
+			}
+			component.SetLocalPosition(localTransform.position);
+			component.SetLocalRotation(localTransform.rotation);
+			component.SetLocalScale(localTransform.scale);
+			component.RefreshWorldTransform();
+		}
+
+		void ApplyActorParent(Actor* actor, Actor* parentActor, const EditorTransform& worldTransform)
+		{
+			if (!actor || !actor->GetRootComponent()) return;
+			SceneComponent* root = actor->GetRootComponent();
+			root->Detach();
+			if (parentActor && parentActor->GetRootComponent()) root->AttachTo(parentActor->GetRootComponent());
+			WriteSceneComponentWorldTransform(*root, worldTransform); // 親変更前のWorld Transformを維持する。
+		}
+
+		void FocusEditorCamera(const Vector3& target)
+		{
+			CameraManager* cameraManager = CameraManager::GetInstance();
+			DebugCamera* debugCamera = cameraManager ? cameraManager->GetDebugCamera() : nullptr;
+			if (!debugCamera) return;
+			const Vector3 forward = Vector3::NormalizeSafe(cameraManager->GetActiveCameraForward(), { 0.0f, 0.0f, 1.0f });
+			debugCamera->SetTranslate(target - forward * 8.0f);
+			debugCamera->RefreshViewProjection();
+		}
+
 		void ExecuteActiveCommand(const EditorObjectInfo& object, bool active)
 		{
 			bool before = active;
@@ -26,6 +170,32 @@ namespace Ken4lowEngine
 				[object](const bool& value)
 				{
 					object.WriteActive(value);
+					EditorContext::GetInstance()->MarkLevelDirty();
+				}));
+		}
+
+		void ExecuteVisibilityCommand(const EditorObjectInfo& object, bool visible)
+		{
+			bool before = visible;
+			if (!object.ReadVisible(before) || before == visible) return;
+			EditorCommandHistory::GetInstance()->Execute(std::make_unique<EditorValueCommand<bool>>(
+				"Editor表示変更", before, visible,
+				[object](const bool& value)
+				{
+					object.WriteVisible(value);
+					EditorContext::GetInstance()->MarkLevelDirty();
+				}));
+		}
+
+		void ExecuteLockedCommand(const EditorObjectInfo& object, bool locked)
+		{
+			bool before = locked;
+			if (!object.ReadLocked(before) || before == locked) return;
+			EditorCommandHistory::GetInstance()->Execute(std::make_unique<EditorValueCommand<bool>>(
+				"Editorロック変更", before, locked,
+				[object](const bool& value)
+				{
+					object.WriteLocked(value);
 					EditorContext::GetInstance()->MarkLevelDirty();
 				}));
 		}
@@ -41,11 +211,157 @@ namespace Ken4lowEngine
 					EditorContext::GetInstance()->MarkLevelDirty();
 				}));
 		}
+
+		void ExecuteFolderCommand(const EditorObjectInfo& object, std::string_view folderPath)
+		{
+			const std::string normalized = NormalizeFolderPath(folderPath);
+			if (object.folderPath == normalized) return;
+			EditorCommandHistory::GetInstance()->Execute(std::make_unique<EditorValueCommand<std::string>>(
+				"フォルダー変更", object.folderPath, normalized,
+				[object](const std::string& value)
+				{
+					object.SetFolder(value);
+					EditorContext::GetInstance()->MarkLevelDirty();
+				}));
+		}
+
+		void ExecuteReparentCommand(ActorWorld& actorWorld, Actor* actor, Actor* newParent)
+		{
+			if (!actor || !actor->GetRootComponent() || actor == newParent || WouldCreateActorCycle(actor, newParent)) return;
+			Actor* oldParent = GetParentActor(actor);
+			if (oldParent == newParent) return;
+			const EditorTransform worldTransform = ReadSceneComponentWorldTransform(*actor->GetRootComponent());
+
+			EditorCommandHistory::GetInstance()->Execute(std::make_unique<EditorLambdaCommand>(
+				"アクタ親子変更",
+				[&actorWorld, actor, newParent, worldTransform]()
+				{
+					ApplyActorParent(actor, newParent, worldTransform);
+					actorWorld.SetSelectedEditorObject(actor, nullptr);
+					EditorContext::GetInstance()->MarkLevelDirty();
+				},
+				[&actorWorld, actor, oldParent, worldTransform]()
+				{
+					ApplyActorParent(actor, oldParent, worldTransform);
+					actorWorld.SetSelectedEditorObject(actor, nullptr);
+					EditorContext::GetInstance()->MarkLevelDirty();
+				}));
+		}
+
+		std::string MakeEditorActorSnapshotPath(const char* prefix, const Actor* actor)
+		{
+			static std::atomic_uint64_t serial = 0;
+			return "../Generated/Intermediate/EditorUndo/" + std::string(prefix) + "_" +
+				std::to_string(reinterpret_cast<uintptr_t>(actor)) + "_" + std::to_string(++serial) + ".json";
+		}
+
+		void SelectActor(ActorWorld& actorWorld, Actor* actor)
+		{
+			actorWorld.SetSelectedEditorObject(actor, nullptr);
+			EditorContext::GetInstance()->GetSelection().Clear();
+		}
+
+		void ExecuteDuplicateActorCommand(ActorWorld& actorWorld, Actor* sourceActor)
+		{
+			if (!sourceActor) return;
+			const std::string snapshotPath = MakeEditorActorSnapshotPath("DuplicateActor", sourceActor);
+			if (!ActorJsonSerializer::SaveActorToFile(*sourceActor, snapshotPath)) return;
+
+			const EditorActorState sourceState = EditorActorStateRegistry::GetInstance()->GetState(sourceActor);
+			Actor* sourceParent = GetParentActor(sourceActor);
+			const EditorTransform sourceWorld = sourceActor->GetRootComponent()
+				? ReadSceneComponentWorldTransform(*sourceActor->GetRootComponent())
+				: EditorTransform{};
+			auto duplicatedActor = std::make_shared<Actor*>(nullptr);
+
+			EditorCommandHistory::GetInstance()->Clear();
+			EditorCommandHistory::GetInstance()->Execute(std::make_unique<EditorLambdaCommand>(
+				"アクタ複製",
+				[&actorWorld, duplicatedActor, snapshotPath, sourceState, sourceParent, sourceWorld]()
+				{
+					*duplicatedActor = actorWorld.SpawnActorFromJson(snapshotPath);
+					if (!*duplicatedActor) return;
+					EditorActorStateRegistry::GetInstance()->SetState(*duplicatedActor, sourceState);
+					if ((*duplicatedActor)->GetRootComponent()) ApplyActorParent(*duplicatedActor, sourceParent, sourceWorld);
+					SelectActor(actorWorld, *duplicatedActor);
+					EditorContext::GetInstance()->MarkLevelDirty();
+				},
+				[&actorWorld, duplicatedActor]()
+				{
+					if (!*duplicatedActor) return;
+					EditorActorStateRegistry::GetInstance()->Remove(*duplicatedActor);
+					(*duplicatedActor)->Destroy();
+					*duplicatedActor = nullptr;
+					SelectActor(actorWorld, nullptr);
+					EditorContext::GetInstance()->MarkLevelDirty();
+				}));
+		}
+
+		struct ChildActorState
+		{
+			Actor* actor = nullptr;
+			EditorTransform worldTransform{};
+		};
+
+		void ExecuteDeleteActorCommand(ActorWorld& actorWorld, Actor* sourceActor)
+		{
+			if (!sourceActor) return;
+			const std::string snapshotPath = MakeEditorActorSnapshotPath("DeleteActor", sourceActor);
+			if (!ActorJsonSerializer::SaveActorToFile(*sourceActor, snapshotPath)) return;
+
+			const EditorActorState sourceState = EditorActorStateRegistry::GetInstance()->GetState(sourceActor);
+			Actor* sourceParent = GetParentActor(sourceActor);
+			const EditorTransform sourceWorld = sourceActor->GetRootComponent()
+				? ReadSceneComponentWorldTransform(*sourceActor->GetRootComponent())
+				: EditorTransform{};
+			std::vector<ChildActorState> childActors;
+			for (const auto& actorOwner : actorWorld.GetActors())
+			{
+				Actor* child = actorOwner.get();
+				if (child && GetParentActor(child) == sourceActor && child->GetRootComponent())
+				{
+					childActors.push_back({ child, ReadSceneComponentWorldTransform(*child->GetRootComponent()) });
+				}
+			}
+			auto currentActor = std::make_shared<Actor*>(sourceActor);
+
+			EditorCommandHistory::GetInstance()->Clear();
+			EditorCommandHistory::GetInstance()->Execute(std::make_unique<EditorLambdaCommand>(
+				"アクタ削除",
+				[&actorWorld, currentActor, childActors]()
+				{
+					if (!*currentActor) return;
+					for (const ChildActorState& childState : childActors)
+					{
+						ApplyActorParent(childState.actor, nullptr, childState.worldTransform);
+					}
+					EditorActorStateRegistry::GetInstance()->Remove(*currentActor);
+					(*currentActor)->Destroy();
+					*currentActor = nullptr;
+					SelectActor(actorWorld, nullptr);
+					EditorContext::GetInstance()->MarkLevelDirty();
+				},
+				[&actorWorld, currentActor, snapshotPath, sourceState, sourceParent, sourceWorld, childActors]()
+				{
+					*currentActor = actorWorld.SpawnActorFromJson(snapshotPath);
+					if (!*currentActor) return;
+					EditorActorStateRegistry::GetInstance()->SetState(*currentActor, sourceState);
+					if ((*currentActor)->GetRootComponent()) ApplyActorParent(*currentActor, sourceParent, sourceWorld);
+					for (const ChildActorState& childState : childActors)
+					{
+						ApplyActorParent(childState.actor, *currentActor, childState.worldTransform);
+					}
+					SelectActor(actorWorld, *currentActor);
+					EditorContext::GetInstance()->MarkLevelDirty();
+				}));
+		}
 	}
 
 	bool BuildInstancedModelInstanceEditorInfo(InstancedModelComponent* component, size_t instanceIndex, uint64_t componentId, std::string_view sceneName, EditorObjectInfo& outInfo)
 	{
 		if (!component || instanceIndex >= component->GetEditableInstanceCount()) return false;
+		Actor* owner = component->GetOwner();
+		const bool locked = owner && EditorActorStateRegistry::GetInstance()->IsLocked(owner);
 
 		const std::string instanceKey = std::to_string(componentId) + "/Instance/" + std::to_string(instanceIndex);
 		outInfo = {};
@@ -57,7 +373,8 @@ namespace Ken4lowEngine
 		outInfo.sceneName = std::string(sceneName);
 		outInfo.icon = "[I]";
 		outInfo.objectKind = EditorObjectKind::Instance;
-		outInfo.canEditTransform = true;
+		outInfo.canEditTransform = !locked;
+		outInfo.transformUnavailableReason = locked ? "所有Actorがロックされています。" : outInfo.transformUnavailableReason;
 		outInfo.inspectorType = EditorInspectorType::Transform;
 		outInfo.inspectorHint = "GPU Instancing内の個別Transform";
 		outInfo.readTransform = [component, instanceIndex](EditorTransform& outTransform)
@@ -96,7 +413,13 @@ namespace Ken4lowEngine
 				instanceTransform.scale = transform.scale;
 				component->SetInstanceWorldTransform(instanceIndex, instanceTransform);
 			};
-		outInfo.canCaptureState = true;
+		outInfo.canFocus = true;
+		outInfo.requestFocus = [component, instanceIndex]()
+			{
+				InstancedModelComponent::InstanceTransform transform{};
+				if (component->GetInstanceWorldTransform(instanceIndex, transform)) FocusEditorCamera(transform.position);
+			};
+		outInfo.canCaptureState = !locked;
 		outInfo.captureState = [component, instanceIndex]()
 			{
 				InstancedModelComponent::InstanceTransform transform{};
@@ -120,7 +443,7 @@ namespace Ken4lowEngine
 				if (position.size() == 3) transform.position = { position[0], position[1], position[2] };
 				if (rotation.size() == 3) transform.rotation = { rotation[0], rotation[1], rotation[2] };
 				if (scale.size() == 3) transform.scale = { scale[0], scale[1], scale[2] };
-				component->SetInstanceLocalTransform(instanceIndex, transform); // 個別InstanceのUndoはGPU Buffer更新までComponentへ任せる。
+				component->SetInstanceLocalTransform(instanceIndex, transform);
 			};
 		outInfo.canDrawObjectId = false;
 		return true;
@@ -129,36 +452,97 @@ namespace Ken4lowEngine
 	void CollectActorWorldEditorObjects(ActorWorld& actorWorld, std::vector<EditorObjectInfo>& outObjects, std::string_view sceneName)
 	{
 		const std::string sceneNameText(sceneName);
-		int actorSortOrder = 0;
+		EditorActorStateRegistry* stateRegistry = EditorActorStateRegistry::GetInstance();
+		std::unordered_map<const Actor*, uint64_t> actorIds;
+		std::unordered_set<std::string> folderPaths;
 
 		for (const auto& actorOwner : actorWorld.GetActors())
 		{
 			Actor* actor = actorOwner.get();
 			if (!actor || actor->IsPendingDestroy()) continue;
+			actorIds.emplace(actor, MakeActorEditorId(sceneNameText, actor));
+			CollectFolderPrefixes(stateRegistry->GetFolderPath(actor), folderPaths);
+		}
 
-			const std::string actorKey = sceneNameText + "/Actor/" + std::to_string(static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(actor)));
-			const uint64_t actorId = MakeStableEditorObjectId(actorKey);
+		std::vector<std::string> sortedFolders(folderPaths.begin(), folderPaths.end());
+		std::sort(sortedFolders.begin(), sortedFolders.end());
+		for (size_t folderIndex = 0; folderIndex < sortedFolders.size(); ++folderIndex)
+		{
+			const std::string& folderPath = sortedFolders[folderIndex];
+			EditorObjectInfo folderInfo{};
+			folderInfo.id = MakeFolderEditorId(sceneNameText, folderPath);
+			const std::string parentFolder = GetParentFolderPath(folderPath);
+			folderInfo.parentId = parentFolder.empty() ? 0 : MakeFolderEditorId(sceneNameText, parentFolder);
+			folderInfo.sortOrder = static_cast<int>(folderIndex);
+			folderInfo.displayName = GetFolderName(folderPath);
+			folderInfo.typeName = "Folder";
+			folderInfo.sceneName = sceneNameText;
+			folderInfo.icon = "[F]";
+			folderInfo.folderPath = folderPath;
+			folderInfo.objectKind = EditorObjectKind::Folder;
+			folderInfo.inspectorHint = folderPath;
+			outObjects.push_back(std::move(folderInfo));
+		}
+
+		int actorSortOrder = 0;
+		for (const auto& actorOwner : actorWorld.GetActors())
+		{
+			Actor* actor = actorOwner.get();
+			if (!actor || actor->IsPendingDestroy()) continue;
+			const uint64_t actorId = actorIds.at(actor);
+			const EditorActorState actorState = stateRegistry->GetState(actor);
+			Actor* parentActor = GetParentActor(actor);
 
 			EditorObjectInfo actorInfo{};
 			actorInfo.id = actorId;
+			actorInfo.parentId = parentActor && actorIds.contains(parentActor)
+				? actorIds.at(parentActor)
+				: (actorState.folderPath.empty() ? 0 : MakeFolderEditorId(sceneNameText, NormalizeFolderPath(actorState.folderPath)));
 			actorInfo.sortOrder = actorSortOrder++;
 			actorInfo.displayName = actor->GetName().empty() ? actor->GetClassTypeName() : actor->GetName();
 			actorInfo.typeName = actor->GetClassTypeName();
 			actorInfo.sceneName = sceneNameText;
 			actorInfo.icon = "[A]";
+			actorInfo.folderPath = NormalizeFolderPath(actorState.folderPath);
 			actorInfo.objectKind = EditorObjectKind::Actor;
 			actorInfo.canToggleActive = true;
 			actorInfo.readActive = [actor]() { return actor->IsActive(); };
 			actorInfo.writeActive = [actor](bool active) { actor->SetActive(active); };
+			actorInfo.canToggleVisibility = true;
+			actorInfo.readVisible = [actor]() { return EditorActorStateRegistry::GetInstance()->IsVisible(actor); };
+			actorInfo.writeVisible = [actor](bool visible) { EditorActorStateRegistry::GetInstance()->SetVisible(actor, visible); };
+			actorInfo.canToggleLocked = true;
+			actorInfo.readLocked = [actor]() { return EditorActorStateRegistry::GetInstance()->IsLocked(actor); };
+			actorInfo.writeLocked = [actor](bool locked) { EditorActorStateRegistry::GetInstance()->SetLocked(actor, locked); };
 			actorInfo.canRename = true;
 			actorInfo.rename = [actor](std::string_view name) { actor->SetName(name); };
-			actorInfo.inspectorHint = "Actor / Component Details";
+			actorInfo.canDuplicate = true;
+			actorInfo.requestDuplicate = [&actorWorld, actor]() { ExecuteDuplicateActorCommand(actorWorld, actor); };
+			actorInfo.canDelete = true;
+			actorInfo.requestDelete = [&actorWorld, actor]() { ExecuteDeleteActorCommand(actorWorld, actor); };
+			actorInfo.canFocus = actor->GetRootComponent() != nullptr;
+			actorInfo.requestFocus = [actor]()
+				{
+					if (actor->GetRootComponent()) FocusEditorCamera(actor->GetRootComponent()->GetWorldPosition());
+				};
+			actorInfo.canReparent = actor->GetRootComponent() != nullptr;
+			actorInfo.requestReparent = [&actorWorld, actor, sceneNameText](uint64_t targetParentId)
+				{
+					Actor* targetParent = targetParentId == 0 ? nullptr : FindActorByEditorId(actorWorld, sceneNameText, targetParentId);
+					ExecuteReparentCommand(actorWorld, actor, targetParent);
+				};
+			actorInfo.canSetFolder = true;
+			actorInfo.setFolder = [actor](std::string_view folderPath)
+				{
+					EditorActorStateRegistry::GetInstance()->SetFolderPath(actor, NormalizeFolderPath(folderPath));
+				};
+			actorInfo.inspectorHint = actorState.locked ? "ActorはEditorでロックされています。" : "Actor / Component Details";
 			actorInfo.canCaptureState = true;
 			actorInfo.captureState = [actor]()
 				{
 					nlohmann::json state;
 					actor->ToJson(state);
-					state.erase("Components"); // Actor Inspectorの履歴ではComponent構成を作り直さずActor共通値だけ保持する。
+					state.erase("Components");
 					return state.dump();
 				};
 			actorInfo.restoreState = [actor](std::string_view stateText)
@@ -169,7 +553,8 @@ namespace Ken4lowEngine
 
 			if (SceneComponent* root = actor->GetRootComponent())
 			{
-				actorInfo.canEditTransform = true;
+				actorInfo.canEditTransform = !actorState.locked;
+				actorInfo.transformUnavailableReason = actorState.locked ? "Actorがロックされています。" : actorInfo.transformUnavailableReason;
 				actorInfo.inspectorType = EditorInspectorType::Transform;
 				actorInfo.readTransform = [root](EditorTransform& outTransform)
 					{
@@ -187,12 +572,10 @@ namespace Ken4lowEngine
 					};
 				actorInfo.readWorldTransform = [root](EditorTransform& outTransform)
 					{
-						outTransform.position = root->GetWorldPosition();
-						outTransform.rotation = root->GetWorldRotation();
-						outTransform.scale = root->GetWorldScale();
+						outTransform = ReadSceneComponentWorldTransform(*root);
 						return true;
 					};
-				actorInfo.writeWorldTransform = actorInfo.writeTransform;
+				actorInfo.writeWorldTransform = [root](const EditorTransform& transform) { WriteSceneComponentWorldTransform(*root, transform); };
 			}
 
 			actorInfo.drawInspector = [&actorWorld, actor]()
@@ -203,16 +586,22 @@ namespace Ken4lowEngine
 
 			EditorObjectInfo actorCommandProxy = actorInfo;
 			actorInfo.writeActive = [actorCommandProxy](bool active) { ExecuteActiveCommand(actorCommandProxy, active); };
+			actorInfo.writeVisible = [actorCommandProxy](bool visible) { ExecuteVisibilityCommand(actorCommandProxy, visible); };
+			actorInfo.writeLocked = [actorCommandProxy](bool locked) { ExecuteLockedCommand(actorCommandProxy, locked); };
 			actorInfo.rename = [actorCommandProxy](std::string_view name) { ExecuteRenameCommand(actorCommandProxy, name); };
+			actorInfo.setFolder = [actorCommandProxy](std::string_view folderPath) { ExecuteFolderCommand(actorCommandProxy, folderPath); };
 			outObjects.push_back(std::move(actorInfo));
 
 			std::unordered_map<const ActorComponent*, uint64_t> componentIds;
 			int componentSortOrder = 0;
+			const std::string actorKey = sceneNameText + "/Actor/" +
+				std::to_string(static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(actor)));
 			for (const auto& componentOwner : actor->GetComponents())
 			{
 				ActorComponent* component = componentOwner.get();
 				if (!component) continue;
-				const std::string componentKey = actorKey + "/Component/" + std::to_string(static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(component)));
+				const std::string componentKey = actorKey + "/Component/" +
+					std::to_string(static_cast<unsigned long long>(reinterpret_cast<uintptr_t>(component)));
 				componentIds.emplace(component, MakeStableEditorObjectId(componentKey));
 			}
 
@@ -236,8 +625,13 @@ namespace Ken4lowEngine
 				componentInfo.writeActive = [component](bool active) { component->SetActive(active); };
 				componentInfo.canRename = true;
 				componentInfo.rename = [component](std::string_view name) { component->SetName(name); };
+				componentInfo.canFocus = dynamic_cast<SceneComponent*>(component) != nullptr;
+				componentInfo.requestFocus = [component]()
+					{
+						if (SceneComponent* sceneComponent = dynamic_cast<SceneComponent*>(component)) FocusEditorCamera(sceneComponent->GetWorldPosition());
+					};
 				componentInfo.inspectorHint = componentInfo.isRootComponent ? "Root Component" : "Actor Component";
-				componentInfo.canCaptureState = true;
+				componentInfo.canCaptureState = !actorState.locked;
 				componentInfo.captureState = [component]()
 					{
 						nlohmann::json state;
@@ -249,7 +643,8 @@ namespace Ken4lowEngine
 						const nlohmann::json state = nlohmann::json::parse(stateText, nullptr, false);
 						if (!state.is_discarded()) component->FromJson(state);
 					};
-				componentInfo.canDrawObjectId = actor->IsActive() && component->IsActiveInHierarchy() && component->SupportsEditorObjectId();
+				componentInfo.canDrawObjectId = actor->IsActive() && actorState.visible && !actorState.locked &&
+					component->IsActiveInHierarchy() && component->SupportsEditorObjectId();
 				componentInfo.drawObjectId = [component](uint32_t objectId) { component->DrawEditorObjectId(objectId); };
 
 				if (auto* sceneComponent = dynamic_cast<SceneComponent*>(component))
@@ -259,7 +654,8 @@ namespace Ken4lowEngine
 						const auto parentId = componentIds.find(parent);
 						if (parentId != componentIds.end()) componentInfo.parentId = parentId->second;
 					}
-					componentInfo.canEditTransform = true;
+					componentInfo.canEditTransform = !actorState.locked;
+					componentInfo.transformUnavailableReason = actorState.locked ? "所有Actorがロックされています。" : componentInfo.transformUnavailableReason;
 					componentInfo.inspectorType = EditorInspectorType::Transform;
 					componentInfo.readTransform = [sceneComponent](EditorTransform& outTransform)
 						{
@@ -277,32 +673,10 @@ namespace Ken4lowEngine
 						};
 					componentInfo.readWorldTransform = [sceneComponent](EditorTransform& outTransform)
 						{
-							outTransform.position = sceneComponent->GetWorldPosition();
-							outTransform.rotation = sceneComponent->GetWorldRotation();
-							outTransform.scale = sceneComponent->GetWorldScale();
+							outTransform = ReadSceneComponentWorldTransform(*sceneComponent);
 							return true;
 						};
-					componentInfo.writeWorldTransform = [sceneComponent](const EditorTransform& worldTransform)
-						{
-							EditorTransform localTransform = worldTransform;
-							if (const SceneComponent* parent = sceneComponent->GetParent())
-							{
-								const Vector3& parentPosition = parent->GetWorldPosition();
-								const Vector3& parentRotation = parent->GetWorldRotation();
-								const Vector3& parentScale = parent->GetWorldScale();
-								localTransform.position = worldTransform.position - parentPosition;
-								localTransform.rotation = worldTransform.rotation - parentRotation;
-								localTransform.scale = {
-									std::abs(parentScale.x) > 0.0001f ? worldTransform.scale.x / parentScale.x : worldTransform.scale.x,
-									std::abs(parentScale.y) > 0.0001f ? worldTransform.scale.y / parentScale.y : worldTransform.scale.y,
-									std::abs(parentScale.z) > 0.0001f ? worldTransform.scale.z / parentScale.z : worldTransform.scale.z,
-								};
-							}
-							sceneComponent->SetLocalPosition(localTransform.position);
-							sceneComponent->SetLocalRotation(localTransform.rotation);
-							sceneComponent->SetLocalScale(localTransform.scale);
-							sceneComponent->RefreshWorldTransform();
-						};
+					componentInfo.writeWorldTransform = [sceneComponent](const EditorTransform& transform) { WriteSceneComponentWorldTransform(*sceneComponent, transform); };
 				}
 
 				componentInfo.drawInspector = [&actorWorld, actor, component]()
@@ -329,30 +703,28 @@ namespace Ken4lowEngine
 
 				const uint64_t componentId = componentInfo.id;
 				outObjects.push_back(std::move(componentInfo));
+				if (!instancedComponent) continue;
 
-				if (instancedComponent)
+				constexpr size_t kOutlinerInstanceLimit = 512;
+				const size_t instanceCount = instancedComponent->GetEditableInstanceCount();
+				const size_t visibleCount = std::min(instanceCount, kOutlinerInstanceLimit);
+				for (size_t instanceIndex = 0; instanceIndex < visibleCount; ++instanceIndex)
 				{
-					constexpr size_t kOutlinerInstanceLimit = 512;
-					const size_t instanceCount = instancedComponent->GetEditableInstanceCount();
-					const size_t visibleCount = std::min(instanceCount, kOutlinerInstanceLimit);
-					for (size_t instanceIndex = 0; instanceIndex < visibleCount; ++instanceIndex)
-					{
-						EditorObjectInfo instanceInfo{};
-						if (BuildInstancedModelInstanceEditorInfo(instancedComponent, instanceIndex, componentId, sceneNameText, instanceInfo)) outObjects.push_back(std::move(instanceInfo));
-					}
+					EditorObjectInfo instanceInfo{};
+					if (BuildInstancedModelInstanceEditorInfo(instancedComponent, instanceIndex, componentId, sceneNameText, instanceInfo)) outObjects.push_back(std::move(instanceInfo));
+				}
 
-					const EditorSelection& selection = EditorContext::GetInstance()->GetSelection();
-					if (instanceCount > visibleCount && selection.HasSelection())
+				const EditorSelection& selection = EditorContext::GetInstance()->GetSelection();
+				if (instanceCount > visibleCount && selection.HasSelection())
+				{
+					const EditorObjectInfo& selected = selection.GetSelected();
+					if (selected.objectKind == EditorObjectKind::Instance && selected.parentId == componentId && selected.sortOrder >= 0)
 					{
-						const EditorObjectInfo& selected = selection.GetSelected();
-						if (selected.objectKind == EditorObjectKind::Instance && selected.parentId == componentId && selected.sortOrder >= 0)
+						const size_t selectedIndex = static_cast<size_t>(selected.sortOrder);
+						if (selectedIndex >= visibleCount && selectedIndex < instanceCount)
 						{
-							const size_t selectedIndex = static_cast<size_t>(selected.sortOrder);
-							if (selectedIndex >= visibleCount && selectedIndex < instanceCount)
-							{
-								EditorObjectInfo selectedInfo{};
-								if (BuildInstancedModelInstanceEditorInfo(instancedComponent, selectedIndex, componentId, sceneNameText, selectedInfo)) outObjects.push_back(std::move(selectedInfo));
-							}
+							EditorObjectInfo selectedInfo{};
+							if (BuildInstancedModelInstanceEditorInfo(instancedComponent, selectedIndex, componentId, sceneNameText, selectedInfo)) outObjects.push_back(std::move(selectedInfo));
 						}
 					}
 				}

--- a/Project/Engine/Editor/EditorActorStateRegistry.h
+++ b/Project/Engine/Editor/EditorActorStateRegistry.h
@@ -1,0 +1,67 @@
+#pragma once
+
+#include <string>
+#include <string_view>
+#include <unordered_map>
+
+namespace Ken4lowEngine
+{
+	class Actor;
+
+	/// <summary>
+	/// World Outliner専用の表示、ロック、フォルダー状態をActor本体から分離して保持します。
+	/// </summary>
+	struct EditorActorState
+	{
+		bool visible = true;
+		bool locked = false;
+		std::string folderPath;
+	};
+
+	/// <summary>
+	/// Scene編集中だけ必要なActor状態をActorポインタ単位で管理します。
+	/// </summary>
+	class EditorActorStateRegistry
+	{
+	public:
+		static EditorActorStateRegistry* GetInstance()
+		{
+			static EditorActorStateRegistry instance;
+			return &instance;
+		}
+
+		const EditorActorState& GetState(const Actor* actor) const
+		{
+			const auto found = states_.find(actor);
+			return found != states_.end() ? found->second : defaultState_;
+		}
+
+		EditorActorState& GetOrCreateState(const Actor* actor)
+		{
+			return states_[actor]; // 初回参照時はEditor既定値で状態を生成する。
+		}
+
+		bool IsVisible(const Actor* actor) const { return GetState(actor).visible; }
+		bool IsLocked(const Actor* actor) const { return GetState(actor).locked; }
+		const std::string& GetFolderPath(const Actor* actor) const { return GetState(actor).folderPath; }
+
+		void SetVisible(const Actor* actor, bool visible) { GetOrCreateState(actor).visible = visible; }
+		void SetLocked(const Actor* actor, bool locked) { GetOrCreateState(actor).locked = locked; }
+		void SetFolderPath(const Actor* actor, std::string_view folderPath)
+		{
+			GetOrCreateState(actor).folderPath.assign(folderPath.begin(), folderPath.end());
+		}
+
+		void SetState(const Actor* actor, const EditorActorState& state) { states_[actor] = state; }
+		void Remove(const Actor* actor) { states_.erase(actor); }
+		void Clear() { states_.clear(); }
+
+	private:
+		EditorActorStateRegistry() = default;
+		EditorActorStateRegistry(const EditorActorStateRegistry&) = delete;
+		EditorActorStateRegistry& operator=(const EditorActorStateRegistry&) = delete;
+
+		std::unordered_map<const Actor*, EditorActorState> states_;
+		EditorActorState defaultState_{};
+	};
+} // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorContext.h
+++ b/Project/Engine/Editor/EditorContext.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "EditorActorStateRegistry.h"
 #include "EditorSelection.h"
 
 #include <cstdint>
@@ -85,7 +86,7 @@ namespace Ken4lowEngine
 		{
 			selection_.Clear();
 			ClearPlacementRequest();
-			// Scene切り替え時は寿命の短いEditor状態だけを破棄し、Level名とDirty状態は呼び出し側で決める。
+			EditorActorStateRegistry::GetInstance()->Clear(); // Scene切り替え時に古いActorポインタへ紐づくOutliner状態を破棄する。
 		}
 
 	private:

--- a/Project/Engine/Editor/EditorHierarchyPanel.h
+++ b/Project/Engine/Editor/EditorHierarchyPanel.h
@@ -26,7 +26,7 @@
 
 namespace Ken4lowEngine
 {
-	/// <summary>World OutlinerとDetailsを同じEditorSelectionへ接続します。</summary>
+	/// <summary>World Outliner V2とDetailsを同じEditorSelectionへ接続します。</summary>
 	class EditorHierarchyPanel
 	{
 	public:
@@ -53,6 +53,8 @@ namespace Ken4lowEngine
 		EditorHierarchyPanel& operator=(const EditorHierarchyPanel&) = delete;
 
 #ifdef USE_IMGUI
+		static constexpr const char* kActorDragPayload = "K4E_OUTLINER_ACTOR";
+
 		static char ToLowerAscii(unsigned char character)
 		{
 			return character >= 'A' && character <= 'Z' ? static_cast<char>(character - 'A' + 'a') : static_cast<char>(character);
@@ -77,9 +79,28 @@ namespace Ken4lowEngine
 			std::stable_sort(objects_.begin(), objects_.end(), [](const EditorObjectInfo& lhs, const EditorObjectInfo& rhs)
 				{
 					if (lhs.parentId != rhs.parentId) return lhs.parentId < rhs.parentId;
+					if (lhs.objectKind != rhs.objectKind) return lhs.objectKind == EditorObjectKind::Folder;
 					if (lhs.sortOrder != rhs.sortOrder) return lhs.sortOrder < rhs.sortOrder;
 					return lhs.displayName < rhs.displayName;
 				});
+		}
+
+		EditorObjectInfo* FindObject(uint64_t objectId)
+		{
+			const auto found = std::find_if(objects_.begin(), objects_.end(), [objectId](const EditorObjectInfo& object)
+				{
+					return object.id == objectId;
+				});
+			return found != objects_.end() ? &*found : nullptr;
+		}
+
+		const EditorObjectInfo* FindObject(uint64_t objectId) const
+		{
+			const auto found = std::find_if(objects_.begin(), objects_.end(), [objectId](const EditorObjectInfo& object)
+				{
+					return object.id == objectId;
+				});
+			return found != objects_.end() ? &*found : nullptr;
 		}
 
 		void RefreshSelection()
@@ -102,7 +123,10 @@ namespace Ken4lowEngine
 		bool MatchesFilter(const EditorObjectInfo& object) const
 		{
 			const std::string_view filter(outlinerSearch_.data());
-			return ContainsCaseInsensitive(object.displayName, filter) || ContainsCaseInsensitive(object.typeName, filter) || ContainsCaseInsensitive(object.sceneName, filter);
+			return ContainsCaseInsensitive(object.displayName, filter) ||
+				ContainsCaseInsensitive(object.typeName, filter) ||
+				ContainsCaseInsensitive(object.sceneName, filter) ||
+				ContainsCaseInsensitive(object.folderPath, filter);
 		}
 
 		bool HasMatchingDescendant(uint64_t objectId) const
@@ -116,13 +140,75 @@ namespace Ken4lowEngine
 
 		bool HasChildren(uint64_t objectId) const
 		{
-			return std::any_of(objects_.begin(), objects_.end(), [objectId](const EditorObjectInfo& object) { return object.parentId == objectId; });
+			return std::any_of(objects_.begin(), objects_.end(), [objectId](const EditorObjectInfo& object)
+				{
+					return object.parentId == objectId;
+				});
 		}
 
 		bool IsSelected(const EditorObjectInfo& object) const
 		{
 			const EditorSelection& selection = EditorContext::GetInstance()->GetSelection();
 			return selection.HasSelection() && selection.GetSelected().id == object.id && selection.GetSelected().sceneName == object.sceneName;
+		}
+
+		void BeginActorDragSource(const EditorObjectInfo& object)
+		{
+			if (object.objectKind != EditorObjectKind::Actor || !object.canReparent) return;
+			if (ImGui::BeginDragDropSource(ImGuiDragDropFlags_SourceAllowNullID))
+			{
+				const uint64_t actorId = object.id;
+				ImGui::SetDragDropPayload(kActorDragPayload, &actorId, sizeof(actorId));
+				ImGui::Text("%s  %s", object.icon.c_str(), object.displayName.c_str());
+				ImGui::TextDisabled("アクタまたはフォルダーへドロップして親子・分類を変更");
+				ImGui::EndDragDropSource();
+			}
+		}
+
+		void ApplyActorDrop(const EditorObjectInfo& target)
+		{
+			if (!ImGui::BeginDragDropTarget()) return;
+			if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload(kActorDragPayload))
+			{
+				if (payload->DataSize == sizeof(uint64_t))
+				{
+					const uint64_t draggedId = *static_cast<const uint64_t*>(payload->Data);
+					EditorObjectInfo* dragged = FindObject(draggedId);
+					if (dragged && dragged->objectKind == EditorObjectKind::Actor && dragged->id != target.id)
+					{
+						if (target.objectKind == EditorObjectKind::Actor)
+						{
+							dragged->RequestReparent(target.id);
+						}
+						else if (target.objectKind == EditorObjectKind::Folder)
+						{
+							dragged->RequestReparent(0);
+							dragged->SetFolder(target.folderPath);
+						}
+					}
+				}
+			}
+			ImGui::EndDragDropTarget();
+		}
+
+		void DrawVisibilityButton(const EditorObjectInfo& object)
+		{
+			bool visible = true;
+			if (!object.ReadVisible(visible)) return;
+			const char* label = visible ? "V" : "H";
+			if (ImGui::SmallButton(label)) object.WriteVisible(!visible);
+			if (ImGui::IsItemHovered()) ImGui::SetTooltip(visible ? "Editor Viewportで非表示にする" : "Editor Viewportで表示する");
+			ImGui::SameLine();
+		}
+
+		void DrawLockButton(const EditorObjectInfo& object)
+		{
+			bool locked = false;
+			if (!object.ReadLocked(locked)) return;
+			const char* label = locked ? "L" : "U";
+			if (ImGui::SmallButton(label)) object.WriteLocked(!locked);
+			if (ImGui::IsItemHovered()) ImGui::SetTooltip(locked ? "ロックを解除する" : "Viewport選択とTransform編集をロックする");
+			ImGui::SameLine();
 		}
 
 		void DrawObjectNode(const EditorObjectInfo& object)
@@ -132,6 +218,9 @@ namespace Ken4lowEngine
 			if (filterActive && !MatchesFilter(object) && !HasMatchingDescendant(object.id)) return;
 
 			ImGui::PushID(static_cast<int>(object.id & 0x7fffffff));
+			DrawVisibilityButton(object);
+			DrawLockButton(object);
+
 			bool active = true;
 			if (object.ReadActive(active))
 			{
@@ -144,7 +233,7 @@ namespace Ken4lowEngine
 			ImGuiTreeNodeFlags flags = ImGuiTreeNodeFlags_SpanAvailWidth | ImGuiTreeNodeFlags_OpenOnArrow | ImGuiTreeNodeFlags_OpenOnDoubleClick;
 			if (!hasChildren) flags |= ImGuiTreeNodeFlags_Leaf | ImGuiTreeNodeFlags_NoTreePushOnOpen;
 			if (IsSelected(object)) flags |= ImGuiTreeNodeFlags_Selected;
-			if (object.objectKind == EditorObjectKind::Actor) flags |= ImGuiTreeNodeFlags_DefaultOpen;
+			if (object.objectKind == EditorObjectKind::Actor || object.objectKind == EditorObjectKind::Folder) flags |= ImGuiTreeNodeFlags_DefaultOpen;
 			if (filterActive && hasChildren) ImGui::SetNextItemOpen(true, ImGuiCond_Always);
 
 			const std::string label = object.icon + "  " + object.displayName + "##OutlinerNode";
@@ -153,17 +242,30 @@ namespace Ken4lowEngine
 			{
 				CommitInspectorTransaction();
 				EditorContext::GetInstance()->GetSelection().Select(object);
+				if (ImGui::IsMouseDoubleClicked(ImGuiMouseButton_Left)) object.RequestFocus();
 			}
+
+			BeginActorDragSource(object);
+			if (object.objectKind == EditorObjectKind::Actor || object.objectKind == EditorObjectKind::Folder) ApplyActorDrop(object);
 
 			if (ImGui::BeginPopupContextItem("##OutlinerContext"))
 			{
 				ImGui::TextDisabled("%s", object.typeName.c_str());
+				if (object.canFocus && ImGui::MenuItem("選択へフォーカス", "F")) object.RequestFocus();
 				if (object.canRename && ImGui::MenuItem("名前を変更"))
 				{
 					renameTargetId_ = object.id;
 					std::snprintf(renameBuffer_.data(), renameBuffer_.size(), "%s", object.displayName.c_str());
 					openRenamePopup_ = true;
 				}
+				if (object.canSetFolder && ImGui::MenuItem("フォルダーを設定..."))
+				{
+					folderTargetId_ = object.id;
+					std::snprintf(folderBuffer_.data(), folderBuffer_.size(), "%s", object.folderPath.c_str());
+					openFolderPopup_ = true;
+				}
+				if (object.canReparent && object.parentId != 0 && ImGui::MenuItem("ルートへ移動")) object.RequestReparent(0);
+				ImGui::Separator();
 				if (object.canDuplicate && ImGui::MenuItem("複製")) object.RequestDuplicate();
 				if (object.canDelete && ImGui::MenuItem("削除")) object.RequestDelete();
 				ImGui::EndPopup();
@@ -171,7 +273,10 @@ namespace Ken4lowEngine
 
 			if (hasChildren && opened)
 			{
-				for (const EditorObjectInfo& child : objects_) if (child.parentId == object.id) DrawObjectNode(child);
+				for (const EditorObjectInfo& child : objects_)
+				{
+					if (child.parentId == object.id) DrawObjectNode(child);
+				}
 				ImGui::TreePop();
 			}
 			ImGui::PopID();
@@ -191,14 +296,62 @@ namespace Ken4lowEngine
 				ImGui::Separator();
 				if (ImGui::Button("変更", ImVec2(120.0f, 0.0f)))
 				{
-					const auto target = std::find_if(objects_.begin(), objects_.end(), [this](const EditorObjectInfo& object) { return object.id == renameTargetId_; });
-					if (target != objects_.end()) target->Rename(renameBuffer_.data());
+					if (EditorObjectInfo* target = FindObject(renameTargetId_)) target->Rename(renameBuffer_.data());
 					ImGui::CloseCurrentPopup();
 				}
 				ImGui::SameLine();
 				if (ImGui::Button("キャンセル", ImVec2(120.0f, 0.0f))) ImGui::CloseCurrentPopup();
 				ImGui::EndPopup();
 			}
+		}
+
+		void DrawFolderPopup()
+		{
+			if (openFolderPopup_)
+			{
+				ImGui::OpenPopup("フォルダーを設定##OutlinerFolder");
+				openFolderPopup_ = false;
+			}
+			if (ImGui::BeginPopupModal("フォルダーを設定##OutlinerFolder", nullptr, ImGuiWindowFlags_AlwaysAutoResize))
+			{
+				ImGui::TextDisabled("例: Environment/Buildings");
+				ImGui::SetNextItemWidth(360.0f);
+				ImGui::InputText("フォルダーパス", folderBuffer_.data(), folderBuffer_.size());
+				ImGui::Separator();
+				if (ImGui::Button("設定", ImVec2(120.0f, 0.0f)))
+				{
+					if (EditorObjectInfo* target = FindObject(folderTargetId_)) target->SetFolder(folderBuffer_.data());
+					ImGui::CloseCurrentPopup();
+				}
+				ImGui::SameLine();
+				if (ImGui::Button("ルート", ImVec2(120.0f, 0.0f)))
+				{
+					if (EditorObjectInfo* target = FindObject(folderTargetId_)) target->SetFolder("");
+					ImGui::CloseCurrentPopup();
+				}
+				ImGui::SameLine();
+				if (ImGui::Button("キャンセル", ImVec2(120.0f, 0.0f))) ImGui::CloseCurrentPopup();
+				ImGui::EndPopup();
+			}
+		}
+
+		void DrawSceneRootDropTarget()
+		{
+			ImGui::Dummy(ImVec2(ImGui::GetContentRegionAvail().x, 8.0f));
+			if (!ImGui::BeginDragDropTarget()) return;
+			if (const ImGuiPayload* payload = ImGui::AcceptDragDropPayload(kActorDragPayload))
+			{
+				if (payload->DataSize == sizeof(uint64_t))
+				{
+					const uint64_t draggedId = *static_cast<const uint64_t*>(payload->Data);
+					if (EditorObjectInfo* dragged = FindObject(draggedId))
+					{
+						dragged->RequestReparent(0);
+						dragged->SetFolder("");
+					}
+				}
+			}
+			ImGui::EndDragDropTarget();
 		}
 
 		void DrawWorldOutliner()
@@ -209,8 +362,12 @@ namespace Ken4lowEngine
 			if (ImGui::Begin(EditorPanelIds::WorldOutliner, &windowState.showWorldOutliner, windowFlags))
 			{
 				ImGui::SetNextItemWidth(-1.0f);
-				ImGui::InputTextWithHint("##OutlinerSearch", "アクタやコンポーネントを検索...", outlinerSearch_.data(), outlinerSearch_.size());
-				ImGui::TextDisabled("表示中: %zu", objects_.size());
+				ImGui::InputTextWithHint("##OutlinerSearch", "アクタ、コンポーネント、フォルダーを検索...", outlinerSearch_.data(), outlinerSearch_.size());
+				const size_t actorCount = static_cast<size_t>(std::count_if(objects_.begin(), objects_.end(), [](const EditorObjectInfo& object)
+					{
+						return object.objectKind == EditorObjectKind::Actor;
+					}));
+				ImGui::TextDisabled("Actors: %zu  Objects: %zu", actorCount, objects_.size());
 				ImGui::Separator();
 				if (ImGui::BeginChild("##WorldOutlinerBody", ImVec2(0.0f, 0.0f), false))
 				{
@@ -218,12 +375,17 @@ namespace Ken4lowEngine
 					if (ImGui::TreeNodeEx(sceneLabel, ImGuiTreeNodeFlags_DefaultOpen | ImGuiTreeNodeFlags_SpanAvailWidth))
 					{
 						if (objects_.empty()) ImGui::TextDisabled("表示できるEditorオブジェクトがありません。");
-						for (const EditorObjectInfo& object : objects_) if (object.parentId == 0) DrawObjectNode(object);
+						for (const EditorObjectInfo& object : objects_)
+						{
+							if (object.parentId == 0) DrawObjectNode(object);
+						}
+						DrawSceneRootDropTarget();
 						ImGui::TreePop();
 					}
 				}
 				ImGui::EndChild();
 				DrawRenamePopup();
+				DrawFolderPopup();
 			}
 			ImGui::End();
 		}
@@ -282,7 +444,6 @@ namespace Ken4lowEngine
 
 			const std::string beforeFrame = selected.CaptureState();
 			drawInspector();
-
 			const EditorSelection& selection = EditorContext::GetInstance()->GetSelection();
 			if (!selection.HasSelection() || selection.GetSelected().id != selected.id || selection.GetSelected().sceneName != selected.sceneName)
 			{
@@ -329,6 +490,8 @@ namespace Ken4lowEngine
 						ImGui::Text("%s  %s", selected.icon.c_str(), selected.displayName.c_str());
 						ImGui::TextDisabled("%s", selected.typeName.c_str());
 
+						if (selected.canFocus && ImGui::Button("選択へフォーカス (F)")) selected.RequestFocus();
+
 						if (selected.canRename)
 						{
 							std::array<char, 256> nameBuffer{};
@@ -339,11 +502,24 @@ namespace Ken4lowEngine
 
 						bool active = true;
 						if (selected.ReadActive(active) && ImGui::Checkbox("有効##SelectedObjectActive", &active)) selected.WriteActive(active);
+						bool visible = true;
+						if (selected.ReadVisible(visible) && ImGui::Checkbox("Editorで表示##SelectedObjectVisible", &visible)) selected.WriteVisible(visible);
+						bool locked = false;
+						if (selected.ReadLocked(locked) && ImGui::Checkbox("Editorでロック##SelectedObjectLocked", &locked)) selected.WriteLocked(locked);
+
+						if (selected.canSetFolder)
+						{
+							std::array<char, 256> folderBuffer{};
+							std::snprintf(folderBuffer.data(), folderBuffer.size(), "%s", selected.folderPath.c_str());
+							ImGui::SetNextItemWidth(-1.0f);
+							if (ImGui::InputText("フォルダー##SelectedObjectFolder", folderBuffer.data(), folderBuffer.size(), ImGuiInputTextFlags_EnterReturnsTrue)) selected.SetFolder(folderBuffer.data());
+						}
 
 						if (ImGui::CollapsingHeader("基本情報##SelectedObjectInfo", ImGuiTreeNodeFlags_DefaultOpen))
 						{
 							ImGui::Text("種類: %s", selected.typeName.c_str());
 							ImGui::Text("シーン: %s", selected.sceneName.c_str());
+							if (!selected.folderPath.empty()) ImGui::Text("フォルダー: %s", selected.folderPath.c_str());
 							ImGui::TextDisabled("Editor ID: %llu", static_cast<unsigned long long>(selected.id));
 							if (!selected.inspectorHint.empty()) ImGui::TextDisabled("%s", selected.inspectorHint.c_str());
 						}
@@ -377,8 +553,11 @@ namespace Ken4lowEngine
 		std::vector<EditorObjectInfo> objects_;
 		std::array<char, 128> outlinerSearch_{};
 		std::array<char, 256> renameBuffer_{};
+		std::array<char, 256> folderBuffer_{};
 		uint64_t renameTargetId_ = 0;
+		uint64_t folderTargetId_ = 0;
 		bool openRenamePopup_ = false;
+		bool openFolderPopup_ = false;
 		bool inspectorTransactionActive_ = false;
 		EditorObjectInfo inspectorTarget_{};
 		std::string inspectorBeforeState_;

--- a/Project/Engine/Editor/EditorObjectInfo.h
+++ b/Project/Engine/Editor/EditorObjectInfo.h
@@ -31,6 +31,7 @@ namespace Ken4lowEngine
 	enum class EditorObjectKind
 	{
 		Generic,
+		Folder,
 		Actor,
 		Component,
 		Instance,
@@ -81,10 +82,12 @@ namespace Ken4lowEngine
 		using DrawInspectorFunc = std::function<void()>;
 		using DrawObjectIdFunc = std::function<void(uint32_t)>;
 		using BuildObjectIdEntryFunc = std::function<bool(uint32_t, EditorObjectInfo&)>;
-		using ReadActiveFunc = std::function<bool()>;
-		using WriteActiveFunc = std::function<void(bool)>;
+		using ReadBoolFunc = std::function<bool()>;
+		using WriteBoolFunc = std::function<void(bool)>;
 		using RenameFunc = std::function<void(std::string_view)>;
 		using RequestActionFunc = std::function<void()>;
+		using ReparentFunc = std::function<void(uint64_t)>;
+		using SetFolderFunc = std::function<void(std::string_view)>;
 		using CaptureStateFunc = std::function<std::string()>;
 		using RestoreStateFunc = std::function<void(std::string_view)>;
 
@@ -99,6 +102,7 @@ namespace Ken4lowEngine
 		std::string typeName;
 		std::string sceneName;
 		std::string icon = "[O]";
+		std::string folderPath;
 		EditorObjectKind objectKind = EditorObjectKind::Generic;
 		bool isRootComponent = false;
 
@@ -113,14 +117,26 @@ namespace Ken4lowEngine
 		WriteTransformFunc writeWorldTransform;
 
 		bool canToggleActive = false;
-		ReadActiveFunc readActive;
-		WriteActiveFunc writeActive;
+		ReadBoolFunc readActive;
+		WriteBoolFunc writeActive;
+		bool canToggleVisibility = false;
+		ReadBoolFunc readVisible;
+		WriteBoolFunc writeVisible;
+		bool canToggleLocked = false;
+		ReadBoolFunc readLocked;
+		WriteBoolFunc writeLocked;
 		bool canRename = false;
 		RenameFunc rename;
 		bool canDuplicate = false;
 		RequestActionFunc requestDuplicate;
 		bool canDelete = false;
 		RequestActionFunc requestDelete;
+		bool canFocus = false;
+		RequestActionFunc requestFocus;
+		bool canReparent = false;
+		ReparentFunc requestReparent;
+		bool canSetFolder = false;
+		SetFolderFunc setFolder;
 
 		bool canCaptureState = false;
 		CaptureStateFunc captureState;
@@ -170,6 +186,30 @@ namespace Ken4lowEngine
 			if (canToggleActive && writeActive) writeActive(active);
 		}
 
+		bool ReadVisible(bool& outVisible) const
+		{
+			if (!canToggleVisibility || !readVisible) return false;
+			outVisible = readVisible();
+			return true;
+		}
+
+		void WriteVisible(bool visible) const
+		{
+			if (canToggleVisibility && writeVisible) writeVisible(visible);
+		}
+
+		bool ReadLocked(bool& outLocked) const
+		{
+			if (!canToggleLocked || !readLocked) return false;
+			outLocked = readLocked();
+			return true;
+		}
+
+		void WriteLocked(bool locked) const
+		{
+			if (canToggleLocked && writeLocked) writeLocked(locked);
+		}
+
 		void Rename(std::string_view name) const
 		{
 			if (canRename && rename && !name.empty()) rename(name);
@@ -183,6 +223,21 @@ namespace Ken4lowEngine
 		void RequestDelete() const
 		{
 			if (canDelete && requestDelete) requestDelete();
+		}
+
+		void RequestFocus() const
+		{
+			if (canFocus && requestFocus) requestFocus();
+		}
+
+		void RequestReparent(uint64_t targetParentId) const
+		{
+			if (canReparent && requestReparent) requestReparent(targetParentId);
+		}
+
+		void SetFolder(std::string_view path) const
+		{
+			if (canSetFolder && setFolder) setFolder(path);
 		}
 
 		std::string CaptureState() const

--- a/Project/Engine/Editor/EditorTransformGizmo.cpp
+++ b/Project/Engine/Editor/EditorTransformGizmo.cpp
@@ -12,10 +12,14 @@
 #include <CameraManager.h>
 #include <DebugCamera.h>
 #include <Matrix4x4.h>
-#include <imgui.h>
-#include <imgui_internal.h>
-#include <Externals/ImGuizmo/ImGuizmo.h>
-#include <Externals/ImGuizmo/ImGuizmo.cpp> // Debug構成でもImGuizmo実装をこの翻訳単位へ確実に組み込む。
+
+#ifdef _MSC_VER
+#pragma warning(push, 0)
+#endif
+#include <Externals/ImGuizmo/ImGuizmo.cpp> // ImGuizmo側でMath Operatorを定義してからImGui内部実装を読み込む。
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif
 
 #include <algorithm>
 #include <cmath>

--- a/Project/Engine/Editor/EditorTransformGizmo.cpp
+++ b/Project/Engine/Editor/EditorTransformGizmo.cpp
@@ -15,6 +15,7 @@
 #include <imgui.h>
 #include <imgui_internal.h>
 #include <Externals/ImGuizmo/ImGuizmo.h>
+#include <Externals/ImGuizmo/ImGuizmo.cpp> // Debug構成でもImGuizmo実装をこの翻訳単位へ確実に組み込む。
 
 #include <algorithm>
 #include <cmath>

--- a/Project/Engine/Editor/EditorTransformGizmo.h
+++ b/Project/Engine/Editor/EditorTransformGizmo.h
@@ -1,8 +1,8 @@
 #pragma once
 
 #ifdef USE_IMGUI
-#ifndef IMGUI_DEFINE_MATH_OPERATORS
-#define IMGUI_DEFINE_MATH_OPERATORS // ImGuizmo実装より先にImGuiのMath Operatorを有効化する。
+#if !defined(IMGUI_VERSION) && !defined(IMGUI_DEFINE_MATH_OPERATORS)
+#define IMGUI_DEFINE_MATH_OPERATORS // ImGui未読込の翻訳単位だけMath Operatorを先行定義する。
 #endif
 #include "EditorObjectInfo.h"
 

--- a/Project/Engine/Editor/EditorTransformGizmo.h
+++ b/Project/Engine/Editor/EditorTransformGizmo.h
@@ -1,6 +1,9 @@
 #pragma once
 
 #ifdef USE_IMGUI
+#ifndef IMGUI_DEFINE_MATH_OPERATORS
+#define IMGUI_DEFINE_MATH_OPERATORS // ImGuizmo実装より先にImGuiのMath Operatorを有効化する。
+#endif
 #include "EditorObjectInfo.h"
 
 namespace Ken4lowEngine

--- a/Project/Engine/Scene/Actor/Core/ActorWorld_Draw.cpp
+++ b/Project/Engine/Scene/Actor/Core/ActorWorld_Draw.cpp
@@ -13,6 +13,12 @@
 #include "SceneComponent.h"
 #include "SpriteManager.h"
 
+#ifdef USE_IMGUI
+#include <Editor/EditorActorStateRegistry.h>
+#include <Editor/EditorModeController.h>
+#include <Editor/EditorPlayController.h>
+#endif
+
 #include <algorithm>
 #include <cmath>
 #include <numbers>
@@ -20,15 +26,30 @@
 
 namespace Ken4lowEngine
 {
+	namespace
+	{
+		bool IsHiddenByEditorOutliner(const Actor& actor)
+		{
+#ifdef USE_IMGUI
+			const bool isEditorEditing = EditorModeController::GetInstance()->IsEditorModeEnabled() &&
+				EditorPlayController::GetInstance()->IsEditing();
+			return isEditorEditing && !EditorActorStateRegistry::GetInstance()->IsVisible(&actor);
+#else
+			(void)actor;
+			return false;
+#endif
+		}
+	}
+
 	void ActorWorld::Draw()
 	{
 		SyncLightComponentsToLightManager(); // 描画直前のLightComponent設定をLightManagerへ渡す
 
 		for (auto& actor : actors_)
 		{
-			if (!actor || !actor->IsActive())
+			if (!actor || !actor->IsActive() || IsHiddenByEditorOutliner(*actor))
 			{
-				continue; // 無効なActorは通常描画対象から外す
+				continue; // 無効またはEditorで非表示のActorは通常描画対象から外す
 			}
 
 			// 通常描画を持つActorだけが内部Component経由で描画される
@@ -49,9 +70,9 @@ namespace Ken4lowEngine
 
 		for (auto& actor : actors_)
 		{
-			if (!actor || actor->IsPendingDestroy() || !actor->IsActive())
+			if (!actor || actor->IsPendingDestroy() || !actor->IsActive() || IsHiddenByEditorOutliner(*actor))
 			{
-				continue; // 削除予定または無効なActorはUI描画対象から外す
+				continue; // 削除予定、無効、Editor非表示のActorはUI描画対象から外す
 			}
 
 			const auto components = actor->GetComponents<SpriteComponent>();
@@ -194,9 +215,9 @@ namespace Ken4lowEngine
 	{
 		for (auto& actor : actors_)
 		{
-			if (!actor || !actor->IsActive())
+			if (!actor || !actor->IsActive() || IsHiddenByEditorOutliner(*actor))
 			{
-				continue; // 無効なActorはShadow描画対象から外す
+				continue; // 無効またはEditorで非表示のActorはShadow描画対象から外す
 			}
 
 			// 影を落とすActorだけが内部Component経由でShadow描画される
@@ -210,9 +231,9 @@ namespace Ken4lowEngine
 
 		for (const auto& actor : actors_)
 		{
-			if (!actor || actor->IsPendingDestroy() || !actor->IsActive())
+			if (!actor || actor->IsPendingDestroy() || !actor->IsActive() || IsHiddenByEditorOutliner(*actor))
 			{
-				continue; // 削除予定または無効なActorはライト反映対象から外す
+				continue; // 削除予定、無効、Editor非表示のActorはライト反映対象から外す
 			}
 
 			const auto lightComponents = actor->GetComponents<LightComponent>();
@@ -249,4 +270,4 @@ namespace Ken4lowEngine
 		LightManager::GetInstance()->SetLightComponentLights(componentLights);
 	}
 
-}
+} // namespace Ken4lowEngine


### PR DESCRIPTION
## 概要
UE風Editor計画のPhase 10として、World OutlinerをActor編集の中心へ拡張しました。

## 実装内容
- Actor / Component / Folderを対象にした検索
- Editor専用の表示・非表示状態
- Editorロック状態
- Actorの親子階層表示
- Actorを別Actorへドラッグ＆ドロップするReparent
- 循環参照を防ぐ親子変更チェック
- Reparent前後でWorld Transformを維持
- 階層化されたフォルダー分類
- Actor名変更、複製、削除
- Active切り替え
- Outlinerのダブルクリック、Details、Fキーによる選択対象へのカメラフォーカス
- Hidden Actorを通常描画、UI、Shadow、Light、Viewport Pickingから除外
- Locked ActorをViewport PickingとTransform編集から除外
- Actor / Component / Instanceへロック状態を反映
- 表示、ロック、名前、Active、フォルダー、ReparentをUndo / Redoへ接続
- Actor複製・削除時にEditor状態と親子関係を復元
- Scene切り替え時に古いActorポインタへ紐づくEditor状態を破棄
- Debug構成で不足していたImGuizmo実装のリンクを修正

## 操作
- `V / H`ボタン: Editor Viewportで表示／非表示
- `U / L`ボタン: Editorロック／解除
- ActorをActorへドロップ: 親子関係を変更
- ActorをFolderへドロップ: Folderへ分類
- Sceneルート下部へドロップ: 親子関係とFolder分類を解除
- Actorをダブルクリック: 選択対象へフォーカス
- `F`: 選択対象へフォーカス
- 右クリック: Focus、Rename、Folder、Duplicate、Delete

## 確認項目
1. Actor親子階層がOutlinerへ正しく表示される
2. Actorを別Actorへドラッグして親子関係を変更できる
3. 親変更後もActorのWorld位置が飛ばない
4. Folderへドラッグして分類できる
5. 表示を切るとEditor ViewportとPickingから除外される
6. ロックするとViewport選択とTransform編集が無効になる
7. 名前変更、複製、削除を操作できる
8. 検索でActor / Component / Folderを絞り込める
9. ダブルクリック、Details、Fキーから選択対象へフォーカスできる
10. 上記の編集操作をUndo / Redoできる

## 検証
- GitHub Actions: Debug Build 成功
- GitHub Actions: Release Build 成功
- Diagnostics Job 成功