### PR TITLE
Data-driven scene management foundation

### DIFF
--- a/Project/ApplicationLayer/SceneManagement/SceneFactory/SceneFactory.cpp
+++ b/Project/ApplicationLayer/SceneManagement/SceneFactory/SceneFactory.cpp
@@ -1,35 +1,38 @@
 #include "SceneFactory.h"
+
 #include "TitleScene.h"
 #include "GamePlayScene.h"
 #include "StageSelectScene.h"
 #include "DebugScene.h"
 
+#include <stdexcept>
+#include <utility>
+
 namespace Ken4lowEngine
 {
-	/// -------------------------------------------------------------
-	///				　		    シーン生成
-	/// -------------------------------------------------------------
-	std::unique_ptr<BaseScene> SceneFactory::CreateScene(const std::string& sceneName)
+	SceneFactory::SceneFactory()
 	{
-		// 次のシーンを生成
-		std::unique_ptr<BaseScene> newScene = nullptr;
-
-		// タイトルシーン
-		if (sceneName == "TitleScene")				return std::make_unique<TitleScene>();
-
-		// ステージセレクトシーン
-		else if (sceneName == "StageSelectScene")	return std::make_unique<StageSelectScene>();
-
-		// ゲームプレイシーン
-		else if (sceneName == "GamePlayScene")		return std::make_unique<GamePlayScene>();
-
+		RegisterSceneClass("TitleScene", []() { return std::make_unique<TitleScene>(); });
+		RegisterSceneClass("StageSelectScene", []() { return std::make_unique<StageSelectScene>(); });
+		RegisterSceneClass("GamePlayScene", []() { return std::make_unique<GamePlayScene>(); });
 #ifdef _DEBUG
-		// デバッグシーン
-		else if (sceneName == "DebugScene")			return std::make_unique<DebugScene>();
-#endif // _DEBUG
-
-		// 不明なシーン名の場合は例外を投げる
-		throw std::runtime_error("Unknown scene name: " + sceneName);
+		RegisterSceneClass("DebugScene", []() { return std::make_unique<DebugScene>(); });
+#endif
 	}
 
-}
+	void SceneFactory::RegisterSceneClass(std::string sceneClassName, SceneCreator creator)
+	{
+		if (sceneClassName.empty() || !creator) return;
+		creators_.insert_or_assign(std::move(sceneClassName), std::move(creator)); // Scene追加時のif/else連鎖を登録表へ置き換える。
+	}
+
+	std::unique_ptr<BaseScene> SceneFactory::CreateScene(const std::string& sceneClassName)
+	{
+		const auto creator = creators_.find(sceneClassName);
+		if (creator == creators_.end())
+		{
+			throw std::runtime_error("Unknown scene class: " + sceneClassName);
+		}
+		return creator->second();
+	}
+} // namespace Ken4lowEngine

--- a/Project/ApplicationLayer/SceneManagement/SceneFactory/SceneFactory.h
+++ b/Project/ApplicationLayer/SceneManagement/SceneFactory/SceneFactory.h
@@ -1,5 +1,12 @@
 #pragma once
+
 #include "AbstractSceneFactory.h"
+
+#include <functional>
+#include <memory>
+#include <string>
+#include <string_view>
+#include <unordered_map>
 
 namespace Ken4lowEngine
 {
@@ -8,14 +15,17 @@ namespace Ken4lowEngine
 	/// -------------------------------------------------------------
 	class SceneFactory : public AbstractSceneFactory
 	{
-	public: /// ---------- メンバ関数 ---------- ///
+	public:
+		using SceneCreator = std::function<std::unique_ptr<BaseScene>()>;
 
-		/// <summary>
-		/// シーン生成
-		/// </summary>
-		/// <param name="sceneName">シーン名</param>
-		/// <returns>生成したシーン</returns>
-		std::unique_ptr<BaseScene> CreateScene(const std::string& sceneName) override;
+		SceneFactory();
+
+		/// <summary>SceneClass名からC++ Sceneインスタンスを生成します。</summary>
+		std::unique_ptr<BaseScene> CreateScene(const std::string& sceneClassName) override;
+
+	private:
+		void RegisterSceneClass(std::string sceneClassName, SceneCreator creator);
+
+		std::unordered_map<std::string, SceneCreator> creators_; // JSONのSceneNameとC++型名を分離して登録する。
 	};
-
-}
+} // namespace Ken4lowEngine

--- a/Project/Engine/Core/Application/GameApplication.cpp
+++ b/Project/Engine/Core/Application/GameApplication.cpp
@@ -74,15 +74,14 @@ namespace Ken4lowEngine
 		// 文字列のシーン名から実際の Scene インスタンスを作れるよう、Factory を SceneManager へ登録する。
 		auto sceneFactory = std::make_unique<SceneFactory>();
 		sceneManager_->SetAbstractSceneFactory(std::move(sceneFactory));
+		sceneManager_->LoadSceneDefinitions("Resources/JSON/Scenes"); // Scene構成と起動SceneをC++直書きではなくJSONから解決する。
 
 #ifdef _DEBUG
-		// Debugビルドでは最初からDebugSceneを起動して、ゲームプレイ中もすぐ切り替えられるようにする。
-		const std::string startSceneName = "DebugScene";
+		const std::string startSceneName = sceneManager_->GetConfiguredStartSceneName(true, "DebugScene");
 #else
