### PR TITLE
Boss攻撃選択・フェーズ管理を型安全化

### DIFF
--- a/Project/ApplicationLayer/Character/Boss/Actor/BossActorAttackComponent.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Actor/BossActorAttackComponent.cpp
@@ -3,6 +3,7 @@
 #include <Scene/Actor/Character/AttackBehaviors.h>
 
 #include <array>
+#include <sstream>
 #include <span>
 #include <string>
 #include <string_view>
@@ -181,14 +182,14 @@ namespace Ken4lowEngine
 			}
 		}};
 
-		constexpr const BossAttackSelectionRule& FindSelectionRule(BossAttackProfile profile, BossPhase phase)
+		constexpr const BossAttackSelectionRule* FindSelectionRule(BossAttackProfile profile, BossPhase phase)
 		{
 			for (const BossAttackSelectionRule& rule : kAttackSelectionRules)
 			{
-				if (rule.profile == profile && rule.phase == phase) return rule;
+				if (rule.profile == profile && rule.phase == phase) return &rule;
 			}
 
-			return kAttackSelectionRules.front();
+			return nullptr;
 		}
 
 		constexpr BossDistanceBand ClassifyDistance(const BossAttackSelectionRule& rule, float distanceToTarget)
@@ -248,9 +249,11 @@ namespace Ken4lowEngine
 
 	bool BossAttackComponent::TryStartBestAttack(float distanceToTarget, BossPhase bossPhase)
 	{
-		const BossAttackSelectionRule& rule = FindSelectionRule(attackProfile_, bossPhase);
-		const BossDistanceBand distanceBand = ClassifyDistance(rule, distanceToTarget);
-		const BossAttackIdList candidates = GetCandidates(rule, distanceBand);
+		const BossAttackSelectionRule* rule = FindSelectionRule(attackProfile_, bossPhase);
+		if (!rule) return false;
+
+		const BossDistanceBand distanceBand = ClassifyDistance(*rule, distanceToTarget);
+		const BossAttackIdList candidates = GetCandidates(*rule, distanceBand);
 
 		for (const BossAttackId attackId : candidates)
 		{
@@ -260,6 +263,59 @@ namespace Ken4lowEngine
 		}
 
 		return false;
+	}
+
+	bool BossAttackComponent::ValidateSelectionRules(std::string& outSummary) const
+	{
+		constexpr std::array<BossPhase, 3> phases{
+			BossPhase::Phase1,
+			BossPhase::Phase2,
+			BossPhase::Phase3
+		};
+		constexpr std::array<BossDistanceBand, 3> distanceBands{
+			BossDistanceBand::Near,
+			BossDistanceBand::Middle,
+			BossDistanceBand::Far
+		};
+
+		bool valid = true;
+		std::ostringstream summary;
+		summary << GetAttackProfileName() << " ";
+
+		for (const BossPhase phase : phases)
+		{
+			const BossAttackSelectionRule* rule = FindSelectionRule(attackProfile_, phase);
+			if (!rule)
+			{
+				valid = false;
+				summary << "P" << ToInt(phase) << "=RuleMissing ";
+				continue;
+			}
+
+			for (const BossDistanceBand distanceBand : distanceBands)
+			{
+				const BossAttackIdList candidates = GetCandidates(*rule, distanceBand);
+				summary << "P" << ToInt(phase) << "/" << ToString(distanceBand) << "=";
+				if (candidates.empty())
+				{
+					valid = false;
+					summary << "Empty ";
+					continue;
+				}
+
+				summary << ToString(candidates.front());
+				for (const BossAttackId attackId : candidates)
+				{
+					if (FindAttackData(ToString(attackId))) continue;
+					valid = false;
+					summary << "(Missing:" << ToString(attackId) << ")";
+				}
+				summary << " ";
+			}
+		}
+
+		outSummary = summary.str(); // DebugSceneで全組み合わせの先頭候補と登録漏れを一度に確認できる形へまとめる。
+		return valid;
 	}
 
 	void BossAttackComponent::RegisterDefaultAttacks()

--- a/Project/ApplicationLayer/Character/Boss/Actor/BossActorAttackComponent.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Actor/BossActorAttackComponent.cpp
@@ -3,6 +3,8 @@
 #include <Scene/Actor/Character/AttackBehaviors.h>
 
 #include <array>
+#include <span>
+#include <string>
 #include <string_view>
 #include <utility>
 
