### PR TITLE
Phase 12: Log, profiler and error panel integration

### DIFF
--- a/Project/Engine/DebugTools/Performance/PerformanceMonitor.cpp
+++ b/Project/Engine/DebugTools/Performance/PerformanceMonitor.cpp
@@ -4,6 +4,8 @@
 #include <Windows.h>
 #include <psapi.h>
 
+#include <algorithm>
+
 using namespace Ken4lowEngine;
 
 namespace
@@ -17,15 +19,35 @@ namespace
 	}
 }
 
-void PerformanceMonitor::Update(float deltaSeconds, float fps)
+void PerformanceMonitor::Update(
+	float deltaSeconds,
+	float fps,
+	float updateMs,
+	float drawMs,
+	float presentMs,
+	float sleepMs,
+	float totalFrameMs)
 {
 	stats_.fps = fps;
 	stats_.frameTimeMs = (deltaSeconds > 0.0f) ? (deltaSeconds * 1000.0f) : 0.0f;
 	stats_.instantFps = (deltaSeconds > 0.0f) ? (1.0f / deltaSeconds) : 0.0f;
+	stats_.updateMs = (std::max)(0.0f, updateMs);
+	stats_.drawMs = (std::max)(0.0f, drawMs);
+	stats_.presentMs = (std::max)(0.0f, presentMs);
+	stats_.sleepMs = (std::max)(0.0f, sleepMs);
+	stats_.totalFrameMs = totalFrameMs > 0.0f ? totalFrameMs : stats_.frameTimeMs;
+	++stats_.frameCount;
+	if (stats_.totalFrameMs > spikeThresholdMs_) ++stats_.frameSpikeCount;
 
 	fpsHistory_[historyWriteIndex_] = stats_.instantFps;
-	frameTimeHistory_[historyWriteIndex_] = stats_.frameTimeMs;
+	frameTimeHistory_[historyWriteIndex_] = stats_.totalFrameMs;
+	updateHistory_[historyWriteIndex_] = stats_.updateMs;
+	drawHistory_[historyWriteIndex_] = stats_.drawMs;
+	presentHistory_[historyWriteIndex_] = stats_.presentMs;
+	sleepHistory_[historyWriteIndex_] = stats_.sleepMs;
 	historyWriteIndex_ = (historyWriteIndex_ + 1) % kHistorySize;
+	validHistoryCount_ = (std::min)(validHistoryCount_ + 1, kHistorySize);
+	RecalculateFrameAggregates(); // 240フレームだけを対象に平均と最大値を毎フレーム更新する。
 
 	statsRefreshAccumulator_ += static_cast<double>(deltaSeconds);
 	if (statsRefreshAccumulator_ >= 0.5)
@@ -34,6 +56,41 @@ void PerformanceMonitor::Update(float deltaSeconds, float fps)
 		UpdateSystemStats();
 		statsRefreshAccumulator_ = 0.0;
 	}
+}
+
+void PerformanceMonitor::Reset()
+{
+	stats_ = {};
+	fpsHistory_.fill(0.0f);
+	frameTimeHistory_.fill(0.0f);
+	updateHistory_.fill(0.0f);
+	drawHistory_.fill(0.0f);
+	presentHistory_.fill(0.0f);
+	sleepHistory_.fill(0.0f);
+	historyWriteIndex_ = 0;
+	validHistoryCount_ = 0;
+	statsRefreshAccumulator_ = 0.0;
+}
+
+void PerformanceMonitor::RecalculateFrameAggregates()
+{
+	if (validHistoryCount_ == 0)
+	{
+		stats_.averageFrameTimeMs = 0.0f;
+		stats_.maxFrameTimeMs = 0.0f;
+		return;
+	}
+
+	float total = 0.0f;
+	float maximum = 0.0f;
+	for (size_t index = 0; index < validHistoryCount_; ++index)
+	{
+		const float value = frameTimeHistory_[index];
+		total += value;
+		maximum = (std::max)(maximum, value);
+	}
+	stats_.averageFrameTimeMs = total / static_cast<float>(validHistoryCount_);
+	stats_.maxFrameTimeMs = maximum;
 }
 
 void PerformanceMonitor::UpdateSystemStats()
