### PR TITLE
Data-drive scene management with JSON definitions

### DIFF
--- a/Project/ApplicationLayer/SceneManagement/SceneFactory/SceneFactory.cpp
+++ b/Project/ApplicationLayer/SceneManagement/SceneFactory/SceneFactory.cpp
@@ -4,32 +4,40 @@
 #include "StageSelectScene.h"
 #include "DebugScene.h"
 
+#include <functional>
+#include <unordered_map>
+
 namespace Ken4lowEngine
 {
-	/// -------------------------------------------------------------
-	///				　		    シーン生成
-	/// -------------------------------------------------------------
-	std::unique_ptr<BaseScene> SceneFactory::CreateScene(const std::string& sceneName)
+	namespace
 	{
-		// 次のシーンを生成
-		std::unique_ptr<BaseScene> newScene = nullptr;
+		using SceneCreator = std::function<std::unique_ptr<BaseScene>()>;
 
-		// タイトルシーン
-		if (sceneName == "TitleScene")				return std::make_unique<TitleScene>();
-
-		// ステージセレクトシーン
-		else if (sceneName == "StageSelectScene")	return std::make_unique<StageSelectScene>();
-
-		// ゲームプレイシーン
-		else if (sceneName == "GamePlayScene")		return std::make_unique<GamePlayScene>();
-
+		const std::unordered_map<std::string, SceneCreator>& GetSceneCreators()
+		{
+			static const std::unordered_map<std::string, SceneCreator> creators = []
+				{
+					std::unordered_map<std::string, SceneCreator> result;
+					result.emplace("TitleScene", [] { return std::make_unique<TitleScene>(); });
+					result.emplace("StageSelectScene", [] { return std::make_unique<StageSelectScene>(); });
+					result.emplace("GamePlayScene", [] { return std::make_unique<GamePlayScene>(); });
 #ifdef _DEBUG
-		// デバッグシーン
-		else if (sceneName == "DebugScene")			return std::make_unique<DebugScene>();
-#endif // _DEBUG
-
-		// 不明なシーン名の場合は例外を投げる
-		throw std::runtime_error("Unknown scene name: " + sceneName);
+					result.emplace("DebugScene", [] { return std::make_unique<DebugScene>(); });
+#endif
+					return result; // JSONのScene IDとC++ Class名を分離できるようClass生成だけを登録表へ集約する。
+				}();
+			return creators;
+		}
 	}
 
-}
+	std::unique_ptr<BaseScene> SceneFactory::CreateScene(const std::string& sceneName)
+	{
+		const auto& creators = GetSceneCreators();
+		const auto iterator = creators.find(sceneName);
+		if (iterator == creators.end())
+		{
+			throw std::runtime_error("Unknown scene class: " + sceneName);
+		}
+		return iterator->second();
+	}
+} // namespace Ken4lowEngine

--- a/Project/Engine/Scene/Management/BaseScene.h
+++ b/Project/Engine/Scene/Management/BaseScene.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "SceneDefinition.h"
+
 #include <Editor/EditorObjectInfo.h>
 
 #include <vector>
@@ -24,6 +26,14 @@ namespace Ken4lowEngine
 		virtual ~BaseScene() = default;
 		virtual void Initialize() = 0;
 		virtual void Update() = 0;
+
+		/// <summary>SceneManagerがJSON定義をInitialize前に適用します。</summary>
+		virtual void ApplySceneDefinition(const SceneDefinition& definition)
+		{
+			sceneDefinition_ = definition; // C++ Scene固有処理を残しつつ、使用Levelや遷移先をデータから参照できるようにする。
+		}
+
+		[[nodiscard]] const SceneDefinition& GetSceneDefinition() const { return sceneDefinition_; }
 
 		/// <summary>Editor Mode中にゲーム進行を止めたまま確認用更新だけ行う。</summary>
 		virtual void UpdateEditor(float /*deltaTime*/) {}
@@ -53,5 +63,6 @@ namespace Ken4lowEngine
 
 	protected:
 		SceneManager* sceneManager_ = nullptr;
+		SceneDefinition sceneDefinition_{};
 	};
 } // namespace Ken4lowEngine

--- a/Project/Engine/Scene/Management/SceneDefinition.h
+++ b/Project/Engine/Scene/Management/SceneDefinition.h
@@ -1,0 +1,36 @@
+#pragma once
+
+#include <json.hpp>
+
+#include <string>
+
+namespace Ken4lowEngine
+{
+	/// <summary>Scene遷移や使用Levelなど、C++ Sceneへ適用するデータ定義です。</summary>
+	struct SceneDefinition
+	{
+		struct TransitionSettings
+		{
+			std::string type = "Fade";
+			float duration = 1.0f;
+		};
+
+		std::string id;
+		std::string className;
+		std::string levelPath;
+		std::string gameMode;
+		std::string playerActor;
+		std::string uiLayout;
+		std::string bgmPath;
+		std::string nextScene;
+		std::string retryScene;
+		bool editorOnly = false;
+		TransitionSettings transition{};
+		nlohmann::json parameters = nlohmann::json::object();
+
+		[[nodiscard]] bool IsValid() const
+		{
+			return !id.empty() && !className.empty(); // Scene IDと生成するC++ Classは必須項目として扱う。
+		}
+	};
+} // namespace Ken4lowEngine