@@ -12,6 +14,210 @@
 
 namespace Ken4lowEngine
 {
+	namespace
+	{
+		using BossAttackIdList = std::span<const BossAttackId>;
+
+		struct BossAttackSelectionRule
+		{
+			BossAttackProfile profile;
+			BossPhase phase;
+			float middleDistance;
+			float farDistance;
+			BossAttackIdList nearCandidates;
+			BossAttackIdList middleCandidates;
+			BossAttackIdList farCandidates;
+		};
+
+		constexpr std::array<BossAttackId, 2> kGuardianPhase1Near{
+			BossAttackId::HeavyPunch,
+			BossAttackId::Punch
+		};
+		constexpr std::array<BossAttackId, 1> kGuardianPhase1Far{
+			BossAttackId::Charge
+		};
+
+		constexpr std::array<BossAttackId, 3> kGuardianPhase2Near{
+			BossAttackId::GroundSlam,
+			BossAttackId::HeavyPunch,
+			BossAttackId::Punch
+		};
+		constexpr std::array<BossAttackId, 5> kGuardianPhase2Middle{
+			BossAttackId::Shockwave,
+			BossAttackId::GroundSlam,
+			BossAttackId::HeavyPunch,
+			BossAttackId::Punch,
+			BossAttackId::Charge
+		};
+		constexpr std::array<BossAttackId, 3> kGuardianPhase2Far{
+			BossAttackId::Charge,
+			BossAttackId::Shockwave,
+			BossAttackId::GroundSlam
+		};
+
+		constexpr std::array<BossAttackId, 4> kGuardianPhase3Near{
+			BossAttackId::RapidPunch,
+			BossAttackId::GroundSlam,
+			BossAttackId::Punch,
+			BossAttackId::HeavyPunch
+		};
+		constexpr std::array<BossAttackId, 6> kGuardianPhase3Middle{
+			BossAttackId::FastShockwave,
+			BossAttackId::RapidPunch,
+			BossAttackId::GroundSlam,
+			BossAttackId::FrenzyCharge,
+			BossAttackId::HeavyPunch,
+			BossAttackId::Punch
+		};
+		constexpr std::array<BossAttackId, 4> kGuardianPhase3Far{
+			BossAttackId::FrenzyCharge,
+			BossAttackId::FastShockwave,
+			BossAttackId::Charge,
+			BossAttackId::Shockwave
+		};
+
+		constexpr std::array<BossAttackId, 3> kMineCrusherPhase1Near{
+			BossAttackId::HeavyPunch,
+			BossAttackId::Punch,
+			BossAttackId::GroundSlam
+		};
+		constexpr std::array<BossAttackId, 2> kMineCrusherPhase1Far{
+			BossAttackId::Charge,
+			BossAttackId::Shockwave
+		};
+
+		constexpr std::array<BossAttackId, 3> kMineCrusherPhase2Near{
+			BossAttackId::GroundSlam,
+			BossAttackId::HeavyPunch,
+			BossAttackId::Punch
+		};
+		constexpr std::array<BossAttackId, 5> kMineCrusherPhase2Middle{
+			BossAttackId::GroundSlam,
+			BossAttackId::Shockwave,
+			BossAttackId::HeavyPunch,
+			BossAttackId::Charge,
+			BossAttackId::Punch
+		};
+		constexpr std::array<BossAttackId, 3> kMineCrusherPhase2Far{
+			BossAttackId::Shockwave,
+			BossAttackId::Charge,
+			BossAttackId::GroundSlam
+		};
+
+		constexpr std::array<BossAttackId, 4> kMineCrusherPhase3Near{
+			BossAttackId::GroundSlam,
+			BossAttackId::RapidPunch,
+			BossAttackId::HeavyPunch,
+			BossAttackId::Punch
+		};
+		constexpr std::array<BossAttackId, 5> kMineCrusherPhase3Middle{
+			BossAttackId::FastShockwave,
+			BossAttackId::GroundSlam,
+			BossAttackId::Shockwave,
+			BossAttackId::HeavyPunch,
+			BossAttackId::FrenzyCharge
+		};
+		constexpr std::array<BossAttackId, 4> kMineCrusherPhase3Far{
+			BossAttackId::FrenzyCharge,
+			BossAttackId::FastShockwave,
+			BossAttackId::Shockwave,
+			BossAttackId::Charge
+		};
+
+		constexpr std::array<BossAttackSelectionRule, 6> kAttackSelectionRules{{
+			{
+				BossAttackProfile::Guardian,
+				BossPhase::Phase1,
+				3.4f,
+				3.4f,
+				BossAttackIdList{ kGuardianPhase1Near },
+				BossAttackIdList{ kGuardianPhase1Near },
+				BossAttackIdList{ kGuardianPhase1Far }
+			},
+			{
+				BossAttackProfile::Guardian,
+				BossPhase::Phase2,
+				2.2f,
+				4.5f,
+				BossAttackIdList{ kGuardianPhase2Near },
+				BossAttackIdList{ kGuardianPhase2Middle },
+				BossAttackIdList{ kGuardianPhase2Far }
+			},
+			{
+				BossAttackProfile::Guardian,
+				BossPhase::Phase3,
+				2.2f,
+				4.5f,
+				BossAttackIdList{ kGuardianPhase3Near },
+				BossAttackIdList{ kGuardianPhase3Middle },
+				BossAttackIdList{ kGuardianPhase3Far }
+			},
+			{
+				BossAttackProfile::MineCrusher,
+				BossPhase::Phase1,
+				5.0f,
+				5.0f,
+				BossAttackIdList{ kMineCrusherPhase1Near },
+				BossAttackIdList{ kMineCrusherPhase1Near },
+				BossAttackIdList{ kMineCrusherPhase1Far }
+			},
+			{
+				BossAttackProfile::MineCrusher,
+				BossPhase::Phase2,
+				3.0f,
+				6.0f,
+				BossAttackIdList{ kMineCrusherPhase2Near },
+				BossAttackIdList{ kMineCrusherPhase2Middle },
+				BossAttackIdList{ kMineCrusherPhase2Far }
+			},
+			{
+				BossAttackProfile::MineCrusher,
+				BossPhase::Phase3,
+				3.0f,
+				6.0f,
+				BossAttackIdList{ kMineCrusherPhase3Near },
+				BossAttackIdList{ kMineCrusherPhase3Middle },
+				BossAttackIdList{ kMineCrusherPhase3Far }
+			}
+		}};
+
+		constexpr const BossAttackSelectionRule& FindSelectionRule(BossAttackProfile profile, BossPhase phase)
+		{
+			for (const BossAttackSelectionRule& rule : kAttackSelectionRules)
+			{
+				if (rule.profile == profile && rule.phase == phase) return rule;
+			}
+
+			return kAttackSelectionRules.front();
+		}
+
+		constexpr BossDistanceBand ClassifyDistance(const BossAttackSelectionRule& rule, float distanceToTarget)
+		{
+			if (distanceToTarget > rule.farDistance) return BossDistanceBand::Far;
+			if (distanceToTarget > rule.middleDistance) return BossDistanceBand::Middle;
+			return BossDistanceBand::Near;
+		}
+
+		constexpr BossAttackIdList GetCandidates(const BossAttackSelectionRule& rule, BossDistanceBand distanceBand)
+		{
+			switch (distanceBand)
+			{
+			case BossDistanceBand::Far:
+				return rule.farCandidates;
+			case BossDistanceBand::Middle:
+				return rule.middleCandidates;
+			case BossDistanceBand::Near:
+			default:
+				return rule.nearCandidates;
+			}
+		}
+
+		std::string ToAttackKey(BossAttackId attackId)
+		{
+			return std::string(ToString(attackId));
+		}
+	}
+
 	void BossAttackComponent::Initialize()
 	{
 		RegisterDefaultAttacks();
@@ -22,156 +228,52 @@ namespace Ken4lowEngine
 	{
 		AttackComponent::DrawImGui();
 #ifdef USE_IMGUI
-		ImGui::Text("Bossプロファイル: %s", attackProfile_.c_str());
-		ImGui::Text("Boss選択: %s", lastSelectedAttackId_.c_str());
+		ImGui::Text("Bossプロファイル: %s", GetAttackProfileName().data());
+		ImGui::Text("Boss選択: %s", GetLastSelectedAttackName().data());
 #endif
 	}
 
 	void BossAttackComponent::ToJson(nlohmann::json& outJson) const
 	{
 		AttackComponent::ToJson(outJson);
-		outJson["AttackProfile"] = attackProfile_;
+		outJson["AttackProfile"] = ToString(attackProfile_);
 	}
 
 	void BossAttackComponent::FromJson(const nlohmann::json& inJson)
 	{
 		AttackComponent::FromJson(inJson);
-		attackProfile_ = inJson.value("AttackProfile", attackProfile_); // Prefabごとの攻撃構成をInitialize前に確定する。
-		if (attackProfile_.empty()) attackProfile_ = "Guardian";
+		const std::string profileName = inJson.value("AttackProfile", std::string(ToString(attackProfile_)));
+		attackProfile_ = BossAttackProfileFromString(profileName); // Prefab文字列は読込境界で列挙型へ変換する。
 	}
 
-	bool BossAttackComponent::TryStartBestAttack(float distanceToTarget, int bossPhase)
+	bool BossAttackComponent::TryStartBestAttack(float distanceToTarget, BossPhase bossPhase)
 	{
-		auto tryCandidates = [this](const auto& candidates)
+		const BossAttackSelectionRule& rule = FindSelectionRule(attackProfile_, bossPhase);
+		const BossDistanceBand distanceBand = ClassifyDistance(rule, distanceToTarget);
+		const BossAttackIdList candidates = GetCandidates(rule, distanceBand);
+
+		for (const BossAttackId attackId : candidates)
 		{
-			for (const std::string_view attackId : candidates)
-			{
-				if (!StartAttack(attackId)) continue;
-				lastSelectedAttackId_ = std::string(attackId);
-				return true;
-			}
-			return false;
-		};
-
-		if (attackProfile_ == "MineCrusher")
-		{
-			if (bossPhase >= 3)
-			{
-				if (distanceToTarget > 6.0f)
-				{
-					static constexpr std::array<std::string_view, 4> farCandidates{
-						"FrenzyCharge", "FastShockwave", "Shockwave", "Charge"
-					};
-					return tryCandidates(farCandidates);
-				}
-				if (distanceToTarget > 3.0f)
-				{
-					static constexpr std::array<std::string_view, 5> middleCandidates{
-						"FastShockwave", "GroundSlam", "Shockwave", "HeavyPunch", "FrenzyCharge"
-					};
-					return tryCandidates(middleCandidates);
-				}
-				static constexpr std::array<std::string_view, 4> nearCandidates{
-					"GroundSlam", "RapidPunch", "HeavyPunch", "Punch"
-				};
-				return tryCandidates(nearCandidates);
-			}
-
-			if (bossPhase == 2)
-			{
-				if (distanceToTarget > 6.0f)
-				{
-					static constexpr std::array<std::string_view, 3> farCandidates{
-						"Shockwave", "Charge", "GroundSlam"
-					};
-					return tryCandidates(farCandidates);
-				}
-				if (distanceToTarget > 3.0f)
-				{
-					static constexpr std::array<std::string_view, 5> middleCandidates{
-						"GroundSlam", "Shockwave", "HeavyPunch", "Charge", "Punch"
-					};
-					return tryCandidates(middleCandidates);
-				}
-				static constexpr std::array<std::string_view, 3> nearCandidates{
-					"GroundSlam", "HeavyPunch", "Punch"
-				};
-				return tryCandidates(nearCandidates);
-			}
-
-			if (distanceToTarget > 5.0f)
-			{
-				static constexpr std::array<std::string_view, 2> farCandidates{ "Charge", "Shockwave" };
-				return tryCandidates(farCandidates);
-			}
-			static constexpr std::array<std::string_view, 3> nearCandidates{ "HeavyPunch", "Punch", "GroundSlam" };
-			return tryCandidates(nearCandidates);
+			if (!StartAttack(ToString(attackId))) continue;
+			lastSelectedAttackId_ = attackId;
+			return true;
 		}
 
-		if (bossPhase >= 3)
-		{
-			if (distanceToTarget > 4.5f)
-			{
-				static constexpr std::array<std::string_view, 4> farCandidates{
-					"FrenzyCharge", "FastShockwave", "Charge", "Shockwave"
-				};
-				return tryCandidates(farCandidates);
-			}
-			if (distanceToTarget > 2.2f)
-			{
-				static constexpr std::array<std::string_view, 6> middleCandidates{
-					"FastShockwave", "RapidPunch", "GroundSlam", "FrenzyCharge", "HeavyPunch", "Punch"
-				};
-				return tryCandidates(middleCandidates);
-			}
-
-			static constexpr std::array<std::string_view, 4> nearCandidates{
-				"RapidPunch", "GroundSlam", "Punch", "HeavyPunch"
-			};
-			return tryCandidates(nearCandidates);
-		}
-
-		if (bossPhase == 2)
-		{
-			if (distanceToTarget > 4.5f)
-			{
-				static constexpr std::array<std::string_view, 3> farCandidates{
-					"Charge", "Shockwave", "GroundSlam"
-				};
-				return tryCandidates(farCandidates);
-			}
-			if (distanceToTarget > 2.2f)
-			{
-				static constexpr std::array<std::string_view, 5> middleCandidates{
-					"Shockwave", "GroundSlam", "HeavyPunch", "Punch", "Charge"
-				};
-				return tryCandidates(middleCandidates);
-			}
-
-			static constexpr std::array<std::string_view, 3> nearCandidates{
-				"GroundSlam", "HeavyPunch", "Punch"
-			};
-			return tryCandidates(nearCandidates);
-		}
-
-		if (distanceToTarget > 3.4f)
-		{
-			static constexpr std::array<std::string_view, 1> farCandidates{ "Charge" };
-			return tryCandidates(farCandidates);
-		}
-
-		static constexpr std::array<std::string_view, 2> nearCandidates{ "HeavyPunch", "Punch" };
-		return tryCandidates(nearCandidates);
+		return false;
 	}
 
 	void BossAttackComponent::RegisterDefaultAttacks()
 	{
-		if (attackProfile_ == "MineCrusher")
+		switch (attackProfile_)
 		{
+		case BossAttackProfile::MineCrusher:
 			RegisterMineCrusherAttacks();
 			return;
+		case BossAttackProfile::Guardian:
+		default:
+			RegisterGuardianAttacks();
+			return;
 		}
-		RegisterGuardianAttacks();
 	}
 
 	void BossAttackComponent::RegisterGuardianAttacks()
@@ -188,35 +290,35 @@ namespace Ken4lowEngine
 			RegisterAttack(std::move(data), CreateAttackBehavior(behaviorType));
 		};
 
-		AttackData punch{ "Punch", "Melee", "Attack.Melee", 24.0f, 0.95f, 0.17f, 0.10f, 0.24f, 0.0f, 3.2f, 0.0f };
+		AttackData punch{ ToAttackKey(BossAttackId::Punch), "Melee", "Attack.Melee", 24.0f, 0.95f, 0.17f, 0.10f, 0.24f, 0.0f, 3.2f, 0.0f };
 		punch.maxHeightDifference = 3.0f;
 		upsertAttack(std::move(punch));
 
-		AttackData heavyPunch{ "HeavyPunch", "Melee", "Attack.Melee", 42.0f, 1.65f, 0.32f, 0.13f, 0.36f, 0.0f, 4.0f, 0.0f };
+		AttackData heavyPunch{ ToAttackKey(BossAttackId::HeavyPunch), "Melee", "Attack.Melee", 42.0f, 1.65f, 0.32f, 0.13f, 0.36f, 0.0f, 4.0f, 0.0f };
 		heavyPunch.maxHeightDifference = 3.5f;
 		upsertAttack(std::move(heavyPunch));
 
-		AttackData charge{ "Charge", "Charge", "Attack.Charge", 36.0f, 2.35f, 0.28f, 0.82f, 0.24f, 3.2f, 18.0f, 18.0f };
+		AttackData charge{ ToAttackKey(BossAttackId::Charge), "Charge", "Attack.Charge", 36.0f, 2.35f, 0.28f, 0.82f, 0.24f, 3.2f, 18.0f, 18.0f };
 		charge.maxHeightDifference = 2.5f;
 		upsertAttack(std::move(charge));
 
-		AttackData shockwave{ "Shockwave", "Shockwave", "Attack.Shockwave", 44.0f, 3.15f, 0.54f, 0.10f, 0.38f, 2.0f, 10.0f, 0.0f };
+		AttackData shockwave{ ToAttackKey(BossAttackId::Shockwave), "Shockwave", "Attack.Shockwave", 44.0f, 3.15f, 0.54f, 0.10f, 0.38f, 2.0f, 10.0f, 0.0f };
 		shockwave.maxHeightDifference = 2.0f;
 		upsertAttack(std::move(shockwave));
 
-		AttackData groundSlam{ "GroundSlam", "Shockwave", "Attack.Shockwave", 52.0f, 3.75f, 0.62f, 0.11f, 0.45f, 0.0f, 5.8f, 0.0f };
+		AttackData groundSlam{ ToAttackKey(BossAttackId::GroundSlam), "Shockwave", "Attack.Shockwave", 52.0f, 3.75f, 0.62f, 0.11f, 0.45f, 0.0f, 5.8f, 0.0f };
 		groundSlam.maxHeightDifference = 2.3f;
 		upsertAttack(std::move(groundSlam));
 
-		AttackData rapidPunch{ "RapidPunch", "Melee", "Attack.Melee", 30.0f, 0.52f, 0.11f, 0.08f, 0.14f, 0.0f, 3.4f, 0.0f };
+		AttackData rapidPunch{ ToAttackKey(BossAttackId::RapidPunch), "Melee", "Attack.Melee", 30.0f, 0.52f, 0.11f, 0.08f, 0.14f, 0.0f, 3.4f, 0.0f };
 		rapidPunch.maxHeightDifference = 3.0f;
 		upsertAttack(std::move(rapidPunch));
 
-		AttackData frenzyCharge{ "FrenzyCharge", "Charge", "Attack.Charge", 42.0f, 1.55f, 0.16f, 0.78f, 0.13f, 3.0f, 22.0f, 24.0f };
+		AttackData frenzyCharge{ ToAttackKey(BossAttackId::FrenzyCharge), "Charge", "Attack.Charge", 42.0f, 1.55f, 0.16f, 0.78f, 0.13f, 3.0f, 22.0f, 24.0f };
 		frenzyCharge.maxHeightDifference = 2.5f;
 		upsertAttack(std::move(frenzyCharge));
 
-		AttackData fastShockwave{ "FastShockwave", "Shockwave", "Attack.Shockwave", 48.0f, 1.90f, 0.29f, 0.08f, 0.21f, 1.5f, 10.5f, 0.0f };
+		AttackData fastShockwave{ ToAttackKey(BossAttackId::FastShockwave), "Shockwave", "Attack.Shockwave", 48.0f, 1.90f, 0.29f, 0.08f, 0.21f, 1.5f, 10.5f, 0.0f };
 		fastShockwave.maxHeightDifference = 2.0f;
 		upsertAttack(std::move(fastShockwave));
 	}