@@ -51,10 +108,7 @@ void PerformanceMonitor::UpdateSystemStats()
 float PerformanceMonitor::ComputeCpuUsagePercent()
 {
 	FILETIME idleTime{}, kernelTime{}, userTime{};
-	if (!GetSystemTimes(&idleTime, &kernelTime, &userTime))
-	{
-		return stats_.cpuUsagePercent;
-	}
+	if (!GetSystemTimes(&idleTime, &kernelTime, &userTime)) return stats_.cpuUsagePercent;
 
 	const unsigned long long currentIdle = ToUInt64(idleTime);
 	const unsigned long long currentKernel = ToUInt64(kernelTime);
@@ -76,11 +130,7 @@ float PerformanceMonitor::ComputeCpuUsagePercent()
 	prevSystemIdle_ = currentIdle;
 	prevSystemKernel_ = currentKernel;
 	prevSystemUser_ = currentUser;
-
-	if (total == 0)
-	{
-		return stats_.cpuUsagePercent;
-	}
+	if (total == 0) return stats_.cpuUsagePercent;
 
 	const double usage = (1.0 - (static_cast<double>(idleDelta) / static_cast<double>(total))) * 100.0;
 	return static_cast<float>((usage < 0.0) ? 0.0 : usage);
@@ -89,10 +139,7 @@ float PerformanceMonitor::ComputeCpuUsagePercent()
 float PerformanceMonitor::ComputeProcessCpuUsagePercent()
 {
 	FILETIME createTime{}, exitTime{}, kernelTime{}, userTime{};
-	if (!GetProcessTimes(GetCurrentProcess(), &createTime, &exitTime, &kernelTime, &userTime))
-	{
-		return stats_.processCpuUsagePercent;
-	}
+	if (!GetProcessTimes(GetCurrentProcess(), &createTime, &exitTime, &kernelTime, &userTime)) return stats_.processCpuUsagePercent;
 
 	const unsigned long long currentKernel = ToUInt64(kernelTime);
 	const unsigned long long currentUser = ToUInt64(userTime);
@@ -114,7 +161,6 @@ float PerformanceMonitor::ComputeProcessCpuUsagePercent()
 	SYSTEM_INFO systemInfo{};
 	GetSystemInfo(&systemInfo);
 	const unsigned int cpuCount = (systemInfo.dwNumberOfProcessors == 0) ? 1 : systemInfo.dwNumberOfProcessors;
-
 	const double interval100ns = 0.5 * 10000000.0;
 	const double usage = (static_cast<double>(processDelta) / (interval100ns * static_cast<double>(cpuCount))) * 100.0;
 	return static_cast<float>((usage < 0.0) ? 0.0 : usage);

--- a/Project/Engine/DebugTools/Performance/PerformanceMonitor.h
+++ b/Project/Engine/DebugTools/Performance/PerformanceMonitor.h
@@ -2,6 +2,7 @@
 
 #include <array>
 #include <cstddef>
+#include <cstdint>
 
 namespace Ken4lowEngine
 {
@@ -10,9 +11,18 @@ namespace Ken4lowEngine
 		float fps = 0.0f; // 1秒単位で集計した平均FPS
 		float instantFps = 0.0f; // frameTimeMs と同じ deltaSeconds から算出した瞬間FPS
 		float frameTimeMs = 0.0f;
+		float updateMs = 0.0f;
+		float drawMs = 0.0f;
+		float presentMs = 0.0f;
+		float sleepMs = 0.0f;
+		float totalFrameMs = 0.0f;
+		float averageFrameTimeMs = 0.0f;
+		float maxFrameTimeMs = 0.0f;
 		float cpuUsagePercent = 0.0f;
 		float processCpuUsagePercent = 0.0f;
 		float memoryUsageMB = 0.0f;
+		uint64_t frameCount = 0;
+		uint64_t frameSpikeCount = 0;
 	};
 
 	class PerformanceMonitor
@@ -20,13 +30,31 @@ namespace Ken4lowEngine
 	public:
 		static constexpr size_t kHistorySize = 240;
 
-		void Update(float deltaSeconds, float fps);
+		void Update(
+			float deltaSeconds,
+			float fps,
+			float updateMs = 0.0f,
+			float drawMs = 0.0f,
+			float presentMs = 0.0f,
+			float sleepMs = 0.0f,
+			float totalFrameMs = 0.0f);
+		void Reset();
+		void SetSpikeThresholdMs(float thresholdMs) { spikeThresholdMs_ = thresholdMs > 0.0f ? thresholdMs : 1.0f; }
+
 		const PerformanceStats& GetStats() const { return stats_; }
 		const std::array<float, kHistorySize>& GetFpsHistory() const { return fpsHistory_; }
 		const std::array<float, kHistorySize>& GetFrameTimeHistory() const { return frameTimeHistory_; }
+		const std::array<float, kHistorySize>& GetUpdateHistory() const { return updateHistory_; }
+		const std::array<float, kHistorySize>& GetDrawHistory() const { return drawHistory_; }
+		const std::array<float, kHistorySize>& GetPresentHistory() const { return presentHistory_; }
+		const std::array<float, kHistorySize>& GetSleepHistory() const { return sleepHistory_; }
+		size_t GetHistoryWriteIndex() const { return historyWriteIndex_; }
+		size_t GetValidHistoryCount() const { return validHistoryCount_; }
+		float GetSpikeThresholdMs() const { return spikeThresholdMs_; }
 
 	private:
 		void UpdateSystemStats();
+		void RecalculateFrameAggregates();
 		float ComputeCpuUsagePercent();
 		float ComputeProcessCpuUsagePercent();
 
@@ -34,7 +62,13 @@ namespace Ken4lowEngine
 		PerformanceStats stats_{};
 		std::array<float, kHistorySize> fpsHistory_{};
 		std::array<float, kHistorySize> frameTimeHistory_{};
+		std::array<float, kHistorySize> updateHistory_{};
+		std::array<float, kHistorySize> drawHistory_{};
+		std::array<float, kHistorySize> presentHistory_{};
+		std::array<float, kHistorySize> sleepHistory_{};
 		size_t historyWriteIndex_ = 0;
+		size_t validHistoryCount_ = 0;
+		float spikeThresholdMs_ = 33.333f;
 
 		double statsRefreshAccumulator_ = 0.0;
 
@@ -44,4 +78,4 @@ namespace Ken4lowEngine
 		unsigned long long prevProcessKernel_ = 0;
 		unsigned long long prevProcessUser_ = 0;
 	};
-}
+} // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorDiagnosticsPanel.h
+++ b/Project/Engine/Editor/EditorDiagnosticsPanel.h
@@ -1,0 +1,499 @@
+#pragma once
+
+#include "EditorOutputLog.h"
+
+#include <GameTimer.h>
+#include <PerformanceMonitor.h>
+
+#include <algorithm>
+#include <array>
+#include <cctype>
+#include <chrono>
+#include <cstdio>
+#include <ctime>
+#include <filesystem>
+#include <fstream>
+#include <iomanip>
+#include <sstream>
+#include <string>
+#include <string_view>
+#include <vector>
+
+#ifdef USE_IMGUI
+#include <imgui.h>
+#endif
+
+namespace Ken4lowEngine
+{
+	/// <summary>
+	/// EditorのLog、Profiler、Warning / Errorを一つのDockable Panelへ統合します。
+	/// F9で表示を切り替え、旧Output Logの共有バッファも同じ内容として参照します。
+	/// </summary>
+	class EditorDiagnosticsPanel
+	{
+	public:
+		static EditorDiagnosticsPanel* GetInstance()
+		{
+			static EditorDiagnosticsPanel instance;
+			return &instance;
+		}
+
+		void SetVisible(bool visible) { visible_ = visible; }
+		bool IsVisible() const { return visible_; }
+
+		void Draw()
+		{
+#ifdef USE_IMGUI
+			UpdateProfiler();
+
+			if (ImGui::IsKeyPressed(ImGuiKey_F9, false))
+			{
+				visible_ = !visible_; // Diagnosticsを閉じた後もキーボードから再表示できるようにする。
+			}
+
+			const EditorDiagnosticCounts counts = outputLog_->GetCounts();
+			if (autoOpenOnError_ && counts.activeErrorCount > previousActiveErrorCount_)
+			{
+				visible_ = true;
+				requestErrorTabFocus_ = true;
+			}
+			previousActiveErrorCount_ = counts.activeErrorCount;
+			if (!visible_) return;
+
+			if (ImGui::Begin("診断###Diagnostics", &visible_, ImGuiWindowFlags_MenuBar))
+			{
+				DrawMenuBar();
+				ImGui::TextDisabled("F9: 表示切替");
+				ImGui::SameLine();
+				DrawStatusSummary(counts);
+				ImGui::Separator();
+
+				if (ImGui::BeginTabBar("##DiagnosticsTabs", ImGuiTabBarFlags_Reorderable))
+				{
+					const std::string logLabel = "ログ (" + std::to_string(counts.infoCount + counts.warningCount + counts.errorCount) + ")###DiagnosticsLog";
+					if (ImGui::BeginTabItem(logLabel.c_str()))
+					{
+						DrawLogTab();
+						ImGui::EndTabItem();
+					}
+
+					if (ImGui::BeginTabItem("プロファイラー###DiagnosticsProfiler"))
+					{
+						DrawProfilerTab();
+						ImGui::EndTabItem();
+					}
+
+					const std::string errorLabel = "エラー (" + std::to_string(counts.activeErrorCount) + ")###DiagnosticsErrors";
+					const ImGuiTabItemFlags errorFlags = requestErrorTabFocus_ ? ImGuiTabItemFlags_SetSelected : ImGuiTabItemFlags_None;
+					if (ImGui::BeginTabItem(errorLabel.c_str(), nullptr, errorFlags))
+					{
+						requestErrorTabFocus_ = false;
+						DrawErrorTab();
+						ImGui::EndTabItem();
+					}
+					ImGui::EndTabBar();
+				}
+			}
+			ImGui::End();
+#endif
+		}
+
+	private:
+		EditorDiagnosticsPanel() = default;
+		~EditorDiagnosticsPanel() = default;
+		EditorDiagnosticsPanel(const EditorDiagnosticsPanel&) = delete;
+		EditorDiagnosticsPanel& operator=(const EditorDiagnosticsPanel&) = delete;
+
+#ifdef USE_IMGUI
+		static ImVec4 GetLevelColor(EditorLogLevel level)
+		{
+			if (level == EditorLogLevel::Warning) return ImVec4(1.0f, 0.82f, 0.2f, 1.0f);
+			if (level == EditorLogLevel::Error) return ImVec4(1.0f, 0.28f, 0.28f, 1.0f);
+			return ImGui::GetStyleColorVec4(ImGuiCol_Text);
+		}
+
+		static bool ContainsCaseInsensitive(std::string_view text, std::string_view filter)
+		{
+			if (filter.empty()) return true;
+			if (text.find(filter) != std::string_view::npos) return true;
+
+			std::string loweredText(text);
+			std::string loweredFilter(filter);
+			std::transform(loweredText.begin(), loweredText.end(), loweredText.begin(), [](unsigned char value)
+				{
+					return static_cast<char>(std::tolower(value));
+				});
+			std::transform(loweredFilter.begin(), loweredFilter.end(), loweredFilter.begin(), [](unsigned char value)
+				{
+					return static_cast<char>(std::tolower(value));
+				});
+			return loweredText.find(loweredFilter) != std::string::npos;
+		}
+
+		static bool MatchesLogSearch(const EditorLogEntry& entry, std::string_view filter)
+		{
+			return ContainsCaseInsensitive(entry.message, filter) ||
+				ContainsCaseInsensitive(entry.category, filter) ||
+				ContainsCaseInsensitive(entry.source, filter);
+		}
+
+		static bool MatchesIssueSearch(const EditorDiagnosticIssue& issue, std::string_view filter)
+		{
+			return ContainsCaseInsensitive(issue.message, filter) ||
+				ContainsCaseInsensitive(issue.category, filter) ||
+				ContainsCaseInsensitive(issue.source, filter);
+		}
+
+		void DrawMenuBar()
+		{
+			if (!ImGui::BeginMenuBar()) return;
+			if (ImGui::BeginMenu("表示"))
+			{
+				ImGui::MenuItem("エラー発生時に開く", nullptr, &autoOpenOnError_);
+				ImGui::MenuItem("フレームスパイクをWarningへ記録", nullptr, &reportFrameSpikes_);
+				ImGui::EndMenu();
+			}
+			if (ImGui::BeginMenu("操作"))
+			{
+				if (ImGui::MenuItem("ログを書き出す")) ExportLogs();
+				if (ImGui::MenuItem("ログを消去")) outputLog_->Clear();
+				if (ImGui::MenuItem("解決済みIssueを消去")) outputLog_->ClearResolvedIssues();
+				ImGui::EndMenu();
+			}
+			ImGui::EndMenuBar();
+		}
+
+		void DrawStatusSummary(const EditorDiagnosticCounts& counts)
+		{
+			ImGui::Text("Info %zu", counts.infoCount);
+			ImGui::SameLine();
+			ImGui::PushStyleColor(ImGuiCol_Text, GetLevelColor(EditorLogLevel::Warning));
+			ImGui::Text("Warning %zu / 未解決 %zu", counts.warningCount, counts.activeWarningCount);
+			ImGui::PopStyleColor();
+			ImGui::SameLine();
+			ImGui::PushStyleColor(ImGuiCol_Text, GetLevelColor(EditorLogLevel::Error));
+			ImGui::Text("Error %zu / 未解決 %zu", counts.errorCount, counts.activeErrorCount);
+			ImGui::PopStyleColor();
+		}
+
+		void DrawLogTab()
+		{
+			if (ImGui::Button("消去")) outputLog_->Clear();
+			ImGui::SameLine();
+			if (ImGui::Button("書き出し")) ExportLogs();
+			ImGui::SameLine();
+			ImGui::Checkbox("自動スクロール", &logAutoScroll_);
+			ImGui::SameLine();
+			ImGui::Checkbox("Info", &showInfo_);
+			ImGui::SameLine();
+			ImGui::Checkbox("Warning", &showWarnings_);
+			ImGui::SameLine();
+			ImGui::Checkbox("Error", &showErrors_);
+
+			ImGui::SetNextItemWidth((std::max)(220.0f, ImGui::GetContentRegionAvail().x * 0.45f));
+			ImGui::InputTextWithHint("##DiagnosticsLogSearch", "メッセージ・カテゴリ・発生元を検索", logSearch_.data(), logSearch_.size());
+			if (!lastExportPath_.empty())
+			{
+				ImGui::SameLine();
+				ImGui::TextDisabled("出力: %s", lastExportPath_.c_str());
+			}
+
+			const std::vector<EditorLogEntry> entries = outputLog_->GetEntries();
+			std::vector<const EditorLogEntry*> visibleEntries;
+			visibleEntries.reserve(entries.size());
+			for (const EditorLogEntry& entry : entries)
+			{
+				if (entry.level == EditorLogLevel::Info && !showInfo_) continue;
+				if (entry.level == EditorLogLevel::Warning && !showWarnings_) continue;
+				if (entry.level == EditorLogLevel::Error && !showErrors_) continue;
+				if (!MatchesLogSearch(entry, logSearch_.data())) continue;
+				visibleEntries.push_back(&entry);
+			}
+
+			const ImGuiTableFlags flags = ImGuiTableFlags_BordersV | ImGuiTableFlags_RowBg |
+				ImGuiTableFlags_Resizable | ImGuiTableFlags_ScrollY | ImGuiTableFlags_SizingStretchProp;
+			if (ImGui::BeginTable("##DiagnosticsLogTable", 5, flags, ImVec2(0.0f, 0.0f)))
+			{
+				ImGui::TableSetupScrollFreeze(0, 1);
+				ImGui::TableSetupColumn("時刻", ImGuiTableColumnFlags_WidthFixed, 105.0f);
+				ImGui::TableSetupColumn("レベル", ImGuiTableColumnFlags_WidthFixed, 82.0f);
+				ImGui::TableSetupColumn("カテゴリ", ImGuiTableColumnFlags_WidthFixed, 120.0f);
+				ImGui::TableSetupColumn("メッセージ", ImGuiTableColumnFlags_WidthStretch);
+				ImGui::TableSetupColumn("回数", ImGuiTableColumnFlags_WidthFixed, 52.0f);
+				ImGui::TableHeadersRow();
+
+				ImGuiListClipper clipper;
+				clipper.Begin(static_cast<int>(visibleEntries.size()));
+				while (clipper.Step())
+				{
+					for (int row = clipper.DisplayStart; row < clipper.DisplayEnd; ++row)
+					{
+						const EditorLogEntry& entry = *visibleEntries[static_cast<std::size_t>(row)];
+						ImGui::PushID(static_cast<int>(entry.serial));
+						ImGui::TableNextRow();
+						ImGui::TableSetColumnIndex(0);
+						ImGui::TextUnformatted(entry.timestamp.c_str());
+						ImGui::TableSetColumnIndex(1);
+						ImGui::PushStyleColor(ImGuiCol_Text, GetLevelColor(entry.level));
+						ImGui::TextUnformatted(ToString(entry.level));
+						ImGui::PopStyleColor();
+						ImGui::TableSetColumnIndex(2);
+						ImGui::TextUnformatted(entry.category.c_str());
+						ImGui::TableSetColumnIndex(3);
+						ImGui::TextWrapped("%s%s%s", entry.message.c_str(), entry.source.empty() ? "" : "  [", entry.source.empty() ? "" : entry.source.c_str());
+						if (!entry.source.empty())
+						{
+							ImGui::SameLine(0.0f, 0.0f);
+							ImGui::TextUnformatted("]");
+						}
+						if (ImGui::BeginPopupContextItem("##LogContext"))
+						{
+							if (ImGui::MenuItem("メッセージをコピー")) ImGui::SetClipboardText(entry.message.c_str());
+							ImGui::EndPopup();
+						}
+						ImGui::TableSetColumnIndex(4);
+						ImGui::Text("%u", entry.repeatCount);
+						ImGui::PopID();
+					}
+				}
+				if (logAutoScroll_ && ImGui::GetScrollY() >= ImGui::GetScrollMaxY() - 6.0f) ImGui::SetScrollHereY(1.0f);
+				ImGui::EndTable();
+			}
+		}
+
+		void DrawProfilerTab()
+		{
+			if (ImGui::Button(profilerPaused_ ? "計測再開" : "計測一時停止")) profilerPaused_ = !profilerPaused_;
+			ImGui::SameLine();
+			if (ImGui::Button("履歴リセット")) profiler_.Reset();
+			ImGui::SameLine();
+			ImGui::Checkbox("スパイクをWarningへ記録", &reportFrameSpikes_);
+			ImGui::SameLine();
+			ImGui::SetNextItemWidth(110.0f);
+			if (ImGui::DragFloat("閾値 ms", &frameSpikeThresholdMs_, 0.5f, 1.0f, 500.0f, "%.1f"))
+			{
+				profiler_.SetSpikeThresholdMs(frameSpikeThresholdMs_);
+			}
+
+			const PerformanceStats& stats = profiler_.GetStats();
+			const float targetBudgetMs = 1000.0f / static_cast<float>((std::max)(1, GameTimer::GetInstance()->GetTargetFPS()));
+			if (ImGui::BeginTable("##ProfilerSummary", 4, ImGuiTableFlags_Borders | ImGuiTableFlags_RowBg | ImGuiTableFlags_SizingStretchSame))
+			{
+				DrawProfilerMetric("FPS", stats.instantFps, "%.1f");
+				DrawProfilerMetric("Frame", stats.totalFrameMs, "%.2f ms");
+				DrawProfilerMetric("平均", stats.averageFrameTimeMs, "%.2f ms");
+				DrawProfilerMetric("最大", stats.maxFrameTimeMs, "%.2f ms");
+				DrawProfilerMetric("Update", stats.updateMs, "%.2f ms");
+				DrawProfilerMetric("Draw", stats.drawMs, "%.2f ms");
+				DrawProfilerMetric("Present", stats.presentMs, "%.2f ms");
+				DrawProfilerMetric("Sleep", stats.sleepMs, "%.2f ms");
+				DrawProfilerMetric("CPU", stats.cpuUsagePercent, "%.1f %%");
+				DrawProfilerMetric("Process CPU", stats.processCpuUsagePercent, "%.1f %%");
+				DrawProfilerMetric("Memory", stats.memoryUsageMB, "%.1f MB");
+				DrawProfilerMetric("Spike", static_cast<float>(stats.frameSpikeCount), "%.0f");
+				ImGui::EndTable();
+			}
+
+			ImGui::TextDisabled("目標フレーム予算: %.2f ms / 完了済み直前フレームを表示", targetBudgetMs);
+			const float graphMaximum = (std::max)({ 40.0f, stats.maxFrameTimeMs * 1.15f, frameSpikeThresholdMs_ * 1.15f });
+			const int historyOffset = static_cast<int>(profiler_.GetHistoryWriteIndex());
+			ImGui::PlotLines("Frame Time", profiler_.GetFrameTimeHistory().data(), static_cast<int>(PerformanceMonitor::kHistorySize), historyOffset, nullptr, 0.0f, graphMaximum, ImVec2(0.0f, 90.0f));
+			ImGui::PlotLines("Update", profiler_.GetUpdateHistory().data(), static_cast<int>(PerformanceMonitor::kHistorySize), historyOffset, nullptr, 0.0f, graphMaximum, ImVec2(0.0f, 65.0f));
+			ImGui::PlotLines("Draw", profiler_.GetDrawHistory().data(), static_cast<int>(PerformanceMonitor::kHistorySize), historyOffset, nullptr, 0.0f, graphMaximum, ImVec2(0.0f, 65.0f));
+			ImGui::PlotLines("Present", profiler_.GetPresentHistory().data(), static_cast<int>(PerformanceMonitor::kHistorySize), historyOffset, nullptr, 0.0f, graphMaximum, ImVec2(0.0f, 65.0f));
+		}
+
+		static void DrawProfilerMetric(const char* label, float value, const char* format)
+		{
+			ImGui::TableNextColumn();
+			ImGui::TextDisabled("%s", label);
+			ImGui::Text(format, value);
+		}
+
+		void DrawErrorTab()
+		{
+			if (ImGui::Button("すべて解決")) outputLog_->ResolveAllIssues();
+			ImGui::SameLine();
+			if (ImGui::Button("解決済みを消去")) outputLog_->ClearResolvedIssues();
+			ImGui::SameLine();
+			ImGui::Checkbox("未解決", &showActiveIssues_);
+			ImGui::SameLine();
+			ImGui::Checkbox("解決済み", &showResolvedIssues_);
+			ImGui::SameLine();
+			ImGui::Checkbox("Warning", &showIssueWarnings_);
+			ImGui::SameLine();
+			ImGui::Checkbox("Error", &showIssueErrors_);
+
+			ImGui::SetNextItemWidth((std::max)(220.0f, ImGui::GetContentRegionAvail().x * 0.45f));
+			ImGui::InputTextWithHint("##DiagnosticsIssueSearch", "Issueを検索", issueSearch_.data(), issueSearch_.size());
+
+			const std::vector<EditorDiagnosticIssue> issues = outputLog_->GetIssues();
+			std::vector<const EditorDiagnosticIssue*> visibleIssues;
+			visibleIssues.reserve(issues.size());
+			for (const EditorDiagnosticIssue& issue : issues)
+			{
+				if (issue.resolved && !showResolvedIssues_) continue;
+				if (!issue.resolved && !showActiveIssues_) continue;
+				if (issue.level == EditorLogLevel::Warning && !showIssueWarnings_) continue;
+				if (issue.level == EditorLogLevel::Error && !showIssueErrors_) continue;
+				if (!MatchesIssueSearch(issue, issueSearch_.data())) continue;
+				visibleIssues.push_back(&issue);
+			}
+
+			const float detailsHeight = selectedIssueSerial_ != 0 ? 145.0f : 0.0f;
+			const ImGuiTableFlags flags = ImGuiTableFlags_BordersV | ImGuiTableFlags_RowBg |
+				ImGuiTableFlags_Resizable | ImGuiTableFlags_ScrollY | ImGuiTableFlags_SizingStretchProp;
+			if (ImGui::BeginTable("##DiagnosticsIssueTable", 6, flags, ImVec2(0.0f, detailsHeight > 0.0f ? -detailsHeight : 0.0f)))
+			{
+				ImGui::TableSetupScrollFreeze(0, 1);
+				ImGui::TableSetupColumn("状態", ImGuiTableColumnFlags_WidthFixed, 72.0f);
+				ImGui::TableSetupColumn("最終", ImGuiTableColumnFlags_WidthFixed, 105.0f);
+				ImGui::TableSetupColumn("レベル", ImGuiTableColumnFlags_WidthFixed, 82.0f);
+				ImGui::TableSetupColumn("カテゴリ", ImGuiTableColumnFlags_WidthFixed, 120.0f);
+				ImGui::TableSetupColumn("内容", ImGuiTableColumnFlags_WidthStretch);
+				ImGui::TableSetupColumn("回数", ImGuiTableColumnFlags_WidthFixed, 52.0f);
+				ImGui::TableHeadersRow();
+
+				for (const EditorDiagnosticIssue* issue : visibleIssues)
+				{
+					ImGui::PushID(static_cast<int>(issue->serial));
+					ImGui::TableNextRow();
+					ImGui::TableSetColumnIndex(0);
+					const bool selected = selectedIssueSerial_ == issue->serial;
+					if (ImGui::Selectable(issue->resolved ? "解決済み" : "未解決", selected, ImGuiSelectableFlags_SpanAllColumns)) selectedIssueSerial_ = issue->serial;
+					ImGui::TableSetColumnIndex(1);
+					ImGui::TextUnformatted(issue->lastTimestamp.c_str());
+					ImGui::TableSetColumnIndex(2);
+					ImGui::PushStyleColor(ImGuiCol_Text, GetLevelColor(issue->level));
+					ImGui::TextUnformatted(ToString(issue->level));
+					ImGui::PopStyleColor();
+					ImGui::TableSetColumnIndex(3);
+					ImGui::TextUnformatted(issue->category.c_str());
+					ImGui::TableSetColumnIndex(4);
+					ImGui::TextWrapped("%s", issue->message.c_str());
+					ImGui::TableSetColumnIndex(5);
+					ImGui::Text("%u", issue->occurrenceCount);
+					if (ImGui::BeginPopupContextItem("##IssueContext"))
+					{
+						if (ImGui::MenuItem(issue->resolved ? "再オープン" : "解決にする")) outputLog_->SetIssueResolved(issue->serial, !issue->resolved);
+						if (ImGui::MenuItem("内容をコピー")) ImGui::SetClipboardText(issue->message.c_str());
+						ImGui::EndPopup();
+					}
+					ImGui::PopID();
+				}
+				ImGui::EndTable();
+			}
+
+			const auto selected = std::find_if(issues.begin(), issues.end(), [&](const EditorDiagnosticIssue& issue) { return issue.serial == selectedIssueSerial_; });
+			if (selected != issues.end())
+			{
+				ImGui::SeparatorText("Issue Details");
+				ImGui::Text("%s / %s / %u回", ToString(selected->level), selected->category.c_str(), selected->occurrenceCount);
+				ImGui::TextDisabled("初回 %s   最終 %s", selected->firstTimestamp.c_str(), selected->lastTimestamp.c_str());
+				if (!selected->source.empty()) ImGui::TextDisabled("発生元: %s", selected->source.c_str());
+				ImGui::TextWrapped("%s", selected->message.c_str());
+				if (ImGui::Button(selected->resolved ? "再オープン" : "解決にする")) outputLog_->SetIssueResolved(selected->serial, !selected->resolved);
+				ImGui::SameLine();
+				if (ImGui::Button("コピー")) ImGui::SetClipboardText(selected->message.c_str());
+			}
+		}
+
+		void UpdateProfiler()
+		{
+			if (profilerPaused_) return;
+			GameTimer* timer = GameTimer::GetInstance();
+			profiler_.SetSpikeThresholdMs(frameSpikeThresholdMs_);
+			profiler_.Update(
+				timer->GetDeltaTime(),
+				timer->GetFPS(),
+				timer->GetUpdateMs(),
+				timer->GetDrawMs(),
+				timer->GetPresentMs(),
+				timer->GetSleepMs(),
+				timer->GetTotalFrameMs());
+
+			const PerformanceStats& stats = profiler_.GetStats();
+			const double now = ImGui::GetTime();
+			if (reportFrameSpikes_ && stats.totalFrameMs > frameSpikeThresholdMs_ && now - lastSpikeReportSeconds_ >= 1.0)
+			{
+				char message[256]{};
+				std::snprintf(
+					message,
+					sizeof(message),
+					"フレームスパイク %.2f ms (Update %.2f / Draw %.2f / Present %.2f / Sleep %.2f)",
+					stats.totalFrameMs,
+					stats.updateMs,
+					stats.drawMs,
+					stats.presentMs,
+					stats.sleepMs);
+				outputLog_->Warning("Profiler", message, "GameTimer");
+				lastSpikeReportSeconds_ = now; // 同じ重い状態で毎フレームIssueを増やさないよう通知間隔を制限する。
+			}
+		}
+
+		static std::string BuildFileTimestamp()
+		{
+			const auto now = std::chrono::system_clock::now();
+			const std::time_t timeValue = std::chrono::system_clock::to_time_t(now);
+			std::tm localTime{};
+#ifdef _WIN32
+			localtime_s(&localTime, &timeValue);
+#else
+			localtime_r(&timeValue, &localTime);
+#endif
+			std::ostringstream stream;
+			stream << std::put_time(&localTime, "%Y%m%d_%H%M%S");
+			return stream.str();
+		}
+
+		void ExportLogs()
+		{
+			const std::filesystem::path directory = "../Generated/Logs";
+			std::error_code error;
+			std::filesystem::create_directories(directory, error);
+			const std::filesystem::path path = directory / ("EditorDiagnostics_" + BuildFileTimestamp() + ".log");
+			std::ofstream file(path);
+			if (!file.is_open())
+			{
+				outputLog_->Error("Diagnostics", "Diagnostics Logを書き出せませんでした。", path.generic_string());
+				return;
+			}
+
+			for (const EditorLogEntry& entry : outputLog_->GetEntries())
+			{
+				file << '[' << entry.timestamp << "] [" << ToString(entry.level) << "] [" << entry.category << "] " << entry.message;
+				if (!entry.source.empty()) file << " [" << entry.source << ']';
+				if (entry.repeatCount > 1) file << " (x" << entry.repeatCount << ')';
+				file << '\n';
+			}
+			file.close();
+			lastExportPath_ = path.generic_string();
+			outputLog_->Info("Diagnostics", "Diagnostics Logを書き出しました。", lastExportPath_);
+		}
+#endif
+
+		EditorOutputLog* outputLog_ = EditorOutputLog::GetInstance();
+		PerformanceMonitor profiler_{};
+		bool visible_ = true;
+		bool profilerPaused_ = false;
+		bool reportFrameSpikes_ = true;
+		bool autoOpenOnError_ = true;
+		bool requestErrorTabFocus_ = false;
+		bool logAutoScroll_ = true;
+		bool showInfo_ = true;
+		bool showWarnings_ = true;
+		bool showErrors_ = true;
+		bool showActiveIssues_ = true;
+		bool showResolvedIssues_ = false;
+		bool showIssueWarnings_ = true;
+		bool showIssueErrors_ = true;
+		float frameSpikeThresholdMs_ = 33.333f;
+		double lastSpikeReportSeconds_ = -1000.0;
+		std::size_t previousActiveErrorCount_ = 0;
+		uint64_t selectedIssueSerial_ = 0;
+		std::array<char, 256> logSearch_{};
+		std::array<char, 256> issueSearch_{};
+		std::string lastExportPath_;
+	};
+
+} // namespace Ken4lowEngine

