### PR TITLE
Phase 11: Play In Editor and runtime world separation

### DIFF
--- a/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
+++ b/Project/ApplicationLayer/Scene/DebugScene/DebugScene.h
@@ -10,13 +10,11 @@
 #include <LightManager.h>
 #include <PhysicsWorld.h>
 #include <PhysicsDebugDraw.h>
-#include <RigidbodyComponent.h>
-#include <SceneComponent.h>
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <cstdint>
-#include <array>
 #include <memory>
 #include <numbers>
 #include <string>
@@ -48,44 +46,12 @@ public:
 
 	void BeginEditorPlay() override
 	{
-		editorActorSnapshots_.clear();
-		for (const auto& actorOwner : actorWorld_.GetActors())
-		{
-			K4E::Actor* actor = actorOwner.get();
-			K4E::SceneComponent* root = actor ? actor->GetRootComponent() : nullptr;
-			if (!actor || !root || actor->IsPendingDestroy())
-			{
-				continue;
-			}
-			editorActorSnapshots_.push_back({ actor, root->GetLocalPosition(), root->GetLocalRotation(), root->GetLocalScale() });
-		}
-		// Play開始時点のEdit Worldだけを保存し、Pause再開では取り直さない。
+		// ActorWorldの複製とEditor状態退避はEditorPlaySessionManagerへ一元化する。
 	}
 
 	void EndEditorPlay() override
 	{
-		for (const EditorActorTransformSnapshot& snapshot : editorActorSnapshots_)
-		{
-			const bool actorExists = std::any_of(actorWorld_.GetActors().begin(), actorWorld_.GetActors().end(),
-				[&snapshot](const std::unique_ptr<K4E::Actor>& actor) { return actor.get() == snapshot.actor; });
-			if (!actorExists || !snapshot.actor)
-			{
-				continue;
-			}
-
-			if (K4E::SceneComponent* root = snapshot.actor->GetRootComponent())
-			{
-				root->SetLocalPosition(snapshot.position);
-				root->SetLocalRotation(snapshot.rotation);
-				root->SetLocalScale(snapshot.scale);
-				root->RefreshWorldTransform();
-			}
-			for (K4E::RigidbodyComponent* rigidbody : snapshot.actor->GetComponents<K4E::RigidbodyComponent>())
-			{
-				if (rigidbody) rigidbody->SetVelocity({ 0.0f, 0.0f, 0.0f });
-			}
-		}
-		editorActorSnapshots_.clear(); // Stop後はPlay中の物理変化を残さず編集状態へ戻す。
+		// Runtime World固有の後処理だけをScene Hookへ残し、Editor World復元はManagerへ任せる。
 	}
 
 	void CollectEditorObjects(std::vector<K4E::EditorObjectInfo>& outObjects) override
@@ -134,14 +100,6 @@ public:
 	void DrawImGui() override;
 
 private:
-	struct EditorActorTransformSnapshot
-	{
-		K4E::Actor* actor = nullptr;
-		K4E::Vector3 position{};
-		K4E::Vector3 rotation{};
-		K4E::Vector3 scale{ 1.0f, 1.0f, 1.0f };
-	};
-
 	void UpdateDebug();
 	void RebuildInstancingTest();
 	void ReloadAnimationModelTest();
@@ -215,5 +173,4 @@ private:
 	K4E::ActorWorld actorWorld_;
 	K4E::PhysicsWorld actorPhysicsWorld_;
 	K4E::PhysicsDebugDraw actorPhysicsDebugDraw_;
-	std::vector<EditorActorTransformSnapshot> editorActorSnapshots_;
 };

--- a/Project/Engine/Core/Application/GameApplication.cpp
+++ b/Project/Engine/Core/Application/GameApplication.cpp
@@ -103,6 +103,8 @@ namespace Ken4lowEngine
 #ifdef USE_IMGUI
 		// F1でEditor Mode / Game Preview Modeを切り替え、Preview中はゲーム入力を優先する。
 		EditorModeController::GetInstance()->Update(Input::GetInstance());
+		// FrameworkがCameraやParticleのGPU処理を積む前に、予約されたPIE Worldの生成・破棄を完了する。
+		sceneManager_->ProcessEditorPlayRequests();
 #endif // USE_IMGUI
 
 		// FPSカメラを使っていない場面でも、メインカメラの行列を最新状態にしておく。

--- a/Project/Engine/Editor/EditorLevelOverlay.h
+++ b/Project/Engine/Editor/EditorLevelOverlay.h
@@ -3,6 +3,8 @@
 #include "EditorContext.h"
 #include "EditorLevelDeferredController.h"
 #include "EditorLevelService.h"
+#include "EditorPlayController.h"
+#include "EditorPlaySessionManager.h"
 #include "EditorWindowManager.h"
 
 #include <string>
