### PR TITLE
P0: アイテム出現高さとプレイヤー移動を調整

### DIFF
--- a/Project/ApplicationLayer/Character/Player/Migration/GamePlayPlayerMigrationRuntime.h
+++ b/Project/ApplicationLayer/Character/Player/Migration/GamePlayPlayerMigrationRuntime.h
@@ -52,6 +52,7 @@ public:
 		player_->SetLayer("Player");
 		player_->AddTag("Player");
 		stageColliders_ = stage_->GetWorldColliderPointers();
+		ApplyP0MovementTuning(player_->GetPlayerMovementComponent());
 		player_->ResetForValidation(ResolveSpawnRootPosition(spawnPosition));
 		if (K4E::WeaponComponent* weapon = player_->GetWeaponComponent()) weapon->ConfigureAmmoState(30, 30, 90, 120);
 		RefreshPlayerRuntimeBindings();
@@ -82,6 +83,7 @@ public:
 		ClearNearbyStageColliders();
 		stageColliders_.clear();
 		player_ = nullptr;
+		lastTunedMovement_ = nullptr;
 		bulletManager_ = nullptr;
 		legacyCollisionManager_ = nullptr;
 		stage_ = nullptr;
@@ -160,9 +162,22 @@ public:
 	K4E::Vector3 GetPlayerPosition() const { return player_ ? player_->GetWorldPosition() : K4E::Vector3{}; }
 
 private:
+	void ApplyP0MovementTuning(K4E::PlayerMovementComponent* movement)
+	{
+		if (!movement || movement == lastTunedMovement_) return;
+		nlohmann::json tuning;
+		movement->ToJson(tuning);
+		tuning["MoveSpeed"] = kGroundedMoveSpeed;
+		tuning["SprintSpeedMultiplier"] = kGroundedSprintMultiplier;
+		tuning["JumpSpeed"] = kGroundedJumpSpeed;
+		movement->FromJson(tuning); // Prefabの他設定を維持したままP0の重い操作感だけを一度適用する。
+		lastTunedMovement_ = movement;
+	}
+
 	void RefreshPlayerRuntimeBindings()
 	{
 		if (!player_) return;
+		ApplyP0MovementTuning(player_->GetPlayerMovementComponent());
 		if (K4E::PlayerMeleeAttackComponent* melee = player_->GetPlayerMeleeAttackComponent())
 		{
 			melee->SetCollisionManager(legacyCollisionManager_);
@@ -305,12 +320,16 @@ private:
 	static constexpr const char* kPlayerPrefabPath = "Resources/ActorPrefabs/Player.json";
 	static constexpr float kMouseLookSensitivity = 0.0025f;
 	static constexpr float kSpawnGroundClearance = 0.02f;
+	static constexpr float kGroundedMoveSpeed = 5.5f;
+	static constexpr float kGroundedSprintMultiplier = 1.4f;
+	static constexpr float kGroundedJumpSpeed = 6.0f;
 	static constexpr float kStageActivationRadius = 72.0f;
 	static constexpr float kStageRefreshDistance = 5.0f;
 	static constexpr size_t kMaxActiveStageColliders = 256;
 	K4E::ActorWorld* actorWorld_ = nullptr;
 	K4E::PhysicsWorld* physicsWorld_ = nullptr;
 	K4E::PlayerActor* player_ = nullptr;
+	K4E::PlayerMovementComponent* lastTunedMovement_ = nullptr;
 	BulletManager* bulletManager_ = nullptr;
 	CollisionManager* legacyCollisionManager_ = nullptr;
 	K4E::Stage* stage_ = nullptr;

--- a/Project/ApplicationLayer/Item/Item.cpp
+++ b/Project/ApplicationLayer/Item/Item.cpp
@@ -44,6 +44,7 @@ void Item::Initialize(ItemType type, const K4E::Vector3& pos, int healAmount, in
 	type_ = type;
 	position_ = pos;
 	basePosition_ = pos;
+	visualPosition_ = pos;
 	active_ = (type_ != ItemType::None);
 	SetEnabled(active_);
 	pickupRadius_ = pickupRadius;
@@ -55,7 +56,7 @@ void Item::Initialize(ItemType type, const K4E::Vector3& pos, int healAmount, in
 
 	object3d_ = std::make_unique<K4E::Object3D>();
 	object3d_->Initialize(GetModelPath(type_));
-	object3d_->SetTranslate(position_);
+	object3d_->SetTranslate(visualPosition_);
 	object3d_->SetScale(scale_);
 
 	switch (type_)
@@ -105,17 +106,18 @@ void Item::Update()
 	// 非アクティブ状態なら更新処理をスキップ
 	if (!active_) return;
 
-	float deltaTime = GameTimer::GetInstance()->GetDeltaTime();
+	const float deltaTime = GameTimer::GetInstance()->GetDeltaTime();
 
 	lifetime_ += deltaTime;
 	floatTimer_ += floatSpeed_ * deltaTime;
 	const float floatOffset = std::sinf(floatTimer_) * floatAmplitude_;
-	position_.y = basePosition_.y + floatOffset + 1.0f;
+	visualPosition_ = basePosition_;
+	visualPosition_.y += floatOffset; // 見た目だけを浮遊させ、取得Colliderは床付近の固定位置に残す。
 	rotation_.y += rotationSpeed_ * deltaTime;
 
 	if (object3d_)
 	{
-		object3d_->SetTranslate(position_);
+		object3d_->SetTranslate(visualPosition_);
 		object3d_->SetRotate(rotation_);
 		object3d_->Update();
 	}

--- a/Project/ApplicationLayer/Item/Item.h
+++ b/Project/ApplicationLayer/Item/Item.h
@@ -68,8 +68,11 @@ public: /// ---------- ゲッター ---------- ///
 	// アイテムの種類を返す
 	ItemType GetType() const { return type_; }
 
-	// アイテムの位置を返す
+	// 取得判定とColliderに使用する固定位置を返す
 	const K4E::Vector3& GetPosition() const { return position_; }
+
+	// 浮遊・回転する見た目と演出に使用する位置を返す
+	const K4E::Vector3& GetVisualPosition() const { return visualPosition_; }
 
 	// アイテムの取得半径を返す
 	float GetPickupRadius() const { return pickupRadius_; }
@@ -91,8 +94,13 @@ public: /// ---------- オーバーライド ---------- ///
 	// OBBのメンバ関数のオーバーライド
 	K4E::Vector3 GetCenterPosition() const override { return position_; }
 
-	// OBBのメンバ関数のオーバーライド
-	void SetCenterPosition(const K4E::Vector3& pos) override { position_ = pos; }
+	// Collider位置を変更した時は浮遊基準も同じ場所へ移す
+	void SetCenterPosition(const K4E::Vector3& pos) override
+	{
+		position_ = pos;
+		basePosition_ = pos;
+		visualPosition_ = pos;
+	}
 
 	// OBBのメンバ関数のオーバーライド
 	K4E::Vector3 GetOBBHalfSize() const override { return scale_; }
@@ -112,19 +120,20 @@ private: /// ---------- メンバ変数 ---------- ///
 	std::unique_ptr<K4E::Object3D> object3d_;
 
 	ItemType type_ = ItemType::None; // アイテムの種類
-	K4E::Vector3 position_ = {};	 // アイテムの位置
-	bool active_ = false;			 // アイテムがアクティブかどうか
-	float pickupRadius_ = 2.0f;		 // アイテムの取得半径
-	int healAmount_ = 25;			 // アイテムの回復量
-	int ammoAmount_ = 30;			 // アイテムの弾薬量
+	K4E::Vector3 position_ = {}; // Colliderと取得判定に使用する固定位置
+	K4E::Vector3 visualPosition_ = {}; // 浮遊するモデルと演出に使用する位置
+	bool active_ = false; // アイテムがアクティブかどうか
+	float pickupRadius_ = 2.0f; // アイテムの取得半径
+	int healAmount_ = 25; // アイテムの回復量
+	int ammoAmount_ = 30; // アイテムの弾薬量
 
-	K4E::Vector3 scale_ = { 0.4f, 0.4f, 0.4f };		// アイテムのスケール
-	float floatTimer_ = 0.0f;						// 浮遊アニメーション用のタイマー
-	float floatAmplitude_ = 0.6f;					// 浮遊アニメーションの振幅
-	float floatSpeed_ = 4.0f;						// 浮遊アニメーションの速度
-	K4E::Vector3 basePosition_ = {};				// 浮遊アニメーションの基準位置
-	K4E::Vector3 rotation_ = { 0.0f, 0.0f, 0.0f };	// 回転角度
-	float rotationSpeed_ = 0.01f;					// 回転速度
-	float lifetime_ = 0.0f;							// アイテムの寿命
-	const float maxLifetime_ = 999.0f;				// アイテムの最大寿命（999秒で事実上無限）
+	K4E::Vector3 scale_ = { 0.4f, 0.4f, 0.4f }; // アイテムのスケール
+	float floatTimer_ = 0.0f; // 浮遊アニメーション用のタイマー
+	float floatAmplitude_ = 0.6f; // 浮遊アニメーションの振幅
+	float floatSpeed_ = 4.0f; // 浮遊アニメーションの速度
+	K4E::Vector3 basePosition_ = {}; // 浮遊アニメーションの基準位置
+	K4E::Vector3 rotation_ = { 0.0f, 0.0f, 0.0f }; // 回転角度
+	float rotationSpeed_ = 0.01f; // 回転速度
+	float lifetime_ = 0.0f; // アイテムの寿命
+	const float maxLifetime_ = 999.0f; // アイテムの最大寿命（999秒で事実上無限）
 };

--- a/Project/ApplicationLayer/Item/ItemManager.cpp
+++ b/Project/ApplicationLayer/Item/ItemManager.cpp
@@ -2,12 +2,15 @@
 #include "ItemManager.h"
 #include "ApplicationLayer/Character/Player/IPlayerRuntime.h"
 #include "CollisionManager.h"
+#include "Stage.h"
 
 #ifdef USE_IMGUI
 #include <imgui.h>
 #endif
 
 #include <algorithm>
+#include <cmath>
+#include <limits>
 #include <sstream>
 #include <string>
 #include <Windows.h>
@@ -16,6 +19,10 @@ namespace K4E = ::Ken4lowEngine;
 
 namespace
 {
+	constexpr float kDropGroundClearance = 0.45f;
+	constexpr float kFloorHorizontalTolerance = 0.05f;
+	constexpr float kMaximumFloorAboveDeath = 0.5f;
+
 	const char* ToItemTypeName(ItemType type)
 	{
 		switch (type)
@@ -26,6 +33,28 @@ namespace
 		case ItemType::None:
 		default: return "None";
 		}
+	}
+
+	K4E::Vector3 ResolveEnemyDropPosition(const K4E::Vector3& deathPosition)
+	{
+		K4E::Stage* stage = K4E::Stage::GetActiveRuntimeStage();
+		if (!stage) return deathPosition;
+
+		float highestFloorY = -std::numeric_limits<float>::infinity();
+		for (const K4E::AABB& floor : stage->GetFloorAABBs())
+		{
+			const bool containsXZ = deathPosition.x >= floor.min.x - kFloorHorizontalTolerance &&
+				deathPosition.x <= floor.max.x + kFloorHorizontalTolerance &&
+				deathPosition.z >= floor.min.z - kFloorHorizontalTolerance &&
+				deathPosition.z <= floor.max.z + kFloorHorizontalTolerance;
+			if (!containsXZ || floor.max.y > deathPosition.y + kMaximumFloorAboveDeath) continue;
+			highestFloorY = std::max(highestFloorY, floor.max.y);
+		}
+
+		if (!std::isfinite(highestFloorY)) return deathPosition;
+		K4E::Vector3 groundedPosition = deathPosition;
+		groundedPosition.y = highestFloorY + kDropGroundClearance; // 敵の中心位置ではなく足元の床面を基準にItemを生成する。
+		return groundedPosition;
 	}
 }
 
@@ -46,7 +75,10 @@ void ItemManager::Update(IPlayerRuntime* player)
 
 void ItemManager::Draw()
 {
-	for (auto& item : items_) if (item) item->Draw();
+	for (auto& item : items_)
+	{
+		if (item) item->Draw();
+	}
 }
 
 void ItemManager::RegisterColliders(CollisionManager* collisionManager)
@@ -54,27 +86,36 @@ void ItemManager::RegisterColliders(CollisionManager* collisionManager)
 	if (!collisionManager) return;
 	if (registeredCollisionManager_)
 	{
-		for (auto& item : items_) if (item) registeredCollisionManager_->RemoveCollider(item.get());
+		for (auto& item : items_)
+		{
+			if (item) registeredCollisionManager_->RemoveCollider(item.get());
+		}
 	}
 	registeredCollisionManager_ = collisionManager;
-	for (auto& item : items_) if (item && item->IsActive()) registeredCollisionManager_->AddCollider(item.get());
+	for (auto& item : items_)
+	{
+		if (item && item->IsActive()) registeredCollisionManager_->AddCollider(item.get());
+	}
 }
 
-void ItemManager::Spawn(ItemType type, const K4E::Vector3& position) { SpawnConfigured(type, position); }
-void ItemManager::SpawnHealSmall(const K4E::Vector3& position) { SpawnConfigured(ItemType::HealSmall, position); }
+void ItemManager::Spawn(ItemType type, const K4E::Vector3& position)
+{
+	SpawnConfigured(type, position);
+}
+
+void ItemManager::SpawnHealSmall(const K4E::Vector3& position)
+{
+	SpawnConfigured(ItemType::HealSmall, position);
+}
 
 void ItemManager::SpawnAmmoSmall(const K4E::Vector3& position)
 {
-	K4E::Vector3 spawnPosition = position;
-	spawnPosition.y += 0.5f;
-	SpawnConfigured(ItemType::AmmoSmall, spawnPosition);
+	SpawnConfigured(ItemType::AmmoSmall, position);
 }
 
 void ItemManager::SpawnAmmoSmall(const K4E::Vector3& position, int ammoAmount)
 {
-	K4E::Vector3 spawnPosition = position;
-	spawnPosition.y += 0.5f;
-	SpawnConfigured(ItemType::AmmoSmall, spawnPosition, ammoAmount);
+	SpawnConfigured(ItemType::AmmoSmall, position, ammoAmount);
 }
 
 bool ItemManager::TryGetFirstActiveItemPosition(ItemType type, K4E::Vector3& outPosition) const
@@ -90,12 +131,14 @@ bool ItemManager::TryGetFirstActiveItemPosition(ItemType type, K4E::Vector3& out
 	return false;
 }
 
-void ItemManager::TryDropFromEnemyDeath(const K4E::Vector3& deathPosition) { TryDropEnemyItem(deathPosition); }
+void ItemManager::TryDropFromEnemyDeath(const K4E::Vector3& deathPosition)
+{
+	TryDropEnemyItem(deathPosition);
+}
 
 void ItemManager::TryDropEnemyItem(const K4E::Vector3& deathPosition)
 {
-	K4E::Vector3 dropPosition = deathPosition;
-	dropPosition.y += 0.5f;
+	const K4E::Vector3 dropPosition = ResolveEnemyDropPosition(deathPosition);
 	lastDropPosition_ = dropPosition;
 	if (!enemyDeathDropEnabled_)
 	{
@@ -146,7 +189,7 @@ void ItemManager::CheckPickup(IPlayerRuntime& player)
 		const bool consumePickedItem = effectApplied || (consumeItemWhenFull_ && lastItemEffectDebugInfo_.noEffectBecauseFull);
 		if (consumePickedItem)
 		{
-			itemVisualEffect_.PlayPickup(lastItemEffectDebugInfo_.itemType, item->GetPosition());
+			itemVisualEffect_.PlayPickup(lastItemEffectDebugInfo_.itemType, item->GetVisualPosition());
 			itemVisualEffect_.StopIdle(*item);
 			item->MarkCollected();
 			collectedEvents_.push_back(lastItemEffectDebugInfo_.itemType);
@@ -236,7 +279,10 @@ void ItemManager::Clear()
 {
 	if (registeredCollisionManager_)
 	{
-		for (auto& item : items_) if (item) registeredCollisionManager_->RemoveCollider(item.get());
+		for (auto& item : items_)
+		{
+			if (item) registeredCollisionManager_->RemoveCollider(item.get());
+		}
 	}
 	items_.clear();
 	collectedEvents_.clear();
@@ -262,12 +308,18 @@ bool ItemManager::ConsumeCollected(ItemType type)
 
 int ItemManager::GetActiveItemCount() const
 {
-	return static_cast<int>(std::count_if(items_.begin(), items_.end(), [](const std::unique_ptr<Item>& item) { return item && item->IsActive(); }));
+	return static_cast<int>(std::count_if(items_.begin(), items_.end(), [](const std::unique_ptr<Item>& item)
+		{
+			return item && item->IsActive();
+		}));
 }
 
 int ItemManager::GetActiveItemCount(ItemType type) const
 {
-	return static_cast<int>(std::count_if(items_.begin(), items_.end(), [type](const std::unique_ptr<Item>& item) { return item && item->IsActive() && item->GetType() == type; }));
+	return static_cast<int>(std::count_if(items_.begin(), items_.end(), [type](const std::unique_ptr<Item>& item)
+		{
+			return item && item->IsActive() && item->GetType() == type;
+		}));
 }
 
 float ItemManager::GetNoneDropChance() const
@@ -309,18 +361,22 @@ void ItemManager::DrawImGui()
 
 void ItemManager::RemoveInactiveItems()
 {
-	items_.erase(std::remove_if(items_.begin(), items_.end(), [this](const std::unique_ptr<Item>& item) {
-		const bool shouldRemove = !item || item->IsCollected() || item->IsExpired();
-		if (shouldRemove && item)
+	items_.erase(std::remove_if(items_.begin(), items_.end(), [this](const std::unique_ptr<Item>& item)
 		{
-			itemVisualEffect_.StopIdle(*item);
-			if (registeredCollisionManager_) registeredCollisionManager_->RemoveCollider(item.get());
-		}
-		return shouldRemove;
+			const bool shouldRemove = !item || item->IsCollected() || item->IsExpired();
+			if (shouldRemove && item)
+			{
+				itemVisualEffect_.StopIdle(*item);
+				if (registeredCollisionManager_) registeredCollisionManager_->RemoveCollider(item.get());
+			}
+			return shouldRemove;
 		}), items_.end());
 }
 
-void ItemManager::SpawnDropItem(ItemType type, const K4E::Vector3& position) { SpawnConfigured(type, position); }
+void ItemManager::SpawnDropItem(ItemType type, const K4E::Vector3& position)
+{
+	SpawnConfigured(type, position);
+}
 
 void ItemManager::SpawnConfigured(ItemType type, const K4E::Vector3& position, int overrideAmmoAmount)
 {


### PR DESCRIPTION
## 変更内容

- 敵死亡時のItem座標をStage床面へ補正
- Ammo生成と敵ドロップで重複していた固定Y加算を削除
- Itemの取得Collider位置と浮遊するVisual位置を分離
- Pickup演出をVisual位置から再生
- GamePlayのPlayer生成・Prefab再読込時にP0移動調整を一度だけ適用
  - MoveSpeed: 6.0 → 5.5
  - Sprint倍率: 1.55 → 1.4
  - JumpSpeed: 7.0 → 6.0

## 原因

ItemManager側のY加算とItem更新側の浮遊用固定加算が重なり、敵の死亡位置より高い場所へItemとColliderが出現していました。また、モデルの浮遊処理がCollider座標そのものを書き換えていました。

## 確認事項

- GitHub上の差分と参照関係を確認
- この環境にはWindows/Visual Studioビルド環境とGitHub Actions実行結果がないため、実機ビルドと操作感確認は未実施

## 実機で確認する項目

- 各Stageの通常床・高所床で敵を倒した際のItem高さ
- Itemモデルだけが浮遊し、取得範囲が上下しないこと
- 通常移動、Sprint、Jumpの重さ
- Prefab再読込後も移動調整が維持されること