--- a/Project/Engine/Editor/EditorLevelOverlay.h
+++ b/Project/Engine/Editor/EditorLevelOverlay.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "EditorContext.h"
+#include "EditorDiagnosticsPanel.h"
 #include "EditorLevelDeferredController.h"
 #include "EditorLevelService.h"
 #include "EditorPlayController.h"
@@ -19,6 +20,8 @@ namespace Ken4lowEngine
 	/// <summary>Level操作と現在のEditor / PIE World状態をMain Viewport右上へ表示します。</summary>
 	inline void DrawEditorLevelOverlay()
 	{
+		EditorDiagnosticsPanel::GetInstance()->Draw(); // Phase 12のLog / Profiler / Error統合PanelをEditor中は毎フレーム更新する。
+
 		EditorWindowManager* windowManager = EditorWindowManager::GetInstance();
 		EditorLevelService* levelService = EditorLevelService::GetInstance();
 		EditorLevelDeferredController* deferredController = EditorLevelDeferredController::GetInstance();

--- a/Project/Engine/Editor/EditorOutputLog.cpp
+++ b/Project/Engine/Editor/EditorOutputLog.cpp
@@ -1,32 +1,162 @@
 #include "EditorOutputLog.h"
 
+#include <algorithm>
+#include <chrono>
+#include <ctime>
+#include <iomanip>
+#include <sstream>
+
 namespace Ken4lowEngine
 {
+	std::mutex EditorOutputLog::mutex_{};
+	std::vector<EditorLogEntry> EditorOutputLog::entries_{};
+	std::vector<EditorDiagnosticIssue> EditorOutputLog::issues_{};
+	uint64_t EditorOutputLog::nextLogSerial_ = 1;
+	uint64_t EditorOutputLog::nextIssueSerial_ = 1;
+
+	EditorOutputLog* EditorOutputLog::GetInstance()
+	{
+		static EditorOutputLog instance;
+		return &instance;
+	}
+
+	std::string EditorOutputLog::BuildTimestamp()
+	{
+		const auto now = std::chrono::system_clock::now();
+		const auto milliseconds = std::chrono::duration_cast<std::chrono::milliseconds>(now.time_since_epoch()) % 1000;
+		const std::time_t timeValue = std::chrono::system_clock::to_time_t(now);
+		std::tm localTime{};
+#ifdef _WIN32
+		localtime_s(&localTime, &timeValue);
+#else
+		localtime_r(&timeValue, &localTime);
+#endif
+		std::ostringstream stream;
+		stream << std::put_time(&localTime, "%H:%M:%S") << '.' << std::setw(3) << std::setfill('0') << milliseconds.count();
+		return stream.str();
+	}
+
+	bool EditorOutputLog::IsSameLog(const EditorLogEntry& entry, EditorLogLevel level, std::string_view category, std::string_view message, std::string_view source)
+	{
+		return entry.level == level && entry.category == category && entry.message == message && entry.source == source;
+	}
+
+	bool EditorOutputLog::IsSameIssue(const EditorDiagnosticIssue& issue, EditorLogLevel level, std::string_view category, std::string_view message, std::string_view source)
+	{
+		return !issue.resolved && issue.level == level && issue.category == category && issue.message == message && issue.source == source;
+	}
+
+	void EditorOutputLog::TrimBuffers()
+	{
+		if (entries_.size() > kMaximumLogEntries)
+		{
+			entries_.erase(entries_.begin(), entries_.begin() + static_cast<std::ptrdiff_t>(entries_.size() - kMaximumLogEntries));
+		}
+		if (issues_.size() > kMaximumIssues)
+		{
+			const auto resolved = std::find_if(issues_.begin(), issues_.end(), [](const EditorDiagnosticIssue& issue) { return issue.resolved; });
+			if (resolved != issues_.end()) issues_.erase(resolved);
+			else issues_.erase(issues_.begin());
+		}
+	}
+
 	void EditorOutputLog::Add(EditorLogLevel level, const std::string& message)
 	{
+		Add(level, "Editor", message, {});
+	}
+
+	void EditorOutputLog::Add(EditorLogLevel level, std::string_view category, const std::string& message, std::string_view source)
+	{
+		if (message.empty()) return;
+
+		const std::string timestamp = BuildTimestamp();
+		const std::string normalizedCategory = category.empty() ? "Editor" : std::string(category);
 		std::lock_guard<std::mutex> lock(mutex_);
-		entries_.push_back({ level, message });
+
+		if (!entries_.empty() && IsSameLog(entries_.back(), level, normalizedCategory, message, source))
+		{
+			EditorLogEntry& entry = entries_.back();
+			entry.timestamp = timestamp;
+			++entry.repeatCount; // 連続する同一ログは1行へ集約して大量出力時の可読性を保つ。
+		}
+		else
+		{
+			EditorLogEntry entry{};
+			entry.serial = nextLogSerial_++;
+			entry.level = level;
+			entry.timestamp = timestamp;
+			entry.category = normalizedCategory;
+			entry.message = message;
+			entry.source.assign(source.begin(), source.end());
+			entries_.push_back(std::move(entry));
+		}
+
+		if (level == EditorLogLevel::Warning || level == EditorLogLevel::Error)
+		{
+			auto found = std::find_if(issues_.begin(), issues_.end(), [&](const EditorDiagnosticIssue& issue)
+				{
+					return IsSameIssue(issue, level, normalizedCategory, message, source);
+				});
+			if (found != issues_.end())
+			{
+				found->lastTimestamp = timestamp;
+				++found->occurrenceCount;
+			}
+			else
+			{
+				EditorDiagnosticIssue issue{};
+				issue.serial = nextIssueSerial_++;
+				issue.level = level;
+				issue.category = normalizedCategory;
+				issue.message = message;
+				issue.source.assign(source.begin(), source.end());
+				issue.firstTimestamp = timestamp;
+				issue.lastTimestamp = timestamp;
+				issues_.push_back(std::move(issue));
+			}
+		}
+
+		TrimBuffers();
 	}
 
-	void EditorOutputLog::Info(const std::string& message)
-	{
-		Add(EditorLogLevel::Info, message);
-	}
-
-	void EditorOutputLog::Warning(const std::string& message)
-	{
-		Add(EditorLogLevel::Warning, message);
-	}
-
-	void EditorOutputLog::Error(const std::string& message)
-	{
-		Add(EditorLogLevel::Error, message);
-	}
+	void EditorOutputLog::Info(const std::string& message) { Add(EditorLogLevel::Info, message); }
+	void EditorOutputLog::Warning(const std::string& message) { Add(EditorLogLevel::Warning, message); }
+	void EditorOutputLog::Error(const std::string& message) { Add(EditorLogLevel::Error, message); }
+	void EditorOutputLog::Info(std::string_view category, const std::string& message, std::string_view source) { Add(EditorLogLevel::Info, category, message, source); }
+	void EditorOutputLog::Warning(std::string_view category, const std::string& message, std::string_view source) { Add(EditorLogLevel::Warning, category, message, source); }
+	void EditorOutputLog::Error(std::string_view category, const std::string& message, std::string_view source) { Add(EditorLogLevel::Error, category, message, source); }
 
 	void EditorOutputLog::Clear()
 	{
 		std::lock_guard<std::mutex> lock(mutex_);
 		entries_.clear();
+	}
+
+	void EditorOutputLog::ClearIssues()
+	{
+		std::lock_guard<std::mutex> lock(mutex_);
+		issues_.clear();
+	}
+
+	void EditorOutputLog::ClearResolvedIssues()
+	{
+		std::lock_guard<std::mutex> lock(mutex_);
+		std::erase_if(issues_, [](const EditorDiagnosticIssue& issue) { return issue.resolved; });
+	}
+
+	void EditorOutputLog::ResolveAllIssues()
+	{
+		std::lock_guard<std::mutex> lock(mutex_);
+		for (EditorDiagnosticIssue& issue : issues_) issue.resolved = true;
+	}
+
+	bool EditorOutputLog::SetIssueResolved(uint64_t serial, bool resolved)
+	{
+		std::lock_guard<std::mutex> lock(mutex_);
+		auto found = std::find_if(issues_.begin(), issues_.end(), [serial](const EditorDiagnosticIssue& issue) { return issue.serial == serial; });
+		if (found == issues_.end()) return false;
+		found->resolved = resolved;
+		return true;
 	}
 
 	std::vector<EditorLogEntry> EditorOutputLog::GetEntries() const
@@ -35,18 +165,40 @@ namespace Ken4lowEngine
 		return entries_;
 	}
 
+	std::vector<EditorDiagnosticIssue> EditorOutputLog::GetIssues() const
+	{
+		std::lock_guard<std::mutex> lock(mutex_);
+		return issues_;
+	}
+
+	EditorDiagnosticCounts EditorOutputLog::GetCounts() const
+	{
+		std::lock_guard<std::mutex> lock(mutex_);
+		EditorDiagnosticCounts counts{};
+		for (const EditorLogEntry& entry : entries_)
+		{
+			const std::size_t amount = static_cast<std::size_t>(entry.repeatCount);
+			if (entry.level == EditorLogLevel::Info) counts.infoCount += amount;
+			else if (entry.level == EditorLogLevel::Warning) counts.warningCount += amount;
+			else if (entry.level == EditorLogLevel::Error) counts.errorCount += amount;
+		}
+		for (const EditorDiagnosticIssue& issue : issues_)
+		{
+			if (issue.resolved) continue;
+			if (issue.level == EditorLogLevel::Warning) ++counts.activeWarningCount;
+			else if (issue.level == EditorLogLevel::Error) ++counts.activeErrorCount;
+		}
+		return counts;
+	}
+
 	const char* ToString(EditorLogLevel level)
 	{
 		switch (level)
 		{
-		case EditorLogLevel::Info:
-			return "Info";
-		case EditorLogLevel::Warning:
-			return "Warning";
-		case EditorLogLevel::Error:
-			return "Error";
-		default:
-			return "Info";
+		case EditorLogLevel::Info: return "Info";
+		case EditorLogLevel::Warning: return "Warning";
+		case EditorLogLevel::Error: return "Error";
+		default: return "Info";
 		}
 	}
 

--- a/Project/Engine/Editor/EditorOutputLog.h
+++ b/Project/Engine/Editor/EditorOutputLog.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include <cstddef>
+#include <cstdint>
 #include <mutex>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace Ken4lowEngine
@@ -13,25 +16,83 @@ namespace Ken4lowEngine
 		Error
 	};
 