--- a/Project/Engine/Scene/Management/SceneDefinition.h
+++ b/Project/Engine/Scene/Management/SceneDefinition.h
@@ -2,6 +2,7 @@
 
 #include <json.hpp>
 
+#include <exception>
 #include <string>
 
 namespace Ken4lowEngine

--- a/Project/Engine/Scene/Management/SceneDefinitionRegistry.h
+++ b/Project/Engine/Scene/Management/SceneDefinitionRegistry.h
@@ -1,0 +1,181 @@
+#pragma once
+
+#include "SceneDefinition.h"
+
+#include <filesystem>
+#include <fstream>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace Ken4lowEngine
+{
+	/// <summary>Scene Registryと各Scene JSONを読み込み、Scene IDから定義を解決します。</summary>
+	class SceneDefinitionRegistry
+	{
+	public:
+		bool Load(const std::filesystem::path& registryPath)
+		{
+			Clear();
+			registryPath_ = registryPath;
+
+			try
+			{
+				std::ifstream registryFile(registryPath);
+				if (!registryFile.is_open())
+				{
+					lastError_ = "Scene Registryを開けません: " + registryPath.generic_string();
+					RegisterFallbackDefinitions();
+					return false;
+				}
+
+				nlohmann::json registryJson;
+				registryFile >> registryJson;
+				if (!registryJson.is_object() || registryJson.value("Format", std::string{}) != "Ken4lowSceneRegistry")
+				{
+					lastError_ = "Scene Registry形式が不正です: " + registryPath.generic_string();
+					RegisterFallbackDefinitions();
+					return false;
+				}
+
+				startupScene_ = registryJson.value("StartupScene", "TitleScene");
+				debugStartupScene_ = registryJson.value("DebugStartupScene", startupScene_);
+				const std::filesystem::path baseDirectory = registryPath.parent_path();
+
+				if (registryJson.contains("Scenes") && registryJson["Scenes"].is_array())
+				{
+					for (const nlohmann::json& sceneEntry : registryJson["Scenes"])
+					{
+						if (!sceneEntry.is_string()) continue;
+						LoadSceneFile(baseDirectory / sceneEntry.get<std::string>());
+					}
+				}
+
+				if (definitions_.empty())
+				{
+					lastError_ = "Scene定義が1件も読み込まれませんでした。";
+					RegisterFallbackDefinitions();
+					return false;
+				}
+
+				return lastError_.empty(); // 一部失敗時も読めたSceneは利用し、警告だけ保持する。
+			}
+			catch (const std::exception& exception)
+			{
+				lastError_ = std::string("Scene Registry読込中に例外が発生しました: ") + exception.what();
+				RegisterFallbackDefinitions();
+				return false;
+			}
+		}
+
+		void Clear()
+		{
+			definitions_.clear();
+			startupScene_ = "TitleScene";
+			debugStartupScene_ = "DebugScene";
+			lastError_.clear();
+			registryPath_.clear(); // 再読込時に前回のRegistry情報を残さない。
+		}
+
+		[[nodiscard]] const SceneDefinition* Find(const std::string& sceneId) const
+		{
+			const auto iterator = definitions_.find(sceneId);
+			return iterator != definitions_.end() ? &iterator->second : nullptr;
+		}
+
+		[[nodiscard]] std::string GetStartupScene(bool debugBuild) const
+		{
+			const std::string& requested = debugBuild ? debugStartupScene_ : startupScene_;
+			if (Find(requested)) return requested;
+			return definitions_.empty() ? requested : definitions_.begin()->first;
+		}
+
+		[[nodiscard]] const std::unordered_map<std::string, SceneDefinition>& GetDefinitions() const { return definitions_; }
+		[[nodiscard]] const std::string& GetLastError() const { return lastError_; }
+		[[nodiscard]] const std::filesystem::path& GetRegistryPath() const { return registryPath_; }
+
+	private:
+		bool LoadSceneFile(const std::filesystem::path& path)
+		{
+			try
+			{
+				std::ifstream file(path);
+				if (!file.is_open())
+				{
+					AppendError("Scene定義を開けません: " + path.generic_string());
+					return false;
+				}
+
+				nlohmann::json json;
+				file >> json;
+				SceneDefinition definition{};
+				definition.id = json.value("Id", path.stem().string());
+				definition.className = json.value("Class", definition.id);
+				definition.levelPath = json.value("Level", std::string{});
+				definition.gameMode = json.value("GameMode", std::string{});
+				definition.playerActor = json.value("PlayerActor", std::string{});
+				definition.uiLayout = json.value("UILayout", std::string{});
+				definition.bgmPath = json.value("BGM", std::string{});
+				definition.nextScene = json.value("NextScene", std::string{});
+				definition.retryScene = json.value("RetryScene", std::string{});
+				definition.editorOnly = json.value("EditorOnly", false);
+
+				if (json.contains("Transition") && json["Transition"].is_object())
+				{
+					definition.transition.type = json["Transition"].value("Type", "Fade");
+					definition.transition.duration = json["Transition"].value("Duration", 1.0f);
+				}
+				if (json.contains("Parameters") && json["Parameters"].is_object())
+				{
+					definition.parameters = json["Parameters"];
+				}
+
+				if (!definition.IsValid())
+				{
+					AppendError("必須項目が不足したScene定義です: " + path.generic_string());
+					return false;
+				}
+
+				definitions_[definition.id] = std::move(definition); // 同じIDは後から読んだ定義で明示的に上書きする。
+				return true;
+			}
+			catch (const std::exception& exception)
+			{
+				AppendError(path.generic_string() + ": " + exception.what());
+				return false;
+			}
+		}
+
+		void AppendError(std::string message)
+		{
+			if (!lastError_.empty()) lastError_ += "\n";
+			lastError_ += std::move(message);
+		}
+
+		void RegisterFallbackDefinitions()
+		{
+			const std::vector<std::pair<std::string, bool>> fallbackScenes = {
+				{ "TitleScene", false },
+				{ "StageSelectScene", false },
+				{ "GamePlayScene", false },
+				{ "DebugScene", true },
+			};
+			for (const auto& [name, editorOnly] : fallbackScenes)
+			{
+				if (definitions_.contains(name)) continue;
+				SceneDefinition definition{};
+				definition.id = name;
+				definition.className = name;
+				definition.editorOnly = editorOnly;
+				definitions_.emplace(name, std::move(definition));
+			}
+		}
+
+		std::unordered_map<std::string, SceneDefinition> definitions_;
+		std::string startupScene_ = "TitleScene";
+		std::string debugStartupScene_ = "DebugScene";
+		std::string lastError_;
+		std::filesystem::path registryPath_;
+	};
+} // namespace Ken4lowEngine

