### PR TITLE
坑道ステージに隠し通路とドーム型ボス広間を追加

### DIFF
--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/BossBattleController.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/BossBattleController.cpp
@@ -539,7 +539,9 @@ void BossBattleController::FinalizeMineArena(const Dependencies& deps)
 	if (!mineArenaEnabled_) return;
 	for (MineArenaBlock& block : mineArenaBlocks_)
 	{
-		if (block.collider && deps.collisionManager) deps.collisionManager->RemoveCollider(block.collider.get());
+		if (!block.collider) continue;
+		if (deps.characters) deps.characters->GetPhysicsWorld().UnregisterCollider(block.collider.get());
+		if (deps.collisionManager) deps.collisionManager->RemoveCollider(block.collider.get());
 	}
 	mineArenaBlocks_.clear();
 	mineCorridorLightIndices_.clear();
@@ -715,6 +717,7 @@ size_t BossBattleController::AddMineArenaBlock(
 		block.collider->SetOBBHalfSize(scale * 0.5f);
 		block.collider->SetOrientation(rotation);
 		block.collider->SetDebugName(debugName ? debugName : "MineArenaBlock");
+		if (deps.characters) deps.characters->GetPhysicsWorld().RegisterCollider(block.collider.get());
 		if (deps.collisionManager) deps.collisionManager->AddCollider(block.collider.get());
 	}
 	mineArenaBlocks_.push_back(std::move(block));

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/BossBattleController.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/BossBattleController.cpp
@@ -23,6 +23,7 @@
 #include <cmath>
 #include <limits>
 #include <numbers>
+#include <utility>
 
 #ifdef USE_IMGUI
 #include <imgui.h>

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/BossBattleController.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/BossBattleController.cpp
@@ -13,6 +13,7 @@
 #include "CrystalManager.h"
 #include "GamePlayStageContext.h"
 #include "HUDManager.h"
+#include "Input.h"
 #include "Scene/Actor/Character/CharacterHealthComponent.h"
 #include "Stage.h"
 #include <LogString.h>
@@ -112,15 +113,27 @@ void BossBattleController::Initialize(GamePlayStageContext& stageContext, bool b
 	minePassageDoorOpenAmount_ = 0.0f;
 	mineArenaGateOpenAmount_ = 1.0f;
 	mineArenaBlocks_.clear();
+	mineDevices_.clear();
 	mineCorridorLightIndices_.clear();
 	mineArenaLightIndices_.clear();
 	minePassageDoorLeftIndex_ = minePassageDoorRightIndex_ = kInvalidMineBlockIndex;
 	mineArenaGateLeftIndex_ = mineArenaGateRightIndex_ = kInvalidMineBlockIndex;
 	mineLightingSaved_ = false;
+	mineActivatedDeviceCount_ = 0;
+	mineFocusedDeviceIndex_ = -1;
+	mineRequiredDeviceCount_ = std::max(1, stageContext.GetCurrentStageRule().requiredDeviceCount);
 
-	bossSpawnPosition_ = mineArenaEnabled_
-		? mineArenaCenter_
-		: (stageContext.HasBossSpawnPoint() ? stageContext.GetBossSpawnPoint() : K4E::Vector3{ 0.0f, 2.25f, 30.0f });
+	bossSpawnPosition_ = stageContext.HasBossSpawnPoint()
+		? stageContext.GetBossSpawnPoint()
+		: (mineArenaEnabled_ ? mineArenaCenter_ : K4E::Vector3{ 0.0f, 2.25f, 30.0f });
+	if (mineArenaEnabled_)
+	{
+		mineArenaCenter_ = bossSpawnPosition_;
+		mineArenaCenter_.y = std::max(2.25f, mineArenaCenter_.y);
+		minePassageDoorCenter_ = { mineArenaCenter_.x, 3.5f, mineArenaCenter_.z - 60.0f };
+		mineArenaGateCenter_ = { mineArenaCenter_.x, 3.5f, mineArenaCenter_.z - 23.0f };
+		bossSpawnPosition_ = mineArenaCenter_;
+	}
 	bossDeathPosition_ = bossSpawnPosition_;
 	bossActor_ = nullptr;
 	clearItem_.reset();
@@ -150,17 +163,16 @@ void BossBattleController::Finalize(const Dependencies& deps)
 
 void BossBattleController::UpdateSpawnProgress(const Dependencies& deps)
 {
-	if (!deps.crystalManager) return;
 	EnsureMineArenaInitialized(deps);
-	const bool devicesCompleted = deps.crystalManager->AreAllCrystalsDestroyed();
 	if (mineArenaEnabled_)
 	{
-		minePassageUnlocked_ = devicesCompleted;
-		bossSpawnConditionMet_ = devicesCompleted && mineArenaEntered_ && !bossSpawned_;
+		minePassageUnlocked_ = mineActivatedDeviceCount_ >= mineRequiredDeviceCount_;
+		bossSpawnConditionMet_ = minePassageUnlocked_ && mineArenaEntered_ && !bossSpawned_;
 	}
 	else
 	{
-		bossSpawnConditionMet_ = devicesCompleted && !bossSpawned_;
+		if (!deps.crystalManager) return;
+		bossSpawnConditionMet_ = deps.crystalManager->AreAllCrystalsDestroyed() && !bossSpawned_;
 	}
 	if (bossSpawnConditionMet_ && !bossIntroController_.HasPlayed() && !bossIntroController_.IsRunning()) bossIntroController_.RequestStart(bossSpawnPosition_);
 }
@@ -308,6 +320,7 @@ void BossBattleController::DrawImGui(const Dependencies& deps, bool introPresent
 			minePassageDoorOpenAmount_,
 			mineArenaEntered_ ? "yes" : "no",
 			mineArenaGateOpenAmount_);
+		ImGui::Text("Devices: %d / %d / Focus: %d", mineActivatedDeviceCount_, mineRequiredDeviceCount_, mineFocusedDeviceIndex_);
 		ImGui::Text("Mine arena blocks: %zu / Lights: %zu", mineArenaBlocks_.size(), mineCorridorLightIndices_.size() + mineArenaLightIndices_.size());
 	}
 	bossIntroController_.SetDebugSnapshot(bossActor_, deps.characters && deps.characters->GetPlayerRuntime() ? deps.characters->GetPlayerRuntime()->GetCamera() : nullptr);
@@ -344,533 +357,8 @@ bool BossBattleController::IsBossBattleActive() const
 float BossBattleController::GetBossHP() const { return bossActor_ ? bossActor_->GetHP() : 0.0f; }
 float BossBattleController::GetBossMaxHP() const { return bossActor_ ? bossActor_->GetMaxHP() : 0.0f; }
 