@@ -235,35 +337,35 @@ namespace Ken4lowEngine
 			RegisterAttack(std::move(data), CreateAttackBehavior(behaviorType));
 		};
 
-		AttackData crusherClaw{ "Punch", "Melee", "Attack.Melee", 32.0f, 1.10f, 0.24f, 0.14f, 0.30f, 0.0f, 4.2f, 0.0f };
+		AttackData crusherClaw{ ToAttackKey(BossAttackId::Punch), "Melee", "Attack.Melee", 32.0f, 1.10f, 0.24f, 0.14f, 0.30f, 0.0f, 4.2f, 0.0f };
 		crusherClaw.maxHeightDifference = 4.0f;
 		upsertAttack(std::move(crusherClaw));
 
-		AttackData drillHammer{ "HeavyPunch", "Melee", "Attack.Melee", 48.0f, 1.85f, 0.44f, 0.16f, 0.42f, 0.0f, 5.0f, 0.0f };
+		AttackData drillHammer{ ToAttackKey(BossAttackId::HeavyPunch), "Melee", "Attack.Melee", 48.0f, 1.85f, 0.44f, 0.16f, 0.42f, 0.0f, 5.0f, 0.0f };
 		drillHammer.maxHeightDifference = 4.5f;
 		upsertAttack(std::move(drillHammer));
 