--- a/Project/Engine/Scene/Management/SceneDefinitionRegistry.h
+++ b/Project/Engine/Scene/Management/SceneDefinitionRegistry.h
@@ -15,6 +15,11 @@ namespace Ken4lowEngine
 	class SceneDefinitionRegistry
 	{
 	public:
+		SceneDefinitionRegistry()
+		{
+			Load("Resources/JSON/Scenes/SceneRegistry.json"); // SceneManager生成時に標準Registryを自動読込して既存ChangeScene呼び出しをデータ化する。
+		}
+
 		bool Load(const std::filesystem::path& registryPath)
 		{
 			Clear();

--- a/Project/Engine/Scene/Management/SceneManager.cpp
+++ b/Project/Engine/Scene/Management/SceneManager.cpp
@@ -38,6 +38,7 @@ namespace Ken4lowEngine
 		uncoverDelayCounter_ = 0;
 		unloadRequested_ = false;
 		editorPlaySessionActive_ = false;
+		editorPlayUsesSceneRecreate_ = false;
 		editorSingleStepRequested_ = false;
 	}
 
@@ -84,21 +85,43 @@ namespace Ken4lowEngine
 
 		K4E::EditorPlayController* playController = K4E::EditorPlayController::GetInstance();
 		K4E::EditorPlaySessionManager* sessionManager = K4E::EditorPlaySessionManager::GetInstance();
+		K4E::EditorWindowManager* windowManager = K4E::EditorWindowManager::GetInstance();
 		const K4E::EditorPlayRequest request = playController->ConsumePendingRequest();
 
 		switch (request)
 		{
 		case K4E::EditorPlayRequest::Start:
-			if (!editorPlaySessionActive_ && sessionManager->BeginPlaySession(*scene_))
+			if (editorPlaySessionActive_)
 			{
-				scene_->BeginEditorPlay();
-				editorPlaySessionActive_ = true;
-				editorSingleStepRequested_ = false;
-				playController->CommitPlayStarted();
+				playController->CommitPlayResumed();
+				break;
+			}
+
+			if (scene_->GetEditorActorWorld())
+			{
+				if (sessionManager->BeginPlaySession(*scene_))
+				{
+					scene_->BeginEditorPlay();
+					editorPlaySessionActive_ = true;
+					editorPlayUsesSceneRecreate_ = false;
+					editorSingleStepRequested_ = false;
+					playController->CommitPlayStarted();
+				}
+				else
+				{
+					playController->CommitStopped();
+				}
 			}
 			else
 			{
-				playController->CommitStopped();
+				scene_->BeginEditorPlay();
+				editorPlaySessionActive_ = true;
+				editorPlayUsesSceneRecreate_ = true;
+				editorSingleStepRequested_ = false;
+				playController->CommitPlayStarted();
+				windowManager->AddOutputLog(
+					K4E::EditorLogLevel::Info,
+					"このSceneはEditor ActorWorldを公開していないため、Stop時にSceneを再生成するPIE互換モードで開始しました。"); // 旧Sceneも再生可能にしつつRuntime変更はStop時の再生成で破棄する。
 			}
 			break;
 
@@ -131,7 +154,29 @@ namespace Ken4lowEngine
 			{
 				scene_->EndEditorPlay();
 				const bool keepChanges = request == K4E::EditorPlayRequest::KeepChangesAndStop;
-				if (sessionManager->EndPlaySession(*scene_, keepChanges))
+
+				if (editorPlayUsesSceneRecreate_)
+				{
+					const std::string reloadSceneId = !currentSceneDefinition_.id.empty()
+						? currentSceneDefinition_.id
+						: currentSceneDefinition_.className;
+					editorPlaySessionActive_ = false;
+					editorPlayUsesSceneRecreate_ = false;
+					editorSingleStepRequested_ = false;
+					playController->CommitStopped();
+
+					if (keepChanges)
+					{
+						windowManager->AddOutputLog(
+							K4E::EditorLogLevel::Warning,
+							"Editor ActorWorldを公開しないSceneではRuntime変更の保持に対応していないため、通常Stopとして再生成します。");
+					}
+					windowManager->AddOutputLog(
+						K4E::EditorLogLevel::Info,
+						"PIE互換モードを停止し、Play前のScene定義からSceneを再生成します: " + reloadSceneId);
+					ChangeScene(reloadSceneId); // Data-driven Scene定義から同じSceneを作り直してRuntime状態を編集側へ残さない。
+				}
+				else if (sessionManager->EndPlaySession(*scene_, keepChanges))
 				{
 					editorPlaySessionActive_ = false;
 					editorSingleStepRequested_ = false;
@@ -157,7 +202,7 @@ namespace Ken4lowEngine
 		bool statusSucceeded = false;
 		if (sessionManager->ConsumeStatus(statusMessage, statusSucceeded))
 		{
-			K4E::EditorWindowManager::GetInstance()->AddOutputLog(
+			windowManager->AddOutputLog(
 				statusSucceeded ? K4E::EditorLogLevel::Info : K4E::EditorLogLevel::Error,
 				statusMessage);
 		}
@@ -318,8 +363,12 @@ namespace Ken4lowEngine
 			if (editorPlaySessionActive_)
 			{
 				scene_->EndEditorPlay();
-				K4E::EditorPlaySessionManager::GetInstance()->CancelSessionWithoutRestore();
+				if (!editorPlayUsesSceneRecreate_)
+				{
+					K4E::EditorPlaySessionManager::GetInstance()->CancelSessionWithoutRestore();
+				}
 				editorPlaySessionActive_ = false;
+				editorPlayUsesSceneRecreate_ = false;
 				K4E::EditorPlayController::GetInstance()->CommitStopped();
 			}
 #endif
@@ -405,8 +454,12 @@ namespace Ken4lowEngine
 			if (editorPlaySessionActive_)
 			{
 				scene_->EndEditorPlay();
-				K4E::EditorPlaySessionManager::GetInstance()->CancelSessionWithoutRestore();
+				if (!editorPlayUsesSceneRecreate_)
+				{
+					K4E::EditorPlaySessionManager::GetInstance()->CancelSessionWithoutRestore();
+				}
 				editorPlaySessionActive_ = false;
+				editorPlayUsesSceneRecreate_ = false;
 				K4E::EditorPlayController::GetInstance()->CommitStopped();
 			}
 #endif

--- a/Project/Engine/Scene/Management/SceneManager.cpp
+++ b/Project/Engine/Scene/Management/SceneManager.cpp
@@ -39,6 +39,7 @@ namespace Ken4lowEngine
 		unloadRequested_ = false;
 		editorPlaySessionActive_ = false;
 		editorPlayUsesSceneRecreate_ = false;
+		editorPlayOriginSceneId_.clear();
 		editorSingleStepRequested_ = false;
 	}
 
@@ -104,6 +105,7 @@ namespace Ken4lowEngine
 					scene_->BeginEditorPlay();
 					editorPlaySessionActive_ = true;
 					editorPlayUsesSceneRecreate_ = false;
+					editorPlayOriginSceneId_.clear();
 					editorSingleStepRequested_ = false;
 					playController->CommitPlayStarted();
 				}
@@ -114,6 +116,9 @@ namespace Ken4lowEngine
 			}
 			else
 			{
+				editorPlayOriginSceneId_ = !currentSceneDefinition_.id.empty()
+					? currentSceneDefinition_.id
+					: currentSceneDefinition_.className;
 				scene_->BeginEditorPlay();
 				editorPlaySessionActive_ = true;
 				editorPlayUsesSceneRecreate_ = true;
@@ -157,11 +162,12 @@ namespace Ken4lowEngine
 
 				if (editorPlayUsesSceneRecreate_)
 				{
-					const std::string reloadSceneId = !currentSceneDefinition_.id.empty()
-						? currentSceneDefinition_.id
-						: currentSceneDefinition_.className;
+					const std::string reloadSceneId = !editorPlayOriginSceneId_.empty()
+						? editorPlayOriginSceneId_
+						: (!currentSceneDefinition_.id.empty() ? currentSceneDefinition_.id : currentSceneDefinition_.className);
 					editorPlaySessionActive_ = false;
 					editorPlayUsesSceneRecreate_ = false;
+					editorPlayOriginSceneId_.clear();
 					editorSingleStepRequested_ = false;
 					playController->CommitStopped();
 
@@ -173,8 +179,8 @@ namespace Ken4lowEngine
 					}
 					windowManager->AddOutputLog(
 						K4E::EditorLogLevel::Info,
-						"PIE互換モードを停止し、Play前のScene定義からSceneを再生成します: " + reloadSceneId);
-					ChangeScene(reloadSceneId); // Data-driven Scene定義から同じSceneを作り直してRuntime状態を編集側へ残さない。
+						"PIE互換モードを停止し、Play開始元のScene定義からSceneを再生成します: " + reloadSceneId);
+					ChangeScene(reloadSceneId); // Runtime中に別Sceneへ遷移していてもPlay開始元のEditor Sceneへ戻す。
 				}
 				else if (sessionManager->EndPlaySession(*scene_, keepChanges))
 				{
@@ -369,6 +375,7 @@ namespace Ken4lowEngine
 				}
 				editorPlaySessionActive_ = false;
 				editorPlayUsesSceneRecreate_ = false;
+				editorPlayOriginSceneId_.clear();
 				K4E::EditorPlayController::GetInstance()->CommitStopped();
 			}
 #endif