-void BossBattleController::SpawnBossActor(const Dependencies& deps, bool enableBattleImmediately)
-{
-	if (bossSpawned_ || !deps.characters) return;
-	RegisterApplicationActorTypes();
-	K4E::ActorWorld& world = deps.characters->GetActorWorld();
-	K4E::BossActor* actor = nullptr;
-	if (K4E::Actor* prefabActor = world.SpawnActorFromJson(kBossPrefabPath))
-	{
-		actor = dynamic_cast<K4E::BossActor*>(prefabActor);
-		if (!actor) world.DestroyActor(prefabActor);
-	}
-	if (!actor) actor = &world.SpawnActor<K4E::BossActor>();
-	else actor->Initialize();
-
-	bossActor_ = actor;
-	bossActor_->SetName("GameplayBossActor");
-	bossActor_->SetLayer("Boss");
-	bossActor_->AddTag("Boss");
-	bossActor_->AddTag("GameplayBoss");
-	bossActor_->SetTargetActor(deps.characters->GetPlayer());
-	if (stage1BeginnerBalanceEnabled_)
-	{
-		if (auto* health = bossActor_->GetHealthComponent()) health->ResetHealth(kBeginnerBossMaxHp);
-	}
-	bossDeathPositionCaptured_ = false;
-	bossDeathPosition_ = bossSpawnPosition_;
-	bossActor_->SetPosition(enableBattleImmediately ? bossSpawnPosition_ : bossIntroController_.GetBossStartPosition());
-	bossActor_->SetYaw(kPi);
-	bossActor_->SetBattleEnabled(enableBattleImmediately);
-	bossActor_->SetHealthHudVisible(enableBattleImmediately);
-	bossActor_->ForceSyncWorldTransform();
-	bossSpawned_ = true;
-	lastPresentedPhaseRevision_ = bossActor_->GetPhaseRevision();
-	if (enableBattleImmediately) RegisterBossCollider(deps);
-}
-
-void BossBattleController::RegisterBossCollider(const Dependencies& deps)
-{
-	if (!bossActor_ || bossColliderRegistered_) return;
-	bossActor_->ClearRootParentKeepingWorldPosition();
-	bossActor_->SetPosition(bossIntroController_.GetBossAppearPosition());
-	bossActor_->SetYaw(kPi);
-	bossActor_->SetBattleEnabled(true);
-	bossActor_->SetHealthHudVisible(true);
-	bossActor_->ForceSyncWorldTransform();
-	if (deps.collisionManager && bossActor_->GetCollisionPrimitive()) deps.collisionManager->AddCollider(bossActor_->GetCollisionPrimitive());
-	bossColliderRegistered_ = true;
-	K4E::Log("[BossActor] Legacy query collider registered.\n");
-}
-
-void BossBattleController::DestroyBossActor(const Dependencies& deps)
-{
-	if (!bossActor_) return;
-	if (deps.collisionManager && bossColliderRegistered_ && bossActor_->GetCollisionPrimitive()) deps.collisionManager->RemoveCollider(bossActor_->GetCollisionPrimitive());
-	bossActor_->SetBattleEnabled(false);
-	bossActor_->SetHealthHudVisible(false);
-	bossActor_->SetActive(false);
-	if (deps.characters) deps.characters->GetActorWorld().DestroyActor(bossActor_);
-	bossActor_ = nullptr;
-	bossColliderRegistered_ = false;
-}
-
-void BossBattleController::AlignPlayerViewToBossAfterIntro(IPlayerRuntime& player) const
-{
-	K4E::Camera* camera = player.GetCamera();
-	if (!camera) return;
-	float pitch = 0.0f;
-	float yaw = 0.0f;
-	if (CalcLookAnglesToTarget(camera->GetTranslate(), bossIntroController_.GetBossLookTarget(), pitch, yaw)) player.SetViewLookAngles(pitch, yaw);
-	K4E::CameraManager::GetInstance()->SetMainCamera(camera);
-	camera->Update();
-}
-
-void BossBattleController::UpdateBossClearProgress(const Dependencies& deps, float deltaTime)
-{
-	if (bossActor_ && bossActor_->IsDead() && !bossDefeated_)
-	{
-		bossDefeated_ = true;
-		if (!bossDeathPositionCaptured_)
-		{
-			bossDeathPosition_ = bossActor_->GetDeathWorldPosition();
-			bossDeathPositionCaptured_ = true;
-		}
-		if (deps.setBossDefeated) deps.setBossDefeated(false);
-	}
-	if (bossDefeated_ && bossActor_ && bossActor_->IsDeathPresentationComplete() && !clearItemSpawned_ && bossDeathPositionCaptured_) SpawnClearItem(deps, bossDeathPosition_);
-	if (clearItem_ && !clearItemCollected_)
-	{
-		clearItem_->Update(deltaTime);
-		IPlayerRuntime* player = deps.characters ? deps.characters->GetPlayerRuntime() : nullptr;
-		if (player && clearItem_->CheckPickup(*player)) CollectClearItem(deps);
-	}
-}
-
-void BossBattleController::SpawnClearItem(const Dependencies& deps, const K4E::Vector3& deathPosition)
-{
-	if (clearItemSpawned_) return;
-	K4E::Vector3 position = deathPosition;
-	if (deps.stage)
-	{
-		float floorY = -std::numeric_limits<float>::infinity();
-		float nearest = std::numeric_limits<float>::infinity();
-		for (const K4E::AABB& floor : deps.stage->GetFloorAABBs())
-		{
-			if (position.x < floor.min.x || position.x > floor.max.x || position.z < floor.min.z || position.z > floor.max.z) continue;
-			const float distance = std::abs(floor.max.y - position.y);
-			if (distance < nearest){ nearest = distance; floorY = floor.max.y; }
-		}
-		if (std::isfinite(floorY)) position.y = floorY;
-	}
-	position.y = std::max(position.y, 0.0f);
-	clearItem_ = std::make_unique<BossClearItem>();
-	clearItem_->Initialize(position);
-	if (deps.collisionManager) deps.collisionManager->AddCollider(clearItem_.get());
-	clearItemSpawned_ = true;
-	K4E::Log("[GameClear] BossClearItem spawned at BossActor death position.\n");
-}
-
-void BossBattleController::CollectClearItem(const Dependencies& deps)
-{
-	if (clearItemCollected_ || isGameClear_) return;
-	clearItemCollected_ = true;
-	isGameClear_ = true;
-	if (clearItem_)
-	{
-		clearItem_->MarkCollected();
-		if (deps.collisionManager) deps.collisionManager->RemoveCollider(clearItem_.get());
-	}
-	if (deps.setBossDefeated) deps.setBossDefeated(true);
-}
-
-void BossBattleController::HandleBossPhasePresentation(const Dependencies& deps)
-{
-	(void)deps;
-	if (!bossActor_) return;
-	const unsigned int revision = bossActor_->GetPhaseRevision();
-	if (revision == lastPresentedPhaseRevision_) return;
-	lastPresentedPhaseRevision_ = revision;
-	const int phase = bossActor_->GetCurrentPhase();
-	if (phase >= 3) StartCameraShake(0.85f, 0.40f, 25.0f);
-	else if (phase >= 2) StartCameraShake(0.55f, 0.24f, 20.0f);
-}
-
-void BossBattleController::StartCameraShake(float duration, float amplitude, float frequency)
-{
-	if (duration <= 0.0f || amplitude <= 0.0f) return;
-	cameraShakeDuration_ = cameraShakeTimer_ = duration;
-	cameraShakeAmplitude_ = amplitude;
-	cameraShakeFrequency_ = std::max(1.0f, frequency);
-	cameraShakeSeed_ += 2.31f;
-}
-
-void BossBattleController::UpdateCameraShake(float deltaTime, IPlayerRuntime* player)
-{
-	if (cameraShakeTimer_ <= 0.0f) return;
-	cameraShakeTimer_ = std::max(0.0f, cameraShakeTimer_ - deltaTime);
-	K4E::Camera* camera = player ? player->GetCamera() : nullptr;
-	if (!camera) return;
-	camera->SetTranslate(camera->GetTranslate() + BuildCameraShakeOffset());
-	camera->Update();
-}
-
-K4E::Vector3 BossBattleController::BuildCameraShakeOffset() const
-{
-	if (cameraShakeTimer_ <= 0.0f || cameraShakeDuration_ <= 0.0f) return {};
-	const float rate = std::clamp(cameraShakeTimer_ / cameraShakeDuration_, 0.0f, 1.0f);
-	const float t = (cameraShakeDuration_ - cameraShakeTimer_) * cameraShakeFrequency_ + cameraShakeSeed_;
-	const float amplitude = cameraShakeAmplitude_ * rate * rate;
-	return { std::sin(t * 1.51f) * amplitude, std::cos(t * 1.13f) * amplitude * 0.50f, std::sin(t * 0.83f) * amplitude * 0.30f };
-}
-
-bool BossBattleController::CalcLookAnglesToTarget(const K4E::Vector3& from, const K4E::Vector3& target, float& pitch, float& yaw)
-{
-	K4E::Vector3 direction = target - from;
-	if (K4E::Vector3::LengthSquared(direction) <= 0.000001f) return false;
-	direction = K4E::Vector3::Normalize(direction);
-	yaw = std::atan2(-direction.x, direction.z);
-	pitch = std::atan2(-direction.y, std::sqrt(direction.x * direction.x + direction.z * direction.z));
-	return true;
-}
-
-void BossBattleController::EnsureMineArenaInitialized(const Dependencies& deps)
-{
-	if (!mineArenaEnabled_ || mineArenaInitialized_) return;
-	BuildMinePassageAndArena(deps);
-	ApplyMineLighting();
-	mineArenaInitialized_ = true;
-	K4E::Log("[MineArena] Hidden passage and dome arena initialized.\n");
-}
-
-void BossBattleController::FinalizeMineArena(const Dependencies& deps)
-{
-	if (!mineArenaEnabled_) return;
-	for (MineArenaBlock& block : mineArenaBlocks_)
-	{
-		if (!block.collider) continue;
-		if (deps.characters) deps.characters->GetPhysicsWorld().UnregisterCollider(block.collider.get());
-		if (deps.collisionManager) deps.collisionManager->RemoveCollider(block.collider.get());
-	}
-	mineArenaBlocks_.clear();
-	mineCorridorLightIndices_.clear();
-	mineArenaLightIndices_.clear();
-	RestoreMineLighting();
-	mineArenaInitialized_ = false;
-}
-
-void BossBattleController::BuildMinePassageAndArena(const Dependencies& deps)
-{
-	const K4E::Vector4 rock{ 0.115f, 0.105f, 0.095f, 1.0f };
-	const K4E::Vector4 rockLight{ 0.17f, 0.15f, 0.13f, 1.0f };
-	const K4E::Vector4 floorColor{ 0.14f, 0.125f, 0.11f, 1.0f };
-	const K4E::Vector4 metal{ 0.19f, 0.205f, 0.215f, 1.0f };
-
-	AddMineArenaBlock(deps, { 0.0f, -1.15f, 42.0f }, { 108.0f, 2.0f, 164.0f }, {}, floorColor, true, "MineGapSealFloor");
-	AddMineArenaBlock(deps, { -53.0f, 11.0f, 42.0f }, { 2.5f, 25.0f, 164.0f }, {}, rock, true, "MineGapSealWallLeft");
-	AddMineArenaBlock(deps, { 53.0f, 11.0f, 42.0f }, { 2.5f, 25.0f, 164.0f }, {}, rock, true, "MineGapSealWallRight");
-	AddMineArenaBlock(deps, { 0.0f, 24.0f, 42.0f }, { 108.0f, 2.5f, 164.0f }, {}, rock, true, "MineGapSealCeiling");
-
-	const float corridorCenterZ = (minePassageDoorCenter_.z + mineArenaGateCenter_.z) * 0.5f;
-	const float corridorLength = mineArenaGateCenter_.z - minePassageDoorCenter_.z + 4.0f;
-	AddMineArenaBlock(deps, { 0.0f, -0.5f, corridorCenterZ }, { 13.0f, 1.0f, corridorLength }, {}, floorColor, true, "MineHiddenPassageFloor");
-	AddMineArenaBlock(deps, { -6.4f, 4.2f, corridorCenterZ }, { 1.4f, 9.5f, corridorLength }, {}, rockLight, true, "MineHiddenPassageWallLeft");
-	AddMineArenaBlock(deps, { 6.4f, 4.2f, corridorCenterZ }, { 1.4f, 9.5f, corridorLength }, {}, rockLight, true, "MineHiddenPassageWallRight");
-	AddMineArenaBlock(deps, { 0.0f, 8.7f, corridorCenterZ }, { 13.0f, 1.2f, corridorLength }, {}, rock, true, "MineHiddenPassageCeiling");
-
-	AddMineArenaBlock(deps, { -9.0f, 4.2f, minePassageDoorCenter_.z }, { 7.2f, 9.5f, 3.0f }, {}, rockLight, true, "MineSecretDoorFrameLeft");
-	AddMineArenaBlock(deps, { 9.0f, 4.2f, minePassageDoorCenter_.z }, { 7.2f, 9.5f, 3.0f }, {}, rockLight, true, "MineSecretDoorFrameRight");
-	AddMineArenaBlock(deps, { 0.0f, 8.3f, minePassageDoorCenter_.z }, { 18.0f, 2.0f, 3.0f }, {}, rock, true, "MineSecretDoorFrameTop");
-
-	minePassageDoorLeftIndex_ = AddMineArenaBlock(
-		deps, { -2.65f, minePassageDoorCenter_.y, minePassageDoorCenter_.z }, { 5.5f, 7.2f, 1.6f }, {}, metal, true, "MineSecretDoorLeft");
-	minePassageDoorRightIndex_ = AddMineArenaBlock(
-		deps, { 2.65f, minePassageDoorCenter_.y, minePassageDoorCenter_.z }, { 5.5f, 7.2f, 1.6f }, {}, metal, true, "MineSecretDoorRight");
-	SetMineMovableBlock(minePassageDoorLeftIndex_, { -2.65f, minePassageDoorCenter_.y, minePassageDoorCenter_.z }, { -7.4f, minePassageDoorCenter_.y, minePassageDoorCenter_.z });
-	SetMineMovableBlock(minePassageDoorRightIndex_, { 2.65f, minePassageDoorCenter_.y, minePassageDoorCenter_.z }, { 7.4f, minePassageDoorCenter_.y, minePassageDoorCenter_.z });
-
-	AddMineArenaBlock(deps, { mineArenaCenter_.x, -0.5f, mineArenaCenter_.z }, { 50.0f, 1.0f, 50.0f }, {}, floorColor, true, "MineBossArenaFloor");
-
-	constexpr int lowerSegmentCount = 24;
-	const float lowerRadius = 23.5f;
-	const float lowerWidth = (kTwoPi * lowerRadius / static_cast<float>(lowerSegmentCount)) * 1.16f;
-	for (int i = 0; i < lowerSegmentCount; ++i)
-	{
-		const float angle = kTwoPi * static_cast<float>(i) / static_cast<float>(lowerSegmentCount);
-		const bool entranceOpening = std::abs(std::cos(angle) + 1.0f) < 0.10f && std::abs(std::sin(angle)) < 0.42f;
-		if (entranceOpening) continue;
-		const K4E::Vector3 position{
-			mineArenaCenter_.x + std::sin(angle) * lowerRadius,
-			5.0f,
-			mineArenaCenter_.z + std::cos(angle) * lowerRadius
-		};
-		AddMineArenaBlock(deps, position, { lowerWidth, 11.0f, 3.0f }, { 0.0f, angle, 0.0f }, rockLight, true, "MineBossArenaLowerWall");
-	}
-
-	constexpr int upperSegmentCount = 20;
-	const float upperRadius = 18.6f;
-	const float upperWidth = (kTwoPi * upperRadius / static_cast<float>(upperSegmentCount)) * 1.18f;
-	for (int i = 0; i < upperSegmentCount; ++i)
-	{
-		const float angle = kTwoPi * static_cast<float>(i) / static_cast<float>(upperSegmentCount);
-		const K4E::Vector3 position{
-			mineArenaCenter_.x + std::sin(angle) * upperRadius,
-			13.0f,
-			mineArenaCenter_.z + std::cos(angle) * upperRadius
-		};
-		AddMineArenaBlock(deps, position, { upperWidth, 6.5f, 3.2f }, { 0.0f, angle, 0.0f }, rock, true, "MineBossArenaUpperDome");
-	}
-	AddMineArenaBlock(deps, { mineArenaCenter_.x, 16.9f, mineArenaCenter_.z }, { 38.0f, 2.4f, 38.0f }, {}, rock, true, "MineBossArenaDomeCap");
-
-	AddMineArenaBlock(deps, { -9.0f, 4.2f, mineArenaGateCenter_.z }, { 7.2f, 9.5f, 3.0f }, {}, rockLight, true, "MineArenaGateFrameLeft");
-	AddMineArenaBlock(deps, { 9.0f, 4.2f, mineArenaGateCenter_.z }, { 7.2f, 9.5f, 3.0f }, {}, rockLight, true, "MineArenaGateFrameRight");
-	AddMineArenaBlock(deps, { 0.0f, 8.3f, mineArenaGateCenter_.z }, { 18.0f, 2.0f, 3.0f }, {}, rock, true, "MineArenaGateFrameTop");
-
-	mineArenaGateLeftIndex_ = AddMineArenaBlock(
-		deps, { -7.4f, mineArenaGateCenter_.y, mineArenaGateCenter_.z }, { 5.5f, 7.2f, 1.6f }, {}, metal, true, "MineArenaGateLeft");
-	mineArenaGateRightIndex_ = AddMineArenaBlock(
-		deps, { 7.4f, mineArenaGateCenter_.y, mineArenaGateCenter_.z }, { 5.5f, 7.2f, 1.6f }, {}, metal, true, "MineArenaGateRight");
-	SetMineMovableBlock(mineArenaGateLeftIndex_, { -2.65f, mineArenaGateCenter_.y, mineArenaGateCenter_.z }, { -7.4f, mineArenaGateCenter_.y, mineArenaGateCenter_.z });
-	SetMineMovableBlock(mineArenaGateRightIndex_, { 2.65f, mineArenaGateCenter_.y, mineArenaGateCenter_.z }, { 7.4f, mineArenaGateCenter_.y, mineArenaGateCenter_.z });
-	UpdateMineMovableBlock(mineArenaGateLeftIndex_, 1.0f);
-	UpdateMineMovableBlock(mineArenaGateRightIndex_, 1.0f);
-
-	for (int i = 0; i < 8; ++i)
-	{
-		const float angle = kTwoPi * static_cast<float>(i) / 8.0f;
-		const K4E::Vector3 position{
-			mineArenaCenter_.x + std::sin(angle) * 19.0f,
-			2.0f,
-			mineArenaCenter_.z + std::cos(angle) * 19.0f
-		};
-		AddMineArenaBlock(deps, position, { 2.2f, 5.0f, 2.2f }, { 0.0f, angle, 0.0f }, metal, true, "MineBossArenaSupport");
-	}
-}
-
-void BossBattleController::UpdateMineArena(const Dependencies& deps, float deltaTime)
-{
-	if (!mineArenaEnabled_ || !mineArenaInitialized_) return;
-	const float passageTarget = minePassageUnlocked_ ? 1.0f : 0.0f;
-	minePassageDoorOpenAmount_ = Approach(minePassageDoorOpenAmount_, passageTarget, 0.48f, deltaTime);
-	UpdateMineMovableBlock(minePassageDoorLeftIndex_, minePassageDoorOpenAmount_);
-	UpdateMineMovableBlock(minePassageDoorRightIndex_, minePassageDoorOpenAmount_);
-
-	IPlayerRuntime* player = deps.characters ? deps.characters->GetPlayerRuntime() : nullptr;
-	if (!mineArenaEntered_ && minePassageDoorOpenAmount_ >= 0.92f && player && IsPlayerInsideMineArena(*player))
-	{
-		mineArenaEntered_ = true;
-		StartCameraShake(0.55f, 0.24f, 18.0f);
-		K4E::Log("[MineArena] Player entered dome; entrance gate closing.\n");
-	}
-	const float gateTarget = mineArenaEntered_ ? 0.0f : 1.0f;
-	mineArenaGateOpenAmount_ = Approach(mineArenaGateOpenAmount_, gateTarget, 0.70f, deltaTime);
-	UpdateMineMovableBlock(mineArenaGateLeftIndex_, mineArenaGateOpenAmount_);
-	UpdateMineMovableBlock(mineArenaGateRightIndex_, mineArenaGateOpenAmount_);
-
-	UpdateMineLighting();
-	for (MineArenaBlock& block : mineArenaBlocks_)
-	{
-		if (!block.visual) continue;
-		if (deps.shadowLightViewProjection) block.visual->UpdateShadowMatrix(*deps.shadowLightViewProjection);
-		block.visual->Update();
-	}
-}
-
-void BossBattleController::DrawMineArena()
-{
-	if (!mineArenaEnabled_ || !mineArenaInitialized_) return;
-	for (MineArenaBlock& block : mineArenaBlocks_)
-	{
-		if (block.visual) block.visual->Draw();
-	}
-}
-
-void BossBattleController::DrawMineArenaShadow()
-{
-	if (!mineArenaEnabled_ || !mineArenaInitialized_) return;
-	for (MineArenaBlock& block : mineArenaBlocks_)
-	{
-		if (block.visual) block.visual->DrawShadow();
-	}
-}
-
-size_t BossBattleController::AddMineArenaBlock(
-	const Dependencies& deps,
-	const K4E::Vector3& position,
-	const K4E::Vector3& scale,
-	const K4E::Vector3& rotation,
-	const K4E::Vector4& color,
-	bool collisionEnabled,
-	const char* debugName)
-{
-	MineArenaBlock block{};
-	block.closedPosition = position;
-	block.openPosition = position;
-	block.visual = std::make_unique<K4E::Object3D>();
-	block.visual->Initialize(kMineBlockModelPath);
-	block.visual->SetScale(scale);
-	block.visual->SetRotate(rotation);
-	block.visual->SetTranslate(position);
-	block.visual->SetColor(color);
-	block.visual->SetMetallic(0.05f);
-	block.visual->SetRoughness(0.88f);
-	block.visual->SetFrustumCullingEnabled(false);
-	block.visual->SetIgnoreStageChunkCulling(true);
-	block.visual->Update();
-
-	if (collisionEnabled)
-	{
-		block.collider = std::make_unique<K4E::Collider>();
-		ApplyCollisionPreset(*block.collider, ECollisionPresetId::WorldStatic);
-		block.collider->SetCenterPosition(position);
-		block.collider->SetOBBHalfSize(scale * 0.5f);
-		block.collider->SetOrientation(rotation);
-		block.collider->SetDebugName(debugName ? debugName : "MineArenaBlock");
-		if (deps.characters) deps.characters->GetPhysicsWorld().RegisterCollider(block.collider.get());
-		if (deps.collisionManager) deps.collisionManager->AddCollider(block.collider.get());
-	}
-	mineArenaBlocks_.push_back(std::move(block));
-	return mineArenaBlocks_.size() - 1;
-}
-
-void BossBattleController::SetMineMovableBlock(size_t blockIndex, const K4E::Vector3& closedPosition, const K4E::Vector3& openPosition)
-{
-	if (blockIndex >= mineArenaBlocks_.size()) return;
-	mineArenaBlocks_[blockIndex].closedPosition = closedPosition;
-	mineArenaBlocks_[blockIndex].openPosition = openPosition;
-}
-
-void BossBattleController::UpdateMineMovableBlock(size_t blockIndex, float openAmount)
-{
-	if (blockIndex >= mineArenaBlocks_.size()) return;
-	MineArenaBlock& block = mineArenaBlocks_[blockIndex];
-	const K4E::Vector3 position = LerpVector(block.closedPosition, block.openPosition, std::clamp(openAmount, 0.0f, 1.0f));
-	if (block.visual) block.visual->SetTranslate(position);
-	if (block.collider) block.collider->SetCenterPosition(position);
-}
-
-bool BossBattleController::IsPlayerInsideMineArena(const IPlayerRuntime& player) const
-{
-	const K4E::Vector3 position = player.GetWorldPosition();
-	const K4E::Vector3 delta = position - mineArenaCenter_;
-	return std::abs(delta.x) <= 17.5f && delta.z >= -18.0f && delta.z <= 19.5f && position.y >= -2.0f && position.y <= 12.0f;
-}
-
-void BossBattleController::ApplyMineLighting()
-{
-	if (!mineArenaEnabled_ || mineLightingSaved_) return;
-	K4E::LightManager* lightManager = K4E::LightManager::GetInstance();
-	auto& lights = lightManager->GetMutablePunctualLightsForEditor();
-	auto& settings = lightManager->GetMutableLightingSettingsForEditor();
-	savedMineLights_ = lights;
-	savedMineLightingSettings_ = settings;
-	mineLightingSaved_ = true;
-
-	for (auto& light : lights)
-	{
-		if (light.lightType == 1) light.intensity *= 0.16f;
-	}
-	settings.ambientColor = { 0.025f, 0.028f, 0.032f, 0.10f };
-	settings.fogColor = { 0.045f, 0.052f, 0.058f, 1.0f };
-	settings.exposure = 0.72f;
-	settings.contrast = 1.18f;
-	settings.fogStart = 16.0f;
-	settings.fogEnd = 105.0f;
-	settings.enableFog = 1;
-	settings.specularStrength = 0.05f;
-	settings.diffuseStrength = 0.82f;
-
-	auto addPoint = [&lights](const K4E::Vector3& position, const K4E::Vector4& color, float intensity, float radius)
-	{
-		K4E::LightManager::PunctualLightGPU light{};
-		light.lightType = 2;
-		light.color = color;
-		light.intensity = intensity;
-		light.position = position;
-		light.radius = radius;
-		light.decay = 2.0f;
-		light.direction = { 0.0f, -1.0f, 0.0f };
-		light.distance = radius;
-		light.cosFalloffStart = 0.86f;
-		light.cosAngle = 0.72f;
-		light.areaSize = { 0.4f, 0.4f, 0.0f };
-		light.enabled = 1;
-		lights.push_back(light);
-		return lights.size() - 1;
-	};
-	auto addSpot = [&lights](const K4E::Vector3& position, const K4E::Vector3& direction, const K4E::Vector4& color, float intensity, float distance)
-	{
-		K4E::LightManager::PunctualLightGPU light{};
-		light.lightType = 3;
-		light.color = color;
-		light.intensity = intensity;
-		light.position = position;
-		light.radius = distance;
-		light.decay = 1.5f;
-		light.direction = direction;
-		light.distance = distance;
-		light.cosFalloffStart = 0.82f;
-		light.cosAngle = 0.52f;
-		light.areaSize = { 1.0f, 1.0f, 0.0f };
-		light.enabled = 1;
-		lights.push_back(light);
-		return lights.size() - 1;
-	};
-
-	mineCorridorLightIndices_.push_back(addPoint({ 0.0f, 6.4f, 52.0f }, { 1.0f, 0.58f, 0.25f, 1.0f }, 0.7f, 13.0f));
-	mineCorridorLightIndices_.push_back(addPoint({ 0.0f, 6.4f, 64.0f }, { 1.0f, 0.52f, 0.20f, 1.0f }, 0.7f, 13.0f));
-	mineCorridorLightIndices_.push_back(addPoint({ 0.0f, 6.4f, 76.0f }, { 0.72f, 0.82f, 1.0f, 1.0f }, 0.7f, 14.0f));
-
-	mineArenaLightIndices_.push_back(addSpot(
-		{ mineArenaCenter_.x, 16.5f, mineArenaCenter_.z - 2.0f },
-		{ 0.0f, -1.0f, 0.08f },
-		{ 0.58f, 0.72f, 1.0f, 1.0f },
-		1.4f,
-		32.0f));
-	for (int i = 0; i < 4; ++i)
-	{
-		const float angle = kTwoPi * static_cast<float>(i) / 4.0f + kPi * 0.25f;
-		mineArenaLightIndices_.push_back(addPoint(
-			{ mineArenaCenter_.x + std::sin(angle) * 16.5f, 5.0f, mineArenaCenter_.z + std::cos(angle) * 16.5f },
-			{ 1.0f, 0.36f, 0.16f, 1.0f },
-			0.8f,
-			18.0f));
-	}
-}
-
-void BossBattleController::UpdateMineLighting()
-{
-	if (!mineArenaEnabled_ || !mineLightingSaved_) return;
-	K4E::LightManager* lightManager = K4E::LightManager::GetInstance();
-	auto& lights = lightManager->GetMutablePunctualLightsForEditor();
-	auto& settings = lightManager->GetMutableLightingSettingsForEditor();
-
-	settings.ambientColor = mineArenaEntered_
-		? K4E::Vector4{ 0.035f, 0.038f, 0.045f, 0.12f }
-		: K4E::Vector4{ 0.022f, 0.024f, 0.028f, 0.09f };
-	settings.fogColor = { 0.045f, 0.052f, 0.058f, 1.0f };
-	settings.exposure = mineArenaEntered_ ? 0.78f : 0.70f;
-	settings.contrast = 1.18f;
-	settings.fogStart = 16.0f;
-	settings.fogEnd = mineArenaEntered_ ? 125.0f : 100.0f;
-	settings.enableFog = 1;
-
-	const float corridorIntensity = 0.55f + minePassageDoorOpenAmount_ * 5.8f;
-	for (size_t index : mineCorridorLightIndices_)
-	{
-		if (index < lights.size()) lights[index].intensity = corridorIntensity;
-	}
-	const float arenaFactor = mineArenaEntered_ ? 1.0f : (0.12f + minePassageDoorOpenAmount_ * 0.18f);
-	for (size_t i = 0; i < mineArenaLightIndices_.size(); ++i)
-	{
-		const size_t index = mineArenaLightIndices_[i];
-		if (index >= lights.size()) continue;
-		lights[index].intensity = (i == 0 ? 11.0f : 6.8f) * arenaFactor;
-	}
-}
-
-void BossBattleController::RestoreMineLighting()
-{
-	if (!mineLightingSaved_) return;
-	K4E::LightManager* lightManager = K4E::LightManager::GetInstance();
-	lightManager->GetMutablePunctualLightsForEditor() = savedMineLights_;
-	lightManager->GetMutableLightingSettingsForEditor() = savedMineLightingSettings_;
-	savedMineLights_.clear();
-	mineLightingSaved_ = false;
-}
-
-K4E::Vector3 BossBattleController::LerpVector(const K4E::Vector3& a, const K4E::Vector3& b, float t)
-{
-	return a + (b - a) * std::clamp(t, 0.0f, 1.0f);
-}
+// 大きくなったBoss/Mine実装は責務ごとの内部includeへ分割し、1つのTranslation Unitとしてビルドする。
+#include "BossBattleControllerBossRuntime.inl"
+#include "BossBattleControllerMineArena.inl"
+#include "BossBattleControllerMineDevices.inl"
+#include "BossBattleControllerMineRendering.inl"

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/BossBattleController.cpp
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/BossBattleController.cpp
@@ -32,8 +32,18 @@ using namespace Ken4lowEngine;
 namespace
 {
 	constexpr float kPi = std::numbers::pi_v<float>;
+	constexpr float kTwoPi = kPi * 2.0f;
 	constexpr float kBeginnerBossMaxHp = 900.0f;
+	constexpr int kForgottenMineStageIndex = 1;
 	constexpr const char* kBossPrefabPath = "Resources/ActorPrefabs/ComponentBoss.json";
+	constexpr const char* kMineBlockModelPath = "Sample/cube.gltf";
+
+	float Approach(float current, float target, float speed, float deltaTime)
+	{
+		const float step = std::max(0.0f, speed * deltaTime);
+		if (current < target) return std::min(target, current + step);
+		return std::max(target, current - step);
+	}
 }
 
 void BossClearItem::Initialize(const K4E::Vector3& position)