-		AttackData tunnelCharge{ "Charge", "Charge", "Attack.Charge", 44.0f, 2.70f, 0.50f, 1.00f, 0.35f, 4.0f, 20.0f, 14.0f };
+		AttackData tunnelCharge{ ToAttackKey(BossAttackId::Charge), "Charge", "Attack.Charge", 44.0f, 2.70f, 0.50f, 1.00f, 0.35f, 4.0f, 20.0f, 14.0f };
 		tunnelCharge.maxHeightDifference = 4.0f;
 		upsertAttack(std::move(tunnelCharge));
 
-		AttackData oreBurst{ "Shockwave", "Shockwave", "Attack.Shockwave", 38.0f, 2.40f, 0.70f, 0.12f, 0.42f, 2.5f, 12.0f, 0.0f };
+		AttackData oreBurst{ ToAttackKey(BossAttackId::Shockwave), "Shockwave", "Attack.Shockwave", 38.0f, 2.40f, 0.70f, 0.12f, 0.42f, 2.5f, 12.0f, 0.0f };
 		oreBurst.maxHeightDifference = 5.0f;
 		upsertAttack(std::move(oreBurst));
 
-		AttackData caveIn{ "GroundSlam", "Shockwave", "Attack.Shockwave", 56.0f, 4.20f, 0.95f, 0.16f, 0.55f, 0.0f, 8.0f, 0.0f };
+		AttackData caveIn{ ToAttackKey(BossAttackId::GroundSlam), "Shockwave", "Attack.Shockwave", 56.0f, 4.20f, 0.95f, 0.16f, 0.55f, 0.0f, 8.0f, 0.0f };
 		caveIn.maxHeightDifference = 5.0f;
 		upsertAttack(std::move(caveIn));
 
-		AttackData crusherCombo{ "RapidPunch", "Melee", "Attack.Melee", 34.0f, 0.68f, 0.16f, 0.10f, 0.18f, 0.0f, 4.5f, 0.0f };
+		AttackData crusherCombo{ ToAttackKey(BossAttackId::RapidPunch), "Melee", "Attack.Melee", 34.0f, 0.68f, 0.16f, 0.10f, 0.18f, 0.0f, 4.5f, 0.0f };
 		crusherCombo.maxHeightDifference = 4.0f;
 		upsertAttack(std::move(crusherCombo));
 
-		AttackData tunnelRush{ "FrenzyCharge", "Charge", "Attack.Charge", 48.0f, 1.90f, 0.30f, 0.92f, 0.20f, 3.5f, 23.0f, 18.0f };
+		AttackData tunnelRush{ ToAttackKey(BossAttackId::FrenzyCharge), "Charge", "Attack.Charge", 48.0f, 1.90f, 0.30f, 0.92f, 0.20f, 3.5f, 23.0f, 18.0f };
 		tunnelRush.maxHeightDifference = 4.5f;
 		upsertAttack(std::move(tunnelRush));
 