@@ -14,12 +16,14 @@
 namespace Ken4lowEngine
 {
 #ifdef USE_IMGUI
-	/// <summary>Level保存・読み込み操作をMain Viewport右上へ表示します。</summary>
+	/// <summary>Level操作と現在のEditor / PIE World状態をMain Viewport右上へ表示します。</summary>
 	inline void DrawEditorLevelOverlay()
 	{
 		EditorWindowManager* windowManager = EditorWindowManager::GetInstance();
 		EditorLevelService* levelService = EditorLevelService::GetInstance();
 		EditorLevelDeferredController* deferredController = EditorLevelDeferredController::GetInstance();
+		EditorPlayController* playController = EditorPlayController::GetInstance();
+		EditorPlaySessionManager* sessionManager = EditorPlaySessionManager::GetInstance();
 		levelService->SetSceneManager(windowManager->GetSceneManager());
 		levelService->Update(ImGui::GetIO().DeltaTime);
 		deferredController->UpdateShortcuts();
@@ -27,7 +31,7 @@ namespace Ken4lowEngine
 		const EditorViewportRect& viewportRect = windowManager->GetMainViewportRect();
 		if (viewportRect.valid)
 		{
-			const float width = 330.0f;
+			const float width = sessionManager->IsSessionActive() ? 440.0f : 330.0f;
 			ImGui::SetNextWindowPos(
 				ImVec2(viewportRect.screenMax.x - width - 8.0f, viewportRect.screenMin.y + 8.0f),
 				ImGuiCond_Always);
@@ -46,7 +50,11 @@ namespace Ken4lowEngine
 
 			if (ImGui::Begin("##EditorLevelToolbar", nullptr, flags))
 			{
+				const bool levelEditable = playController->IsEditing() && !playController->IsTransitionPending();
+				if (!levelEditable) ImGui::BeginDisabled();
 				if (ImGui::Button("Level", ImVec2(58.0f, 24.0f))) ImGui::OpenPopup("##EditorLevelMenu");
+				if (!levelEditable) ImGui::EndDisabled();
+
 				if (ImGui::BeginPopup("##EditorLevelMenu"))
 				{
 					deferredController->DrawFileMenuItems();
@@ -54,13 +62,41 @@ namespace Ken4lowEngine
 				}
 
 				ImGui::SameLine();
+				if (!levelEditable) ImGui::BeginDisabled();
 				if (ImGui::Button("保存", ImVec2(48.0f, 24.0f))) levelService->RequestSaveLevel();
-				if (ImGui::IsItemHovered()) ImGui::SetTooltip("Level保存  Ctrl+S");
+				if (ImGui::IsItemHovered(ImGuiHoveredFlags_AllowWhenDisabled))
+				{
+					ImGui::SetTooltip(levelEditable ? "Level保存  Ctrl+S" : "PIE中はEditor Levelを保存できません。");
+				}
+				if (!levelEditable) ImGui::EndDisabled();
 
 				ImGui::SameLine();
 				const EditorContext* context = EditorContext::GetInstance();
 				const std::string displayName = context->GetActiveLevelName() + (context->IsLevelDirty() ? "*" : "");
-				ImGui::TextDisabled("%s", displayName.c_str()); // Dirty状態はLevel名末尾の*で常時確認できる。
+				ImGui::TextDisabled("%s", displayName.c_str());
+
+				if (sessionManager->IsSessionActive())
+				{
+					ImGui::SameLine();
+					if (ImGui::Button("PIE Runtime", ImVec2(92.0f, 24.0f))) ImGui::OpenPopup("##PIERuntimeStatus");
+					if (ImGui::IsItemHovered())
+					{
+						ImGui::SetTooltip("Editor Worldとは別Actorインスタンスで実行中です。StopでPlay前へ戻ります。");
+					}
+					if (ImGui::BeginPopup("##PIERuntimeStatus"))
+					{
+						ImGui::TextUnformatted("PIE Runtime World");
+						ImGui::Separator();
+						ImGui::Text("Time: %.2f sec", sessionManager->GetRuntimeElapsedSeconds());
+						ImGui::Text("Frames: %llu", static_cast<unsigned long long>(sessionManager->GetRuntimeFrameCount()));
+						ImGui::Text("Actors: %zu", sessionManager->GetRuntimeActorCount());
+						ImGui::Text("State: %s", playController->GetPlayStateText());
+						if (playController->IsPaused() && ImGui::MenuItem("1フレーム実行")) playController->Step();
+						if (ImGui::MenuItem("Runtime変更を反映して停止")) playController->KeepChangesAndStop();
+						ImGui::TextDisabled("通常のStopではRuntime変更を破棄します。");
+						ImGui::EndPopup();
+					}
+				}
 			}
 			ImGui::End();
 		}

--- a/Project/Engine/Editor/EditorModeController.cpp
+++ b/Project/Engine/Editor/EditorModeController.cpp
@@ -36,13 +36,22 @@ namespace Ken4lowEngine
 	{
 #ifdef _DEBUG
 		EditorLevelDeferredController::GetInstance()->ProcessSafePoint(); // 前フレームのGPU完了後かつ新しいDraw開始前にLevel破棄・復元を行う。
+		EditorPlayController* playController = EditorPlayController::GetInstance();
 
 		if (input != nullptr && input->TriggerRawKey(DIK_F1))
 		{
-			SetEditorModeEnabled(!editorModeEnabled_); // F1はEditor / Game Preview切り替え専用にする。
+			if (playController->IsRuntimeSessionActive() || playController->GetPendingRequest() == EditorPlayRequest::Start)
+			{
+				EditorWindowManager::GetInstance()->AddOutputLog(
+					EditorLogLevel::Warning,
+					"PIE Runtime Worldを保護するためF1切り替えを無効にしました。先にStopしてください。");
+			}
+			else
+			{
+				SetEditorModeEnabled(!editorModeEnabled_); // PIE外だけEditor / Game Previewを切り替える。
+			}
 		}
 
-		EditorPlayController* playController = EditorPlayController::GetInstance();
 		if (input != nullptr && IsEditorModeEnabled() && playController->IsEditing())
 		{
 			bool allowHistoryShortcut = true;
@@ -94,8 +103,13 @@ namespace Ken4lowEngine
 			return;
 		}
 
+		if (!enabled && EditorPlayController::GetInstance()->IsRuntimeSessionActive())
+		{
+			return; // PIE中にEditor UIだけ消えてStop不能になる状態を防ぐ。
+		}
+
 		editorModeEnabled_ = enabled;
-		if (!editorModeEnabled_) EditorCommandHistory::GetInstance()->Clear(); // Editor対象が無効になる前に古いポインタを持つ履歴を破棄する。
+		if (!editorModeEnabled_) EditorCommandHistory::GetInstance()->Clear();
 		ApplyModeSideEffects();
 		NotifyModeChanged();
 	}

--- a/Project/Engine/Editor/EditorPlayController.cpp
+++ b/Project/Engine/Editor/EditorPlayController.cpp
@@ -9,26 +9,83 @@ namespace Ken4lowEngine
 		return &instance;
 	}
 
+	void EditorPlayController::QueueRequest(EditorPlayRequest request)
+	{
+		pendingRequest_ = request; // UI Draw中は状態を直接切り替えずSceneManagerの安全地点へ要求だけ渡す。
+	}
+
 	void EditorPlayController::Play()
 	{
 		if (playState_ == EditorPlayState::Edit)
 		{
-			EditorCommandHistory::GetInstance()->Clear(); // Runtime更新でEditor対象が変化する前に履歴を破棄する。
+			QueueRequest(EditorPlayRequest::Start);
 		}
+		else if (playState_ == EditorPlayState::Pause)
+		{
+			QueueRequest(EditorPlayRequest::Resume);
+		}
+	}
+
+	void EditorPlayController::Pause()
+	{
+		if (playState_ == EditorPlayState::Play) QueueRequest(EditorPlayRequest::Pause);
+	}
+
+	void EditorPlayController::Stop()
+	{
+		if (playState_ != EditorPlayState::Edit || pendingRequest_ == EditorPlayRequest::Start)
+		{
+			QueueRequest(EditorPlayRequest::Stop);
+		}
+	}
+
+	void EditorPlayController::Step()
+	{
+		if (playState_ == EditorPlayState::Pause) QueueRequest(EditorPlayRequest::Step);
+	}
+
+	void EditorPlayController::KeepChangesAndStop()
+	{
+		if (playState_ != EditorPlayState::Edit) QueueRequest(EditorPlayRequest::KeepChangesAndStop);
+	}
+
+	EditorPlayRequest EditorPlayController::ConsumePendingRequest()
+	{
+		const EditorPlayRequest request = pendingRequest_;
+		pendingRequest_ = EditorPlayRequest::None;
+		return request;
+	}
+
+	void EditorPlayController::CommitPlayStarted()
+	{
+		EditorCommandHistory::GetInstance()->Clear(); // Runtime WorldはEditor Command履歴と別ライフタイムにする。
 		playState_ = EditorPlayState::Play;
 		inputMode_ = EditorInputMode::GameCaptured;
 	}
 
-	void EditorPlayController::Pause()
+	void EditorPlayController::CommitPlayResumed()
+	{
+		playState_ = EditorPlayState::Play;
+		inputMode_ = EditorInputMode::GameCaptured;
+	}
+
+	void EditorPlayController::CommitPaused()
 	{
 		playState_ = EditorPlayState::Pause;
 		inputMode_ = EditorInputMode::GameReleased;
 	}
 
-	void EditorPlayController::Stop()
+	void EditorPlayController::CommitStopped()
 	{
 		playState_ = EditorPlayState::Edit;
 		inputMode_ = EditorInputMode::GameReleased;
+		pendingRequest_ = EditorPlayRequest::None;
+	}
+
+	void EditorPlayController::RejectPendingRequest()
+	{
+		pendingRequest_ = EditorPlayRequest::None;
+		if (playState_ == EditorPlayState::Edit) inputMode_ = EditorInputMode::GameReleased;
 	}
 
 	void EditorPlayController::ToggleInputCapture()
@@ -41,13 +98,18 @@ namespace Ken4lowEngine
 		CaptureGameInput();
 	}
 