@@ -95,7 +105,22 @@ void BossClearItem::OnCollision(K4E::Collider* other){ (void)other; }
 void BossBattleController::Initialize(GamePlayStageContext& stageContext, bool beginnerBalance)
 {
 	stage1BeginnerBalanceEnabled_ = beginnerBalance;
-	bossSpawnPosition_ = stageContext.HasBossSpawnPoint() ? stageContext.GetBossSpawnPoint() : K4E::Vector3{ 0.0f, 2.25f, 30.0f };
+	mineArenaEnabled_ = stageContext.GetCurrentStageIndex() == kForgottenMineStageIndex;
+	mineArenaInitialized_ = false;
+	minePassageUnlocked_ = false;
+	mineArenaEntered_ = false;
+	minePassageDoorOpenAmount_ = 0.0f;
+	mineArenaGateOpenAmount_ = 1.0f;
+	mineArenaBlocks_.clear();
+	mineCorridorLightIndices_.clear();
+	mineArenaLightIndices_.clear();
+	minePassageDoorLeftIndex_ = minePassageDoorRightIndex_ = kInvalidMineBlockIndex;
+	mineArenaGateLeftIndex_ = mineArenaGateRightIndex_ = kInvalidMineBlockIndex;
+	mineLightingSaved_ = false;
+
+	bossSpawnPosition_ = mineArenaEnabled_
+		? mineArenaCenter_
+		: (stageContext.HasBossSpawnPoint() ? stageContext.GetBossSpawnPoint() : K4E::Vector3{ 0.0f, 2.25f, 30.0f });
 	bossDeathPosition_ = bossSpawnPosition_;
 	bossActor_ = nullptr;
 	clearItem_.reset();
@@ -109,7 +134,9 @@ void BossBattleController::Initialize(GamePlayStageContext& stageContext, bool b
 	isGameClear_ = false;
 	cameraShakeTimer_ = cameraShakeDuration_ = cameraShakeAmplitude_ = cameraShakeFrequency_ = cameraShakeSeed_ = 0.0f;
 	lastPresentedPhaseRevision_ = 0;
+	bossIntroController_.ClearRuntimeBossPositionOverride();
 	bossIntroController_.Initialize(bossSpawnPosition_);
+	if (mineArenaEnabled_) bossIntroController_.SetRuntimeBossPositionOverride(mineArenaCenter_);
 }
 
 void BossBattleController::Finalize(const Dependencies& deps)
@@ -117,13 +144,24 @@ void BossBattleController::Finalize(const Dependencies& deps)
 	DestroyBossActor(deps);
 	if (clearItem_ && deps.collisionManager) deps.collisionManager->RemoveCollider(clearItem_.get());
 	clearItem_.reset();
+	FinalizeMineArena(deps);
 	bossIntroController_.Finalize();
 }
 
 void BossBattleController::UpdateSpawnProgress(const Dependencies& deps)
 {
 	if (!deps.crystalManager) return;
-	bossSpawnConditionMet_ = deps.crystalManager->AreAllCrystalsDestroyed() && !bossSpawned_;
+	EnsureMineArenaInitialized(deps);
+	const bool devicesCompleted = deps.crystalManager->AreAllCrystalsDestroyed();
+	if (mineArenaEnabled_)
+	{
+		minePassageUnlocked_ = devicesCompleted;
+		bossSpawnConditionMet_ = devicesCompleted && mineArenaEntered_ && !bossSpawned_;
+	}
+	else
+	{
+		bossSpawnConditionMet_ = devicesCompleted && !bossSpawned_;
+	}
 	if (bossSpawnConditionMet_ && !bossIntroController_.HasPlayed() && !bossIntroController_.IsRunning()) bossIntroController_.RequestStart(bossSpawnPosition_);
 }
 