+	/// <summary>Logタブへ表示する時刻・カテゴリ付きの構造化ログです。</summary>
 	struct EditorLogEntry
 	{
+		uint64_t serial = 0;
 		EditorLogLevel level = EditorLogLevel::Info;
+		std::string timestamp;
+		std::string category = "Editor";
 		std::string message;
+		std::string source;
+		uint32_t repeatCount = 1;
 	};
 
+	/// <summary>Warning / Errorを同一内容ごとに集約してErrorタブへ表示します。</summary>
+	struct EditorDiagnosticIssue
+	{
+		uint64_t serial = 0;
+		EditorLogLevel level = EditorLogLevel::Warning;
+		std::string category = "Editor";
+		std::string message;
+		std::string source;
+		std::string firstTimestamp;
+		std::string lastTimestamp;
+		uint32_t occurrenceCount = 1;
+		bool resolved = false;
+	};
+
+	struct EditorDiagnosticCounts
+	{
+		std::size_t infoCount = 0;
+		std::size_t warningCount = 0;
+		std::size_t errorCount = 0;
+		std::size_t activeWarningCount = 0;
+		std::size_t activeErrorCount = 0;
+	};
+
+	/// <summary>
+	/// Editor全体のLogとIssueを共有バッファへ集約します。
+	/// 既存コードが個別インスタンスを保持していても同じDiagnostics内容を参照します。
+	/// </summary>
 	class EditorOutputLog
 	{
 	public:
+		static EditorOutputLog* GetInstance();
+
 		void Add(EditorLogLevel level, const std::string& message);
+		void Add(EditorLogLevel level, std::string_view category, const std::string& message, std::string_view source = {});
+
 		void Info(const std::string& message);
 		void Warning(const std::string& message);
 		void Error(const std::string& message);
+		void Info(std::string_view category, const std::string& message, std::string_view source = {});
+		void Warning(std::string_view category, const std::string& message, std::string_view source = {});
+		void Error(std::string_view category, const std::string& message, std::string_view source = {});
+
 		void Clear();
+		void ClearIssues();
+		void ClearResolvedIssues();
+		void ResolveAllIssues();
+		bool SetIssueResolved(uint64_t serial, bool resolved);
+
 		std::vector<EditorLogEntry> GetEntries() const;
+		std::vector<EditorDiagnosticIssue> GetIssues() const;
+		EditorDiagnosticCounts GetCounts() const;
 
 	private:
-		mutable std::mutex mutex_;
-		std::vector<EditorLogEntry> entries_;
+		static std::string BuildTimestamp();
+		static bool IsSameLog(const EditorLogEntry& entry, EditorLogLevel level, std::string_view category, std::string_view message, std::string_view source);
+		static bool IsSameIssue(const EditorDiagnosticIssue& issue, EditorLogLevel level, std::string_view category, std::string_view message, std::string_view source);
+		static void TrimBuffers();
+
+		static constexpr std::size_t kMaximumLogEntries = 4096;
+		static constexpr std::size_t kMaximumIssues = 512;
+		static std::mutex mutex_;
+		static std::vector<EditorLogEntry> entries_;
+		static std::vector<EditorDiagnosticIssue> issues_;
+		static uint64_t nextLogSerial_;
+		static uint64_t nextIssueSerial_;
 	};
 
 	const char* ToString(EditorLogLevel level);