-	void EditorPlayController::CaptureGameInput() { inputMode_ = EditorInputMode::GameCaptured; }
+	void EditorPlayController::CaptureGameInput()
+	{
+		if (IsRuntimeSessionActive()) inputMode_ = EditorInputMode::GameCaptured;
+	}
+
 	void EditorPlayController::ReleaseGameInput() { inputMode_ = EditorInputMode::GameReleased; }
 	void EditorPlayController::ForceReleaseToEditor() { ReleaseGameInput(); }
 	void EditorPlayController::SetDebugFreezeEnabled(bool enabled) { debugFreezeEnabled_ = enabled; }
 	bool EditorPlayController::IsEditing() const { return playState_ == EditorPlayState::Edit; }
 	bool EditorPlayController::IsPlaying() const { return playState_ == EditorPlayState::Play; }
 	bool EditorPlayController::IsPaused() const { return playState_ == EditorPlayState::Pause; }
+	bool EditorPlayController::IsRuntimeSessionActive() const { return playState_ != EditorPlayState::Edit; }
 	bool EditorPlayController::IsGameCaptured() const { return inputMode_ == EditorInputMode::GameCaptured; }
 	bool EditorPlayController::IsGameReleased() const { return inputMode_ == EditorInputMode::GameReleased; }
 	bool EditorPlayController::IsEditorInputMode() const { return inputMode_ == EditorInputMode::Editor; }
@@ -88,5 +150,20 @@ namespace Ken4lowEngine
 	const char* EditorPlayController::GetDebugFreezeStatusText() const
 	{
 		return debugFreezeEnabled_ ? "デバッグ停止: 有効" : "デバッグ停止: 無効";
+	}
+
+	const char* EditorPlayController::GetPendingRequestText() const
+	{
+		switch (pendingRequest_)
+		{
+		case EditorPlayRequest::Start: return "PIE開始待ち";
+		case EditorPlayRequest::Resume: return "再開待ち";
+		case EditorPlayRequest::Pause: return "一時停止待ち";
+		case EditorPlayRequest::Stop: return "停止待ち";
+		case EditorPlayRequest::Step: return "1フレーム実行待ち";
+		case EditorPlayRequest::KeepChangesAndStop: return "変更反映停止待ち";
+		case EditorPlayRequest::None:
+		default: return "";
+		}
 	}
 } // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorPlayController.h
+++ b/Project/Engine/Editor/EditorPlayController.h
@@ -2,7 +2,6 @@
 
 namespace Ken4lowEngine
 {
-
 	enum class EditorPlayState
 	{
 		Edit,
@@ -17,8 +16,20 @@ namespace Ken4lowEngine
 		GameReleased,
 	};
 
+	/// <summary>Draw中のボタン操作を次の安全なUpdate地点へ渡すPIE要求です。</summary>
+	enum class EditorPlayRequest
+	{
+		None,
+		Start,
+		Resume,
+		Pause,
+		Stop,
+		Step,
+		KeepChangesAndStop,
+	};
+
 	/// <summary>
-	/// EditorのPlay状態とMain Viewport上のゲーム入力キャプチャ状態を管理します。
+	/// EditorのPlay状態、Main Viewport入力、PIE Sessionへの遅延要求を管理します。
 	/// </summary>
 	class EditorPlayController
 	{
@@ -28,15 +39,26 @@ namespace Ken4lowEngine
 		void Play();
 		void Pause();
 		void Stop();
+		void Step();
+		void KeepChangesAndStop();
 		void ToggleInputCapture();
 		void CaptureGameInput();
 		void ReleaseGameInput();
 		void ForceReleaseToEditor();
 		void SetDebugFreezeEnabled(bool enabled);
 
+		EditorPlayRequest ConsumePendingRequest();
+		void CommitPlayStarted();
+		void CommitPlayResumed();
+		void CommitPaused();
+		void CommitStopped();
+		void RejectPendingRequest();
+
 		bool IsEditing() const;
 		bool IsPlaying() const;
 		bool IsPaused() const;
+		bool IsRuntimeSessionActive() const;
+		bool IsTransitionPending() const { return pendingRequest_ != EditorPlayRequest::None; }
 		bool IsGameCaptured() const;
 		bool IsGameReleased() const;
 		bool IsEditorInputMode() const;
@@ -44,10 +66,12 @@ namespace Ken4lowEngine
 
 		EditorPlayState GetPlayState() const { return playState_; }
 		EditorInputMode GetInputMode() const { return inputMode_; }
+		EditorPlayRequest GetPendingRequest() const { return pendingRequest_; }
 		const char* GetPlayStateText() const;
 		const char* GetInputModeText() const;
 		const char* GetInputStatusText() const;
 		const char* GetDebugFreezeStatusText() const;
+		const char* GetPendingRequestText() const;
 
 	private:
 		EditorPlayController() = default;
@@ -55,9 +79,11 @@ namespace Ken4lowEngine
 		EditorPlayController(const EditorPlayController&) = delete;
 		EditorPlayController& operator=(const EditorPlayController&) = delete;
 
-		EditorPlayState playState_ = EditorPlayState::Edit; // 起動直後はEditor編集状態から開始する。
-		EditorInputMode inputMode_ = EditorInputMode::GameReleased; // 起動直後はEditor操作を優先して誤クリックを防ぐ。
-		bool debugFreezeEnabled_ = false; // 入力キャプチャとは別の完全停止デバッグ状態をToolbarへ表示する。
-	};
+		void QueueRequest(EditorPlayRequest request);
 
+		EditorPlayState playState_ = EditorPlayState::Edit; // 起動直後はEditor Worldを表示する。
+		EditorInputMode inputMode_ = EditorInputMode::GameReleased; // 起動直後はEditor操作を優先する。
+		EditorPlayRequest pendingRequest_ = EditorPlayRequest::None; // GPU Resource破棄をDraw中に行わないためUpdateまで遅延する。
+		bool debugFreezeEnabled_ = false;
+	};
 } // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorPlaySessionManager.h