@@ -384,12 +391,13 @@ namespace Ken4lowEngine
 	{
 		assert(sceneFactory_);
 #ifdef USE_IMGUI
-		if (editorPlaySessionActive_ || K4E::EditorPlaySessionManager::GetInstance()->IsSessionActive())
+		const bool protectedActorWorldPie = editorPlaySessionActive_ && !editorPlayUsesSceneRecreate_;
+		if (protectedActorWorldPie || K4E::EditorPlaySessionManager::GetInstance()->IsSessionActive())
 		{
 			K4E::EditorWindowManager::GetInstance()->AddOutputLog(
 				K4E::EditorLogLevel::Warning,
-				"PIE中のScene切り替えはEditor Worldを保護するため無効です。Stop後に切り替えてください。");
-			return; // 現段階では元SceneのEditor Worldを確実に復元することを優先する。
+				"ActorWorld Snapshot型PIE中のScene切り替えはEditor Worldを保護するため無効です。Stop後に切り替えてください。");
+			return; // Scene再生成型PIEではRuntimeの通常Scene遷移を許可し、Snapshot型だけを保護する。
 		}
 #endif
 		if (IsTransitioning())
@@ -447,19 +455,22 @@ namespace Ken4lowEngine
 #ifdef USE_IMGUI
 		K4E::EditorCommandHistory::GetInstance()->Clear();
 		K4E::EditorContext::GetInstance()->ResetTransientState();