@@ -184,6 +222,8 @@ void BossBattleController::UpdateIntro(const Dependencies& deps, float deltaTime
 
 void BossBattleController::UpdateRuntime(const Dependencies& deps, float deltaTime)
 {
+	EnsureMineArenaInitialized(deps);
+	UpdateMineArena(deps, deltaTime);
 	IPlayerRuntime* player = deps.characters ? deps.characters->GetPlayerRuntime() : nullptr;
 	if (bossActor_)
 	{
@@ -203,6 +243,8 @@ void BossBattleController::UpdateRuntime(const Dependencies& deps, float deltaTi
 void BossBattleController::UpdatePausedWorld(const Dependencies& deps, float deltaTime)
 {
 	if (deps.crystalManager && deps.characters) deps.crystalManager->UpdatePresentationOnly(*deps.characters, deltaTime);
+	EnsureMineArenaInitialized(deps);
+	UpdateMineArena(deps, deltaTime);
 	UpdateIntro(deps, deltaTime);
 	if (deps.stage) deps.stage->Update();
 	UpdateBossClearProgress(deps, 0.0f);
@@ -225,13 +267,33 @@ void BossBattleController::UpdateBossGuideHud(IPlayerRuntime& player, HUDManager
 
 void BossBattleController::DrawBoss()
 {
+	DrawMineArena();
 	// 通常描画はCharacterWorldのActorWorld PassがBossActorを他Characterと一緒に描く。
 }
 
 void BossBattleController::DrawClearItem(){ if (clearItem_) clearItem_->Draw(); }
-void BossBattleController::DrawBossIntro3D(){ if (bossActor_) { bossActor_->ForceSyncWorldTransform(); bossActor_->Draw(); } }
-void BossBattleController::DrawShadow(){ /* 通常ShadowはCharacterWorldのActorWorld Passへ統一する。 */ }
-void BossBattleController::DrawBossIntroShadow(){ if (bossActor_) bossActor_->DrawShadow(); }
+
+void BossBattleController::DrawBossIntro3D()
+{
+	DrawMineArena();
+	if (bossActor_)
+	{
+		bossActor_->ForceSyncWorldTransform();
+		bossActor_->Draw();
+	}
+}
+
+void BossBattleController::DrawShadow()
+{
+	DrawMineArenaShadow();
+	// 通常ShadowはCharacterWorldのActorWorld Passへ統一する。
+}
+
+void BossBattleController::DrawBossIntroShadow()
+{
+	DrawMineArenaShadow();
+	if (bossActor_) bossActor_->DrawShadow();
+}
 
 void BossBattleController::DrawImGui(const Dependencies& deps, bool introPresentation)
 {
@@ -239,6 +301,15 @@ void BossBattleController::DrawImGui(const Dependencies& deps, bool introPresent
 	ImGui::SeparatorText("ボス状態");
 	ImGui::Text("ActorWorld Boss: %s / Collider: %s", bossSpawned_ ? "spawned" : "none", bossColliderRegistered_ ? "enabled" : "disabled");
 	ImGui::Text("Intro: %s / Presentation camera: %s", bossIntroController_.IsRunning() ? "active" : "inactive", introPresentation ? "yes" : "no");
+	if (mineArenaEnabled_)
+	{
+		ImGui::Text("Mine passage: %s %.2f / Arena entered: %s / Gate %.2f",
+			minePassageUnlocked_ ? "unlocked" : "locked",
+			minePassageDoorOpenAmount_,
+			mineArenaEntered_ ? "yes" : "no",
+			mineArenaGateOpenAmount_);
+		ImGui::Text("Mine arena blocks: %zu / Lights: %zu", mineArenaBlocks_.size(), mineCorridorLightIndices_.size() + mineArenaLightIndices_.size());
+	}
 	bossIntroController_.SetDebugSnapshot(bossActor_, deps.characters && deps.characters->GetPlayerRuntime() ? deps.characters->GetPlayerRuntime()->GetCamera() : nullptr);
 	bossIntroController_.DrawImGui();
 	if (bossActor_)
@@ -452,4 +523,351 @@ bool BossBattleController::CalcLookAnglesToTarget(const K4E::Vector3& from, cons
 	yaw = std::atan2(-direction.x, direction.z);
 	pitch = std::atan2(-direction.y, std::sqrt(direction.x * direction.x + direction.z * direction.z));
 	return true;
+}
+
+void BossBattleController::EnsureMineArenaInitialized(const Dependencies& deps)
+{
+	if (!mineArenaEnabled_ || mineArenaInitialized_) return;
+	BuildMinePassageAndArena(deps);
+	ApplyMineLighting();
+	mineArenaInitialized_ = true;
+	K4E::Log("[MineArena] Hidden passage and dome arena initialized.\n");
+}
+
+void BossBattleController::FinalizeMineArena(const Dependencies& deps)
+{
+	if (!mineArenaEnabled_) return;
+	for (MineArenaBlock& block : mineArenaBlocks_)
+	{
+		if (block.collider && deps.collisionManager) deps.collisionManager->RemoveCollider(block.collider.get());
+	}
+	mineArenaBlocks_.clear();
+	mineCorridorLightIndices_.clear();
+	mineArenaLightIndices_.clear();
+	RestoreMineLighting();
+	mineArenaInitialized_ = false;
+}
+
+void BossBattleController::BuildMinePassageAndArena(const Dependencies& deps)
+{
+	const K4E::Vector4 rock{ 0.115f, 0.105f, 0.095f, 1.0f };
+	const K4E::Vector4 rockLight{ 0.17f, 0.15f, 0.13f, 1.0f };
+	const K4E::Vector4 floorColor{ 0.14f, 0.125f, 0.11f, 1.0f };
+	const K4E::Vector4 metal{ 0.19f, 0.205f, 0.215f, 1.0f };
+
+	AddMineArenaBlock(deps, { 0.0f, -1.15f, 42.0f }, { 108.0f, 2.0f, 164.0f }, {}, floorColor, true, "MineGapSealFloor");
+	AddMineArenaBlock(deps, { -53.0f, 11.0f, 42.0f }, { 2.5f, 25.0f, 164.0f }, {}, rock, true, "MineGapSealWallLeft");
+	AddMineArenaBlock(deps, { 53.0f, 11.0f, 42.0f }, { 2.5f, 25.0f, 164.0f }, {}, rock, true, "MineGapSealWallRight");
+	AddMineArenaBlock(deps, { 0.0f, 24.0f, 42.0f }, { 108.0f, 2.5f, 164.0f }, {}, rock, true, "MineGapSealCeiling");
+
+	const float corridorCenterZ = (minePassageDoorCenter_.z + mineArenaGateCenter_.z) * 0.5f;
+	const float corridorLength = mineArenaGateCenter_.z - minePassageDoorCenter_.z + 4.0f;
+	AddMineArenaBlock(deps, { 0.0f, -0.5f, corridorCenterZ }, { 13.0f, 1.0f, corridorLength }, {}, floorColor, true, "MineHiddenPassageFloor");
+	AddMineArenaBlock(deps, { -6.4f, 4.2f, corridorCenterZ }, { 1.4f, 9.5f, corridorLength }, {}, rockLight, true, "MineHiddenPassageWallLeft");
+	AddMineArenaBlock(deps, { 6.4f, 4.2f, corridorCenterZ }, { 1.4f, 9.5f, corridorLength }, {}, rockLight, true, "MineHiddenPassageWallRight");
+	AddMineArenaBlock(deps, { 0.0f, 8.7f, corridorCenterZ }, { 13.0f, 1.2f, corridorLength }, {}, rock, true, "MineHiddenPassageCeiling");
+
+	AddMineArenaBlock(deps, { -9.0f, 4.2f, minePassageDoorCenter_.z }, { 7.2f, 9.5f, 3.0f }, {}, rockLight, true, "MineSecretDoorFrameLeft");
+	AddMineArenaBlock(deps, { 9.0f, 4.2f, minePassageDoorCenter_.z }, { 7.2f, 9.5f, 3.0f }, {}, rockLight, true, "MineSecretDoorFrameRight");
+	AddMineArenaBlock(deps, { 0.0f, 8.3f, minePassageDoorCenter_.z }, { 18.0f, 2.0f, 3.0f }, {}, rock, true, "MineSecretDoorFrameTop");
+
+	minePassageDoorLeftIndex_ = AddMineArenaBlock(
+		deps, { -2.65f, minePassageDoorCenter_.y, minePassageDoorCenter_.z }, { 5.5f, 7.2f, 1.6f }, {}, metal, true, "MineSecretDoorLeft");
+	minePassageDoorRightIndex_ = AddMineArenaBlock(
+		deps, { 2.65f, minePassageDoorCenter_.y, minePassageDoorCenter_.z }, { 5.5f, 7.2f, 1.6f }, {}, metal, true, "MineSecretDoorRight");
+	SetMineMovableBlock(minePassageDoorLeftIndex_, { -2.65f, minePassageDoorCenter_.y, minePassageDoorCenter_.z }, { -7.4f, minePassageDoorCenter_.y, minePassageDoorCenter_.z });
+	SetMineMovableBlock(minePassageDoorRightIndex_, { 2.65f, minePassageDoorCenter_.y, minePassageDoorCenter_.z }, { 7.4f, minePassageDoorCenter_.y, minePassageDoorCenter_.z });
+
+	AddMineArenaBlock(deps, { mineArenaCenter_.x, -0.5f, mineArenaCenter_.z }, { 50.0f, 1.0f, 50.0f }, {}, floorColor, true, "MineBossArenaFloor");
+
+	constexpr int lowerSegmentCount = 24;
+	const float lowerRadius = 23.5f;
+	const float lowerWidth = (kTwoPi * lowerRadius / static_cast<float>(lowerSegmentCount)) * 1.16f;
+	for (int i = 0; i < lowerSegmentCount; ++i)
+	{
+		const float angle = kTwoPi * static_cast<float>(i) / static_cast<float>(lowerSegmentCount);
+		const bool entranceOpening = std::abs(std::cos(angle) + 1.0f) < 0.10f && std::abs(std::sin(angle)) < 0.42f;
+		if (entranceOpening) continue;
+		const K4E::Vector3 position{
+			mineArenaCenter_.x + std::sin(angle) * lowerRadius,
+			5.0f,
+			mineArenaCenter_.z + std::cos(angle) * lowerRadius
+		};
+		AddMineArenaBlock(deps, position, { lowerWidth, 11.0f, 3.0f }, { 0.0f, angle, 0.0f }, rockLight, true, "MineBossArenaLowerWall");
+	}
+
+	constexpr int upperSegmentCount = 20;
+	const float upperRadius = 18.6f;
+	const float upperWidth = (kTwoPi * upperRadius / static_cast<float>(upperSegmentCount)) * 1.18f;
+	for (int i = 0; i < upperSegmentCount; ++i)
+	{
+		const float angle = kTwoPi * static_cast<float>(i) / static_cast<float>(upperSegmentCount);
+		const K4E::Vector3 position{
+			mineArenaCenter_.x + std::sin(angle) * upperRadius,
+			13.0f,
+			mineArenaCenter_.z + std::cos(angle) * upperRadius
+		};
+		AddMineArenaBlock(deps, position, { upperWidth, 6.5f, 3.2f }, { 0.0f, angle, 0.0f }, rock, true, "MineBossArenaUpperDome");
+	}
+	AddMineArenaBlock(deps, { mineArenaCenter_.x, 16.9f, mineArenaCenter_.z }, { 38.0f, 2.4f, 38.0f }, {}, rock, true, "MineBossArenaDomeCap");
+
+	AddMineArenaBlock(deps, { -9.0f, 4.2f, mineArenaGateCenter_.z }, { 7.2f, 9.5f, 3.0f }, {}, rockLight, true, "MineArenaGateFrameLeft");
+	AddMineArenaBlock(deps, { 9.0f, 4.2f, mineArenaGateCenter_.z }, { 7.2f, 9.5f, 3.0f }, {}, rockLight, true, "MineArenaGateFrameRight");
+	AddMineArenaBlock(deps, { 0.0f, 8.3f, mineArenaGateCenter_.z }, { 18.0f, 2.0f, 3.0f }, {}, rock, true, "MineArenaGateFrameTop");
+
+	mineArenaGateLeftIndex_ = AddMineArenaBlock(
+		deps, { -7.4f, mineArenaGateCenter_.y, mineArenaGateCenter_.z }, { 5.5f, 7.2f, 1.6f }, {}, metal, true, "MineArenaGateLeft");
+	mineArenaGateRightIndex_ = AddMineArenaBlock(
+		deps, { 7.4f, mineArenaGateCenter_.y, mineArenaGateCenter_.z }, { 5.5f, 7.2f, 1.6f }, {}, metal, true, "MineArenaGateRight");
+	SetMineMovableBlock(mineArenaGateLeftIndex_, { -2.65f, mineArenaGateCenter_.y, mineArenaGateCenter_.z }, { -7.4f, mineArenaGateCenter_.y, mineArenaGateCenter_.z });
+	SetMineMovableBlock(mineArenaGateRightIndex_, { 2.65f, mineArenaGateCenter_.y, mineArenaGateCenter_.z }, { 7.4f, mineArenaGateCenter_.y, mineArenaGateCenter_.z });
+	UpdateMineMovableBlock(mineArenaGateLeftIndex_, 1.0f);
+	UpdateMineMovableBlock(mineArenaGateRightIndex_, 1.0f);
+
+	for (int i = 0; i < 8; ++i)
+	{
+		const float angle = kTwoPi * static_cast<float>(i) / 8.0f;
+		const K4E::Vector3 position{
+			mineArenaCenter_.x + std::sin(angle) * 19.0f,
+			2.0f,
+			mineArenaCenter_.z + std::cos(angle) * 19.0f
+		};
+		AddMineArenaBlock(deps, position, { 2.2f, 5.0f, 2.2f }, { 0.0f, angle, 0.0f }, metal, true, "MineBossArenaSupport");
+	}
+}
+
+void BossBattleController::UpdateMineArena(const Dependencies& deps, float deltaTime)
+{
+	if (!mineArenaEnabled_ || !mineArenaInitialized_) return;
+	const float passageTarget = minePassageUnlocked_ ? 1.0f : 0.0f;
+	minePassageDoorOpenAmount_ = Approach(minePassageDoorOpenAmount_, passageTarget, 0.48f, deltaTime);
+	UpdateMineMovableBlock(minePassageDoorLeftIndex_, minePassageDoorOpenAmount_);
+	UpdateMineMovableBlock(minePassageDoorRightIndex_, minePassageDoorOpenAmount_);
+
+	IPlayerRuntime* player = deps.characters ? deps.characters->GetPlayerRuntime() : nullptr;
+	if (!mineArenaEntered_ && minePassageDoorOpenAmount_ >= 0.92f && player && IsPlayerInsideMineArena(*player))
+	{
+		mineArenaEntered_ = true;
+		StartCameraShake(0.55f, 0.24f, 18.0f);
+		K4E::Log("[MineArena] Player entered dome; entrance gate closing.\n");
+	}
+	const float gateTarget = mineArenaEntered_ ? 0.0f : 1.0f;
+	mineArenaGateOpenAmount_ = Approach(mineArenaGateOpenAmount_, gateTarget, 0.70f, deltaTime);
+	UpdateMineMovableBlock(mineArenaGateLeftIndex_, mineArenaGateOpenAmount_);
+	UpdateMineMovableBlock(mineArenaGateRightIndex_, mineArenaGateOpenAmount_);
+
+	UpdateMineLighting();
+	for (MineArenaBlock& block : mineArenaBlocks_)
+	{
+		if (!block.visual) continue;
+		if (deps.shadowLightViewProjection) block.visual->UpdateShadowMatrix(*deps.shadowLightViewProjection);
+		block.visual->Update();
+	}
+}
+
+void BossBattleController::DrawMineArena()
+{
+	if (!mineArenaEnabled_ || !mineArenaInitialized_) return;
+	for (MineArenaBlock& block : mineArenaBlocks_)
+	{
+		if (block.visual) block.visual->Draw();
+	}
+}
+
+void BossBattleController::DrawMineArenaShadow()
+{
+	if (!mineArenaEnabled_ || !mineArenaInitialized_) return;
+	for (MineArenaBlock& block : mineArenaBlocks_)
+	{
+		if (block.visual) block.visual->DrawShadow();
+	}
+}
+
+size_t BossBattleController::AddMineArenaBlock(
+	const Dependencies& deps,
+	const K4E::Vector3& position,
+	const K4E::Vector3& scale,
+	const K4E::Vector3& rotation,
+	const K4E::Vector4& color,
+	bool collisionEnabled,
+	const char* debugName)
+{
+	MineArenaBlock block{};
+	block.closedPosition = position;
+	block.openPosition = position;
+	block.visual = std::make_unique<K4E::Object3D>();
+	block.visual->Initialize(kMineBlockModelPath);
+	block.visual->SetScale(scale);
+	block.visual->SetRotate(rotation);
+	block.visual->SetTranslate(position);
+	block.visual->SetColor(color);
+	block.visual->SetMetallic(0.05f);
+	block.visual->SetRoughness(0.88f);
+	block.visual->SetFrustumCullingEnabled(false);
+	block.visual->SetIgnoreStageChunkCulling(true);
+	block.visual->Update();
+
+	if (collisionEnabled)
+	{
+		block.collider = std::make_unique<K4E::Collider>();
+		ApplyCollisionPreset(*block.collider, ECollisionPresetId::WorldStatic);
+		block.collider->SetCenterPosition(position);
+		block.collider->SetOBBHalfSize(scale * 0.5f);
+		block.collider->SetOrientation(rotation);
+		block.collider->SetDebugName(debugName ? debugName : "MineArenaBlock");
+		if (deps.collisionManager) deps.collisionManager->AddCollider(block.collider.get());
+	}
+	mineArenaBlocks_.push_back(std::move(block));
+	return mineArenaBlocks_.size() - 1;
+}
+
+void BossBattleController::SetMineMovableBlock(size_t blockIndex, const K4E::Vector3& closedPosition, const K4E::Vector3& openPosition)
+{
+	if (blockIndex >= mineArenaBlocks_.size()) return;
+	mineArenaBlocks_[blockIndex].closedPosition = closedPosition;
+	mineArenaBlocks_[blockIndex].openPosition = openPosition;
+}
+
+void BossBattleController::UpdateMineMovableBlock(size_t blockIndex, float openAmount)
+{
+	if (blockIndex >= mineArenaBlocks_.size()) return;
+	MineArenaBlock& block = mineArenaBlocks_[blockIndex];
+	const K4E::Vector3 position = LerpVector(block.closedPosition, block.openPosition, std::clamp(openAmount, 0.0f, 1.0f));
+	if (block.visual) block.visual->SetTranslate(position);
+	if (block.collider) block.collider->SetCenterPosition(position);
+}
+
+bool BossBattleController::IsPlayerInsideMineArena(const IPlayerRuntime& player) const
+{
+	const K4E::Vector3 position = player.GetWorldPosition();
+	const K4E::Vector3 delta = position - mineArenaCenter_;
+	return std::abs(delta.x) <= 17.5f && delta.z >= -18.0f && delta.z <= 19.5f && position.y >= -2.0f && position.y <= 12.0f;
+}
+
+void BossBattleController::ApplyMineLighting()
+{
+	if (!mineArenaEnabled_ || mineLightingSaved_) return;
+	K4E::LightManager* lightManager = K4E::LightManager::GetInstance();
+	auto& lights = lightManager->GetMutablePunctualLightsForEditor();
+	auto& settings = lightManager->GetMutableLightingSettingsForEditor();
+	savedMineLights_ = lights;
+	savedMineLightingSettings_ = settings;
+	mineLightingSaved_ = true;
+
+	for (auto& light : lights)
+	{
+		if (light.lightType == 1) light.intensity *= 0.16f;
+	}
+	settings.ambientColor = { 0.025f, 0.028f, 0.032f, 0.10f };
+	settings.fogColor = { 0.045f, 0.052f, 0.058f, 1.0f };
+	settings.exposure = 0.72f;
+	settings.contrast = 1.18f;
+	settings.fogStart = 16.0f;
+	settings.fogEnd = 105.0f;
+	settings.enableFog = 1;
+	settings.specularStrength = 0.05f;
+	settings.diffuseStrength = 0.82f;
+
+	auto addPoint = [&lights](const K4E::Vector3& position, const K4E::Vector4& color, float intensity, float radius)
+	{
+		K4E::LightManager::PunctualLightGPU light{};
+		light.lightType = 2;
+		light.color = color;
+		light.intensity = intensity;
+		light.position = position;
+		light.radius = radius;
+		light.decay = 2.0f;
+		light.direction = { 0.0f, -1.0f, 0.0f };
+		light.distance = radius;
+		light.cosFalloffStart = 0.86f;
+		light.cosAngle = 0.72f;
+		light.areaSize = { 0.4f, 0.4f, 0.0f };
+		light.enabled = 1;
+		lights.push_back(light);
+		return lights.size() - 1;
+	};
+	auto addSpot = [&lights](const K4E::Vector3& position, const K4E::Vector3& direction, const K4E::Vector4& color, float intensity, float distance)
+	{
+		K4E::LightManager::PunctualLightGPU light{};
+		light.lightType = 3;
+		light.color = color;
+		light.intensity = intensity;
+		light.position = position;
+		light.radius = distance;
+		light.decay = 1.5f;
+		light.direction = direction;
+		light.distance = distance;
+		light.cosFalloffStart = 0.82f;
+		light.cosAngle = 0.52f;
+		light.areaSize = { 1.0f, 1.0f, 0.0f };
+		light.enabled = 1;
+		lights.push_back(light);
+		return lights.size() - 1;
+	};
+
+	mineCorridorLightIndices_.push_back(addPoint({ 0.0f, 6.4f, 52.0f }, { 1.0f, 0.58f, 0.25f, 1.0f }, 0.7f, 13.0f));
+	mineCorridorLightIndices_.push_back(addPoint({ 0.0f, 6.4f, 64.0f }, { 1.0f, 0.52f, 0.20f, 1.0f }, 0.7f, 13.0f));
+	mineCorridorLightIndices_.push_back(addPoint({ 0.0f, 6.4f, 76.0f }, { 0.72f, 0.82f, 1.0f, 1.0f }, 0.7f, 14.0f));
+
+	mineArenaLightIndices_.push_back(addSpot(
+		{ mineArenaCenter_.x, 16.5f, mineArenaCenter_.z - 2.0f },
+		{ 0.0f, -1.0f, 0.08f },
+		{ 0.58f, 0.72f, 1.0f, 1.0f },
+		1.4f,
+		32.0f));
+	for (int i = 0; i < 4; ++i)
+	{
+		const float angle = kTwoPi * static_cast<float>(i) / 4.0f + kPi * 0.25f;
+		mineArenaLightIndices_.push_back(addPoint(
+			{ mineArenaCenter_.x + std::sin(angle) * 16.5f, 5.0f, mineArenaCenter_.z + std::cos(angle) * 16.5f },
+			{ 1.0f, 0.36f, 0.16f, 1.0f },
+			0.8f,
+			18.0f));
+	}
+}
+
+void BossBattleController::UpdateMineLighting()
+{
+	if (!mineArenaEnabled_ || !mineLightingSaved_) return;
+	K4E::LightManager* lightManager = K4E::LightManager::GetInstance();
+	auto& lights = lightManager->GetMutablePunctualLightsForEditor();
+	auto& settings = lightManager->GetMutableLightingSettingsForEditor();
+
+	settings.ambientColor = mineArenaEntered_
+		? K4E::Vector4{ 0.035f, 0.038f, 0.045f, 0.12f }
+		: K4E::Vector4{ 0.022f, 0.024f, 0.028f, 0.09f };
+	settings.fogColor = { 0.045f, 0.052f, 0.058f, 1.0f };
+	settings.exposure = mineArenaEntered_ ? 0.78f : 0.70f;
+	settings.contrast = 1.18f;
+	settings.fogStart = 16.0f;
+	settings.fogEnd = mineArenaEntered_ ? 125.0f : 100.0f;
+	settings.enableFog = 1;
+
+	const float corridorIntensity = 0.55f + minePassageDoorOpenAmount_ * 5.8f;
+	for (size_t index : mineCorridorLightIndices_)
+	{
+		if (index < lights.size()) lights[index].intensity = corridorIntensity;
+	}
+	const float arenaFactor = mineArenaEntered_ ? 1.0f : (0.12f + minePassageDoorOpenAmount_ * 0.18f);
+	for (size_t i = 0; i < mineArenaLightIndices_.size(); ++i)
+	{
+		const size_t index = mineArenaLightIndices_[i];
+		if (index >= lights.size()) continue;
+		lights[index].intensity = (i == 0 ? 11.0f : 6.8f) * arenaFactor;
+	}
+}
+
+void BossBattleController::RestoreMineLighting()
+{
+	if (!mineLightingSaved_) return;
+	K4E::LightManager* lightManager = K4E::LightManager::GetInstance();
+	lightManager->GetMutablePunctualLightsForEditor() = savedMineLights_;
+	lightManager->GetMutableLightingSettingsForEditor() = savedMineLightingSettings_;
+	savedMineLights_.clear();
+	mineLightingSaved_ = false;
+}
+
+K4E::Vector3 BossBattleController::LerpVector(const K4E::Vector3& a, const K4E::Vector3& b, float t)
+{
+	return a + (b - a) * std::clamp(t, 0.0f, 1.0f);
 }

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/BossBattleController.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/BossBattleController.h
@@ -10,6 +10,7 @@
 #include <cstddef>
 #include <functional>
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace Ken4lowEngine
@@ -114,6 +115,17 @@ private:
 		K4E::Vector3 openPosition{};
 	};
 
+	struct MineDeviceRuntime
+	{
+		std::string name;
+		K4E::Vector3 position{};
+		std::unique_ptr<K4E::Object3D> visual;
+		float activateTime = 1.5f;
+		float activationProgress = 0.0f;
+		float pulseTimer = 0.0f;
+		bool activated = false;
+	};
+
 	void SpawnBossActor(const Dependencies& deps, bool enableBattleImmediately);
 	void RegisterBossCollider(const Dependencies& deps);
 	void DestroyBossActor(const Dependencies& deps);
@@ -130,6 +142,8 @@ private:
 	void EnsureMineArenaInitialized(const Dependencies& deps);
 	void FinalizeMineArena(const Dependencies& deps);
 	void BuildMinePassageAndArena(const Dependencies& deps);
+	void BuildMineDevices(const Dependencies& deps);
+	void UpdateMineDevices(const Dependencies& deps, float deltaTime);
 	void UpdateMineArena(const Dependencies& deps, float deltaTime);
 	void DrawMineArena();
 	void DrawMineArenaShadow();
@@ -182,6 +196,10 @@ private:
 	K4E::Vector3 minePassageDoorCenter_{ 0.0f, 3.5f, 45.0f };
 	K4E::Vector3 mineArenaGateCenter_{ 0.0f, 3.5f, 82.0f };
 	std::vector<MineArenaBlock> mineArenaBlocks_;
+	std::vector<MineDeviceRuntime> mineDevices_;
+	int mineRequiredDeviceCount_ = 3;
+	int mineActivatedDeviceCount_ = 0;
+	int mineFocusedDeviceIndex_ = -1;
 	size_t minePassageDoorLeftIndex_ = kInvalidMineBlockIndex;
 	size_t minePassageDoorRightIndex_ = kInvalidMineBlockIndex;
 	size_t mineArenaGateLeftIndex_ = kInvalidMineBlockIndex;

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/BossBattleController.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/BossBattleController.h
@@ -2,11 +2,15 @@
 
 #include "BossIntroController.h"
 #include "Collider.h"
+#include "LightManager.h"
 #include "Object3D.h"
 #include "Vector3.h"
+#include "Vector4.h"
 
+#include <cstddef>
 #include <functional>
 #include <memory>
+#include <vector>
 
 namespace Ken4lowEngine
 {
@@ -102,6 +106,14 @@ public:
 	K4E::BossActor* GetBoss() const { return bossActor_; }
 
 private:
+	struct MineArenaBlock
+	{
+		std::unique_ptr<K4E::Object3D> visual;
+		std::unique_ptr<K4E::Collider> collider;
+		K4E::Vector3 closedPosition{};
+		K4E::Vector3 openPosition{};
+	};
+
 	void SpawnBossActor(const Dependencies& deps, bool enableBattleImmediately);
 	void RegisterBossCollider(const Dependencies& deps);
 	void DestroyBossActor(const Dependencies& deps);
@@ -115,7 +127,30 @@ private:
 	K4E::Vector3 BuildCameraShakeOffset() const;
 	static bool CalcLookAnglesToTarget(const K4E::Vector3& from, const K4E::Vector3& target, float& outPitch, float& outYaw);
 
+	void EnsureMineArenaInitialized(const Dependencies& deps);
+	void FinalizeMineArena(const Dependencies& deps);
+	void BuildMinePassageAndArena(const Dependencies& deps);
+	void UpdateMineArena(const Dependencies& deps, float deltaTime);
+	void DrawMineArena();
+	void DrawMineArenaShadow();
+	size_t AddMineArenaBlock(
+		const Dependencies& deps,
+		const K4E::Vector3& position,
+		const K4E::Vector3& scale,
+		const K4E::Vector3& rotation,
+		const K4E::Vector4& color,
+		bool collisionEnabled,
+		const char* debugName);
+	void SetMineMovableBlock(size_t blockIndex, const K4E::Vector3& closedPosition, const K4E::Vector3& openPosition);
+	void UpdateMineMovableBlock(size_t blockIndex, float openAmount);
+	bool IsPlayerInsideMineArena(const IPlayerRuntime& player) const;
+	void ApplyMineLighting();
+	void UpdateMineLighting();
+	void RestoreMineLighting();
+	static K4E::Vector3 LerpVector(const K4E::Vector3& a, const K4E::Vector3& b, float t);
+
 private:
+	static constexpr size_t kInvalidMineBlockIndex = static_cast<size_t>(-1);
 	K4E::BossActor* bossActor_ = nullptr; // 実体はCharacterWorldのActorWorldが所有する。
 	std::unique_ptr<BossClearItem> clearItem_;
 	K4E::Vector3 bossSpawnPosition_{ 0.0f, 2.25f, 30.0f };
@@ -136,4 +171,24 @@ private:
 	float cameraShakeFrequency_ = 0.0f;
 	float cameraShakeSeed_ = 0.0f;
 	unsigned int lastPresentedPhaseRevision_ = 0;
+
+	bool mineArenaEnabled_ = false;
+	bool mineArenaInitialized_ = false;
+	bool minePassageUnlocked_ = false;
+	bool mineArenaEntered_ = false;
+	float minePassageDoorOpenAmount_ = 0.0f;
+	float mineArenaGateOpenAmount_ = 1.0f;
+	K4E::Vector3 mineArenaCenter_{ 0.0f, 2.25f, 105.0f };
+	K4E::Vector3 minePassageDoorCenter_{ 0.0f, 3.5f, 45.0f };
+	K4E::Vector3 mineArenaGateCenter_{ 0.0f, 3.5f, 82.0f };
+	std::vector<MineArenaBlock> mineArenaBlocks_;
+	size_t minePassageDoorLeftIndex_ = kInvalidMineBlockIndex;
+	size_t minePassageDoorRightIndex_ = kInvalidMineBlockIndex;
+	size_t mineArenaGateLeftIndex_ = kInvalidMineBlockIndex;
+	size_t mineArenaGateRightIndex_ = kInvalidMineBlockIndex;
+	std::vector<K4E::LightManager::PunctualLightGPU> savedMineLights_;
+	K4E::LightManager::LightingSettingsGPU savedMineLightingSettings_{};
+	std::vector<size_t> mineCorridorLightIndices_;
+	std::vector<size_t> mineArenaLightIndices_;
+	bool mineLightingSaved_ = false;
 };

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/BossBattleControllerBossRuntime.inl
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/BossBattleControllerBossRuntime.inl
@@ -1,0 +1,180 @@
+void BossBattleController::SpawnBossActor(const Dependencies& deps, bool enableBattleImmediately)
+{
+	if (bossSpawned_ || !deps.characters) return;
+	RegisterApplicationActorTypes();
+	K4E::ActorWorld& world = deps.characters->GetActorWorld();
+	K4E::BossActor* actor = nullptr;
+	if (K4E::Actor* prefabActor = world.SpawnActorFromJson(kBossPrefabPath))
+	{
+		actor = dynamic_cast<K4E::BossActor*>(prefabActor);
+		if (!actor) world.DestroyActor(prefabActor);
+	}
+	if (!actor) actor = &world.SpawnActor<K4E::BossActor>();
+	else actor->Initialize();
+
+	bossActor_ = actor;
+	bossActor_->SetName("GameplayBossActor");
+	bossActor_->SetLayer("Boss");
+	bossActor_->AddTag("Boss");
+	bossActor_->AddTag("GameplayBoss");
+	bossActor_->SetTargetActor(deps.characters->GetPlayer());
+	if (stage1BeginnerBalanceEnabled_)
+	{
+		if (auto* health = bossActor_->GetHealthComponent()) health->ResetHealth(kBeginnerBossMaxHp);
+	}
+	bossDeathPositionCaptured_ = false;
+	bossDeathPosition_ = bossSpawnPosition_;
+	bossActor_->SetPosition(enableBattleImmediately ? bossSpawnPosition_ : bossIntroController_.GetBossStartPosition());
+	bossActor_->SetYaw(kPi);
+	bossActor_->SetBattleEnabled(enableBattleImmediately);
+	bossActor_->SetHealthHudVisible(enableBattleImmediately);
+	bossActor_->ForceSyncWorldTransform();
+	bossSpawned_ = true;
+	lastPresentedPhaseRevision_ = bossActor_->GetPhaseRevision();
+	if (enableBattleImmediately) RegisterBossCollider(deps);
+}
+
+void BossBattleController::RegisterBossCollider(const Dependencies& deps)
+{
+	if (!bossActor_ || bossColliderRegistered_) return;
+	bossActor_->ClearRootParentKeepingWorldPosition();
+	bossActor_->SetPosition(bossIntroController_.GetBossAppearPosition());
+	bossActor_->SetYaw(kPi);
+	bossActor_->SetBattleEnabled(true);
+	bossActor_->SetHealthHudVisible(true);
+	bossActor_->ForceSyncWorldTransform();
+	if (deps.collisionManager && bossActor_->GetCollisionPrimitive()) deps.collisionManager->AddCollider(bossActor_->GetCollisionPrimitive());
+	bossColliderRegistered_ = true;
+	K4E::Log("[BossActor] Legacy query collider registered.\n");
+}
+
+void BossBattleController::DestroyBossActor(const Dependencies& deps)
+{
+	if (!bossActor_) return;
+	if (deps.collisionManager && bossColliderRegistered_ && bossActor_->GetCollisionPrimitive()) deps.collisionManager->RemoveCollider(bossActor_->GetCollisionPrimitive());
+	bossActor_->SetBattleEnabled(false);
+	bossActor_->SetHealthHudVisible(false);
+	bossActor_->SetActive(false);
+	if (deps.characters) deps.characters->GetActorWorld().DestroyActor(bossActor_);
+	bossActor_ = nullptr;
+	bossColliderRegistered_ = false;
+}
+
+void BossBattleController::AlignPlayerViewToBossAfterIntro(IPlayerRuntime& player) const
+{
+	K4E::Camera* camera = player.GetCamera();
+	if (!camera) return;
+	float pitch = 0.0f;
+	float yaw = 0.0f;
+	if (CalcLookAnglesToTarget(camera->GetTranslate(), bossIntroController_.GetBossLookTarget(), pitch, yaw)) player.SetViewLookAngles(pitch, yaw);
+	K4E::CameraManager::GetInstance()->SetMainCamera(camera);
+	camera->Update();
+}
+
+void BossBattleController::UpdateBossClearProgress(const Dependencies& deps, float deltaTime)
+{
+	if (bossActor_ && bossActor_->IsDead() && !bossDefeated_)
+	{
+		bossDefeated_ = true;
+		if (!bossDeathPositionCaptured_)
+		{
+			bossDeathPosition_ = bossActor_->GetDeathWorldPosition();
+			bossDeathPositionCaptured_ = true;
+		}
+		if (deps.setBossDefeated) deps.setBossDefeated(false);
+	}
+	if (bossDefeated_ && bossActor_ && bossActor_->IsDeathPresentationComplete() && !clearItemSpawned_ && bossDeathPositionCaptured_) SpawnClearItem(deps, bossDeathPosition_);
+	if (clearItem_ && !clearItemCollected_)
+	{
+		clearItem_->Update(deltaTime);
+		IPlayerRuntime* player = deps.characters ? deps.characters->GetPlayerRuntime() : nullptr;
+		if (player && clearItem_->CheckPickup(*player)) CollectClearItem(deps);
+	}
+}
+
+void BossBattleController::SpawnClearItem(const Dependencies& deps, const K4E::Vector3& deathPosition)
+{
+	if (clearItemSpawned_) return;
+	K4E::Vector3 position = deathPosition;
+	if (deps.stage)
+	{
+		float floorY = -std::numeric_limits<float>::infinity();
+		float nearest = std::numeric_limits<float>::infinity();
+		for (const K4E::AABB& floor : deps.stage->GetFloorAABBs())
+		{
+			if (position.x < floor.min.x || position.x > floor.max.x || position.z < floor.min.z || position.z > floor.max.z) continue;
+			const float distance = std::abs(floor.max.y - position.y);
+			if (distance < nearest){ nearest = distance; floorY = floor.max.y; }
+		}
+		if (std::isfinite(floorY)) position.y = floorY;
+	}
+	position.y = std::max(position.y, 0.0f);
+	clearItem_ = std::make_unique<BossClearItem>();
+	clearItem_->Initialize(position);
+	if (deps.collisionManager) deps.collisionManager->AddCollider(clearItem_.get());
+	clearItemSpawned_ = true;
+	K4E::Log("[GameClear] BossClearItem spawned at BossActor death position.\n");
+}
+
+void BossBattleController::CollectClearItem(const Dependencies& deps)
+{
+	if (clearItemCollected_ || isGameClear_) return;
+	clearItemCollected_ = true;
+	isGameClear_ = true;
+	if (clearItem_)
+	{
+		clearItem_->MarkCollected();
+		if (deps.collisionManager) deps.collisionManager->RemoveCollider(clearItem_.get());
+	}
+	if (deps.setBossDefeated) deps.setBossDefeated(true);
+}
+
+void BossBattleController::HandleBossPhasePresentation(const Dependencies& deps)
+{
+	(void)deps;
+	if (!bossActor_) return;
+	const unsigned int revision = bossActor_->GetPhaseRevision();
+	if (revision == lastPresentedPhaseRevision_) return;
+	lastPresentedPhaseRevision_ = revision;
+	const int phase = bossActor_->GetCurrentPhase();
+	if (phase >= 3) StartCameraShake(0.85f, 0.40f, 25.0f);
+	else if (phase >= 2) StartCameraShake(0.55f, 0.24f, 20.0f);
+}
+
+void BossBattleController::StartCameraShake(float duration, float amplitude, float frequency)
+{
+	if (duration <= 0.0f || amplitude <= 0.0f) return;
+	cameraShakeDuration_ = cameraShakeTimer_ = duration;
+	cameraShakeAmplitude_ = amplitude;
+	cameraShakeFrequency_ = std::max(1.0f, frequency);
+	cameraShakeSeed_ += 2.31f;
+}
+
+void BossBattleController::UpdateCameraShake(float deltaTime, IPlayerRuntime* player)
+{
+	if (cameraShakeTimer_ <= 0.0f) return;
+	cameraShakeTimer_ = std::max(0.0f, cameraShakeTimer_ - deltaTime);
+	K4E::Camera* camera = player ? player->GetCamera() : nullptr;
+	if (!camera) return;
+	camera->SetTranslate(camera->GetTranslate() + BuildCameraShakeOffset());
+	camera->Update();
+}
+
+K4E::Vector3 BossBattleController::BuildCameraShakeOffset() const
+{
+	if (cameraShakeTimer_ <= 0.0f || cameraShakeDuration_ <= 0.0f) return {};
+	const float rate = std::clamp(cameraShakeTimer_ / cameraShakeDuration_, 0.0f, 1.0f);
+	const float t = (cameraShakeDuration_ - cameraShakeTimer_) * cameraShakeFrequency_ + cameraShakeSeed_;
+	const float amplitude = cameraShakeAmplitude_ * rate * rate;
+	return { std::sin(t * 1.51f) * amplitude, std::cos(t * 1.13f) * amplitude * 0.50f, std::sin(t * 0.83f) * amplitude * 0.30f };
+}
+
+bool BossBattleController::CalcLookAnglesToTarget(const K4E::Vector3& from, const K4E::Vector3& target, float& pitch, float& yaw)
+{
+	K4E::Vector3 direction = target - from;
+	if (K4E::Vector3::LengthSquared(direction) <= 0.000001f) return false;
+	direction = K4E::Vector3::Normalize(direction);
+	yaw = std::atan2(-direction.x, direction.z);
+	pitch = std::atan2(-direction.y, std::sqrt(direction.x * direction.x + direction.z * direction.z));
+	return true;
+}

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/BossBattleControllerMineArena.inl
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/BossBattleControllerMineArena.inl
@@ -1,0 +1,112 @@
+void BossBattleController::EnsureMineArenaInitialized(const Dependencies& deps)
+{
+	if (!mineArenaEnabled_ || mineArenaInitialized_) return;
+	if (deps.crystalManager) deps.crystalManager->Finalize(); // ステージ2では破壊用クリスタルを生成物ごと撤去する。
+	BuildMinePassageAndArena(deps);
+	ApplyMineLighting();
+	mineArenaInitialized_ = true;
+	K4E::Log("[MineArena] Hidden passage and dome arena initialized.\n");
+}
+
+void BossBattleController::FinalizeMineArena(const Dependencies& deps)
+{
+	if (!mineArenaEnabled_) return;
+	for (MineArenaBlock& block : mineArenaBlocks_)
+	{
+		if (!block.collider) continue;
+		if (deps.characters) deps.characters->GetPhysicsWorld().UnregisterCollider(block.collider.get());
+		if (deps.collisionManager) deps.collisionManager->RemoveCollider(block.collider.get());
+	}
+	mineArenaBlocks_.clear();
+	mineDevices_.clear();
+	mineCorridorLightIndices_.clear();
+	mineArenaLightIndices_.clear();
+	RestoreMineLighting();
+	mineArenaInitialized_ = false;
+}
+
+void BossBattleController::BuildMinePassageAndArena(const Dependencies& deps)
+{
+	const K4E::Vector4 rock{ 0.115f, 0.105f, 0.095f, 1.0f };
+	const K4E::Vector4 rockLight{ 0.17f, 0.15f, 0.13f, 1.0f };
+	const K4E::Vector4 floorColor{ 0.14f, 0.125f, 0.11f, 1.0f };
+	const K4E::Vector4 metal{ 0.19f, 0.205f, 0.215f, 1.0f };
+
+	BuildMineDevices(deps);
+
+	const float corridorX = mineArenaCenter_.x;
+	const float corridorCenterZ = (minePassageDoorCenter_.z + mineArenaGateCenter_.z) * 0.5f;
+	const float corridorLength = mineArenaGateCenter_.z - minePassageDoorCenter_.z + 4.0f;
+	AddMineArenaBlock(deps, { corridorX, -0.5f, corridorCenterZ }, { 13.0f, 1.0f, corridorLength }, {}, floorColor, true, "MineHiddenPassageFloor");
+	AddMineArenaBlock(deps, { corridorX - 6.4f, 4.2f, corridorCenterZ }, { 1.4f, 9.5f, corridorLength }, {}, rockLight, true, "MineHiddenPassageWallLeft");
+	AddMineArenaBlock(deps, { corridorX + 6.4f, 4.2f, corridorCenterZ }, { 1.4f, 9.5f, corridorLength }, {}, rockLight, true, "MineHiddenPassageWallRight");
+	AddMineArenaBlock(deps, { corridorX, 8.7f, corridorCenterZ }, { 13.0f, 1.2f, corridorLength }, {}, rock, true, "MineHiddenPassageCeiling");
+
+	AddMineArenaBlock(deps, { corridorX - 9.0f, 4.2f, minePassageDoorCenter_.z }, { 7.2f, 9.5f, 3.0f }, {}, rockLight, true, "MineSecretDoorFrameLeft");
+	AddMineArenaBlock(deps, { corridorX + 9.0f, 4.2f, minePassageDoorCenter_.z }, { 7.2f, 9.5f, 3.0f }, {}, rockLight, true, "MineSecretDoorFrameRight");
+	AddMineArenaBlock(deps, { corridorX, 8.3f, minePassageDoorCenter_.z }, { 18.0f, 2.0f, 3.0f }, {}, rock, true, "MineSecretDoorFrameTop");
+
+	minePassageDoorLeftIndex_ = AddMineArenaBlock(
+		deps, { corridorX - 2.65f, minePassageDoorCenter_.y, minePassageDoorCenter_.z }, { 5.5f, 7.2f, 1.6f }, {}, metal, true, "MineSecretDoorLeft");
+	minePassageDoorRightIndex_ = AddMineArenaBlock(
+		deps, { corridorX + 2.65f, minePassageDoorCenter_.y, minePassageDoorCenter_.z }, { 5.5f, 7.2f, 1.6f }, {}, metal, true, "MineSecretDoorRight");
+	SetMineMovableBlock(minePassageDoorLeftIndex_, { corridorX - 2.65f, minePassageDoorCenter_.y, minePassageDoorCenter_.z }, { corridorX - 7.4f, minePassageDoorCenter_.y, minePassageDoorCenter_.z });
+	SetMineMovableBlock(minePassageDoorRightIndex_, { corridorX + 2.65f, minePassageDoorCenter_.y, minePassageDoorCenter_.z }, { corridorX + 7.4f, minePassageDoorCenter_.y, minePassageDoorCenter_.z });
+
+	AddMineArenaBlock(deps, { mineArenaCenter_.x, -0.5f, mineArenaCenter_.z }, { 50.0f, 1.0f, 50.0f }, {}, floorColor, true, "MineBossArenaFloor");
+
+	constexpr int lowerSegmentCount = 24;
+	const float lowerRadius = 23.5f;
+	const float lowerWidth = (kTwoPi * lowerRadius / static_cast<float>(lowerSegmentCount)) * 1.16f;
+	for (int i = 0; i < lowerSegmentCount; ++i)
+	{
+		const float angle = kTwoPi * static_cast<float>(i) / static_cast<float>(lowerSegmentCount);
+		const bool entranceOpening = std::abs(std::cos(angle) + 1.0f) < 0.10f && std::abs(std::sin(angle)) < 0.42f;
+		if (entranceOpening) continue;
+		const K4E::Vector3 position{
+			mineArenaCenter_.x + std::sin(angle) * lowerRadius,
+			5.0f,
+			mineArenaCenter_.z + std::cos(angle) * lowerRadius
+		};
+		AddMineArenaBlock(deps, position, { lowerWidth, 11.0f, 3.0f }, { 0.0f, angle, 0.0f }, rockLight, true, "MineBossArenaLowerWall");
+	}
+
+	constexpr int upperSegmentCount = 20;
+	const float upperRadius = 18.6f;
+	const float upperWidth = (kTwoPi * upperRadius / static_cast<float>(upperSegmentCount)) * 1.18f;
+	for (int i = 0; i < upperSegmentCount; ++i)
+	{
+		const float angle = kTwoPi * static_cast<float>(i) / static_cast<float>(upperSegmentCount);
+		const K4E::Vector3 position{
+			mineArenaCenter_.x + std::sin(angle) * upperRadius,
+			13.0f,
+			mineArenaCenter_.z + std::cos(angle) * upperRadius
+		};
+		AddMineArenaBlock(deps, position, { upperWidth, 6.5f, 3.2f }, { 0.0f, angle, 0.0f }, rock, true, "MineBossArenaUpperDome");
+	}
+	AddMineArenaBlock(deps, { mineArenaCenter_.x, 16.9f, mineArenaCenter_.z }, { 38.0f, 2.4f, 38.0f }, {}, rock, true, "MineBossArenaDomeCap");
+
+	AddMineArenaBlock(deps, { corridorX - 9.0f, 4.2f, mineArenaGateCenter_.z }, { 7.2f, 9.5f, 3.0f }, {}, rockLight, true, "MineArenaGateFrameLeft");
+	AddMineArenaBlock(deps, { corridorX + 9.0f, 4.2f, mineArenaGateCenter_.z }, { 7.2f, 9.5f, 3.0f }, {}, rockLight, true, "MineArenaGateFrameRight");
+	AddMineArenaBlock(deps, { corridorX, 8.3f, mineArenaGateCenter_.z }, { 18.0f, 2.0f, 3.0f }, {}, rock, true, "MineArenaGateFrameTop");
+
+	mineArenaGateLeftIndex_ = AddMineArenaBlock(
+		deps, { corridorX - 7.4f, mineArenaGateCenter_.y, mineArenaGateCenter_.z }, { 5.5f, 7.2f, 1.6f }, {}, metal, true, "MineArenaGateLeft");
+	mineArenaGateRightIndex_ = AddMineArenaBlock(
+		deps, { corridorX + 7.4f, mineArenaGateCenter_.y, mineArenaGateCenter_.z }, { 5.5f, 7.2f, 1.6f }, {}, metal, true, "MineArenaGateRight");
+	SetMineMovableBlock(mineArenaGateLeftIndex_, { corridorX - 2.65f, mineArenaGateCenter_.y, mineArenaGateCenter_.z }, { corridorX - 7.4f, mineArenaGateCenter_.y, mineArenaGateCenter_.z });
+	SetMineMovableBlock(mineArenaGateRightIndex_, { corridorX + 2.65f, mineArenaGateCenter_.y, mineArenaGateCenter_.z }, { corridorX + 7.4f, mineArenaGateCenter_.y, mineArenaGateCenter_.z });
+	UpdateMineMovableBlock(mineArenaGateLeftIndex_, 1.0f);
+	UpdateMineMovableBlock(mineArenaGateRightIndex_, 1.0f);
+
+	for (int i = 0; i < 8; ++i)
+	{
+		const float angle = kTwoPi * static_cast<float>(i) / 8.0f;
+		const K4E::Vector3 position{
+			mineArenaCenter_.x + std::sin(angle) * 19.0f,
+			2.0f,
+			mineArenaCenter_.z + std::cos(angle) * 19.0f
+		};
+		AddMineArenaBlock(deps, position, { 2.2f, 5.0f, 2.2f }, { 0.0f, angle, 0.0f }, metal, true, "MineBossArenaSupport");
+	}
+}

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/BossBattleControllerMineDevices.inl
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/BossBattleControllerMineDevices.inl
@@ -33,6 +33,7 @@ void BossBattleController::BuildMineDevices(const Dependencies& deps)
 		}
 	}
 
+	mineRequiredDeviceCount_ = std::clamp(mineRequiredDeviceCount_, 1, static_cast<int>(mineDevices_.size()));
 	for (MineDeviceRuntime& device : mineDevices_)
 	{
 		device.visual = std::make_unique<K4E::Object3D>();

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/BossBattleControllerMineDevices.inl
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/BossBattleControllerMineDevices.inl
@@ -1,0 +1,178 @@
+void BossBattleController::BuildMineDevices(const Dependencies& deps)
+{
+	mineDevices_.clear();
+	if (deps.stage && deps.stage->GetLevelData())
+	{
+		for (const K4E::ObjectData& object : deps.stage->GetLevelData()->objects)
+		{
+			if (object.type != "DeviceObjective" && object.type != "DevicePoint") continue;
+			MineDeviceRuntime device{};
+			device.name = object.name;
+			device.position = object.position;
+			if (object.hasDeviceObjectiveProps)
+			{
+				if (!object.deviceObjectiveProps.uiName.empty()) device.name = object.deviceObjectiveProps.uiName;
+				device.activateTime = object.deviceObjectiveProps.activateTime > 0.0f ? std::max(0.25f, object.deviceObjectiveProps.activateTime) : 1.5f;
+			}
+			mineDevices_.push_back(std::move(device));
+		}
+	}
+
+	if (mineDevices_.empty())
+	{
+		const IPlayerRuntime* player = deps.characters ? deps.characters->GetPlayerRuntime() : nullptr;
+		const K4E::Vector3 base = player ? player->GetWorldPosition() : K4E::Vector3{};
+		// 旧JSONにDeviceObjectiveが無い場合も探索フローを検証できる仮配置を用意する。
+		for (int i = 0; i < mineRequiredDeviceCount_; ++i)
+		{
+			MineDeviceRuntime device{};
+			device.name = "Mine Device " + std::to_string(i + 1);
+			device.position = base + K4E::Vector3{ (static_cast<float>(i) - 1.0f) * 12.0f, 0.0f, 18.0f + static_cast<float>(i) * 10.0f };
+			device.activateTime = 1.5f;
+			mineDevices_.push_back(std::move(device));
+		}
+	}
+
+	for (MineDeviceRuntime& device : mineDevices_)
+	{
+		device.visual = std::make_unique<K4E::Object3D>();
+		device.visual->Initialize(kMineBlockModelPath);
+		device.visual->SetScale({ 1.25f, 2.1f, 1.25f });
+		device.visual->SetTranslate(device.position + K4E::Vector3{ 0.0f, 1.05f, 0.0f });
+		device.visual->SetColor({ 0.10f, 0.72f, 0.92f, 1.0f });
+		device.visual->SetEmissiveFactor({ 0.05f, 0.75f, 1.0f, 1.0f });
+		device.visual->SetMetallic(0.45f);
+		device.visual->SetRoughness(0.28f);
+		device.visual->SetFrustumCullingEnabled(false);
+		device.visual->SetIgnoreStageChunkCulling(true);
+		device.visual->Update();
+	}
+}
+
+void BossBattleController::UpdateMineDevices(const Dependencies& deps, float deltaTime)
+{
+	mineFocusedDeviceIndex_ = -1;
+	IPlayerRuntime* player = deps.characters ? deps.characters->GetPlayerRuntime() : nullptr;
+	if (!player) return;
+
+	const K4E::Vector3 playerPosition = player->GetWorldPosition();
+	float nearestDistanceSq = 3.25f * 3.25f;
+	for (size_t i = 0; i < mineDevices_.size(); ++i)
+	{
+		const MineDeviceRuntime& device = mineDevices_[i];
+		if (device.activated) continue;
+		const K4E::Vector3 delta = device.position - playerPosition;
+		const float distanceSq = delta.x * delta.x + delta.y * delta.y + delta.z * delta.z;
+		if (distanceSq <= nearestDistanceSq)
+		{
+			nearestDistanceSq = distanceSq;
+			mineFocusedDeviceIndex_ = static_cast<int>(i);
+		}
+	}
+
+	K4E::Input* input = K4E::Input::GetInstance();
+	const bool interactHeld = input && (input->PushKey(DIK_E) || input->PushButton(K4E::XButtons.A));
+	for (size_t i = 0; i < mineDevices_.size(); ++i)
+	{
+		MineDeviceRuntime& device = mineDevices_[i];
+		device.pulseTimer += deltaTime;
+		const bool focused = mineFocusedDeviceIndex_ == static_cast<int>(i);
+		if (!device.activated)
+		{
+			if (focused && interactHeld)
+			{
+				device.activationProgress += deltaTime;
+			}
+			else
+			{
+				device.activationProgress = std::max(0.0f, device.activationProgress - deltaTime * 0.7f);
+			}
+			if (device.activationProgress >= device.activateTime)
+			{
+				device.activationProgress = device.activateTime;
+				device.activated = true;
+				++mineActivatedDeviceCount_;
+				K4E::Log("[MineArena] Search device activated.\n");
+			}
+		}
+
+		if (!device.visual) continue;
+		const float pulse = 0.5f + std::sin(device.pulseTimer * 3.5f) * 0.5f;
+		if (device.activated)
+		{
+			device.visual->SetColor({ 0.20f, 0.95f, 0.48f, 1.0f });
+			device.visual->SetEmissiveFactor({ 0.05f, 1.0f, 0.34f, 1.0f });
+		}
+		else if (focused)
+		{
+			const float progress = std::clamp(device.activationProgress / std::max(0.01f, device.activateTime), 0.0f, 1.0f);
+			device.visual->SetColor({ 0.20f + progress * 0.25f, 0.78f, 1.0f, 1.0f });
+			device.visual->SetEmissiveFactor({ 0.15f + progress * 0.55f, 0.85f, 1.0f, 1.0f });
+		}
+		else
+		{
+			device.visual->SetColor({ 0.08f, 0.48f + pulse * 0.16f, 0.78f + pulse * 0.16f, 1.0f });
+			device.visual->SetEmissiveFactor({ 0.02f, 0.38f + pulse * 0.22f, 0.68f + pulse * 0.25f, 1.0f });
+		}
+		if (deps.shadowLightViewProjection) device.visual->UpdateShadowMatrix(*deps.shadowLightViewProjection);
+		device.visual->Update();
+	}
+
+	minePassageUnlocked_ = mineActivatedDeviceCount_ >= mineRequiredDeviceCount_;
+}
+
+void BossBattleController::UpdateMineArena(const Dependencies& deps, float deltaTime)
+{
+	if (!mineArenaEnabled_ || !mineArenaInitialized_) return;
+	UpdateMineDevices(deps, deltaTime);
+	const float passageTarget = minePassageUnlocked_ ? 1.0f : 0.0f;
+	minePassageDoorOpenAmount_ = Approach(minePassageDoorOpenAmount_, passageTarget, 0.48f, deltaTime);
+	UpdateMineMovableBlock(minePassageDoorLeftIndex_, minePassageDoorOpenAmount_);
+	UpdateMineMovableBlock(minePassageDoorRightIndex_, minePassageDoorOpenAmount_);
+
+	IPlayerRuntime* player = deps.characters ? deps.characters->GetPlayerRuntime() : nullptr;
+	if (!mineArenaEntered_ && minePassageDoorOpenAmount_ >= 0.92f && player && IsPlayerInsideMineArena(*player))
+	{
+		mineArenaEntered_ = true;
+		StartCameraShake(0.55f, 0.24f, 18.0f);
+		K4E::Log("[MineArena] Player entered dome; entrance gate closing.\n");
+	}
+	const float gateTarget = mineArenaEntered_ ? 0.0f : 1.0f;
+	mineArenaGateOpenAmount_ = Approach(mineArenaGateOpenAmount_, gateTarget, 0.70f, deltaTime);
+	UpdateMineMovableBlock(mineArenaGateLeftIndex_, mineArenaGateOpenAmount_);
+	UpdateMineMovableBlock(mineArenaGateRightIndex_, mineArenaGateOpenAmount_);
+
+	UpdateMineLighting();
+	for (MineArenaBlock& block : mineArenaBlocks_)
+	{
+		if (!block.visual) continue;
+		if (deps.shadowLightViewProjection) block.visual->UpdateShadowMatrix(*deps.shadowLightViewProjection);
+		block.visual->Update();
+	}
+}
+
+void BossBattleController::DrawMineArena()
+{
+	if (!mineArenaEnabled_ || !mineArenaInitialized_) return;
+	for (MineDeviceRuntime& device : mineDevices_)
+	{
+		if (device.visual) device.visual->Draw();
+	}
+	for (MineArenaBlock& block : mineArenaBlocks_)
+	{
+		if (block.visual) block.visual->Draw();
+	}
+}
+
+void BossBattleController::DrawMineArenaShadow()
+{
+	if (!mineArenaEnabled_ || !mineArenaInitialized_) return;
+	for (MineDeviceRuntime& device : mineDevices_)
+	{
+		if (device.visual) device.visual->DrawShadow();
+	}
+	for (MineArenaBlock& block : mineArenaBlocks_)
+	{
+		if (block.visual) block.visual->DrawShadow();
+	}
+}

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/BossBattleControllerMineRendering.inl
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/BossBattleControllerMineRendering.inl
@@ -1,0 +1,182 @@
+size_t BossBattleController::AddMineArenaBlock(
+	const Dependencies& deps,
+	const K4E::Vector3& position,
+	const K4E::Vector3& scale,
+	const K4E::Vector3& rotation,
+	const K4E::Vector4& color,
+	bool collisionEnabled,
+	const char* debugName)
+{
+	MineArenaBlock block{};
+	block.closedPosition = position;
+	block.openPosition = position;
+	block.visual = std::make_unique<K4E::Object3D>();
+	block.visual->Initialize(kMineBlockModelPath);
+	block.visual->SetScale(scale);
+	block.visual->SetRotate(rotation);
+	block.visual->SetTranslate(position);
+	block.visual->SetColor(color);
+	block.visual->SetMetallic(0.05f);
+	block.visual->SetRoughness(0.88f);
+	block.visual->SetFrustumCullingEnabled(false);
+	block.visual->SetIgnoreStageChunkCulling(true);
+	block.visual->Update();
+
+	if (collisionEnabled)
+	{
+		block.collider = std::make_unique<K4E::Collider>();
+		ApplyCollisionPreset(*block.collider, ECollisionPresetId::WorldStatic);
+		block.collider->SetCenterPosition(position);
+		block.collider->SetOBBHalfSize(scale * 0.5f);
+		block.collider->SetOrientation(rotation);
+		block.collider->SetDebugName(debugName ? debugName : "MineArenaBlock");
+		if (deps.characters) deps.characters->GetPhysicsWorld().RegisterCollider(block.collider.get());
+		if (deps.collisionManager) deps.collisionManager->AddCollider(block.collider.get());
+	}
+	mineArenaBlocks_.push_back(std::move(block));
+	return mineArenaBlocks_.size() - 1;
+}
+
+void BossBattleController::SetMineMovableBlock(size_t blockIndex, const K4E::Vector3& closedPosition, const K4E::Vector3& openPosition)
+{
+	if (blockIndex >= mineArenaBlocks_.size()) return;
+	mineArenaBlocks_[blockIndex].closedPosition = closedPosition;
+	mineArenaBlocks_[blockIndex].openPosition = openPosition;
+}
+
+void BossBattleController::UpdateMineMovableBlock(size_t blockIndex, float openAmount)
+{
+	if (blockIndex >= mineArenaBlocks_.size()) return;
+	MineArenaBlock& block = mineArenaBlocks_[blockIndex];
+	const K4E::Vector3 position = LerpVector(block.closedPosition, block.openPosition, std::clamp(openAmount, 0.0f, 1.0f));
+	if (block.visual) block.visual->SetTranslate(position);
+	if (block.collider) block.collider->SetCenterPosition(position);
+}
+
+bool BossBattleController::IsPlayerInsideMineArena(const IPlayerRuntime& player) const
+{
+	const K4E::Vector3 position = player.GetWorldPosition();
+	const K4E::Vector3 delta = position - mineArenaCenter_;
+	return std::abs(delta.x) <= 17.5f && delta.z >= -18.0f && delta.z <= 19.5f && position.y >= -2.0f && position.y <= 12.0f;
+}
+
+void BossBattleController::ApplyMineLighting()
+{
+	if (!mineArenaEnabled_ || mineLightingSaved_) return;
+	K4E::LightManager* lightManager = K4E::LightManager::GetInstance();
+	auto& lights = lightManager->GetMutablePunctualLightsForEditor();
+	auto& settings = lightManager->GetMutableLightingSettingsForEditor();
+	savedMineLights_ = lights;
+	savedMineLightingSettings_ = settings;
+	mineLightingSaved_ = true;
+
+	// ステージ全体の既存ライトは維持し、隠し坑道用の局所ライトだけを追加する。
+	settings = savedMineLightingSettings_;
+
+	auto addPoint = [&lights](const K4E::Vector3& position, const K4E::Vector4& color, float intensity, float radius)
+	{
+		K4E::LightManager::PunctualLightGPU light{};
+		light.lightType = 2;
+		light.color = color;
+		light.intensity = intensity;
+		light.position = position;
+		light.radius = radius;
+		light.decay = 2.0f;
+		light.direction = { 0.0f, -1.0f, 0.0f };
+		light.distance = radius;
+		light.cosFalloffStart = 0.86f;
+		light.cosAngle = 0.72f;
+		light.areaSize = { 0.4f, 0.4f, 0.0f };
+		light.enabled = 1;
+		lights.push_back(light);
+		return lights.size() - 1;
+	};
+	auto addSpot = [&lights](const K4E::Vector3& position, const K4E::Vector3& direction, const K4E::Vector4& color, float intensity, float distance)
+	{
+		K4E::LightManager::PunctualLightGPU light{};
+		light.lightType = 3;
+		light.color = color;
+		light.intensity = intensity;
+		light.position = position;
+		light.radius = distance;
+		light.decay = 1.5f;
+		light.direction = direction;
+		light.distance = distance;
+		light.cosFalloffStart = 0.82f;
+		light.cosAngle = 0.52f;
+		light.areaSize = { 1.0f, 1.0f, 0.0f };
+		light.enabled = 1;
+		lights.push_back(light);
+		return lights.size() - 1;
+	};
+
+	mineCorridorLightIndices_.push_back(addPoint({ mineArenaCenter_.x, 6.4f, minePassageDoorCenter_.z + 7.0f }, { 1.0f, 0.58f, 0.25f, 1.0f }, 0.7f, 13.0f));
+	mineCorridorLightIndices_.push_back(addPoint({ mineArenaCenter_.x, 6.4f, minePassageDoorCenter_.z + 19.0f }, { 1.0f, 0.52f, 0.20f, 1.0f }, 0.7f, 13.0f));
+	mineCorridorLightIndices_.push_back(addPoint({ mineArenaCenter_.x, 6.4f, minePassageDoorCenter_.z + 31.0f }, { 0.72f, 0.82f, 1.0f, 1.0f }, 0.7f, 14.0f));
+
+	mineArenaLightIndices_.push_back(addSpot(
+		{ mineArenaCenter_.x, 16.5f, mineArenaCenter_.z - 2.0f },
+		{ 0.0f, -1.0f, 0.08f },
+		{ 0.58f, 0.72f, 1.0f, 1.0f },
+		1.4f,
+		32.0f));
+	for (int i = 0; i < 4; ++i)
+	{
+		const float angle = kTwoPi * static_cast<float>(i) / 4.0f + kPi * 0.25f;
+		mineArenaLightIndices_.push_back(addPoint(
+			{ mineArenaCenter_.x + std::sin(angle) * 16.5f, 5.0f, mineArenaCenter_.z + std::cos(angle) * 16.5f },
+			{ 1.0f, 0.36f, 0.16f, 1.0f },
+			0.8f,
+			18.0f));
+	}
+}
+
+void BossBattleController::UpdateMineLighting()
+{
+	if (!mineArenaEnabled_ || !mineLightingSaved_) return;
+	K4E::LightManager* lightManager = K4E::LightManager::GetInstance();
+	auto& lights = lightManager->GetMutablePunctualLightsForEditor();
+	auto& settings = lightManager->GetMutableLightingSettingsForEditor();
+
+	settings = savedMineLightingSettings_;
+	settings.ambientColor.x = std::max(settings.ambientColor.x, 0.075f);
+	settings.ambientColor.y = std::max(settings.ambientColor.y, 0.080f);
+	settings.ambientColor.z = std::max(settings.ambientColor.z, 0.090f);
+	settings.exposure = std::max(settings.exposure, mineArenaEntered_ ? 1.02f : 0.95f);
+	settings.diffuseStrength = std::max(settings.diffuseStrength, 0.95f);
+	if (minePassageUnlocked_)
+	{
+		settings.fogColor = { 0.075f, 0.082f, 0.095f, 1.0f };
+		settings.fogStart = std::max(28.0f, savedMineLightingSettings_.fogStart);
+		settings.fogEnd = std::max(mineArenaEntered_ ? 150.0f : 125.0f, savedMineLightingSettings_.fogEnd);
+		settings.enableFog = savedMineLightingSettings_.enableFog;
+	}
+
+	const float corridorIntensity = minePassageUnlocked_ ? (2.8f + minePassageDoorOpenAmount_ * 3.4f) : 0.0f;
+	for (size_t index : mineCorridorLightIndices_)
+	{
+		if (index < lights.size()) lights[index].intensity = corridorIntensity;
+	}
+	const float arenaFactor = mineArenaEntered_ ? 1.0f : (minePassageUnlocked_ ? 0.28f : 0.0f);
+	for (size_t i = 0; i < mineArenaLightIndices_.size(); ++i)
+	{
+		const size_t index = mineArenaLightIndices_[i];
+		if (index >= lights.size()) continue;
+		lights[index].intensity = (i == 0 ? 11.0f : 6.8f) * arenaFactor;
+	}
+}
+
+void BossBattleController::RestoreMineLighting()
+{
+	if (!mineLightingSaved_) return;
+	K4E::LightManager* lightManager = K4E::LightManager::GetInstance();
+	lightManager->GetMutablePunctualLightsForEditor() = savedMineLights_;
+	lightManager->GetMutableLightingSettingsForEditor() = savedMineLightingSettings_;
+	savedMineLights_.clear();
+	mineLightingSaved_ = false;
+}
+
+K4E::Vector3 BossBattleController::LerpVector(const K4E::Vector3& a, const K4E::Vector3& b, float t)
+{
+	return a + (b - a) * std::clamp(t, 0.0f, 1.0f);
+}

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/BossIntroController.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/BossIntroController.h
@@ -56,6 +56,7 @@ public:
 	void Finalize();
 	void RequestStart(const K4E::Vector3& bossPosition);
 	void Reset();
+	void ClearRuntimeBossPositionOverride() { hasRuntimeBossPositionOverride_ = false; }
 	void SetRuntimeBossPositionOverride(const K4E::Vector3& position)
 	{
 		runtimeBossPositionOverride_ = position;
@@ -66,6 +67,7 @@ public:
 	void Update(float deltaTime, K4E::BossActor* boss, K4E::Camera* camera)
 	{
 		ApplyParameters();
+		if (hasRuntimeBossPositionOverride_) settings_.bossAppearPosition = runtimeBossPositionOverride_;
 		SetDebugSnapshot(boss, camera);
 		switch (state_)
 		{

--- a/Project/ApplicationLayer/Scene/GamePlayScene/World/BossIntroController.h
+++ b/Project/ApplicationLayer/Scene/GamePlayScene/World/BossIntroController.h
@@ -56,6 +56,12 @@ public:
 	void Finalize();
 	void RequestStart(const K4E::Vector3& bossPosition);
 	void Reset();
+	void SetRuntimeBossPositionOverride(const K4E::Vector3& position)
+	{
+		runtimeBossPositionOverride_ = position;
+		hasRuntimeBossPositionOverride_ = true; // ステージ固有配置を共通Parameterより優先する。
+		settings_.bossAppearPosition = position;
+	}
 
 	void Update(float deltaTime, K4E::BossActor* boss, K4E::Camera* camera)
 	{
@@ -199,6 +205,8 @@ private:
 	K4E::Vector3 savedCameraRotation_{};
 	K4E::Vector3 introCameraPosition_{ 0.0f, 9.0f, 18.0f };
 	K4E::Vector3 introCameraTarget_{};
+	K4E::Vector3 runtimeBossPositionOverride_{};
+	bool hasRuntimeBossPositionOverride_ = false;
 	K4E::Vector3 debugBossPosition_{};
 	K4E::Vector3 debugBossLocalPosition_{};
 	K4E::Vector3 debugBossWorldPosition_{};


### PR DESCRIPTION
## 修正概要
スクリーンショットで3D描画がほぼ真っ黒になっていた問題と、ステージ2を誤ってクリスタル破壊目的として扱っていた問題を修正しました。

## ステージ2の進行
1. 坑道内を探索
2. レベルJSONの `DeviceObjective` / `DevicePoint` を発見
3. 近距離でEキー（ゲームパッドA）を長押しして起動
4. 必要数を起動すると隠し扉が開く
5. 隠し坑道を進みドーム広間へ入る
6. 背後の門が閉じ、既存ボス登場演出を開始
7. ボス戦

## 表示修正
- グローバルDirectional Lightを暗くする処理を撤去
- 既存のambient / exposureを維持
- ステージ全体を覆っていた巨大な床・壁・天井を撤去
- 坑道と広間に局所ライトだけを追加
- 装置完了前は追加ライトを消灯
- 扉開放後に坑道灯、広間侵入後に戦闘灯を点灯

## 実装内容
- ステージ2ではCrystalManagerの生成物を撤去
- `DeviceObjective` の `ui_name` / `activate_time` を利用
- 配置がない旧JSON向けにフォールバック装置を用意
- `requiredDeviceCount` を実配置数へクランプ
- Legacy CollisionManager / PhysicsWorldの両方へ通路・扉・広間Colliderを登録
- BossIntroControllerのステージ固有位置上書きを維持
- 大きくなった処理を内部 `.inl` へ責務分割

## 確認項目
- [ ] Visual StudioでDebugビルド
- [ ] ステージ2開始時に3Dステージが見える
- [ ] クリスタルとCRYSTAL HP表示が消える
- [ ] 装置へ近づきE長押しで青から緑へ変化する
- [ ] 必要数起動後に隠し扉が開く
- [ ] 広間侵入で入口門が閉まりボス演出が始まる
- [ ] 扉・通路・広間の座標とサイズを実機で微調整

Windows / DirectX 12環境での最終ビルドと座標確認は未実施です。