+++ b/Project/Engine/Editor/EditorPlaySessionManager.h
@@ -1,0 +1,439 @@
+#pragma once
+
+#include "EditorActorStateRegistry.h"
+#include "EditorCommandHistory.h"
+#include "EditorContext.h"
+#include "EditorLevelService.h"
+
+#include <ActorJsonSerializer.h>
+#include <ActorSpawnOptions.h>
+#include <ActorWorld.h>
+#include <BaseScene.h>
+#include <Camera.h>
+#include <CameraComponent.h>
+#include <CameraManager.h>
+#include <DebugCamera.h>
+#include <LightManager.h>
+#include <SceneComponent.h>
+#include <ShadowSettings.h>
+#include <json.hpp>
+
+#include <algorithm>
+#include <cstdint>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <string_view>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace Ken4lowEngine
+{
+	/// <summary>Editor WorldとPIE Runtime Worldのどちらを現在表示しているかを表します。</summary>
+	enum class EditorWorldDomain
+	{
+		Editor,
+		Runtime,
+	};
+
+	/// <summary>
+	/// Play開始時にEditor Worldをメモリへ退避し、別ActorインスタンスのRuntime Worldへ差し替えます。
+	/// Stop時はRuntime Worldを破棄してEditor Worldを復元するため、ゲーム中の変更は編集データへ混ざりません。
+	/// </summary>
+	class EditorPlaySessionManager
+	{
+	public:
+		static EditorPlaySessionManager* GetInstance()
+		{
+			static EditorPlaySessionManager instance;
+			return &instance;
+		}
+
+		bool BeginPlaySession(BaseScene& scene)
+		{
+			if (sessionActive_)
+			{
+				SetStatus(false, "PIE Runtime Worldは既に開始されています。");
+				return false;
+			}
+
+			WorldSnapshot snapshot{};
+			if (!CaptureWorldSnapshot(scene, snapshot))
+			{
+				SetStatus(false, "Editor WorldのSnapshot作成に失敗しました。");
+				return false;
+			}
+
+			editorSnapshot_ = std::move(snapshot);
+			if (!ReplaceWorldFromSnapshot(scene, editorSnapshot_, EditorWorldDomain::Runtime, false))
+			{
+				editorSnapshot_ = {};
+				SetStatus(false, "PIE Runtime Worldの生成に失敗しました。");
+				return false;
+			}
+
+			sessionActive_ = true;
+			worldDomain_ = EditorWorldDomain::Runtime;
+			runtimeElapsedSeconds_ = 0.0f;
+			runtimeFrameCount_ = 0;
+			runtimeActorCount_ = CountActors(scene.GetEditorActorWorld());
+			SetStatus(true, "PIE Runtime WorldをEditor Worldの複製から開始しました。");
+			return true;
+		}
+
+		bool EndPlaySession(BaseScene& scene, bool keepRuntimeChanges)
+		{
+			if (!sessionActive_ || !editorSnapshot_.valid)
+			{
+				SetStatus(false, "停止できるPIE Sessionがありません。");
+				return false;
+			}
+
+			WorldSnapshot restoreSnapshot = editorSnapshot_;
+			if (keepRuntimeChanges)
+			{
+				WorldSnapshot runtimeSnapshot{};
+				if (!CaptureWorldSnapshot(scene, runtimeSnapshot))
+				{
+					SetStatus(false, "Runtime変更の取得に失敗したためEditor Worldへ反映できませんでした。");
+					return false;
+				}
+				runtimeSnapshot.levelPath = editorSnapshot_.levelPath;
+				runtimeSnapshot.levelName = editorSnapshot_.levelName;
+				runtimeSnapshot.levelDirty = true;
+				restoreSnapshot = std::move(runtimeSnapshot); // 明示的なKeep Changes時だけRuntime Worldを編集データへ採用する。
+			}
+
+			if (!ReplaceWorldFromSnapshot(scene, restoreSnapshot, EditorWorldDomain::Editor, true))
+			{
+				SetStatus(false, "Editor Worldの復元に失敗しました。");
+				return false;
+			}
+
+			sessionActive_ = false;
+			worldDomain_ = EditorWorldDomain::Editor;
+			runtimeElapsedSeconds_ = 0.0f;
+			runtimeFrameCount_ = 0;
+			runtimeActorCount_ = 0;
+			editorSnapshot_ = {};
+			SetStatus(true, keepRuntimeChanges
+				? "Runtime変更をEditor Worldへ反映してPIEを停止しました。"
+				: "Runtime Worldを破棄してPlay前のEditor Worldへ戻しました。");
+			return true;
+		}
+
+		void CancelSessionWithoutRestore()
+		{
+			sessionActive_ = false;
+			worldDomain_ = EditorWorldDomain::Editor;
+			runtimeElapsedSeconds_ = 0.0f;
+			runtimeFrameCount_ = 0;
+			runtimeActorCount_ = 0;
+			editorSnapshot_ = {};
+			std::error_code error;
+			std::filesystem::remove_all(kTemporaryRoot, error); // Application終了時はEditor Worldの再生成を行わず一時ファイルだけ片付ける。
+		}
+
+		void NotifyRuntimeTick(float deltaTime, const BaseScene& scene)
+		{
+			if (!sessionActive_) return;
+			runtimeElapsedSeconds_ += (std::max)(0.0f, deltaTime);
+			++runtimeFrameCount_;
+			runtimeActorCount_ = CountActors(const_cast<BaseScene&>(scene).GetEditorActorWorld());
+		}
+
+		bool IsSessionActive() const { return sessionActive_; }
+		bool IsRuntimeWorldActive() const { return sessionActive_ && worldDomain_ == EditorWorldDomain::Runtime; }
+		EditorWorldDomain GetWorldDomain() const { return worldDomain_; }
+		float GetRuntimeElapsedSeconds() const { return runtimeElapsedSeconds_; }
+		uint64_t GetRuntimeFrameCount() const { return runtimeFrameCount_; }
+		std::size_t GetRuntimeActorCount() const { return runtimeActorCount_; }
+		const char* GetWorldDomainText() const { return IsRuntimeWorldActive() ? "PIE Runtime World" : "Editor World"; }
+
+		bool ConsumeStatus(std::string& outMessage, bool& outSucceeded)
+		{
+			if (consumedStatusSerial_ == statusSerial_) return false;
+			consumedStatusSerial_ = statusSerial_;
+			outMessage = statusMessage_;
+			outSucceeded = statusSucceeded_;
+			return !outMessage.empty();
+		}
+
+	private:
+		struct ActorSnapshot
+		{
+			std::string id;
+			std::string parentId;
+			nlohmann::json actorJson;
+			EditorActorState editorState{};
+		};
+
+		struct CameraSnapshot
+		{
+			bool valid = false;
+			Vector3 position{};
+			Vector3 rotation{};
+			Vector3 scale{ 1.0f, 1.0f, 1.0f };
+			float fovY = 0.45f;
+			float aspectRatio = 16.0f / 9.0f;
+			float nearClip = 0.1f;
+			float farClip = 1000.0f;
+		};
+
+		struct WorldSnapshot
+		{
+			bool valid = false;
+			std::vector<ActorSnapshot> actors;
+			LightManager::LightingSettingsGPU lighting{};
+			ShadowSettings shadow{};
+			std::vector<LightManager::PunctualLightGPU> punctualLights;
+			CameraSnapshot editorCamera{};
+			CameraSnapshot gameCamera{};
+			std::filesystem::path levelPath;
+			std::string levelName = "Untitled";
+			bool levelDirty = false;
+		};
+
+		static inline const std::filesystem::path kTemporaryRoot = "../Generated/Intermediate/EditorPIE";
+
+		EditorPlaySessionManager() = default;
+		~EditorPlaySessionManager() = default;
+		EditorPlaySessionManager(const EditorPlaySessionManager&) = delete;
+		EditorPlaySessionManager& operator=(const EditorPlaySessionManager&) = delete;
+
+		static std::size_t CountActors(const ActorWorld* actorWorld)
+		{
+			if (!actorWorld) return 0;
+			return static_cast<std::size_t>(std::count_if(actorWorld->GetActors().begin(), actorWorld->GetActors().end(),
+				[](const std::unique_ptr<Actor>& actor)
+				{
+					return actor && !actor->IsPendingDestroy();
+				}));
+		}
+
+		static Actor* GetParentActor(const Actor& actor)
+		{
+			SceneComponent* root = actor.GetRootComponent();
+			SceneComponent* parentComponent = root ? root->GetParent() : nullptr;
+			Actor* parentActor = parentComponent ? parentComponent->GetOwner() : nullptr;
+			return parentActor != &actor ? parentActor : nullptr;
+		}
+
+		static CameraSnapshot CaptureCamera(const Camera* camera)
+		{
+			CameraSnapshot snapshot{};
+			if (!camera) return snapshot;
+			snapshot.valid = true;
+			snapshot.position = camera->GetTranslate();
+			snapshot.rotation = camera->GetRotate();
+			snapshot.scale = camera->GetScale();
+			snapshot.fovY = camera->GetFovY();
+			snapshot.aspectRatio = camera->GetAspectRatio();
+			snapshot.nearClip = camera->GetNearClip();
+			snapshot.farClip = camera->GetFarClip();
+			return snapshot;
+		}
+
+		static CameraSnapshot CaptureDebugCamera(const DebugCamera* camera)
+		{
+			CameraSnapshot snapshot{};
+			if (!camera) return snapshot;
+			snapshot.valid = true;
+			snapshot.position = camera->GetTranslate();
+			snapshot.rotation = camera->GetRotate();
+			snapshot.scale = { 1.0f, 1.0f, 1.0f };
+			snapshot.fovY = camera->GetFovY();
+			snapshot.aspectRatio = camera->GetAspectRatio();
+			snapshot.nearClip = camera->GetNearClip();
+			snapshot.farClip = camera->GetFarClip();
+			return snapshot;
+		}
+
+		static void RestoreCamera(Camera* camera, const CameraSnapshot& snapshot)
+		{
+			if (!camera || !snapshot.valid) return;
+			camera->SetTranslate(snapshot.position);
+			camera->SetRotate(snapshot.rotation);
+			camera->SetScale(snapshot.scale);
+			camera->SetFovY(snapshot.fovY);
+			camera->SetAspectRatio(snapshot.aspectRatio);
+			camera->SetNearClip(snapshot.nearClip);
+			camera->SetFarClip(snapshot.farClip);
+			camera->Update();
+		}
+
+		static void RestoreDebugCamera(DebugCamera* camera, const CameraSnapshot& snapshot)
+		{
+			if (!camera || !snapshot.valid) return;
+			camera->SetTranslate(snapshot.position);
+			camera->SetRotate(snapshot.rotation);
+			camera->SetFovY(snapshot.fovY);
+			camera->SetAspectRatio(snapshot.aspectRatio);
+			camera->SetNearClip(snapshot.nearClip);
+			camera->SetFarClip(snapshot.farClip);
+			camera->RefreshViewProjection();
+		}
+
+		bool CaptureWorldSnapshot(BaseScene& scene, WorldSnapshot& outSnapshot)
+		{
+			ActorWorld* actorWorld = scene.GetEditorActorWorld();
+			if (!actorWorld) return false;
+
+			outSnapshot = {};
+			std::unordered_map<const Actor*, std::string> actorIds;
+			std::size_t actorIndex = 0;
+			for (const auto& actorOwner : actorWorld->GetActors())
+			{
+				Actor* actor = actorOwner.get();
+				if (!actor || actor->IsPendingDestroy()) continue;
+				actorIds.emplace(actor, "Actor_" + std::to_string(actorIndex++));
+			}
+
+			outSnapshot.actors.reserve(actorIds.size());
+			for (const auto& actorOwner : actorWorld->GetActors())
+			{
+				Actor* actor = actorOwner.get();
+				if (!actor || actor->IsPendingDestroy()) continue;
+
+				ActorSnapshot actorSnapshot{};
+				actorSnapshot.id = actorIds.at(actor);
+				if (Actor* parentActor = GetParentActor(*actor))
+				{
+					const auto parentIt = actorIds.find(parentActor);
+					if (parentIt != actorIds.end()) actorSnapshot.parentId = parentIt->second;
+				}
+				actorSnapshot.actorJson = ActorJsonSerializer::SerializeActor(*actor);
+				actorSnapshot.editorState = EditorActorStateRegistry::GetInstance()->GetState(actor);
+				outSnapshot.actors.push_back(std::move(actorSnapshot));
+			}
+
+			LightManager* lightManager = LightManager::GetInstance();
+			outSnapshot.lighting = lightManager->GetLightingSettings();
+			outSnapshot.shadow = lightManager->GetShadowSettingsForParameter();
+			outSnapshot.punctualLights = lightManager->GetPunctualLights();
+
+			CameraManager* cameraManager = CameraManager::GetInstance();
+			outSnapshot.editorCamera = CaptureDebugCamera(cameraManager->GetDebugCamera());
+			outSnapshot.gameCamera = CaptureCamera(cameraManager->GetMainCamera());
+			outSnapshot.levelPath = EditorLevelService::GetInstance()->GetCurrentLevelPath();
+			outSnapshot.levelName = EditorContext::GetInstance()->GetActiveLevelName();
+			outSnapshot.levelDirty = EditorContext::GetInstance()->IsLevelDirty();
+			outSnapshot.valid = true;
+			return true;
+		}
+
+		static void RestoreCameraRegistration(Actor& actor, const nlohmann::json& actorJson)
+		{
+			if (!actorJson.contains("Components") || !actorJson["Components"].is_array()) return;
+			std::vector<CameraComponent*> cameras = actor.GetComponents<CameraComponent>();
+			std::size_t cameraIndex = 0;
+			for (const nlohmann::json& componentJson : actorJson["Components"])
+			{
+				if (!componentJson.is_object() || componentJson.value("Class", std::string{}) != "CameraComponent") continue;
+				if (cameraIndex >= cameras.size()) break;
+				if (cameras[cameraIndex])
+				{
+					cameras[cameraIndex]->SetAutoRegisterMainCamera(componentJson.value("AutoRegisterMainCamera", false));
+				}
+				++cameraIndex;
+			}
+		}
+
+		bool ReplaceWorldFromSnapshot(BaseScene& scene, const WorldSnapshot& snapshot, EditorWorldDomain domain, bool restoreDocumentState)
+		{
+			if (!snapshot.valid) return false;
+			ActorWorld* actorWorld = scene.GetEditorActorWorld();
+			if (!actorWorld) return false;
+
+			const std::filesystem::path sessionDirectory = kTemporaryRoot /
+				(domain == EditorWorldDomain::Runtime ? "RuntimeWorld" : "EditorWorld");
+			std::error_code error;
+			std::filesystem::remove_all(sessionDirectory, error);
+			std::filesystem::create_directories(sessionDirectory, error);
+			if (error) return false;
+
+			EditorContext::GetInstance()->ResetTransientState();
+			EditorCommandHistory::GetInstance()->Clear();
+			actorWorld->SetSelectedEditorObject(nullptr, nullptr);
+			actorWorld->Finalize();
+			actorWorld->Initialize(); // 空Worldを初期化してJSON ActorをRuntime Spawnと同じ経路で登録する。
+
+			std::unordered_map<std::string, Actor*> loadedActors;
+			for (std::size_t index = 0; index < snapshot.actors.size(); ++index)
+			{
+				const ActorSnapshot& actorSnapshot = snapshot.actors[index];
+				const std::filesystem::path actorPath = sessionDirectory / ("Actor_" + std::to_string(index) + ".json");
+				{
+					std::ofstream file(actorPath, std::ios::trunc);
+					if (!file.is_open()) return false;
+					file << actorSnapshot.actorJson.dump(4);
+				}
+
+				ActorSpawnOptions options{};
+				options.applySpawnOffset = false;
+				options.disableAutoRegisterMainCamera = false;
+				Actor* actor = actorWorld->SpawnActorFromJson(actorPath.generic_string(), options);
+				if (!actor) return false;
+				RestoreCameraRegistration(*actor, actorSnapshot.actorJson);
+				EditorActorStateRegistry::GetInstance()->SetState(actor, actorSnapshot.editorState);
+				loadedActors[actorSnapshot.id] = actor;
+			}
+
+			for (const ActorSnapshot& actorSnapshot : snapshot.actors)
+			{
+				if (actorSnapshot.parentId.empty()) continue;
+				const auto childIt = loadedActors.find(actorSnapshot.id);
+				const auto parentIt = loadedActors.find(actorSnapshot.parentId);
+				if (childIt == loadedActors.end() || parentIt == loadedActors.end()) continue;
+				SceneComponent* childRoot = childIt->second ? childIt->second->GetRootComponent() : nullptr;
+				SceneComponent* parentRoot = parentIt->second ? parentIt->second->GetRootComponent() : nullptr;
+				if (childRoot && parentRoot) childRoot->AttachTo(parentRoot); // Actor JSONのLocal Transformを維持してActor間階層だけを復元する。
+			}
+
+			LightManager* lightManager = LightManager::GetInstance();
+			lightManager->GetMutableLightingSettingsForEditor() = snapshot.lighting;
+			lightManager->SetShadowSettingsFromParameter(snapshot.shadow);
+			lightManager->GetMutablePunctualLightsForEditor() = snapshot.punctualLights;
+
+			CameraManager* cameraManager = CameraManager::GetInstance();
+			RestoreDebugCamera(cameraManager->GetDebugCamera(), snapshot.editorCamera);
+			RestoreCamera(cameraManager->GetMainCamera(), snapshot.gameCamera);
+
+			actorWorld->SetSelectedEditorObject(nullptr, nullptr);
+			EditorContext::GetInstance()->GetSelection().Clear();
+			if (restoreDocumentState)
+			{
+				EditorContext::GetInstance()->SetActiveLevelName(snapshot.levelName);
+				EditorContext::GetInstance()->MarkLevelDirty(snapshot.levelDirty);
+			}
+			else
+			{
+				EditorContext::GetInstance()->SetActiveLevelName(snapshot.levelName + " [PIE]");
+				EditorContext::GetInstance()->MarkLevelDirty(false);
+			}
+
+			std::filesystem::remove_all(sessionDirectory, error);
+			worldDomain_ = domain;
+			return true;
+		}
+
+		void SetStatus(bool succeeded, std::string message)
+		{
+			statusSucceeded_ = succeeded;
+			statusMessage_ = std::move(message);
+			++statusSerial_;
+		}
+
+		WorldSnapshot editorSnapshot_{};
+		bool sessionActive_ = false;
+		EditorWorldDomain worldDomain_ = EditorWorldDomain::Editor;
+		float runtimeElapsedSeconds_ = 0.0f;
+		uint64_t runtimeFrameCount_ = 0;
+		std::size_t runtimeActorCount_ = 0;
+		std::string statusMessage_;
+		bool statusSucceeded_ = true;
+		uint64_t statusSerial_ = 0;
+		uint64_t consumedStatusSerial_ = 0;
+	};
+} // namespace Ken4lowEngine