--- a/Project/Engine/Editor/EditorPanelIds.h
+++ b/Project/Engine/Editor/EditorPanelIds.h
@@ -9,7 +9,7 @@ namespace Ken4lowEngine::EditorPanelIds
 	inline constexpr const char* WorldOutliner = "アウトライナー###World Outliner";
 	inline constexpr const char* Details = "詳細###Details";
 	inline constexpr const char* ContentBrowser = "Content Browser";
-	inline constexpr const char* OutputLog = "Output Log";
+	inline constexpr const char* OutputLog = "診断###Diagnostics"; // Phase 12では旧Output LogのDock位置を統合Diagnosticsへ引き継ぐ。
 	inline constexpr const char* Scene = "Scene";
 
 	inline constexpr const char* Parameters = "Parameters";

--- a/Project/Engine/Editor/EditorWindowManager.h
+++ b/Project/Engine/Editor/EditorWindowManager.h
@@ -22,7 +22,7 @@ namespace Ken4lowEngine
 		bool showContentBrowser = true;
 		bool showWorldOutliner = true;
 		bool showDetails = true;
-		bool showOutputLog = true;
+		bool showOutputLog = false; // Phase 12のDiagnosticsへLog / Profiler / Errorを統合したため旧Panelは既定で隠す。
 		bool showScene = true;
 
 		bool showParameters = true;