+		const bool continueSceneRecreatePie = editorPlaySessionActive_ && editorPlayUsesSceneRecreate_;
 #endif
 		if (scene_)
 		{
 #ifdef USE_IMGUI
-			if (editorPlaySessionActive_)
+			if (continueSceneRecreatePie)
+			{
+				scene_->EndEditorPlay(); // Runtime Scene遷移前に現在SceneのPIE後処理だけを実行する。
+			}
+			else if (editorPlaySessionActive_)
 			{
 				scene_->EndEditorPlay();
-				if (!editorPlayUsesSceneRecreate_)
-				{
-					K4E::EditorPlaySessionManager::GetInstance()->CancelSessionWithoutRestore();
-				}
+				K4E::EditorPlaySessionManager::GetInstance()->CancelSessionWithoutRestore();
 				editorPlaySessionActive_ = false;
 				editorPlayUsesSceneRecreate_ = false;
+				editorPlayOriginSceneId_.clear();
 				K4E::EditorPlayController::GetInstance()->CommitStopped();
 			}
 #endif
@@ -474,6 +485,10 @@ namespace Ken4lowEngine
 			scene_->Initialize();
 			scene_->StartLoad();
 #ifdef USE_IMGUI
+			if (continueSceneRecreatePie)
+			{
+				scene_->BeginEditorPlay(); // Runtime中に遷移した新Sceneも同じPIE Sessionとして継続する。
+			}
 			K4E::EditorWindowManager::GetInstance()->AddOutputLog(
 				K4E::EditorLogLevel::Info,
 				"Scene開始: " + currentSceneDefinition_.id + " [Class=" + currentSceneDefinition_.className + "]");

--- a/Project/Engine/Scene/Management/SceneManager.cpp
+++ b/Project/Engine/Scene/Management/SceneManager.cpp
@@ -17,6 +17,7 @@
 
 #include <algorithm>
 #include <cassert>
+#include <exception>
 #include <string>
 #include <vector>
 
@@ -38,6 +39,42 @@ namespace Ken4lowEngine
 		unloadRequested_ = false;
 		editorPlaySessionActive_ = false;
 		editorSingleStepRequested_ = false;
+	}
+
+	bool SceneManager::LoadSceneDefinitions(const std::string& registryPath)
+	{
+		const bool loaded = sceneDefinitionRegistry_.Load(registryPath);
+#ifdef USE_IMGUI
+		K4E::EditorWindowManager::GetInstance()->AddOutputLog(
+			loaded ? K4E::EditorLogLevel::Info : K4E::EditorLogLevel::Warning,
+			loaded
+				? "Scene Registryを読み込みました: " + registryPath
+				: "Scene Registryの一部または全部を読み込めなかったためFallback定義を使用します: " + sceneDefinitionRegistry_.GetLastError());
+#endif
+		return loaded; // 読込失敗時もRegistry内部のFallback定義で従来Scene名を維持する。
+	}
+
+	std::string SceneManager::GetStartupSceneName(bool debugBuild) const
+	{
+		return sceneDefinitionRegistry_.GetStartupScene(debugBuild);
+	}
+
+	const SceneDefinition* SceneManager::FindSceneDefinition(const std::string& sceneId) const
+	{
+		return sceneDefinitionRegistry_.Find(sceneId);
+	}
+
+	SceneDefinition SceneManager::ResolveSceneDefinition(const std::string& sceneId) const
+	{
+		if (const SceneDefinition* definition = sceneDefinitionRegistry_.Find(sceneId))
+		{
+			return *definition;
+		}
+
+		SceneDefinition fallback{};
+		fallback.id = sceneId;
+		fallback.className = sceneId; // 未登録名は従来互換としてC++ Scene Class名と同一扱いにする。
+		return fallback;
 	}
 
 	void SceneManager::ProcessEditorPlayRequests()