--- a/Project/Engine/Scene/Management/SceneManager.cpp
+++ b/Project/Engine/Scene/Management/SceneManager.cpp
@@ -40,7 +40,7 @@ namespace Ken4lowEngine
 		editorSingleStepRequested_ = false;
 	}
 
-	void SceneManager::UpdateEditorPlaySession()
+	void SceneManager::ProcessEditorPlayRequests()
 	{
 #ifdef USE_IMGUI
 		if (!scene_) return;
@@ -226,7 +226,6 @@ namespace Ken4lowEngine
 			}
 		}
 
-		UpdateEditorPlaySession(); // Draw開始前の安全地点でEditor WorldとRuntime Worldを差し替える。
 		if (scene_ && (!isTransitioning_ || sceneSwapped_))
 		{
 			bool shouldUpdateGame = true;

--- a/Project/Engine/Scene/Management/SceneManager.cpp
+++ b/Project/Engine/Scene/Management/SceneManager.cpp
@@ -11,10 +11,13 @@
 #include <Editor/EditorContext.h>
 #include <Editor/EditorModeController.h>
 #include <Editor/EditorPlayController.h>
+#include <Editor/EditorPlaySessionManager.h>
+#include <Editor/EditorWindowManager.h>
 #endif
 
 #include <algorithm>
 #include <cassert>
+#include <string>
 #include <vector>
 
 namespace K4E = ::Ken4lowEngine;
@@ -34,22 +37,92 @@ namespace Ken4lowEngine
 		uncoverDelayCounter_ = 0;
 		unloadRequested_ = false;
 		editorPlaySessionActive_ = false;
+		editorSingleStepRequested_ = false;
 	}
 
 	void SceneManager::UpdateEditorPlaySession()
 	{
 #ifdef USE_IMGUI
-		if (!scene_ || K4E::EditorModeController::GetInstance()->IsGamePreviewMode()) return;
+		if (!scene_) return;
+
 		K4E::EditorPlayController* playController = K4E::EditorPlayController::GetInstance();
-		if (playController->IsPlaying() && !editorPlaySessionActive_)
+		K4E::EditorPlaySessionManager* sessionManager = K4E::EditorPlaySessionManager::GetInstance();
+		const K4E::EditorPlayRequest request = playController->ConsumePendingRequest();
+
+		switch (request)
 		{
-			scene_->BeginEditorPlay();
-			editorPlaySessionActive_ = true;
+		case K4E::EditorPlayRequest::Start:
+			if (!editorPlaySessionActive_ && sessionManager->BeginPlaySession(*scene_))
+			{
+				scene_->BeginEditorPlay();
+				editorPlaySessionActive_ = true;
+				editorSingleStepRequested_ = false;
+				playController->CommitPlayStarted();
+			}
+			else
+			{
+				playController->CommitStopped();
+			}
+			break;
+
+		case K4E::EditorPlayRequest::Resume:
+			if (editorPlaySessionActive_)
+			{
+				playController->CommitPlayResumed();
+			}
+			else
+			{
+				playController->CommitStopped();
+			}
+			break;
+
+		case K4E::EditorPlayRequest::Pause:
+			if (editorPlaySessionActive_) playController->CommitPaused();
+			break;
+
+		case K4E::EditorPlayRequest::Step:
+			if (editorPlaySessionActive_)
+			{
+				playController->CommitPaused();
+				editorSingleStepRequested_ = true; // Pause状態を保ったままこのUpdateだけRuntime Tickを許可する。
+			}
+			break;
+
+		case K4E::EditorPlayRequest::Stop:
+		case K4E::EditorPlayRequest::KeepChangesAndStop:
+			if (editorPlaySessionActive_)
+			{
+				scene_->EndEditorPlay();
+				const bool keepChanges = request == K4E::EditorPlayRequest::KeepChangesAndStop;
+				if (sessionManager->EndPlaySession(*scene_, keepChanges))
+				{
+					editorPlaySessionActive_ = false;
+					editorSingleStepRequested_ = false;
+					playController->CommitStopped();
+				}
+				else
+				{
+					playController->CommitPaused(); // 復元失敗時はRuntimeを進めず再操作できる状態で止める。
+				}
+			}
+			else
+			{
+				playController->CommitStopped();
+			}
+			break;
+
+		case K4E::EditorPlayRequest::None:
+		default:
+			break;
 		}
-		else if (playController->IsEditing() && editorPlaySessionActive_)
+
+		std::string statusMessage;
+		bool statusSucceeded = false;
+		if (sessionManager->ConsumeStatus(statusMessage, statusSucceeded))
 		{
-			scene_->EndEditorPlay();
-			editorPlaySessionActive_ = false;
+			K4E::EditorWindowManager::GetInstance()->AddOutputLog(
+				statusSucceeded ? K4E::EditorLogLevel::Info : K4E::EditorLogLevel::Error,
+				statusMessage);
 		}
 #endif
 	}