-		// Releaseビルドでは最初のシーンをTitleSceneにする。
-		const std::string startSceneName = "TitleScene";
+		const std::string startSceneName = sceneManager_->GetConfiguredStartSceneName(false, "TitleScene");
 #endif
-		// 起動直後に表示するシーンを SceneManager へ依頼する。
+		// JSONが欠けている場合は従来のDebug/TitleをFallbackとして起動する。
 		sceneManager_->ChangeScene(startSceneName);
 	}
 

--- a/Project/Engine/Scene/Management/BaseScene.h
+++ b/Project/Engine/Scene/Management/BaseScene.h
@@ -1,7 +1,10 @@
 #pragma once
 
+#include "SceneDefinition.h"
+
 #include <Editor/EditorObjectInfo.h>
 
+#include <utility>
 #include <vector>
 
 namespace Ken4lowEngine
@@ -51,7 +54,16 @@ namespace Ken4lowEngine
 		virtual bool IsReadyToStartUncover() const { return true; }
 		virtual bool IsReadyToSwapOut() const { return true; }
 
+		void SetSceneDefinition(SceneDefinition definition)
+		{
+			sceneDefinition_ = std::move(definition); // Initializeより前にScene構成値を渡して固有初期化から参照できるようにする。
+		}
+
+		[[nodiscard]] const SceneDefinition& GetSceneDefinition() const { return sceneDefinition_; }
+		[[nodiscard]] const nlohmann::json& GetSceneParameters() const { return sceneDefinition_.parameters; }
+
 	protected:
 		SceneManager* sceneManager_ = nullptr;
+		SceneDefinition sceneDefinition_{};
 	};
 } // namespace Ken4lowEngine

--- a/Project/Engine/Scene/Management/SceneDefinition.h
+++ b/Project/Engine/Scene/Management/SceneDefinition.h
@@ -6,6 +6,7 @@
 #include <filesystem>
 #include <string>
 #include <string_view>
+#include <utility>
 #include <vector>
 
 namespace Ken4lowEngine
@@ -90,7 +91,7 @@ namespace Ken4lowEngine
 				outError = "Scene definition root must be an object: " + sourcePath.generic_string();
 				return false;
 			}