-		AttackData rockBurst{ "FastShockwave", "Shockwave", "Attack.Shockwave", 42.0f, 1.55f, 0.38f, 0.10f, 0.24f, 1.5f, 12.5f, 0.0f };
+		AttackData rockBurst{ ToAttackKey(BossAttackId::FastShockwave), "Shockwave", "Attack.Shockwave", 42.0f, 1.55f, 0.38f, 0.10f, 0.24f, 1.5f, 12.5f, 0.0f };
 		rockBurst.maxHeightDifference = 5.0f;
 		upsertAttack(std::move(rockBurst)); // 坑道ボスは高低差を許容する範囲攻撃を多用し、立体Arenaでも待機状態になりにくくする。
 	}

--- a/Project/ApplicationLayer/Character/Boss/Actor/BossActorAttackComponent.h
+++ b/Project/ApplicationLayer/Character/Boss/Actor/BossActorAttackComponent.h
@@ -1,8 +1,11 @@
 #pragma once
 
+#include "BossAttackTypes.h"
+
 #include <Scene/Actor/Character/AttackComponent.h>
 
 #include <string>
+#include <string_view>
 
 namespace Ken4lowEngine
 {
@@ -24,11 +27,16 @@ namespace Ken4lowEngine
 		std::string GetClassTypeName() const override { return "BossAttackComponent"; }
 
 		/// 距離と現在フェーズに適した登録攻撃を優先順に開始する。
-		bool TryStartBestAttack(float distanceToTarget, int bossPhase);
+		bool TryStartBestAttack(float distanceToTarget, BossPhase bossPhase);
 
-		/// 直近に開始できた攻撃IDを返す。
-		const std::string& GetLastSelectedAttackId() const { return lastSelectedAttackId_; }
-		const std::string& GetAttackProfile() const { return attackProfile_; }
+		/// 直近に開始できた攻撃を型付きIDで返す。
+		BossAttackId GetLastSelectedAttackType() const { return lastSelectedAttackId_; }
+
+		/// 既存Debug表示との互換用に攻撃ID文字列を返す。
+		std::string GetLastSelectedAttackId() const { return std::string(ToString(lastSelectedAttackId_)); }
+		std::string_view GetLastSelectedAttackName() const { return ToString(lastSelectedAttackId_); }
+		BossAttackProfile GetAttackProfile() const { return attackProfile_; }
+		std::string_view GetAttackProfileName() const { return ToString(attackProfile_); }
 
 	private:
 		/// 選択されたArchetypeに対応する近接・突進・範囲攻撃を登録する。
@@ -37,7 +45,7 @@ namespace Ken4lowEngine
 		void RegisterMineCrusherAttacks();
 
 	private:
-		std::string attackProfile_ = "Guardian";
-		std::string lastSelectedAttackId_ = "None";
+		BossAttackProfile attackProfile_ = BossAttackProfile::Guardian;
+		BossAttackId lastSelectedAttackId_ = BossAttackId::None;
 	};
 } // namespace Ken4lowEngine

--- a/Project/ApplicationLayer/Character/Boss/Actor/BossActorAttackComponent.h
+++ b/Project/ApplicationLayer/Character/Boss/Actor/BossActorAttackComponent.h
@@ -29,6 +29,9 @@ namespace Ken4lowEngine
 		/// 距離と現在フェーズに適した登録攻撃を優先順に開始する。
 		bool TryStartBestAttack(float distanceToTarget, BossPhase bossPhase);
 
+		/// 現在プロファイルの全フェーズ・全距離帯に有効な候補が登録されているか検証する。
+		bool ValidateSelectionRules(std::string& outSummary) const;
+
 		/// 直近に開始できた攻撃を型付きIDで返す。
 		BossAttackId GetLastSelectedAttackType() const { return lastSelectedAttackId_; }
 

--- a/Project/ApplicationLayer/Character/Boss/Actor/BossAttackTypes.h
+++ b/Project/ApplicationLayer/Character/Boss/Actor/BossAttackTypes.h
@@ -1,0 +1,111 @@
+#pragma once
+
+#include <string_view>
+
+namespace Ken4lowEngine
+{
+	enum class BossAttackProfile
+	{
+		Guardian,
+		MineCrusher
+	};
+
+	enum class BossAttackId
+	{
+		None,
+		Punch,
+		HeavyPunch,
+		Charge,
+		Shockwave,
+		GroundSlam,
+		RapidPunch,
+		FrenzyCharge,
+		FastShockwave
+	};
+
+	enum class BossPhase
+	{
+		Phase1 = 1,
+		Phase2 = 2,
+		Phase3 = 3
+	};
+
+	enum class BossDistanceBand
+	{
+		Near,
+		Middle,
+		Far
+	};
+
+	constexpr int ToInt(BossPhase phase)
+	{
+		return static_cast<int>(phase);
+	}
+
+	constexpr BossPhase ToBossPhase(int phase)
+	{
+		if (phase <= ToInt(BossPhase::Phase1)) return BossPhase::Phase1;
+		if (phase == ToInt(BossPhase::Phase2)) return BossPhase::Phase2;
+		return BossPhase::Phase3;
+	}
+
+	constexpr std::string_view ToString(BossAttackProfile profile)
+	{
+		switch (profile)
+		{
+		case BossAttackProfile::MineCrusher:
+			return "MineCrusher";
+		case BossAttackProfile::Guardian:
+		default:
+			return "Guardian";
+		}
+	}
+
+	constexpr BossAttackProfile BossAttackProfileFromString(std::string_view value)
+	{
+		// JSON境界だけで文字列を解釈し、実行時の攻撃選択は列挙型で統一する。
+		return value == ToString(BossAttackProfile::MineCrusher)
+			? BossAttackProfile::MineCrusher
+			: BossAttackProfile::Guardian;
+	}
+
+	constexpr std::string_view ToString(BossAttackId attackId)
+	{
+		switch (attackId)
+		{
+		case BossAttackId::Punch:
+			return "Punch";
+		case BossAttackId::HeavyPunch:
+			return "HeavyPunch";
+		case BossAttackId::Charge:
+			return "Charge";
+		case BossAttackId::Shockwave:
+			return "Shockwave";
+		case BossAttackId::GroundSlam:
+			return "GroundSlam";
+		case BossAttackId::RapidPunch:
+			return "RapidPunch";
+		case BossAttackId::FrenzyCharge:
+			return "FrenzyCharge";
+		case BossAttackId::FastShockwave:
+			return "FastShockwave";
+		case BossAttackId::None:
+		default:
+			return "None";
+		}
+	}
+
+	constexpr std::string_view ToString(BossDistanceBand distanceBand)
+	{
+		switch (distanceBand)
+		{
+		case BossDistanceBand::Middle:
+			return "Middle";
+		case BossDistanceBand::Far:
+			return "Far";
+		case BossDistanceBand::Near:
+		default:
+			return "Near";
+		}
+	}
+} // namespace Ken4lowEngine