@@ -294,7 +331,7 @@ namespace Ken4lowEngine
 #endif
 	}
 
-	void SceneManager::ChangeScene(const std::string& sceneName)
+	void SceneManager::ChangeScene(const std::string& sceneId)
 	{
 		assert(sceneFactory_);
 #ifdef USE_IMGUI
@@ -308,11 +345,39 @@ namespace Ken4lowEngine
 #endif
 		if (IsTransitioning())
 		{
-			queuedSceneName_ = sceneName;
+			queuedSceneName_ = sceneId;
 			hasQueuedChange_ = true;
 			return;
 		}
-		nextScene_ = sceneFactory_->CreateScene(sceneName);
+
+		const SceneDefinition definition = ResolveSceneDefinition(sceneId);
+#ifndef _DEBUG
+		if (definition.editorOnly)
+		{
+#ifdef USE_IMGUI
+			K4E::EditorWindowManager::GetInstance()->AddOutputLog(K4E::EditorLogLevel::Error, "ReleaseではEditorOnly Sceneへ遷移できません: " + sceneId);
+#endif
+			return;
+		}
+#endif
+
+		try
+		{
+			nextScene_ = sceneFactory_->CreateScene(definition.className);
+		}
+		catch (const std::exception& exception)
+		{
+#ifdef USE_IMGUI
+			K4E::EditorWindowManager::GetInstance()->AddOutputLog(
+				K4E::EditorLogLevel::Error,
+				"Scene生成に失敗しました: " + sceneId + " / " + exception.what());
+#endif
+			return;
+		}
+		if (!nextScene_) return;
+
+		nextSceneDefinition_ = definition;
+		nextScene_->ApplySceneDefinition(nextSceneDefinition_); // Initializeより前にLevel、BGM、遷移先などの定義を渡す。
 		if (!sceneTransition_)
 		{
 			ApplyNextScene();
@@ -348,11 +413,18 @@ namespace Ken4lowEngine
 			scene_->Finalize();
 		}
 		scene_ = std::move(nextScene_);
+		currentSceneDefinition_ = std::move(nextSceneDefinition_);
+		nextSceneDefinition_ = {};
 		if (scene_)
 		{
 			scene_->SetSceneManager(this);
 			scene_->Initialize();
 			scene_->StartLoad();
+#ifdef USE_IMGUI
+			K4E::EditorWindowManager::GetInstance()->AddOutputLog(
+				K4E::EditorLogLevel::Info,
+				"Scene開始: " + currentSceneDefinition_.id + " [Class=" + currentSceneDefinition_.className + "]");
+#endif
 		}
 	}
 } // namespace Ken4lowEngine

--- a/Project/Engine/Scene/Management/SceneManager.h
+++ b/Project/Engine/Scene/Management/SceneManager.h
@@ -66,7 +66,8 @@ namespace Ken4lowEngine
 		int uncoverDelayFrames_ = 3;
 		int uncoverDelayCounter_ = 0;
 		bool unloadRequested_ = false;