### PR DESCRIPTION
## 概要
UE風Editor計画の最終Phase 12として、Log・Profiler・Warning/Errorを単一のDiagnosticsパネルへ統合しました。

## 実装内容
- 旧Output LogのDock位置へ新しい「診断」パネルを配置
- `F9`でDiagnostics表示切り替え
- Log / Profiler / Errorの3タブ
- Logへ時刻、Severity、Category、Source、繰り返し回数を追加
- 連続する同一Logを1行へ集約
- Warning / ErrorをIssueとして自動集約
- 未解決 / 解決済み管理、再オープン、全解決、解決済み削除
- Error発生時にDiagnosticsを自動表示してErrorタブへ移動
- Log検索、Severityフィルター、コピー、ファイル書き出し
- ProfilerへFrame / Update / Draw / Present / Sleepの履歴を追加
- FPS、平均・最大FrameTime、CPU、Process CPU、Memoryを統合表示
- Frame Spikeの閾値設定とWarning自動記録
- 旧Output Logは互換用に残しつつ既定非表示

## 操作
- `F9`: Diagnosticsの表示／非表示
- ログタブ: 検索、Severity絞り込み、書き出し
- プロファイラータブ: 計測停止、履歴リセット、Spike閾値変更
- エラータブ: Issue選択、解決、再オープン、内容コピー

## 確認項目
1. 初期レイアウトで下部へ「診断」がDockされる
2. Editorの既存Logがログタブへ表示される
3. 同じLogを連続発生させると回数だけ増える
4. Warning / ErrorがエラータブへIssueとして追加される
5. Issueを解決・再オープンできる
6. Error発生時にDiagnosticsが開きエラータブへ移動する
7. Logを書き出すと `../Generated/Logs` に保存される
8. ProfilerのFrame / Update / Draw / Presentグラフが更新される
9. 閾値超過FrameがProfiler Warningへ集約される
10. F9でDiagnosticsを閉じて再表示できる

## 補足
既存の `ken4low_editor_layout_v2.ini` を使っている環境では、`Window > Layout > Rebuild Default Layout` を実行すると旧Output Logの位置へ「診断」がDockされます。

## 検証
- GitHub Actions Debug Build: success
- GitHub Actions Release Build: success
- Diagnostics: success