-			if (json.value("Format", std::string{}) != kFormat)
+			if (json.value("Format", std::string{}) != std::string(kFormat))
 			{
 				outError = "Unsupported scene format: " + sourcePath.generic_string();
 				return false;
@@ -155,7 +156,7 @@ namespace Ken4lowEngine
 		[[nodiscard]] nlohmann::json ToJson() const
 		{
 			nlohmann::json json = {
-				{ "Format", kFormat },
+				{ "Format", std::string(kFormat) }, // JSONへは所有権を持つ文字列として明示的に書き出す。
 				{ "Version", kCurrentVersion },
 				{ "SceneName", sceneName },
 				{ "SceneClass", sceneClass },

--- a/Project/Engine/Scene/Management/SceneDefinition.h
+++ b/Project/Engine/Scene/Management/SceneDefinition.h
@@ -1,0 +1,184 @@
+#pragma once
+
+#include <json.hpp>
+
+#include <algorithm>
+#include <filesystem>
+#include <string>
+#include <string_view>
+#include <vector>
+
+namespace Ken4lowEngine
+{
+	/// <summary>Scene切り替え時に使用するTransition設定です。</summary>
+	struct SceneTransitionDefinition
+	{
+		std::string type = "Fade";
+		int coverHoldFrames = 4;
+		int uncoverDelayFrames = 3;
+		float durationSeconds = 1.0f;
+	};
+
+	/// <summary>Scene開始時に使用するBGM設定です。</summary>
+	struct SceneBgmDefinition
+	{
+		std::string path;
+		bool loop = true;
+		float volume = 1.0f;
+	};
+
+	/// <summary>
+	/// Sceneの進行設定をJSONから読み込むためのデータです。
+	/// C++側はScene固有ロジックを持ち、使用Levelや遷移先などの構成値をこの定義へ分離します。
+	/// </summary>
+	struct SceneDefinition
+	{
+		static constexpr int kCurrentVersion = 1;
+		static constexpr std::string_view kFormat = "Ken4lowScene";
+
+		std::string sceneName;
+		std::string sceneClass;
+		std::string levelPath;
+		std::string gameModeClass;
+		std::string playerActorPath;
+		SceneBgmDefinition bgm;
+		std::vector<std::string> uiAssets;
+		SceneTransitionDefinition transition;
+		std::string nextScene;
+		std::string retryScene;
+		nlohmann::json parameters = nlohmann::json::object();
+		std::filesystem::path sourcePath;
+
+		[[nodiscard]] bool IsValid(std::string& outError) const
+		{
+			if (sceneName.empty())
+			{
+				outError = "SceneName is empty.";
+				return false;
+			}
+			if (sceneClass.empty())
+			{
+				outError = "SceneClass is empty: " + sceneName;
+				return false;
+			}
+			if (transition.coverHoldFrames < 0 || transition.uncoverDelayFrames < 0)
+			{
+				outError = "Transition frame count must be zero or greater: " + sceneName;
+				return false;
+			}
+			if (transition.durationSeconds < 0.0f)
+			{
+				outError = "Transition duration must be zero or greater: " + sceneName;
+				return false;
+			}
+			if (bgm.volume < 0.0f)
+			{
+				outError = "BGM volume must be zero or greater: " + sceneName;
+				return false;
+			}
+			return true;
+		}
+
+		[[nodiscard]] static bool FromJson(
+			const nlohmann::json& json,
+			const std::filesystem::path& sourcePath,
+			SceneDefinition& outDefinition,
+			std::string& outError)
+		{
+			if (!json.is_object())
+			{
+				outError = "Scene definition root must be an object: " + sourcePath.generic_string();
+				return false;
+			}
+			if (json.value("Format", std::string{}) != kFormat)
+			{
+				outError = "Unsupported scene format: " + sourcePath.generic_string();
+				return false;
+			}
+
+			const int version = json.value("Version", 0);
+			if (version <= 0 || version > kCurrentVersion)
+			{
+				outError = "Unsupported scene version " + std::to_string(version) + ": " + sourcePath.generic_string();
+				return false;
+			}
+
+			SceneDefinition definition{};
+			definition.sceneName = json.value("SceneName", json.value("Name", std::string{}));
+			definition.sceneClass = json.value("SceneClass", std::string{});
+			definition.levelPath = json.value("LevelPath", std::string{});
+			definition.gameModeClass = json.value("GameMode", std::string{});
+			definition.playerActorPath = json.value("PlayerActor", std::string{});
+			definition.nextScene = json.value("NextScene", std::string{});
+			definition.retryScene = json.value("RetryScene", std::string{});
+			definition.sourcePath = sourcePath;
+
+			if (json.contains("BGM") && json["BGM"].is_object())
+			{
+				const nlohmann::json& bgmJson = json["BGM"];
+				definition.bgm.path = bgmJson.value("Path", std::string{});
+				definition.bgm.loop = bgmJson.value("Loop", true);
+				definition.bgm.volume = bgmJson.value("Volume", 1.0f);
+			}
+			else if (json.contains("BGM") && json["BGM"].is_string())
+			{
+				definition.bgm.path = json["BGM"].get<std::string>(); // 旧来の文字列指定も読み込み互換として扱う。
+			}
+
+			if (json.contains("UI") && json["UI"].is_array())
+			{
+				for (const nlohmann::json& uiEntry : json["UI"])
+				{
+					if (uiEntry.is_string()) definition.uiAssets.push_back(uiEntry.get<std::string>());
+				}
+			}
+
+			if (json.contains("Transition") && json["Transition"].is_object())
+			{
+				const nlohmann::json& transitionJson = json["Transition"];
+				definition.transition.type = transitionJson.value("Type", definition.transition.type);
+				definition.transition.coverHoldFrames = transitionJson.value("CoverHoldFrames", definition.transition.coverHoldFrames);
+				definition.transition.uncoverDelayFrames = transitionJson.value("UncoverDelayFrames", definition.transition.uncoverDelayFrames);
+				definition.transition.durationSeconds = transitionJson.value("Duration", definition.transition.durationSeconds);
+			}
+
+			if (json.contains("Parameters") && json["Parameters"].is_object())
+			{
+				definition.parameters = json["Parameters"];
+			}
+
+			if (!definition.IsValid(outError)) return false;
+			outDefinition = std::move(definition);
+			return true;
+		}
+
+		[[nodiscard]] nlohmann::json ToJson() const
+		{
+			nlohmann::json json = {
+				{ "Format", kFormat },
+				{ "Version", kCurrentVersion },
+				{ "SceneName", sceneName },
+				{ "SceneClass", sceneClass },
+				{ "LevelPath", levelPath },
+				{ "GameMode", gameModeClass },
+				{ "PlayerActor", playerActorPath },
+				{ "BGM", {
+					{ "Path", bgm.path },
+					{ "Loop", bgm.loop },
+					{ "Volume", bgm.volume },
+				} },
+				{ "UI", uiAssets },
+				{ "Transition", {
+					{ "Type", transition.type },
+					{ "CoverHoldFrames", transition.coverHoldFrames },
+					{ "UncoverDelayFrames", transition.uncoverDelayFrames },
+					{ "Duration", transition.durationSeconds },
+				} },
+				{ "NextScene", nextScene },
+				{ "RetryScene", retryScene },
+				{ "Parameters", parameters },
+			};
+			return json;
+		}
+	};
+} // namespace Ken4lowEngine

--- a/Project/Engine/Scene/Management/SceneManager.cpp
+++ b/Project/Engine/Scene/Management/SceneManager.cpp
@@ -17,7 +17,10 @@
 
 #include <algorithm>
 #include <cassert>
+#include <exception>
+#include <iostream>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace K4E = ::Ken4lowEngine;
@@ -38,6 +41,56 @@ namespace Ken4lowEngine
 		unloadRequested_ = false;
 		editorPlaySessionActive_ = false;
 		editorSingleStepRequested_ = false;
+		currentSceneDefinition_.reset();
+		nextSceneDefinition_.reset();
+	}
+
+	bool SceneManager::LoadSceneDefinitions(const std::filesystem::path& directory)
+	{
+		const bool loaded = sceneRegistry_.LoadDirectory(directory);
+		for (const std::string& warning : sceneRegistry_.GetWarnings())
+		{
+			ReportSceneMessage(true, "[SceneRegistry][Warning] " + warning);
+		}
+		for (const std::string& error : sceneRegistry_.GetErrors())
+		{
+			ReportSceneMessage(false, "[SceneRegistry] " + error);
+		}
+		if (loaded)
+		{
+			ReportSceneMessage(true, "[SceneRegistry] Loaded " +
+				std::to_string(sceneRegistry_.GetDefinitions().size()) + " scene definitions from " + directory.generic_string());
+		}
+		return loaded;
+	}
+
+	std::string SceneManager::GetConfiguredStartSceneName(bool debugBuild, std::string_view fallback) const
+	{
+		return sceneRegistry_.GetStartupSceneName(debugBuild, fallback);
+	}
+
+	SceneDefinition SceneManager::ResolveSceneDefinition(std::string_view sceneName) const
+	{
+		if (const SceneDefinition* definition = sceneRegistry_.Find(sceneName)) return *definition;
+		return SceneRegistry::MakeLegacyDefinition(sceneName); // 未移行の呼び出しは従来どおりSceneClass名として扱う。
+	}
+
+	void SceneManager::ApplyTransitionDefinition(const SceneDefinition& definition)
+	{
+		coverHoldFrames_ = (std::max)(0, definition.transition.coverHoldFrames);
+		uncoverDelayFrames_ = (std::max)(0, definition.transition.uncoverDelayFrames);
+		// Transitionの具体クラスはGameApplicationから注入し、Scene JSONは切り替えタイミングだけを所有する。
+	}
+
+	void SceneManager::ReportSceneMessage(bool succeeded, const std::string& message) const
+	{
+#ifdef USE_IMGUI
+		K4E::EditorWindowManager::GetInstance()->AddOutputLog(
+			succeeded ? K4E::EditorLogLevel::Info : K4E::EditorLogLevel::Error,
+			message);
+#else
+		std::clog << message << '\n';
+#endif
 	}
 
 	void SceneManager::ProcessEditorPlayRequests()
@@ -292,6 +345,8 @@ namespace Ken4lowEngine
 #ifdef USE_IMGUI
 		K4E::EditorCommandHistory::GetInstance()->Clear();
 #endif
+		currentSceneDefinition_.reset();
+		nextSceneDefinition_.reset();
 	}
 
 	void SceneManager::ChangeScene(const std::string& sceneName)
@@ -312,7 +367,30 @@ namespace Ken4lowEngine
 			hasQueuedChange_ = true;
 			return;
 		}