-		bool editorPlaySessionActive_ = false; // Runtime Worldが存在する期間はPause中もtrueを維持する。
+		bool editorPlaySessionActive_ = false; // Runtime WorldまたはScene再生成型PIEが存在する期間はPause中もtrueを維持する。
+		bool editorPlayUsesSceneRecreate_ = false; // ActorWorldを公開しない旧SceneはStop時のScene再生成でRuntime変更を破棄する。
 		bool editorSingleStepRequested_ = false; // Pause中の1フレーム実行を通常Playと分離する。
 	};
 } // namespace Ken4lowEngine

--- a/Project/Engine/Scene/Management/SceneManager.h
+++ b/Project/Engine/Scene/Management/SceneManager.h
@@ -68,6 +68,7 @@ namespace Ken4lowEngine
 		bool unloadRequested_ = false;
 		bool editorPlaySessionActive_ = false; // Runtime WorldまたはScene再生成型PIEが存在する期間はPause中もtrueを維持する。
 		bool editorPlayUsesSceneRecreate_ = false; // ActorWorldを公開しない旧SceneはStop時のScene再生成でRuntime変更を破棄する。
+		std::string editorPlayOriginSceneId_; // Runtime中にScene遷移してもStop時はPlay開始元のScene定義へ戻す。
 		bool editorSingleStepRequested_ = false; // Pause中の1フレーム実行を通常Playと分離する。
 	};
 } // namespace Ken4lowEngine

--- a/Project/Engine/Scene/Management/SceneManager.h
+++ b/Project/Engine/Scene/Management/SceneManager.h
@@ -3,6 +3,7 @@
 #include <BaseScene.h>
 #include "AbstractSceneFactory.h"
 #include "ISceneTransition.h"
+#include "SceneDefinitionRegistry.h"
 
 #include <memory>
 #include <string>
@@ -28,7 +29,12 @@ namespace Ken4lowEngine
 		void SetNextScene(std::unique_ptr<BaseScene> nextScene) { nextScene_ = std::move(nextScene); }
 		void SetAbstractSceneFactory(std::unique_ptr<AbstractSceneFactory> sceneFactory) { sceneFactory_ = std::move(sceneFactory); }
 		void SetSceneTransition(std::unique_ptr<ISceneTransition> sceneTransition) { sceneTransition_ = std::move(sceneTransition); }
-		void ChangeScene(const std::string& sceneName);
+		void ChangeScene(const std::string& sceneId);
+
+		bool LoadSceneDefinitions(const std::string& registryPath);
+		[[nodiscard]] std::string GetStartupSceneName(bool debugBuild) const;
+		[[nodiscard]] const SceneDefinition* FindSceneDefinition(const std::string& sceneId) const;
+		[[nodiscard]] const SceneDefinition& GetCurrentSceneDefinition() const { return currentSceneDefinition_; }
 
 		[[nodiscard]] bool IsTransitioning() const { return isTransitioning_ || (sceneTransition_ && sceneTransition_->IsBusy()); }
 		[[nodiscard]] bool IsPlayInEditorActive() const { return editorPlaySessionActive_; }
@@ -40,11 +46,15 @@ namespace Ken4lowEngine
 	private:
 		void ApplyNextScene();
 		void RefreshEditorVisualState(float deltaTime);
+		SceneDefinition ResolveSceneDefinition(const std::string& sceneId) const;
 
 		std::unique_ptr<BaseScene> scene_;
 		std::unique_ptr<BaseScene> nextScene_;
 		std::unique_ptr<AbstractSceneFactory> sceneFactory_;
 		std::unique_ptr<ISceneTransition> sceneTransition_;
+		SceneDefinitionRegistry sceneDefinitionRegistry_;
+		SceneDefinition currentSceneDefinition_{};
+		SceneDefinition nextSceneDefinition_{};
 
 		bool isTransitioning_ = false;
 		bool sceneSwapped_ = false;

--- a/Resources/JSON/Scenes/DebugScene.json
+++ b/Resources/JSON/Scenes/DebugScene.json
@@ -1,0 +1,19 @@
+{
+  "Id": "DebugScene",
+  "Class": "DebugScene",
+  "Level": "",
+  "GameMode": "DebugGameMode",
+  "PlayerActor": "",
+  "UILayout": "EditorDebugUI",
+  "BGM": "",
+  "NextScene": "TitleScene",
+  "RetryScene": "DebugScene",
+  "EditorOnly": true,
+  "Transition": {
+    "Type": "RockFade",
+    "Duration": 0.5
+  },
+  "Parameters": {
+    "EnableEditorTools": true
+  }
+}