@@ -83,7 +156,7 @@ namespace Ken4lowEngine
 	void SceneManager::Update()
 	{
 		float dtRaw = K4E::GameTimer::GetInstance()->GetDeltaTime();
-		float dtFade = std::min(dtRaw, 1.0f / 30.0f);
+		float dtFade = (std::min)(dtRaw, 1.0f / 30.0f);
 		if (sceneTransition_) sceneTransition_->Update(dtFade);
 
 		if (isTransitioning_)
@@ -153,20 +226,32 @@ namespace Ken4lowEngine
 			}
 		}
 
-		UpdateEditorPlaySession();
+		UpdateEditorPlaySession(); // Draw開始前の安全地点でEditor WorldとRuntime Worldを差し替える。
 		if (scene_ && (!isTransitioning_ || sceneSwapped_))
 		{
 			bool shouldUpdateGame = true;
 #ifdef USE_IMGUI
-			shouldUpdateGame = K4E::EditorModeController::GetInstance()->IsGamePreviewMode() || K4E::EditorPlayController::GetInstance()->IsPlaying();
+			K4E::EditorPlayController* playController = K4E::EditorPlayController::GetInstance();
+			shouldUpdateGame = K4E::EditorModeController::GetInstance()->IsGamePreviewMode() ||
+				playController->IsPlaying() || editorSingleStepRequested_;
 #endif
-			if (shouldUpdateGame) scene_->Update();
+			if (shouldUpdateGame)
+			{
+				scene_->Update();
+#ifdef USE_IMGUI
+				if (editorPlaySessionActive_)
+				{
+					K4E::EditorPlaySessionManager::GetInstance()->NotifyRuntimeTick(dtRaw, *scene_);
+				}
+#endif
+			}
 			else
 			{
 				scene_->UpdateEditor(dtRaw);
 				RefreshEditorVisualState(dtRaw);
 			}
 		}