-		nextScene_ = sceneFactory_->CreateScene(sceneName);
+
+		SceneDefinition definition = ResolveSceneDefinition(sceneName);
+		try
+		{
+			nextScene_ = sceneFactory_->CreateScene(definition.sceneClass);
+		}
+		catch (const std::exception& exception)
+		{
+			nextScene_.reset();
+			ReportSceneMessage(false, "[SceneManager] Failed to create " + definition.sceneName +
+				" (" + definition.sceneClass + "): " + exception.what());
+			return;
+		}
+		if (!nextScene_)
+		{
+			ReportSceneMessage(false, "[SceneManager] SceneFactory returned null: " + definition.sceneClass);
+			return;
+		}
+
+		nextSceneDefinition_ = std::move(definition);
+		ApplyTransitionDefinition(*nextSceneDefinition_);
+		ReportSceneMessage(true, "[SceneManager] ChangeScene: " + nextSceneDefinition_->sceneName +
+			" -> " + nextSceneDefinition_->sceneClass);
+
 		if (!sceneTransition_)
 		{
 			ApplyNextScene();
@@ -325,6 +403,29 @@ namespace Ken4lowEngine
 		coverHoldCounter_ = 0;
 		uncoverDelayCounter_ = 0;
 		unloadRequested_ = false;
+	}
+
+	void SceneManager::ChangeToNextScene()
+	{
+		if (!currentSceneDefinition_ || currentSceneDefinition_->nextScene.empty())
+		{
+			ReportSceneMessage(false, "[SceneManager] NextScene is not configured for the current scene.");
+			return;
+		}
+		ChangeScene(currentSceneDefinition_->nextScene);
+	}
+
+	void SceneManager::RestartCurrentScene()
+	{
+		if (!currentSceneDefinition_)
+		{
+			ReportSceneMessage(false, "[SceneManager] Current scene definition is not available.");
+			return;
+		}
+		const std::string target = currentSceneDefinition_->retryScene.empty()
+			? currentSceneDefinition_->sceneName
+			: currentSceneDefinition_->retryScene;
+		ChangeScene(target);
 	}
 
 	void SceneManager::ApplyNextScene()
@@ -347,10 +448,14 @@ namespace Ken4lowEngine
 #endif
 			scene_->Finalize();
 		}
+
 		scene_ = std::move(nextScene_);
+		currentSceneDefinition_ = nextSceneDefinition_.value_or(SceneRegistry::MakeLegacyDefinition("InjectedScene"));
+		nextSceneDefinition_.reset();
 		if (scene_)
 		{
 			scene_->SetSceneManager(this);
+			scene_->SetSceneDefinition(*currentSceneDefinition_);
 			scene_->Initialize();
 			scene_->StartLoad();
 		}

--- a/Project/Engine/Scene/Management/SceneManager.h
+++ b/Project/Engine/Scene/Management/SceneManager.h
@@ -3,9 +3,13 @@
 #include <BaseScene.h>
 #include "AbstractSceneFactory.h"
 #include "ISceneTransition.h"