--- a/Resources/JSON/Scenes/GamePlayScene.json
+++ b/Resources/JSON/Scenes/GamePlayScene.json
@@ -1,0 +1,20 @@
+{
+  "Id": "GamePlayScene",
+  "Class": "GamePlayScene",
+  "Level": "",
+  "GameMode": "FPSGameMode",
+  "PlayerActor": "Resources/JSON/Actor/PlayerActor.json",
+  "UILayout": "GamePlayHUD",
+  "BGM": "",
+  "NextScene": "TitleScene",
+  "RetryScene": "GamePlayScene",
+  "EditorOnly": false,
+  "Transition": {
+    "Type": "RockFade",
+    "Duration": 1.0
+  },
+  "Parameters": {
+    "EnableTutorial": true,
+    "AllowPause": true
+  }
+}

--- a/Resources/JSON/Scenes/SceneRegistry.json
+++ b/Resources/JSON/Scenes/SceneRegistry.json
@@ -1,0 +1,12 @@
+{
+  "Format": "Ken4lowSceneRegistry",
+  "Version": 1,
+  "StartupScene": "TitleScene",
+  "DebugStartupScene": "DebugScene",
+  "Scenes": [
+    "TitleScene.json",
+    "StageSelectScene.json",
+    "GamePlayScene.json",
+    "DebugScene.json"
+  ]
+}

--- a/Resources/JSON/Scenes/StageSelectScene.json
+++ b/Resources/JSON/Scenes/StageSelectScene.json
@@ -1,0 +1,19 @@
+{
+  "Id": "StageSelectScene",
+  "Class": "StageSelectScene",
+  "Level": "",
+  "GameMode": "StageSelectGameMode",
+  "PlayerActor": "",
+  "UILayout": "StageSelectUI",
+  "BGM": "",
+  "NextScene": "GamePlayScene",
+  "RetryScene": "StageSelectScene",
+  "EditorOnly": false,
+  "Transition": {
+    "Type": "RockFade",
+    "Duration": 1.0
+  },
+  "Parameters": {
+    "DefaultStageIndex": 0
+  }
+}

--- a/Resources/JSON/Scenes/TitleScene.json
+++ b/Resources/JSON/Scenes/TitleScene.json
@@ -1,0 +1,19 @@
+{
+  "Id": "TitleScene",
+  "Class": "TitleScene",
+  "Level": "",
+  "GameMode": "TitleGameMode",
+  "PlayerActor": "",
+  "UILayout": "TitleUI",
+  "BGM": "",
+  "NextScene": "StageSelectScene",
+  "RetryScene": "TitleScene",
+  "EditorOnly": false,
+  "Transition": {
+    "Type": "RockFade",
+    "Duration": 1.0
+  },
+  "Parameters": {
+    "AllowContinue": true
+  }
+}


### PR DESCRIPTION
## 概要
Editor V2完了後の次段階として、Scene IDとC++ Scene Classを分離し、Scene構成をJSONから解決できるようにします。

## 実装内容
- `SceneDefinition`を追加
- `SceneDefinitionRegistry`を追加
- `Resources/JSON/Scenes/SceneRegistry.json`からScene一覧を読込
- SceneごとのJSONからScene ID、C++ Class、Level、GameMode、PlayerActor、UI、BGM、遷移先、Parametersなどを読込
- `SceneManager::ChangeScene()`をScene ID解決方式へ変更
- JSON定義を`BaseScene::ApplySceneDefinition()`でInitialize前に適用
- Registry読込失敗時は従来Scene名をFallback登録
- SceneFactoryをClass Creator登録表へ変更
- Title / StageSelect / GamePlay / Debugの初期Scene JSONを追加

## PIE互換修正
実機確認で、TitleScene・StageSelectScene・GamePlaySceneは`GetEditorActorWorld()`を公開していないため、ActorWorld Snapshot作成が必ず失敗してPlayを開始できないことが判明しました。

- Editor ActorWorldを公開するSceneは従来どおりActorWorld Snapshot型PIEを使用
- Editor ActorWorldを公開しない旧SceneはScene再生成型PIEで開始
- Pause / Resume / 1フレーム実行に対応
- Runtime中の通常Scene遷移を許可
- Play開始元Scene IDを保持し、Stop時は開始元SceneをJSON定義から再生成
- ActorWorldを公開しないSceneのKeep Changesは非対応として通常StopへFallback
- Snapshot型PIE中のScene遷移はEditor World保護のため従来どおり無効

## 互換性
既存の`ChangeScene("TitleScene")`などはそのまま動作します。JSONが読めない場合はScene名＝Class名として従来方式へFallbackします。

## 確認項目
1. DebugSceneでPlay / Pause / Stopが従来どおり動作する
2. TitleSceneでPlayを押すとゲーム更新が開始される
3. Title → StageSelect → GamePlayをPIE中に遷移できる
4. Runtime中に別Sceneへ遷移してからStopしてもPlay開始元Sceneへ戻る
5. StageSelectSceneとGamePlaySceneから直接Playできる
6. Snapshot作成失敗ログが出ない
7. Scene開始ログへScene IDとClass名が表示される
8. Debug / Release Buildが成功する