### PR TITLE
Stabilize Editor V2 camera and rotation gizmo

### DIFF
--- a/Project/Engine/Editor/EditorTransformGizmo.cpp
+++ b/Project/Engine/Editor/EditorTransformGizmo.cpp
@@ -25,7 +25,6 @@
 #include <algorithm>
 #include <cmath>
 #include <memory>
-#include <numbers>
 
 namespace Ken4lowEngine
 {
@@ -181,12 +180,12 @@ namespace Ken4lowEngine
 		ImGuizmo::Enable(true);
 		ImGuizmo::AllowAxisFlip(false);
 		ImGuizmo::SetOrthographic(false);
-		ImGuizmo::SetGizmoSizeClipSpace(0.13f);
+		ImGuizmo::SetGizmoSizeClipSpace(0.16f);
 		ImGuizmo::Style& gizmoStyle = ImGuizmo::GetStyle();
 		gizmoStyle.TranslationLineThickness = 4.0f;
 		gizmoStyle.TranslationLineArrowSize = 8.0f;
-		gizmoStyle.RotationLineThickness = 3.0f;
-		gizmoStyle.RotationOuterLineThickness = 3.0f;
+		gizmoStyle.RotationLineThickness = 5.0f;
+		gizmoStyle.RotationOuterLineThickness = 4.0f; // Yを含む回転Ringの選択幅を広げて軸クリックを安定させる。
 		gizmoStyle.ScaleLineThickness = 4.0f;
 		gizmoStyle.ScaleLineCircleSize = 7.0f;
 		gizmoStyle.CenterCircleSize = 6.0f;
@@ -229,16 +228,19 @@ namespace Ken4lowEngine
 
 		if (changed)
 		{
-			float translation[3] = {};
-			float rotationDegrees[3] = {};
-			float scale[3] = {};
-			ImGuizmo::DecomposeMatrixToComponents(&transformMatrix.m[0][0], translation, rotationDegrees, scale);
+			Vector3 scale{};
+			Vector3 rotation{};
+			Vector3 translation{};
+			Matrix4x4::Decompose(transformMatrix, scale, rotation, translation); // EngineのXYZ回転順で分解し、Y軸回転をImGuizmo固有Euler変換から切り離す。
 
-			constexpr float toRadians = std::numbers::pi_v<float> / 180.0f;
 			EditorTransform editedWorldTransform{};
-			editedWorldTransform.position = { translation[0], translation[1], translation[2] };
-			editedWorldTransform.rotation = { rotationDegrees[0] * toRadians, rotationDegrees[1] * toRadians, rotationDegrees[2] * toRadians };
-			editedWorldTransform.scale = { KeepScaleInvertible(scale[0]), KeepScaleInvertible(scale[1]), KeepScaleInvertible(scale[2]) };
+			editedWorldTransform.position = translation;
+			editedWorldTransform.rotation = rotation;
+			editedWorldTransform.scale = {
+				KeepScaleInvertible(scale.x),
+				KeepScaleInvertible(scale.y),
+				KeepScaleInvertible(scale.z),
+			};
 			selected.WriteWorldTransform(editedWorldTransform);
 			EditorContext::GetInstance()->MarkLevelDirty();
 		}

--- a/Project/Engine/Graphics/Camera/DebugCamera/DebugCamera.cpp
+++ b/Project/Engine/Graphics/Camera/DebugCamera/DebugCamera.cpp
@@ -2,10 +2,12 @@
 #include "DebugCamera.h"
 #include "WinApp.h"
 #include "GameViewportConstants.h"
+#include "GameTimer.h"
 #include "Input.h"
 #include "ParameterManager.h"
 
 #include <algorithm>
+#include <cmath>
 
 namespace Ken4lowEngine
 {
@@ -55,10 +57,10 @@ namespace Ken4lowEngine
 
 	void DebugCamera::Update()
 	{
-		Input* input = Input::GetInstance();
-		if (!input || !input->GetLockCursor())
+		const bool rightMouseDown = (GetAsyncKeyState(VK_RBUTTON) & 0x8000) != 0;
+		if (!rightMouseDown)
 		{
-			editorLookCaptureInitialized_ = false; // RMB解除後は次回クリックの初回差分を再び無効化する。
+			editorLookCaptureInitialized_ = false; // Cursor Lockではなく物理RMBの解放をEditor Look終了条件にする。
 		}
 		Move();
 		UpdateViewProjection();
@@ -72,28 +74,41 @@ namespace Ken4lowEngine
 	void DebugCamera::ApplyEditorNavigation(const Vector3& localMove, float pitchDelta, float yawDelta)
 	{
 		Input* input = Input::GetInstance();
-		if (input && input->GetLockCursor())
+		const bool rightMouseDown = (GetAsyncKeyState(VK_RBUTTON) & 0x8000) != 0;
+		Vector3 editorMove = localMove;
+
+		if (input && rightMouseDown)
 		{
 			if (!editorLookCaptureInitialized_)
 			{
 				pitchDelta = 0.0f;
 				yawDelta = 0.0f;
-				editorLookCaptureInitialized_ = true; // 右クリック開始位置から中央へ飛ぶ差分は回転へ使わない。
+				editorLookCaptureInitialized_ = true; // RMBを押した瞬間の不連続な差分だけを1フレーム捨てる。
 			}
 			else
 			{
-				const float rawX = static_cast<float>(input->GetMouseMoveX());
-				const float rawY = static_cast<float>(input->GetMouseMoveY());
+				const Vector2 rawDelta = input->GetDragDelta();
+				const float rawX = std::abs(rawDelta.x) > 0.0f ? rawDelta.x : (-yawDelta / 0.003f);
+				const float rawY = std::abs(rawDelta.y) > 0.0f ? rawDelta.y : (pitchDelta / 0.003f);
 				pitchDelta = std::clamp(rawY * 0.003f, -0.15f, 0.15f);
-				yawDelta = std::clamp(-rawX * 0.003f, -0.15f, 0.15f); // カーソル絶対位置ではなくDirectInputの相対移動量だけを使う。
+				yawDelta = std::clamp(-rawX * 0.003f, -0.15f, 0.15f); // ゲーム入力抑制を通らないDirectInput相対移動量で連続回転する。
 			}
+
+			editorMove.y = 0.0f; // 旧Q/Eの上下移動を無効化し、Space/Ctrlへ操作を統一する。
+			const float deltaTime = std::clamp(GameTimer::GetInstance()->GetDeltaTime(), 1.0f / 240.0f, 1.0f / 15.0f);
+			const float moveSpeed = input->PushRawKey(DIK_LSHIFT) ? 24.0f : 8.0f;
+			const float verticalStep = moveSpeed * deltaTime;
+			if (input->PushRawKey(DIK_SPACE)) editorMove.y += verticalStep;
+			if (input->PushRawKey(DIK_LCONTROL) || input->PushRawKey(DIK_RCONTROL)) editorMove.y -= verticalStep;
+
+			input->SetLockCursor(false); // OSウィンドウ中央への再配置を止め、Main Viewport操作中の点滅を防ぐ。
 		}
 
 		worldTransform_.rotate_.x = std::clamp(worldTransform_.rotate_.x + pitchDelta, -1.5533f, 1.5533f);
 		worldTransform_.rotate_.y += yawDelta;
 
 		const Matrix4x4 cameraRotation = Matrix4x4::MakeRotateMatrix(worldTransform_.rotate_);
-		worldTransform_.translate_ += Vector3::Transform(localMove, cameraRotation);
+		worldTransform_.translate_ += Vector3::Transform(editorMove, cameraRotation);
 		UpdateViewProjection();
 	}
 
@@ -105,7 +120,7 @@ namespace Ken4lowEngine
 		if (Input::GetInstance()->PushKey(DIK_A)) { move.x -= 0.2f; }
 		if (Input::GetInstance()->PushKey(DIK_D)) { move.x += 0.2f; }
 		if (Input::GetInstance()->PushKey(DIK_SPACE)) { move.y += 0.2f; }
-		if (Input::GetInstance()->PushKey(DIK_LSHIFT)) { move.y -= 0.2f; }
+		if (Input::GetInstance()->PushKey(DIK_LCONTROL) || Input::GetInstance()->PushKey(DIK_RCONTROL)) { move.y -= 0.2f; }
 		if (Input::GetInstance()->PushKey(DIK_UP)) { worldTransform_.rotate_.x -= 0.02f; }
 		if (Input::GetInstance()->PushKey(DIK_DOWN)) { worldTransform_.rotate_.x += 0.02f; }
 		if (Input::GetInstance()->PushKey(DIK_LEFT)) { worldTransform_.rotate_.y += 0.02f; }


### PR DESCRIPTION
## 概要
Phase 1〜12完了後のEditor V2安定化として、実機確認で残ったEditor Cameraと回転Gizmoを修正します。

## 修正内容
- Phase 12の確認完了に伴いPR #660をmasterへマージ
- RMB中のカメラ回転がゲーム入力抑制により常に0になる問題を修正
- `GetMouseMoveX/Y()`ではなく、Editor入力抑制を通らないDirectInput相対差分を使用
- RMB中にOSカーソルをウィンドウ中央へ毎フレーム移動しない
- カーソルの中央点滅を防止
- RMB開始時の最初の1フレームだけ回転差分を破棄
- Camera UpをSpace、DownをLeft/Right Ctrlへ変更
- 旧Q/E上下移動をRMB操作中は無効化
- ImGuizmoの回転Ringを拡大し、選択幅を増加
- ImGuizmo独自のEuler分解をやめ、EngineのXYZ回転順でMatrixを分解
- Y軸回転をEngine側のTransformへ正しく戻す

## 確認項目
1. Main Viewport内でRMBを押してもカーソルがウィンドウ中央へ移動・点滅しない
2. RMBを押したままマウスを動かすと継続してカメラ回転できる
3. RMBを離すとカーソルが再表示される
4. RMB+WASDで前後左右へ移動できる
5. RMB+Spaceで上昇、RMB+Ctrlで下降できる
6. Shiftを押すと移動速度が上がる
7. 回転GizmoのX/Y/Zすべてをドラッグできる
8. Y軸回転値がDetailsとモデル表示へ反映される
9. 回転操作をUndo/Redoできる
10. Debug/Release Buildが成功する