--- a/Project/ApplicationLayer/Character/Boss/Actor/BossBrainComponent.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Actor/BossBrainComponent.cpp
@@ -64,7 +64,7 @@ namespace Ken4lowEngine
 			return;
 		}
 
-		observedPhase_ = phase ? ToBossPhase(phase->GetCurrentPhase()) : BossPhase::Phase1;
+		observedPhase_ = phase ? phase->GetCurrentBossPhase() : BossPhase::Phase1;
 		const BossBrainPhaseTuning phaseTuning = GetPhaseTuning(observedPhase_);
 		appliedMoveSpeed_ = moveSpeed_ * phaseTuning.moveMultiplier;
 		appliedRotateSpeed_ = rotateSpeed_ * phaseTuning.rotateMultiplier;

--- a/Project/ApplicationLayer/Character/Boss/Actor/BossBrainComponent.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Actor/BossBrainComponent.cpp
@@ -18,6 +18,30 @@
 
 namespace Ken4lowEngine
 {
+	namespace
+	{
+		struct BossBrainPhaseTuning
+		{
+			float moveMultiplier;
+			float rotateMultiplier;
+			float approachDistanceMultiplier;
+		};
+
+		constexpr BossBrainPhaseTuning GetPhaseTuning(BossPhase phase)
+		{
+			switch (phase)
+			{
+			case BossPhase::Phase3:
+				return { 1.45f, 1.35f, 0.82f };
+			case BossPhase::Phase2:
+				return { 1.15f, 1.10f, 1.0f };
+			case BossPhase::Phase1:
+			default:
+				return { 1.0f, 1.0f, 1.0f };
+			}
+		}
+	}
+
 	void BossBrainComponent::Update(float deltaTime)
 	{
 		auto* owner = dynamic_cast<CharacterActor*>(GetOwner());
@@ -40,11 +64,10 @@ namespace Ken4lowEngine
 			return;
 		}
 
-		observedPhase_ = phase ? phase->GetCurrentPhase() : 1;
-		const float phaseMoveMultiplier = observedPhase_ >= 3 ? 1.45f : (observedPhase_ == 2 ? 1.15f : 1.0f);
-		const float phaseRotateMultiplier = observedPhase_ >= 3 ? 1.35f : (observedPhase_ == 2 ? 1.10f : 1.0f);
-		appliedMoveSpeed_ = moveSpeed_ * phaseMoveMultiplier;
-		appliedRotateSpeed_ = rotateSpeed_ * phaseRotateMultiplier;
+		observedPhase_ = phase ? ToBossPhase(phase->GetCurrentPhase()) : BossPhase::Phase1;
+		const BossBrainPhaseTuning phaseTuning = GetPhaseTuning(observedPhase_);
+		appliedMoveSpeed_ = moveSpeed_ * phaseTuning.moveMultiplier;
+		appliedRotateSpeed_ = rotateSpeed_ * phaseTuning.rotateMultiplier;
 
 		const Vector3 current = root->GetWorldPosition();
 		const Vector3 toTarget = targetActor_->GetTargetPosition() - current;
@@ -71,7 +94,7 @@ namespace Ken4lowEngine
 			return;
 		}
 
-		const float phaseApproachDistance = observedPhase_ >= 3 ? approachDistance_ * 0.82f : approachDistance_;
+		const float phaseApproachDistance = approachDistance_ * phaseTuning.approachDistanceMultiplier;
 		if (distanceToTarget_ > phaseApproachDistance)
 		{
 			const float length = std::max(distanceToTarget_, 0.0001f);
@@ -92,7 +115,7 @@ namespace Ken4lowEngine
 	{
 #ifdef USE_IMGUI
 		ImGui::SeparatorText("ボス行動判断");
-		ImGui::Text("状態: %s / Phase: %d / Target距離: %.2f", stateName_.c_str(), observedPhase_, distanceToTarget_);
+		ImGui::Text("状態: %s / Phase: %d / Target距離: %.2f", stateName_.c_str(), ToInt(observedPhase_), distanceToTarget_);
 		ImGui::Text("移動: %.2f -> %.2f / 旋回: %.2f -> %.2f", moveSpeed_, appliedMoveSpeed_, rotateSpeed_, appliedRotateSpeed_);
 		ImGui::Text("接近停止: %.2f", approachDistance_);
 #endif
@@ -133,7 +156,7 @@ namespace Ken4lowEngine
 		distanceToTarget_ = 0.0f;
 		appliedMoveSpeed_ = moveSpeed_;
 		appliedRotateSpeed_ = rotateSpeed_;
-		observedPhase_ = 1;
+		observedPhase_ = BossPhase::Phase1;
 		stateName_ = "Idle"; // 再戦時はPhase 1の速度表示へ戻し、前回の高速化状態を残さない。
 	}
 } // namespace Ken4lowEngine

--- a/Project/ApplicationLayer/Character/Boss/Actor/BossBrainComponent.h
+++ b/Project/ApplicationLayer/Character/Boss/Actor/BossBrainComponent.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "BossAttackTypes.h"
+
 #include <ActorComponent.h>
 
 #include <string>
@@ -50,7 +52,7 @@ namespace Ken4lowEngine
 		float distanceToTarget_ = 0.0f;
 		float appliedMoveSpeed_ = 0.0f;
 		float appliedRotateSpeed_ = 0.0f;
-		int observedPhase_ = 1;
+		BossPhase observedPhase_ = BossPhase::Phase1;
 		bool behaviorEnabled_ = true;
 		std::string stateName_ = "Idle";
 	};

--- a/Project/ApplicationLayer/Character/Boss/Components/BossPhaseComponent.cpp
+++ b/Project/ApplicationLayer/Character/Boss/Components/BossPhaseComponent.cpp
@@ -15,7 +15,7 @@ namespace Ken4lowEngine
 	void BossPhaseComponent::Initialize()
 	{
 		SanitizeSettings();
-		currentPhase_ = std::clamp(currentPhase_, 1, 3);
+		currentPhase_ = ToBossPhase(ToInt(currentPhase_));
 		healthCapacityApplied_ = false;
 		phaseInvulnerabilityRemaining_ = 0.0f;
 		phaseInvulnerabilityActive_ = false;
@@ -32,10 +32,11 @@ namespace Ken4lowEngine
 		UpdatePhaseInvulnerability(*health, deltaTime);
 		if (health->IsDead() || phaseInvulnerabilityActive_) return;
 
-		const int evaluated = EvaluatePhase(health->GetHealthRatio());
-		if (evaluated <= currentPhase_) return; // 回復しても戦闘フェーズは巻き戻さない。
+		const BossPhase evaluatedPhase = EvaluatePhase(health->GetHealthRatio());
+		if (ToInt(evaluatedPhase) <= ToInt(currentPhase_)) return; // 回復しても戦闘フェーズは巻き戻さない。
 
-		currentPhase_ = std::min(evaluated, currentPhase_ + 1); // 大ダメージでもPhase 2とPhase 3を順番に見せる。
+		const int nextPhaseNumber = std::min(ToInt(evaluatedPhase), ToInt(currentPhase_) + 1);
+		currentPhase_ = ToBossPhase(nextPhaseNumber); // 大ダメージでもPhase 2とPhase 3を順番に見せる。
 		++phaseRevision_;
 		BeginPhaseInvulnerability(*health);
 	}