+#include "SceneRegistry.h"
 
+#include <filesystem>
 #include <memory>
+#include <optional>
 #include <string>
+#include <string_view>
 
 namespace Ken4lowEngine
 {
@@ -28,7 +32,12 @@ namespace Ken4lowEngine
 		void SetNextScene(std::unique_ptr<BaseScene> nextScene) { nextScene_ = std::move(nextScene); }
 		void SetAbstractSceneFactory(std::unique_ptr<AbstractSceneFactory> sceneFactory) { sceneFactory_ = std::move(sceneFactory); }
 		void SetSceneTransition(std::unique_ptr<ISceneTransition> sceneTransition) { sceneTransition_ = std::move(sceneTransition); }
+
+		bool LoadSceneDefinitions(const std::filesystem::path& directory);
+		[[nodiscard]] std::string GetConfiguredStartSceneName(bool debugBuild, std::string_view fallback) const;
 		void ChangeScene(const std::string& sceneName);
+		void ChangeToNextScene();
+		void RestartCurrentScene();
 
 		[[nodiscard]] bool IsTransitioning() const { return isTransitioning_ || (sceneTransition_ && sceneTransition_->IsBusy()); }
 		[[nodiscard]] bool IsPlayInEditorActive() const { return editorPlaySessionActive_; }
@@ -36,15 +45,26 @@ namespace Ken4lowEngine
 		[[nodiscard]] const BaseScene* GetCurrentScene() const { return scene_.get(); }
 		[[nodiscard]] ISceneTransition* GetSceneTransition() { return sceneTransition_.get(); }
 		[[nodiscard]] const ISceneTransition* GetSceneTransition() const { return sceneTransition_.get(); }
+		[[nodiscard]] const SceneDefinition* GetCurrentSceneDefinition() const
+		{
+			return currentSceneDefinition_ ? &*currentSceneDefinition_ : nullptr;
+		}
+		[[nodiscard]] const SceneRegistry& GetSceneRegistry() const { return sceneRegistry_; }
 
 	private:
 		void ApplyNextScene();
 		void RefreshEditorVisualState(float deltaTime);
+		void ApplyTransitionDefinition(const SceneDefinition& definition);
+		void ReportSceneMessage(bool succeeded, const std::string& message) const;
+		[[nodiscard]] SceneDefinition ResolveSceneDefinition(std::string_view sceneName) const;
 
 		std::unique_ptr<BaseScene> scene_;
 		std::unique_ptr<BaseScene> nextScene_;
 		std::unique_ptr<AbstractSceneFactory> sceneFactory_;
 		std::unique_ptr<ISceneTransition> sceneTransition_;
+		SceneRegistry sceneRegistry_;
+		std::optional<SceneDefinition> currentSceneDefinition_;
+		std::optional<SceneDefinition> nextSceneDefinition_;
 
 		bool isTransitioning_ = false;
 		bool sceneSwapped_ = false;

--- a/Project/Engine/Scene/Management/SceneRegistry.h
+++ b/Project/Engine/Scene/Management/SceneRegistry.h
@@ -20,6 +20,11 @@ namespace Ken4lowEngine
 	public:
 		static constexpr std::string_view kStartupFormat = "Ken4lowSceneStartup";
 
+		SceneRegistry()
+		{
+			LoadDirectory("Resources/JSON/Scenes"); // SceneManager生成時に標準Scene定義を読み込み、既存ChangeScene呼び出しをそのままデータ駆動化する。
+		}
+
 		bool LoadDirectory(const std::filesystem::path& directory)
 		{
 			definitions_.clear();

--- a/Project/Engine/Scene/Management/SceneRegistry.h
+++ b/Project/Engine/Scene/Management/SceneRegistry.h
@@ -54,23 +54,35 @@ namespace Ken4lowEngine
 			return errors_.empty();
 		}
 
-		[[nodiscard]] const SceneDefinition* Find(std::string_view sceneNameOrClass) const
+		[[nodiscard]] const SceneDefinition* FindByName(std::string_view sceneName) const
 		{
-			const auto direct = definitions_.find(std::string(sceneNameOrClass));
-			if (direct != definitions_.end()) return &direct->second;
+			const auto found = definitions_.find(std::string(sceneName));
+			return found != definitions_.end() ? &found->second : nullptr;
+		}
 
+		[[nodiscard]] const SceneDefinition* FindUniqueByClass(std::string_view sceneClass) const
+		{
+			const SceneDefinition* result = nullptr;
 			for (const auto& [name, definition] : definitions_)
 			{
 				(void)name;
-				if (definition.sceneClass == sceneNameOrClass) return &definition;
+				if (definition.sceneClass != sceneClass) continue;
+				if (result) return nullptr; // 同じC++ SceneClassを複数SceneNameで使う場合は名前指定を必須にする。
+				result = &definition;
 			}
-			return nullptr;
+			return result;
+		}
+
+		[[nodiscard]] const SceneDefinition* Find(std::string_view sceneNameOrClass) const
+		{
+			if (const SceneDefinition* byName = FindByName(sceneNameOrClass)) return byName;
+			return FindUniqueByClass(sceneNameOrClass);
 		}
 
 		[[nodiscard]] std::string GetStartupSceneName(bool debugBuild, std::string_view fallback) const
 		{
 			const std::string& configured = debugBuild ? debugStartScene_ : releaseStartScene_;
-			if (!configured.empty() && Find(configured)) return configured;
+			if (!configured.empty() && FindByName(configured)) return configured;
 			return std::string(fallback);
 		}
 
@@ -153,21 +165,21 @@ namespace Ken4lowEngine
 		{
 			for (const auto& [name, definition] : definitions_)
 			{
-				if (!definition.nextScene.empty() && !Find(definition.nextScene))
+				if (!definition.nextScene.empty() && !FindByName(definition.nextScene))
 				{
 					warnings_.push_back("NextScene was not found: " + name + " -> " + definition.nextScene);
 				}
-				if (!definition.retryScene.empty() && !Find(definition.retryScene))
+				if (!definition.retryScene.empty() && !FindByName(definition.retryScene))
 				{
 					warnings_.push_back("RetryScene was not found: " + name + " -> " + definition.retryScene);
 				}
 			}
 
-			if (!debugStartScene_.empty() && !Find(debugStartScene_))
+			if (!debugStartScene_.empty() && !FindByName(debugStartScene_))
 			{
 				warnings_.push_back("Debug startup scene was not found: " + debugStartScene_);
 			}
-			if (!releaseStartScene_.empty() && !Find(releaseStartScene_))
+			if (!releaseStartScene_.empty() && !FindByName(releaseStartScene_))
 			{
 				warnings_.push_back("Release startup scene was not found: " + releaseStartScene_);
 			}

--- a/Project/Engine/Scene/Management/SceneRegistry.h
+++ b/Project/Engine/Scene/Management/SceneRegistry.h
@@ -1,0 +1,183 @@
+#pragma once
+
+#include "SceneDefinition.h"
+
+#include <json.hpp>
+
+#include <algorithm>
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace Ken4lowEngine
+{
+	/// <summary>Resources/JSON/Scenes配下のScene定義を検索・検証します。</summary>
+	class SceneRegistry
+	{
+	public:
+		static constexpr std::string_view kStartupFormat = "Ken4lowSceneStartup";
+
+		bool LoadDirectory(const std::filesystem::path& directory)
+		{
+			definitions_.clear();
+			errors_.clear();
+			warnings_.clear();
+			debugStartScene_.clear();
+			releaseStartScene_.clear();
+			directory_ = directory;
+
+			std::error_code error;
+			if (!std::filesystem::exists(directory_, error) || error)
+			{
+				errors_.push_back("Scene definition directory was not found: " + directory_.generic_string());
+				return false;
+			}
+
+			std::vector<std::filesystem::path> jsonFiles;
+			for (const auto& entry : std::filesystem::recursive_directory_iterator(directory_, error))
+			{
+				if (error) break;
+				if (entry.is_regular_file() && entry.path().extension() == ".json") jsonFiles.push_back(entry.path());
+			}
+			std::sort(jsonFiles.begin(), jsonFiles.end()); // 読込順を固定して重複エラーやログの順序を再現可能にする。
+
+			for (const std::filesystem::path& path : jsonFiles) LoadFile(path);
+			ValidateReferences();
+
+			if (definitions_.empty())
+			{
+				errors_.push_back("No Ken4lowScene definitions were loaded from: " + directory_.generic_string());
+			}
+			return errors_.empty();
+		}
+
+		[[nodiscard]] const SceneDefinition* Find(std::string_view sceneNameOrClass) const
+		{
+			const auto direct = definitions_.find(std::string(sceneNameOrClass));
+			if (direct != definitions_.end()) return &direct->second;
+
+			for (const auto& [name, definition] : definitions_)
+			{
+				(void)name;
+				if (definition.sceneClass == sceneNameOrClass) return &definition;
+			}
+			return nullptr;
+		}
+
+		[[nodiscard]] std::string GetStartupSceneName(bool debugBuild, std::string_view fallback) const
+		{
+			const std::string& configured = debugBuild ? debugStartScene_ : releaseStartScene_;
+			if (!configured.empty() && Find(configured)) return configured;
+			return std::string(fallback);
+		}
+
+		[[nodiscard]] const std::unordered_map<std::string, SceneDefinition>& GetDefinitions() const { return definitions_; }
+		[[nodiscard]] const std::vector<std::string>& GetErrors() const { return errors_; }
+		[[nodiscard]] const std::vector<std::string>& GetWarnings() const { return warnings_; }
+		[[nodiscard]] const std::filesystem::path& GetDirectory() const { return directory_; }
+		[[nodiscard]] bool IsLoaded() const { return !definitions_.empty() && errors_.empty(); }
+
+		[[nodiscard]] static SceneDefinition MakeLegacyDefinition(std::string_view sceneClass)
+		{
+			SceneDefinition definition{};
+			definition.sceneName = std::string(sceneClass);
+			definition.sceneClass = std::string(sceneClass);
+			definition.parameters["LegacyFallback"] = true; // JSONが無い場合も従来のScene名指定を壊さず段階移行できるようにする。
+			return definition;
+		}
+
+	private:
+		void LoadFile(const std::filesystem::path& path)
+		{
+			try
+			{
+				std::ifstream file(path);
+				if (!file.is_open())
+				{
+					errors_.push_back("Failed to open scene definition: " + path.generic_string());
+					return;
+				}
+
+				nlohmann::json json;
+				file >> json;
+				if (!json.is_object())
+				{
+					errors_.push_back("Scene JSON root must be an object: " + path.generic_string());
+					return;
+				}
+
+				const std::string format = json.value("Format", std::string{});
+				if (format == SceneDefinition::kFormat)
+				{
+					SceneDefinition definition{};
+					std::string parseError;
+					if (!SceneDefinition::FromJson(json, path, definition, parseError))
+					{
+						errors_.push_back(parseError);
+						return;
+					}
+					if (definitions_.contains(definition.sceneName))
+					{
+						errors_.push_back("Duplicate SceneName: " + definition.sceneName + " in " + path.generic_string());
+						return;
+					}
+					definitions_.emplace(definition.sceneName, std::move(definition));
+					return;
+				}
+
+				if (format == kStartupFormat)
+				{
+					const int version = json.value("Version", 0);
+					if (version != 1)
+					{
+						errors_.push_back("Unsupported startup scene version: " + path.generic_string());
+						return;
+					}
+					debugStartScene_ = json.value("Debug", std::string{});
+					releaseStartScene_ = json.value("Release", std::string{});
+					return;
+				}
+
+				warnings_.push_back("Skipped unknown JSON format in Scenes directory: " + path.generic_string());
+			}
+			catch (const std::exception& exception)
+			{
+				errors_.push_back("Failed to parse " + path.generic_string() + ": " + exception.what());
+			}
+		}
+
+		void ValidateReferences()
+		{
+			for (const auto& [name, definition] : definitions_)
+			{
+				if (!definition.nextScene.empty() && !Find(definition.nextScene))
+				{
+					warnings_.push_back("NextScene was not found: " + name + " -> " + definition.nextScene);
+				}
+				if (!definition.retryScene.empty() && !Find(definition.retryScene))
+				{
+					warnings_.push_back("RetryScene was not found: " + name + " -> " + definition.retryScene);
+				}
+			}
+
+			if (!debugStartScene_.empty() && !Find(debugStartScene_))
+			{
+				warnings_.push_back("Debug startup scene was not found: " + debugStartScene_);
+			}
+			if (!releaseStartScene_.empty() && !Find(releaseStartScene_))
+			{
+				warnings_.push_back("Release startup scene was not found: " + releaseStartScene_);
+			}
+		}
+
+		std::filesystem::path directory_;
+		std::unordered_map<std::string, SceneDefinition> definitions_;
+		std::vector<std::string> errors_;
+		std::vector<std::string> warnings_;
+		std::string debugStartScene_;
+		std::string releaseStartScene_;
+	};
+} // namespace Ken4lowEngine

--- a/Project/Engine/Scene/Management/SceneRegistry.h
+++ b/Project/Engine/Scene/Management/SceneRegistry.h
@@ -20,11 +20,6 @@ namespace Ken4lowEngine
 	public:
 		static constexpr std::string_view kStartupFormat = "Ken4lowSceneStartup";
 
-		SceneRegistry()
-		{
-			LoadDirectory("Resources/JSON/Scenes"); // SceneManager生成時に標準Scene定義を読み込み、既存ChangeScene呼び出しをそのままデータ駆動化する。
-		}
-
 		bool LoadDirectory(const std::filesystem::path& directory)
 		{
 			definitions_.clear();
@@ -115,7 +110,7 @@ namespace Ken4lowEngine
 				}
 
 				const std::string format = json.value("Format", std::string{});
-				if (format == SceneDefinition::kFormat)
+				if (format == std::string(SceneDefinition::kFormat))
 				{
 					SceneDefinition definition{};
 					std::string parseError;
@@ -133,7 +128,7 @@ namespace Ken4lowEngine
 					return;
 				}
 
-				if (format == kStartupFormat)
+				if (format == std::string(kStartupFormat))
 				{
 					const int version = json.value("Version", 0);
 					if (version != 1)

--- a/Resources/JSON/Scenes/DebugScene.json
+++ b/Resources/JSON/Scenes/DebugScene.json
@@ -1,0 +1,26 @@
+{
+    "Format": "Ken4lowScene",
+    "Version": 1,
+    "SceneName": "DebugScene",
+    "SceneClass": "DebugScene",
+    "LevelPath": "",
+    "GameMode": "DebugGameMode",
+    "PlayerActor": "",
+    "BGM": {
+        "Path": "",
+        "Loop": true,
+        "Volume": 1.0
+    },
+    "UI": [],
+    "Transition": {
+        "Type": "Fade",
+        "CoverHoldFrames": 4,
+        "UncoverDelayFrames": 3,
+        "Duration": 1.0
+    },
+    "NextScene": "TitleScene",
+    "RetryScene": "DebugScene",
+    "Parameters": {
+        "UseLegacyInitialize": true
+    }
+}

--- a/Resources/JSON/Scenes/GamePlayScene.json
+++ b/Resources/JSON/Scenes/GamePlayScene.json
@@ -1,0 +1,26 @@
+{
+    "Format": "Ken4lowScene",
+    "Version": 1,
+    "SceneName": "GamePlayScene",
+    "SceneClass": "GamePlayScene",
+    "LevelPath": "",
+    "GameMode": "FPSGameMode",
+    "PlayerActor": "Resources/JSON/Actor/PlayerActor.json",
+    "BGM": {
+        "Path": "",
+        "Loop": true,
+        "Volume": 1.0
+    },
+    "UI": [],
+    "Transition": {
+        "Type": "Fade",
+        "CoverHoldFrames": 4,
+        "UncoverDelayFrames": 3,
+        "Duration": 1.0
+    },
+    "NextScene": "StageSelectScene",
+    "RetryScene": "GamePlayScene",
+    "Parameters": {
+        "UseLegacyInitialize": true
+    }
+}

--- a/Resources/JSON/Scenes/SceneStartup.json
+++ b/Resources/JSON/Scenes/SceneStartup.json
@@ -1,0 +1,6 @@
+{
+    "Format": "Ken4lowSceneStartup",
+    "Version": 1,
+    "Debug": "DebugScene",
+    "Release": "TitleScene"
+}

--- a/Resources/JSON/Scenes/StageSelectScene.json
+++ b/Resources/JSON/Scenes/StageSelectScene.json
@@ -1,0 +1,26 @@
+{
+    "Format": "Ken4lowScene",
+    "Version": 1,
+    "SceneName": "StageSelectScene",
+    "SceneClass": "StageSelectScene",
+    "LevelPath": "",
+    "GameMode": "StageSelectGameMode",
+    "PlayerActor": "",
+    "BGM": {
+        "Path": "",
+        "Loop": true,
+        "Volume": 1.0
+    },
+    "UI": [],
+    "Transition": {
+        "Type": "Fade",
+        "CoverHoldFrames": 4,
+        "UncoverDelayFrames": 3,
+        "Duration": 1.0
+    },
+    "NextScene": "GamePlayScene",
+    "RetryScene": "StageSelectScene",
+    "Parameters": {
+        "UseLegacyInitialize": true
+    }
+}

--- a/Resources/JSON/Scenes/TitleScene.json
+++ b/Resources/JSON/Scenes/TitleScene.json
@@ -1,0 +1,26 @@
+{
+    "Format": "Ken4lowScene",
+    "Version": 1,
+    "SceneName": "TitleScene",
+    "SceneClass": "TitleScene",
+    "LevelPath": "",
+    "GameMode": "",
+    "PlayerActor": "",
+    "BGM": {
+        "Path": "",
+        "Loop": true,
+        "Volume": 1.0
+    },
+    "UI": [],
+    "Transition": {
+        "Type": "Fade",
+        "CoverHoldFrames": 4,
+        "UncoverDelayFrames": 3,
+        "Duration": 1.0
+    },
+    "NextScene": "StageSelectScene",
+    "RetryScene": "TitleScene",
+    "Parameters": {
+        "UseLegacyInitialize": true
+    }
+}


### PR DESCRIPTION
## 概要
Editor V2完了後の次段階として、Scene管理をJSON定義から解決できる基盤へ移行しました。

## 実装内容
- `SceneDefinition`を追加
- `SceneRegistry`を追加
- `Resources/JSON/Scenes`を起動時に走査
- `SceneStartup.json`からDebug / Releaseの起動Sceneを選択
- SceneNameとC++ SceneClassを分離
- SceneFactoryのif/else生成を登録表へ変更
- SceneManagerがSceneNameからJSON定義を解決してSceneClassを生成
- BaseSceneへSceneDefinitionをInitialize前に注入
- LevelPath / GameMode / PlayerActor / BGM / UI / Transition / NextScene / RetryScene / Parametersを保持
- TransitionのCoverHoldFrames / UncoverDelayFramesをScene JSONから反映
- `ChangeToNextScene()`と`RestartCurrentScene()`を追加
- 未移行Scene名は従来のSceneClass名としてフォールバック
- 不明なSceneClassは例外をSceneManagerで捕捉してError Logへ出力
- Format / Version / SceneName重複 / NextScene / RetryScene / Startup参照を検証
- 同じC++ SceneClassを複数SceneNameで使用できるよう、SceneName検索とClass検索を分離
- Title / StageSelect / GamePlay / Debug / Startupの定義JSONを追加

## JSONの役割
- SceneName: ゲーム進行上のScene識別子
- SceneClass: 生成するC++ Sceneクラス
- LevelPath: 使用するLevel
- GameMode: 使用するゲームルール
- PlayerActor: 初期Player Actor
- BGM / UI: Scene固有アセット
- Transition: Scene切り替え設定
- NextScene / RetryScene: 遷移先
- Parameters: Scene固有の追加設定

## この段階で変わらないもの
- 各SceneのC++固有ロジック
- 現在のLevel生成処理
- BGMやUIの実際の自動適用
- 既存の`ChangeScene("TitleScene")`等の呼び出し

基盤確認後、LevelPath / BGM / UI / GameMode / PlayerActorの実適用と、ハードコードされた遷移先の置換を次段階で行います。

## 確認項目
1. Debug起動時に`SceneStartup.json`指定のDebugSceneが起動する
2. Release起動時に`SceneStartup.json`指定のTitleSceneが起動する
3. Title / StageSelect / GamePlay間を従来どおり遷移できる
4. Scene切り替え時にLogへSceneNameとSceneClassが表示される
5. JSONのCoverHoldFrames / UncoverDelayFrames変更が遷移へ反映される
6. Scene JSONが無い名前でも従来Factory互換で動作する
7. 不明なSceneClassではクラッシュせずError Logを出す

## 検証
- GitHub Actions Debug Build: success
- GitHub Actions Release Build: success
- Phase 7 Diagnostics: success