+		editorSingleStepRequested_ = false;
 	}
 
 	void SceneManager::PrepareShadowPass() { if (scene_) scene_->PrepareShadowPass(); }
@@ -193,11 +278,15 @@ namespace Ken4lowEngine
 	{
 		if (scene_)
 		{
+#ifdef USE_IMGUI
 			if (editorPlaySessionActive_)
 			{
 				scene_->EndEditorPlay();
+				K4E::EditorPlaySessionManager::GetInstance()->CancelSessionWithoutRestore();
 				editorPlaySessionActive_ = false;
+				K4E::EditorPlayController::GetInstance()->CommitStopped();
 			}
+#endif
 			scene_->Finalize();
 		}
 		if (sceneTransition_) sceneTransition_->Finalize();
@@ -209,6 +298,15 @@ namespace Ken4lowEngine
 	void SceneManager::ChangeScene(const std::string& sceneName)
 	{
 		assert(sceneFactory_);
+#ifdef USE_IMGUI
+		if (editorPlaySessionActive_ || K4E::EditorPlaySessionManager::GetInstance()->IsSessionActive())
+		{
+			K4E::EditorWindowManager::GetInstance()->AddOutputLog(
+				K4E::EditorLogLevel::Warning,
+				"PIE中のScene切り替えはEditor Worldを保護するため無効です。Stop後に切り替えてください。");
+			return; // 現段階では元SceneのEditor Worldを確実に復元することを優先する。
+		}
+#endif
 		if (IsTransitioning())
 		{
 			queuedSceneName_ = sceneName;
@@ -235,15 +333,19 @@ namespace Ken4lowEngine
 		if (!nextScene_) return;
 #ifdef USE_IMGUI
 		K4E::EditorCommandHistory::GetInstance()->Clear();
-		K4E::EditorContext::GetInstance()->ResetTransientState(); // Scene固有ポインタを持つSelectionとCommandを同時に破棄する。
+		K4E::EditorContext::GetInstance()->ResetTransientState();
 #endif
 		if (scene_)
 		{
+#ifdef USE_IMGUI
 			if (editorPlaySessionActive_)
 			{
 				scene_->EndEditorPlay();
+				K4E::EditorPlaySessionManager::GetInstance()->CancelSessionWithoutRestore();
 				editorPlaySessionActive_ = false;
+				K4E::EditorPlayController::GetInstance()->CommitStopped();
 			}
+#endif
 			scene_->Finalize();
 		}
 		scene_ = std::move(nextScene_);

--- a/Project/Engine/Scene/Management/SceneManager.h
+++ b/Project/Engine/Scene/Management/SceneManager.h
@@ -30,6 +30,7 @@ namespace Ken4lowEngine
 		void ChangeScene(const std::string& sceneName);
 
 		[[nodiscard]] bool IsTransitioning() const { return isTransitioning_ || (sceneTransition_ && sceneTransition_->IsBusy()); }
+		[[nodiscard]] bool IsPlayInEditorActive() const { return editorPlaySessionActive_; }
 		[[nodiscard]] BaseScene* GetCurrentScene() { return scene_.get(); }
 		[[nodiscard]] const BaseScene* GetCurrentScene() const { return scene_.get(); }
 		[[nodiscard]] ISceneTransition* GetSceneTransition() { return sceneTransition_.get(); }
@@ -55,6 +56,7 @@ namespace Ken4lowEngine
 		int uncoverDelayFrames_ = 3;
 		int uncoverDelayCounter_ = 0;
 		bool unloadRequested_ = false;
-		bool editorPlaySessionActive_ = false; // Pauseでは維持し、Stop時だけEdit Worldを復元する。
+		bool editorPlaySessionActive_ = false; // Runtime Worldが存在する期間はPause中もtrueを維持する。
+		bool editorSingleStepRequested_ = false; // Pause中の1フレーム実行を通常Playと分離する。
 	};
 } // namespace Ken4lowEngine

--- a/Project/Engine/Scene/Management/SceneManager.h
+++ b/Project/Engine/Scene/Management/SceneManager.h
@@ -16,6 +16,7 @@ namespace Ken4lowEngine
 		~SceneManager();
 
 		void Initialize();
+		void ProcessEditorPlayRequests();
 		void Update();
 		void PrepareShadowPass();
 		void Draw3DObjects();
@@ -38,7 +39,6 @@ namespace Ken4lowEngine
 
 	private:
 		void ApplyNextScene();
-		void UpdateEditorPlaySession();
 		void RefreshEditorVisualState(float deltaTime);
 
 		std::unique_ptr<BaseScene> scene_;


### PR DESCRIPTION
## 概要
Phase 11として、Play開始時にEditor WorldをSnapshotへ退避し、別Actorインスタンスで構成したPIE Runtime Worldを実行する仕組みを追加しました。

## 実装内容
- Play / Pause / Resume / StopをImGui Draw中に即実行せず、次フレームの安全なUpdate地点へ遅延
- FrameworkがCamera・ParticleなどのGPU処理を積む前にPIE Worldの生成・破棄を完了
- Play開始時に以下をSnapshot化
  - Actor / Component
  - Actor間の親子関係
  - Rigidbodyを含むJSON保存対象プロパティ
  - World Outlinerの表示・ロック・フォルダー
  - Global Lighting / Shadow / Global Punctual Lights
  - Editor Camera / Game Camera
  - Level名とDirty状態
- Snapshotから別ActorインスタンスのPIE Runtime Worldを生成
- 通常Stop時にRuntime Worldを破棄し、Play前のEditor Worldを復元
- Runtime中のActor移動、物理変化、生成、削除、Component変更を通常StopではEditor Worldへ残さない
- Pause / Resume
- Pause中の1フレーム実行
- 明示的な「Runtime変更を反映して停止」
- Runtime経過時間、Frame数、Actor数のPIE表示
- PIE中のLevel保存、New/Open、F1 Game Preview切り替えを保護
- PIE中のScene切り替えをEditor World保護のためブロック
- DebugScene固有のTransformだけの復元を廃止し、World単位の復元へ統一
- Application終了時はRuntime Worldを再生成せず安全にSessionを破棄

## 操作
- Play: Editor Worldを複製してPIE開始
- Pause: Runtime Worldを維持したまま更新停止
- Play: Pauseから再開
- Stop: Runtime変更を破棄してPlay前へ復元
- `PIE Runtime` メニュー → `1フレーム実行`
- `PIE Runtime` メニュー → `Runtime変更を反映して停止`
- Esc: Play中のゲーム入力だけEditorへ解放

## 確認項目
1. Playで物理挙動が開始する
2. Play中にActorが移動しても通常StopでPlay前の位置へ戻る
3. Runtime中にActorを生成・削除しても通常StopでPlay前へ戻る
4. Runtime中のComponent・Lighting変更が通常Stopでは破棄される
5. Pause / Resumeで同じRuntime Worldを維持する
6. Pause中の1フレーム実行が1回だけUpdateする
7. Runtime変更を反映して停止した場合だけEditor LevelがDirtyになる
8. PIE中にLevel保存、New/Open、F1、Scene切り替えが実行されない
9. Escでゲーム入力をEditorへ戻せる
10. Play / StopでD3D12のResource破棄タイミングエラーが発生しない

## 現在の対象
`BaseScene::GetEditorActorWorld()`でActorWorldを公開しているSceneをPIE対象にします。Scene固有の非Actor状態は既存の`BeginEditorPlay` / `EndEditorPlay` Hookで追加処理できます。

## 検証
- GitHub Actions Debug Build: success
- GitHub Actions Release Build: success
- Diagnostics: success