@@ -58,7 +59,7 @@ namespace Ken4lowEngine
 #ifdef USE_IMGUI
 		ImGui::SeparatorText("ボスフェーズ");
 		ImGui::Text("最大HP設定: %.0f", configuredMaxHealth_);
-		ImGui::Text("現在: Phase %d / Revision %u", currentPhase_, phaseRevision_);
+		ImGui::Text("現在: Phase %d / Revision %u", ToInt(currentPhase_), phaseRevision_);
 		ImGui::Text("Phase 2: HP %.0f%% / Phase 3: HP %.0f%%", phase2HealthRatio_ * 100.0f, phase3HealthRatio_ * 100.0f);
 		ImGui::Text("移行無敵: %s %.2f / %.2f", phaseInvulnerabilityActive_ ? "有効" : "無効", phaseInvulnerabilityRemaining_, phaseInvulnerabilityDuration_);
 #endif
@@ -71,7 +72,7 @@ namespace Ken4lowEngine
 		outJson["Phase2HealthRatio"] = phase2HealthRatio_;
 		outJson["Phase3HealthRatio"] = phase3HealthRatio_;
 		outJson["PhaseInvulnerabilityDuration"] = phaseInvulnerabilityDuration_;
-		outJson["CurrentPhase"] = currentPhase_;
+		outJson["CurrentPhase"] = ToInt(currentPhase_);
 	}
 
 	void BossPhaseComponent::FromJson(const nlohmann::json& inJson)
@@ -81,9 +82,9 @@ namespace Ken4lowEngine
 		phase2HealthRatio_ = inJson.value("Phase2HealthRatio", phase2HealthRatio_);
 		phase3HealthRatio_ = inJson.value("Phase3HealthRatio", phase3HealthRatio_);
 		phaseInvulnerabilityDuration_ = inJson.value("PhaseInvulnerabilityDuration", phaseInvulnerabilityDuration_);
-		currentPhase_ = inJson.value("CurrentPhase", currentPhase_);
+		const int currentPhaseNumber = inJson.value("CurrentPhase", ToInt(currentPhase_));
+		currentPhase_ = ToBossPhase(currentPhaseNumber); // JSONでは既存Prefab互換のため数値を維持し、読込直後に列挙型へ変換する。
 		SanitizeSettings();
-		currentPhase_ = std::clamp(currentPhase_, 1, 3);
 		healthCapacityApplied_ = false;
 	}
 
@@ -94,17 +95,17 @@ namespace Ken4lowEngine
 		{
 			if (phaseInvulnerabilityActive_) EndPhaseInvulnerability(*health);
 		}
-		currentPhase_ = 1;
+		currentPhase_ = BossPhase::Phase1;
 		healthCapacityApplied_ = false;
 		phaseInvulnerabilityRemaining_ = 0.0f;
 		++phaseRevision_; // PresentationへReset後の状態再同期を通知する。
 	}
 
-	int BossPhaseComponent::EvaluatePhase(float healthRatio) const
+	BossPhase BossPhaseComponent::EvaluatePhase(float healthRatio) const
 	{
-		if (healthRatio <= phase3HealthRatio_) return 3;
-		if (healthRatio <= phase2HealthRatio_) return 2;
-		return 1;
+		if (healthRatio <= phase3HealthRatio_) return BossPhase::Phase3;
+		if (healthRatio <= phase2HealthRatio_) return BossPhase::Phase2;
+		return BossPhase::Phase1;
 	}
 
 	void BossPhaseComponent::SanitizeSettings()

--- a/Project/ApplicationLayer/Character/Boss/Components/BossPhaseComponent.h
+++ b/Project/ApplicationLayer/Character/Boss/Components/BossPhaseComponent.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include "ApplicationLayer/Character/Boss/Actor/BossAttackTypes.h"
+
 #include <ActorComponent.h>
 
 #include <string>
@@ -28,7 +30,11 @@ namespace Ken4lowEngine
 		void ToJson(nlohmann::json& outJson) const override;
 		void FromJson(const nlohmann::json& inJson) override;
 
-		int GetCurrentPhase() const { return currentPhase_; }
+		/// 現在フェーズを型付きで返す。
+		BossPhase GetCurrentBossPhase() const { return currentPhase_; }
+
+		/// 既存表示・外部APIとの互換用にフェーズ番号を返す。
+		int GetCurrentPhase() const { return ToInt(currentPhase_); }
 		unsigned int GetPhaseRevision() const { return phaseRevision_; }
 		float GetConfiguredMaxHealth() const { return configuredMaxHealth_; }
 		bool IsPhaseInvulnerabilityActive() const { return phaseInvulnerabilityActive_; }
@@ -38,7 +44,7 @@ namespace Ken4lowEngine
 		void ResetPhase();
 
 	private:
-		int EvaluatePhase(float healthRatio) const;
+		BossPhase EvaluatePhase(float healthRatio) const;
 		void SanitizeSettings();
 		void ApplyConfiguredHealthCapacity(CharacterHealthComponent& health);
 		void BeginPhaseInvulnerability(CharacterHealthComponent& health);
@@ -51,7 +57,7 @@ namespace Ken4lowEngine
 		float phase3HealthRatio_ = 0.35f;
 		float phaseInvulnerabilityDuration_ = 1.20f;
 		float phaseInvulnerabilityRemaining_ = 0.0f;
-		int currentPhase_ = 1;
+		BossPhase currentPhase_ = BossPhase::Phase1;
 		unsigned int phaseRevision_ = 0;
 		bool healthCapacityApplied_ = false;
 		bool phaseInvulnerabilityActive_ = false;

--- a/Project/ApplicationLayer/Scene/DebugScene/Validation/BossMigrationValidation.cpp
+++ b/Project/ApplicationLayer/Scene/DebugScene/Validation/BossMigrationValidation.cpp
@@ -91,12 +91,13 @@ void BossMigrationValidation::DrawImGui()
 	ImGui::SameLine();
 	if (ImGui::Button("Bodyへ100基礎Damage")) requestBodyDamage_ = true;
 	if (ImGui::Button("撃破地点固定テスト")) requestDeathPositionTest_ = true;
+	if (ImGui::Button("全フェーズ攻撃選択を検証")) requestSelectionRuleValidation_ = true;
 	ImGui::SameLine();
 	if (ImGui::Button("Boss Reset")) requestReset_ = true;
 	if (ImGui::Button("Boss JSON保存")) requestSave_ = true;
 	ImGui::SameLine();
 	if (ImGui::Button("Boss JSON再読込")) requestReload_ = true;
-	ImGui::TextDisabled("撃破テスト後も崩壊位置とDeath positionが一致することを確認します。");
+	ImGui::TextDisabled("全フェーズ検証はPhase 1〜3とNear/Middle/Farの全候補登録を確認します。");
 	ImGui::End();
 #endif
 }
@@ -160,6 +161,16 @@ void BossMigrationValidation::ProcessRequests()
 			lastSucceeded_ = result.killed && K4E::Vector3::LengthSquared(after - before) <= 0.0001f;
 			lastMessage_ = lastSucceeded_ ? "Bossは撃破地点を維持したまま死亡演出へ移行しました。" : "Bossの撃破地点固定に失敗しました。";
 		}
+	}
+	if (requestSelectionRuleValidation_)
+	{
+		requestSelectionRuleValidation_ = false;
+		const K4E::BossAttackComponent* attack = boss_ ? boss_->GetBossAttackComponent() : nullptr;
+		std::string validationSummary;
+		lastSucceeded_ = attack && attack->ValidateSelectionRules(validationSummary);
+		lastMessage_ = attack
+			? (lastSucceeded_ ? "攻撃選択ルール検証OK: " : "攻撃選択ルール検証NG: ") + validationSummary
+			: "BossAttackComponentが見つからないため検証できませんでした。"; // DebugScene上で全フェーズ・全距離帯の登録漏れを即座に確認する。
 	}
 	if (requestReset_)
 	{

--- a/Project/ApplicationLayer/Scene/DebugScene/Validation/BossMigrationValidation.h
+++ b/Project/ApplicationLayer/Scene/DebugScene/Validation/BossMigrationValidation.h
@@ -37,6 +37,7 @@ private:
 	bool requestHeadDamage_ = false;
 	bool requestBodyDamage_ = false;
 	bool requestDeathPositionTest_ = false;
+	bool requestSelectionRuleValidation_ = false;
 	bool requestReset_ = false;
 	bool requestSave_ = false;
 	bool requestReload_ = false;

--- a/Project/Directory.Build.targets
+++ b/Project/Directory.Build.targets
@@ -1,6 +1,8 @@
 <Project>
   <!-- Actor移行後に削除した旧Character実装を、残存vcxproj項目から安全に除外する。 -->
   <ItemGroup>
+    <ClInclude Include="ApplicationLayer\Character\Boss\Actor\BossAttackTypes.h" />
+
     <ClCompile Remove="ApplicationLayer\Character\Boss\Core\BossFactory.cpp" />
     <ClCompile Remove="ApplicationLayer\Character\Boss\Components\BossStatusComponent.cpp" />
     <ClCompile Remove="ApplicationLayer\Character\Boss\Core\BossStateMachine.cpp" />

--- a/Project/Directory.Build.targets
+++ b/Project/Directory.Build.targets
@@ -50,12 +50,7 @@
     <ClInclude Remove="ApplicationLayer\Character\Boss\Components\BossAttackComponent.h" />
     <ClInclude Remove="ApplicationLayer\Character\Boss\Core\BossBase.h" />
     <ClInclude Remove="ApplicationLayer\Character\Boss\Components\BossMovementComponent.h" />
-    <ClInclude Remove="ApplicationLayer\Character\Boss\BehaviorTree\BTActionNode.h" />
-    <ClInclude Remove="ApplicationLayer\Character\Boss\BehaviorTree\BTConditionNode.h" />
-    <ClInclude Remove="ApplicationLayer\Character\Boss\BehaviorTree\BTSelectorNode.h" />
-    <ClInclude Remove="ApplicationLayer\Character\Boss\BehaviorTree\BTSequenceNode.h" />
-    <ClInclude Remove="ApplicationLayer\Character\Boss\BehaviorTree\BehaviorStatus.h" />
-    <ClInclude Remove="ApplicationLayer\Character\Boss\BehaviorTree\IBTNode.h" />
+    <ClInclude Remove="ApplicationLayer\Character\Boss\BehaviorTree\*.h" />
     <ClInclude Remove="ApplicationLayer\Character\Boss\Core\BossTypes.h" />
     <ClInclude Remove="ApplicationLayer\Character\Boss\Attacks\IBossAttack.h" />
     <ClInclude Remove="ApplicationLayer\Character\Boss\Attacks\BossMeleeAttackUtility.h" />


### PR DESCRIPTION
## 変更内容

- `BossAttackProfile`、`BossAttackId`、`BossPhase`、`BossDistanceBand`を追加
- Bossの攻撃プロファイルと直近選択攻撃を文字列ではなく列挙型で保持
- フェーズ・距離帯・攻撃候補順を`BossAttackSelectionRule`へ集約
- Guardian／MineCrusherの攻撃選択を共通処理へ統合
- `BossPhaseComponent`の内部状態・判定結果・リセット処理を`BossPhase`へ変更
- 既存表示との互換用に整数取得APIを残し、Brain側は型付きAPIを直接利用
- JSONと共通`AttackComponent`の境界だけで文字列・整数へ変換
- DebugSceneへ「全フェーズ攻撃選択を検証」ボタンを追加
- Phase 1〜3 × Near／Middle／Farの全候補が登録済みか自動検査
- 旧BehaviorTreeの個別除外行をワイルドカード1行へ整理

## 修正理由

従来の`TryStartBestAttack`は、`"MineCrusher"`などの文字列比較、フェーズ番号、距離値、攻撃ID文字列が条件分岐内に分散していました。攻撃追加やフェーズ調整時のタイプミスと修正漏れを防ぐため、型付きIDとルール表へ置き換えています。

旧BehaviorTreeの実ファイルは既に削除され、実際のボス判断は`BossBrainComponent`へ移行済みです。残存する旧プロジェクト項目は現在`Directory.Build.targets`で除外されており、個別ノード名の列挙をワイルドカードへまとめています。

## 確認内容

- masterとの差分はBoss・DebugScene関連10ファイルのみ
- ブランチはmasterから遅れなし
- C++20の最小構成で、ルール表・`std::span`・全組み合わせ検証・フェーズ進行を`-Wall -Wextra -Werror`付きで構文確認
- 元のGuardian／MineCrusherのフェーズ別・距離別候補順を維持

## DebugSceneでの確認手順

1. DebugSceneを起動
2. 「ボス Player Target 検証」を開く
3. 「全フェーズ攻撃選択を検証」を押す
4. GuardianまたはMineCrusherについて、Phase 1〜3 × Near／Middle／Farがすべて`OK`になることを確認
5. 実戦では各フェーズ遷移、Cooldown中の次候補フォールバック、Prefab再読込を確認

## 残作業

- Windows／Visual Studioでのプロジェクト全体ビルド
- 実際のゲーム起動による全フェーズ動作確認
- `.vcxproj`／`.filters`内の旧BehaviorTree表示項目そのものの物理削除
- 必要性を確認した後のJSONデータ駆動化